### PR TITLE
Fix error display handling in Ajax controller

### DIFF
--- a/nuclear-engagement/admin/Controller/Ajax/GenerateController.php
+++ b/nuclear-engagement/admin/Controller/Ajax/GenerateController.php
@@ -39,11 +39,6 @@ class GenerateController {
      */
     public function handle(): void {
         try {
-            // Enable error logging for debugging
-            if (!defined('WP_DEBUG') || !WP_DEBUG) {
-                @ini_set('display_errors', 1);
-                @error_reporting(E_ALL);
-            }
             
             // Security check
             if (!check_ajax_referer('nuclen_admin_ajax_nonce', 'security', false)) {


### PR DESCRIPTION
## Summary
- remove display_errors block from GenerateController

## Testing
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_684907f57fc88327bf9381d2a16b0d5c