### PR TITLE
Add uninstall options

### DIFF
--- a/nuclear-engagement/admin/partials/nuclen-admin-settings.php
+++ b/nuclear-engagement/admin/partials/nuclen-admin-settings.php
@@ -21,7 +21,8 @@ if ( ! defined( 'ABSPATH' ) ) {
 			<a id="theme-tab"       href="#theme"      class="nav-tab"><?php esc_html_e( 'Theme',      'nuclear-engagement' ); ?></a>
 			<a id="display-tab"     href="#display"    class="nav-tab"><?php esc_html_e( 'Display',    'nuclear-engagement' ); ?></a>
 			<a id="optin-tab"       href="#optin"      class="nav-tab"><?php esc_html_e( 'Opt-In',     'nuclear-engagement' ); ?></a>
-			<a id="generation-tab"  href="#generation" class="nav-tab"><?php esc_html_e( 'Generation', 'nuclear-engagement' ); ?></a>
+                       <a id="generation-tab"  href="#generation" class="nav-tab"><?php esc_html_e( 'Generation', 'nuclear-engagement' ); ?></a>
+                       <a id="uninstall-tab"   href="#uninstall"  class="nav-tab"><?php esc_html_e( 'Uninstall', 'nuclear-engagement' ); ?></a>
 		</div>
 
 		<?php
@@ -31,7 +32,8 @@ if ( ! defined( 'ABSPATH' ) ) {
 		require $tabs_dir . 'theme.php';
 		require $tabs_dir . 'display.php';
 		require $tabs_dir . 'optin.php';
-		require $tabs_dir . 'generation.php';
+               require $tabs_dir . 'generation.php';
+               require $tabs_dir . 'uninstall.php';
 		?>
 
 		<!-- ───── Save button ───── -->

--- a/nuclear-engagement/admin/partials/settings/uninstall.php
+++ b/nuclear-engagement/admin/partials/settings/uninstall.php
@@ -1,0 +1,34 @@
+<?php
+// File: admin/partials/settings/uninstall.php
+if ( ! defined( 'ABSPATH' ) ) {
+        exit;
+}
+/**
+ * Uninstall tab
+ *
+ * @package NuclearEngagement\Admin
+ */
+?>
+<!-- UNINSTALL TAB -->
+<div id="uninstall" class="nuclen-tab-content nuclen-section" style="display:none;">
+        <h2 class="nuclen-subheading"><?php esc_html_e( 'Uninstall Options', 'nuclear-engagement' ); ?></h2>
+        <p><?php esc_html_e( 'Choose what to remove when the plugin is deleted.', 'nuclear-engagement' ); ?></p>
+
+        <div class="nuclen-form-group nuclen-row">
+                <label class="nuclen-label-col" for="delete_settings_on_uninstall">
+                        <?php esc_html_e( 'Delete plugin settings', 'nuclear-engagement' ); ?>
+                </label>
+                <div class="nuclen-input-col">
+                        <input type="checkbox" name="delete_settings_on_uninstall" id="delete_settings_on_uninstall" value="1" <?php checked( $settings['delete_settings_on_uninstall'], true ); ?> />
+                </div>
+        </div>
+
+        <div class="nuclen-form-group nuclen-row">
+                <label class="nuclen-label-col" for="delete_generated_content_on_uninstall">
+                        <?php esc_html_e( 'Delete generated post data', 'nuclear-engagement' ); ?>
+                </label>
+                <div class="nuclen-input-col">
+                        <input type="checkbox" name="delete_generated_content_on_uninstall" id="delete_generated_content_on_uninstall" value="1" <?php checked( $settings['delete_generated_content_on_uninstall'], true ); ?> />
+                </div>
+        </div>
+</div><!-- /#uninstall -->

--- a/nuclear-engagement/admin/trait-settings-page-save.php
+++ b/nuclear-engagement/admin/trait-settings-page-save.php
@@ -149,7 +149,9 @@ trait SettingsPageSaveTrait {
 		$raw['update_last_modified']             = isset( $_POST['update_last_modified'] )             ? (bool) wp_unslash( $_POST['update_last_modified'] )             : false;
 		$raw['auto_generate_quiz_on_publish']    = isset( $_POST['auto_generate_quiz_on_publish'] )    ? (bool) wp_unslash( $_POST['auto_generate_quiz_on_publish'] )    : false;
 		$raw['auto_generate_summary_on_publish'] = isset( $_POST['auto_generate_summary_on_publish'] ) ? (bool) wp_unslash( $_POST['auto_generate_summary_on_publish'] ) : false;
-		$raw['show_attribution']                 = isset( $_POST['show_attribution'] )                 ? (bool) wp_unslash( $_POST['show_attribution'] )                 : false;
+                $raw['show_attribution']                 = isset( $_POST['show_attribution'] )                 ? (bool) wp_unslash( $_POST['show_attribution'] )                 : false;
+                $raw['delete_settings_on_uninstall']     = isset( $_POST['delete_settings_on_uninstall'] )     ? (bool) wp_unslash( $_POST['delete_settings_on_uninstall'] )     : false;
+                $raw['delete_generated_content_on_uninstall'] = isset( $_POST['delete_generated_content_on_uninstall'] ) ? (bool) wp_unslash( $_POST['delete_generated_content_on_uninstall'] ) : false;
 
 		/* —— Generation post types —— */
 		$posted_types = filter_input(

--- a/nuclear-engagement/admin/trait-settings-sanitize-general.php
+++ b/nuclear-engagement/admin/trait-settings-sanitize-general.php
@@ -70,10 +70,14 @@ trait SettingsSanitizeGeneralTrait {
 
 		$update_last  = (bool) ( $in['update_last_modified']             ?? false );
 		$auto_quiz    = (bool) ( $in['auto_generate_quiz_on_publish']    ?? false );
-		$auto_summary = (bool) ( $in['auto_generate_summary_on_publish'] ?? false );
+                $auto_summary = (bool) ( $in['auto_generate_summary_on_publish'] ?? false );
 
-		/* Attribution */
-		$show_attr = (bool) ( $in['show_attribution'] ?? false );
+                /* Attribution */
+                $show_attr = (bool) ( $in['show_attribution'] ?? false );
+
+                /* Uninstall options */
+                $delete_settings  = (bool) ( $in['delete_settings_on_uninstall'] ?? false );
+                $delete_generated = (bool) ( $in['delete_generated_content_on_uninstall'] ?? false );
 
 		return array(
 			/* theme */
@@ -110,8 +114,12 @@ trait SettingsSanitizeGeneralTrait {
 			'auto_generate_quiz_on_publish'    => $auto_quiz,
 			'auto_generate_summary_on_publish' => $auto_summary,
 
-			/* attribution */
-			'show_attribution'                 => $show_attr,
-		);
+                        /* attribution */
+                        'show_attribution'                 => $show_attr,
+
+                        /* uninstall */
+                        'delete_settings_on_uninstall'     => $delete_settings,
+                        'delete_generated_content_on_uninstall' => $delete_generated,
+                );
 	}
 }

--- a/nuclear-engagement/includes/Defaults.php
+++ b/nuclear-engagement/includes/Defaults.php
@@ -97,7 +97,11 @@ class Defaults {
 			'generation_post_types'            => array( 'post' ),
 
 			/* ───── Attribution ───── */
-			'show_attribution'                 => false,
-		);
-	}
+                        'show_attribution'                 => false,
+
+                        /* ───── Uninstall ───── */
+                        'delete_settings_on_uninstall'     => false,
+                        'delete_generated_content_on_uninstall' => false,
+                );
+        }
 }

--- a/nuclear-engagement/includes/SettingsRepository.php
+++ b/nuclear-engagement/includes/SettingsRepository.php
@@ -76,6 +76,8 @@ final class SettingsRepository
         'wp_app_pass_created' => 'rest_sanitize_boolean',
         'wp_app_pass_uuid' => 'sanitize_text_field',
         'plugin_password' => 'sanitize_text_field',
+        'delete_settings_on_uninstall' => 'rest_sanitize_boolean',
+        'delete_generated_content_on_uninstall' => 'rest_sanitize_boolean',
         'toc_heading_levels' => [self::class, 'sanitize_heading_levels'],
         'generation_post_types' => [self::class, 'sanitize_post_types'],
     ];

--- a/nuclear-engagement/uninstall.php
+++ b/nuclear-engagement/uninstall.php
@@ -30,5 +30,27 @@ if ( ! defined( 'ABSPATH' ) ) {
 
 // If uninstall not called from WordPress, then exit.
 if ( ! defined( 'WP_UNINSTALL_PLUGIN' ) ) {
-	exit;
+        exit;
+}
+
+// Get plugin settings
+$settings = get_option( 'nuclear_engagement_settings', array() );
+
+$delete_settings  = ! empty( $settings['delete_settings_on_uninstall'] );
+$delete_generated = ! empty( $settings['delete_generated_content_on_uninstall'] );
+
+// Delete generated content from post meta if requested
+if ( $delete_generated ) {
+        global $wpdb;
+        $meta_keys = array( 'nuclen-quiz-data', 'nuclen-summary-data', 'nuclen_quiz_protected', 'nuclen_summary_protected' );
+        foreach ( $meta_keys as $mk ) {
+                $wpdb->query( $wpdb->prepare( "DELETE FROM {$wpdb->postmeta} WHERE meta_key = %s", $mk ) );
+        }
+}
+
+// Delete plugin settings if requested
+if ( $delete_settings ) {
+        delete_option( 'nuclear_engagement_settings' );
+        delete_option( 'nuclear_engagement_setup' );
+        delete_option( 'nuclen_custom_css_version' );
 }


### PR DESCRIPTION
## Summary
- add a new Uninstall tab with 2 checkboxes
- store and sanitize uninstall settings
- handle uninstall behaviour in uninstall.php

## Testing
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_684909aa3830832798453611988e7089