### PR TITLE
Fix auto generation API call

### DIFF
--- a/nuclear-engagement/includes/Services/AutoGenerationService.php
+++ b/nuclear-engagement/includes/Services/AutoGenerationService.php
@@ -146,7 +146,7 @@ class AutoGenerationService {
                 'generation_id' => $generation_id,
             ];
 
-            $result = $this->remote_api->send_generation_request($data_to_send);
+            $result = $this->remote_api->sendPostsToGenerate($data_to_send);
 
             if (is_wp_error($result)) {
                 error_log('Failed to start generation: ' . $result->get_error_message());


### PR DESCRIPTION
## Summary
- use `sendPostsToGenerate` in `AutoGenerationService`

## Testing
- `npm run build` *(fails: Cannot find type definition file for 'node')*

------
https://chatgpt.com/codex/tasks/task_e_684907d891d88327bf0e8a83733c425b