### PR TITLE
Shift table creation to activation

### DIFF
--- a/nuclear-engagement/includes/Activator.php
+++ b/nuclear-engagement/includes/Activator.php
@@ -29,5 +29,8 @@ class Activator {
         if (false === get_option('nuclear_engagement_setup')) {
             update_option('nuclear_engagement_setup', $default_settings);
         }
+
+        // Ensure opt-in table exists on activation
+        OptinData::maybe_create_table();
     }
 }

--- a/nuclear-engagement/includes/OptinData.php
+++ b/nuclear-engagement/includes/OptinData.php
@@ -24,8 +24,7 @@ class OptinData {
 	 *  Bootstrap
 	 * ------------------------------------------------------------------- */
 	public static function init(): void {
-		/* Create/upgrade table on every page-load (cheap via dbDelta).     */
-		add_action( 'init',                               [ self::class, 'maybe_create_table' ],  9 );
+		/* Table creation handled on plugin activation. */
 
 		/* Save via AJAX – front-end */
 		add_action( 'wp_ajax_nuclen_save_optin',          [ self::class, 'handle_ajax' ] );
@@ -42,6 +41,14 @@ class OptinData {
 	private static function table_name(): string {
 		global $wpdb;
 		return $wpdb->prefix . self::TABLE_SLUG;
+	}
+	/**
+	 * Check whether the opt-in table already exists.
+	 */
+	public static function table_exists(): bool {
+		global $wpdb;
+		$table = self::table_name();
+		return $wpdb->get_var( $wpdb->prepare( "SHOW TABLES LIKE %s", $table ) ) === $table;
 	}
 
 	/**

--- a/nuclear-engagement/includes/Plugin.php
+++ b/nuclear-engagement/includes/Plugin.php
@@ -43,11 +43,15 @@ class Plugin {
 		$defaults = Defaults::nuclen_get_default_settings();
 		$this->settings_repository = SettingsRepository::get_instance( $defaults );
 
-		/* ───── Ensure DB table exists on activation ───── */
-		register_activation_hook(
-			dirname( dirname( __FILE__ ) ) . '/nuclear-engagement.php',
-			[ '\NuclearEngagement\OptinData', 'maybe_create_table' ]
-		);
+               /* ───── Ensure DB table exists on activation ───── */
+               register_activation_hook(
+                       dirname( dirname( __FILE__ ) ) . '/nuclear-engagement.php',
+                       function() {
+                               if ( ! \NuclearEngagement\OptinData::table_exists() ) {
+                                       \NuclearEngagement\OptinData::maybe_create_table();
+                               }
+                       }
+               );
 
                 $this->nuclen_load_dependencies();
                 $this->initializeContainer();


### PR DESCRIPTION
## Summary
- create opt-in table during plugin activation
- remove init hook creating the table
- add helper to check if opt-in table exists
- only create table from activation hook if missing

## Testing
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_68494a17026083278ada0d9013c93443