### PR TITLE
Fix namespace for AutoGenerationService

### DIFF
--- a/nuclear-engagement/includes/Services/AutoGenerationService.php
+++ b/nuclear-engagement/includes/Services/AutoGenerationService.php
@@ -8,8 +8,8 @@
 namespace NuclearEngagement\Services;
 
 use NuclearEngagement\SettingsRepository;
-use NuclearEngagement\RemoteApiService;
-use NuclearEngagement\ContentStorageService;
+use NuclearEngagement\Services\RemoteApiService;
+use NuclearEngagement\Services\ContentStorageService;
 
 if ( ! defined( 'ABSPATH' ) ) {
     exit;


### PR DESCRIPTION
## Summary
- correct namespace imports for `AutoGenerationService`

## Testing
- `npm test` *(fails: Missing script)*
- `php -l nuclear-engagement/includes/Services/AutoGenerationService.php` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68490f76dcbc832794f1677bb3af51fb