### PR TITLE
Improve input focus style

### DIFF
--- a/nuclear-engagement/admin/css/nuclen-admin.css
+++ b/nuclear-engagement/admin/css/nuclen-admin.css
@@ -164,8 +164,8 @@ Classes for form groups, labels, inputs, and buttons.
 }
 
 .nuclen-input:focus {
-	border-color: #007cba;
-	outline: none;
+        border-color: #007cba;
+        outline: 2px solid #007cba; /* Provide visible focus style */
 }
 
 /* Buttons */


### PR DESCRIPTION
## Summary
- make focused `.nuclen-input` visible with an outline

## Testing
- `composer lint` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684a53ae0a9c832789c6b3e5c789a7eb