### PR TITLE
Optimize opt‑in table initialization

### DIFF
--- a/nuclear-engagement/includes/OptinData.php
+++ b/nuclear-engagement/includes/OptinData.php
@@ -18,6 +18,13 @@ if ( ! defined( 'ABSPATH' ) ) {
 
 class OptinData {
 
+        /**
+         * Whether we've already ensured the table exists during this request.
+         *
+         * @var bool
+         */
+        private static bool $checked_table = false;
+
 	const TABLE_SLUG = 'nuclen_optins';
 
 	/* ---------------------------------------------------------------------
@@ -88,8 +95,13 @@ class OptinData {
 			return false;
 		}
 
-		/* Make sure the table is present (first-ever submission, etc.) */
-		self::maybe_create_table();
+                /* Ensure the table exists only once per request */
+                if ( ! self::$checked_table ) {
+                        if ( ! self::table_exists() ) {
+                                self::maybe_create_table();
+                        }
+                        self::$checked_table = true;
+                }
 
 		global $wpdb;
 		$ok = $wpdb->insert(

--- a/nuclear-engagement/nuclear-engagement.php
+++ b/nuclear-engagement/nuclear-engagement.php
@@ -171,7 +171,10 @@ function nuclear_engagement_activate_plugin() {
 
     // Initialize SettingsRepository with defaults
     $settings = SettingsRepository::get_instance($defaults);
-    
+
+    // Ensure opt-in table exists so inserts can skip this check
+    NuclearEngagement\OptinData::maybe_create_table();
+
     // Run activation
     NuclearEngagement\Activator::nuclen_activate($settings);
 }


### PR DESCRIPTION
## Summary
- avoid expensive dbDelta calls on every insert by caching table check
- create opt‑in table during plugin activation

## Testing
- `composer lint` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684a52fd9fd08327aeced204932122f5