### PR TITLE
Fix typos in admin CSS

### DIFF
--- a/nuclear-engagement/admin/css/nuclen-admin.css
+++ b/nuclear-engagement/admin/css/nuclen-admin.css
@@ -31,7 +31,7 @@ tbody, tfoot, thead, tr, th, td {
 body {
 	font-family: Arial, sans-serif;
 	font-size: 14px;
-	linuclen-height: 1.5;
+       line-height: 1.5;
 }
 */
 
@@ -170,7 +170,7 @@ Classes for form groups, labels, inputs, and buttons.
 
 /* Buttons */
 .nuclen-button {
-	display: inlinuclen-block;
+       display: inline-block;
 	padding: 8px 12px;
 	border: none;
 	border-radius: 3px;
@@ -351,8 +351,8 @@ Quick helper classes for display, text alignment, etc.
 	display: none !important;
 }
 
-.nuclen-inlinuclen-block {
-	display: inlinuclen-block;
+.nuclen-inline-block {
+       display: inline-block;
 }
 
 .nuclen-float-right {


### PR DESCRIPTION
## Summary
- correct `line-height`
- fix display property and class name typo

## Testing
- `grep -n "inlinuclen-block" -n nuclear-engagement/admin/css/nuclen-admin.css`


------
https://chatgpt.com/codex/tasks/task_e_684a539a2394832796713e3a7d019b81