### PR TITLE
Add WordPress lint setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,3 +18,11 @@ Nuclear Engagement stands out with true sitewide automation: process hundreds or
 
 Learn more:
 https://www.nuclearengagement.com
+
+## Development
+
+Install dependencies with `composer install` and run linting with:
+
+```bash
+composer lint
+```

--- a/composer.json
+++ b/composer.json
@@ -6,7 +6,10 @@
             "dealerdirect/phpcodesniffer-composer-installer": true
         }
     },
-    "require-dev": {
-        "wp-coding-standards/wpcs": "3.0"
-    }
+  "require-dev": {
+    "wp-coding-standards/wpcs": "3.0"
+  },
+  "scripts": {
+    "lint": "phpcs"
+  }
 }

--- a/phpcs.xml
+++ b/phpcs.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0"?>
+<ruleset name="Nuclear Engagement">
+    <rule ref="WordPress" />
+
+    <exclude-pattern>vendor/*</exclude-pattern>
+    <exclude-pattern>node_modules/*</exclude-pattern>
+</ruleset>


### PR DESCRIPTION
## Summary
- configure PHPCS with the WordPress standard
- add a Composer script for running PHPCS
- document linting in development instructions

## Testing
- `composer lint` *(fails: composer not installed)*

------
https://chatgpt.com/codex/tasks/task_e_68494ace1fa08327ae6bdd529cd58b02