### PR TITLE
Add quiz block registration

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,9 +12,18 @@ Nuclear Engagement stands out with true sitewide automation: process hundreds or
 - **Interactive Quizzes**: Create engaging multiple-choice quizzes automatically.  
 - **Email Opt-ins**: Collect leads via built-in Zapier & Make integration.  
 - **Flexible Display**: Auto-append content or use shortcodes before/after post content.  
-- **Engagement Analytics**: Track quiz completions and reader behavior.  
-- **Mobile-Optimized**: Responsive layouts for any device.  
+- **Engagement Analytics**: Track quiz completions and reader behavior.
+- **Mobile-Optimized**: Responsive layouts for any device.
 - **Lightweight & Fast**: Minimal codebase with lazy loading for optimal performance.
+
+## Block Usage
+The plugin provides three blocks that mirror their shortcodes:
+
+- **Nuclear Engagement Quiz** – `[nuclear_engagement_quiz]`
+- **Nuclear Engagement Summary** – `[nuclear_engagement_summary]`
+- **Nuclear Engagement Table of Contents** – `[nuclear_engagement_toc]`
+
+Drop any of these blocks into your post or page and the correct assets will be enqueued automatically.
 
 Learn more:
 https://www.nuclearengagement.com

--- a/nuclear-engagement/front/summary-block.json
+++ b/nuclear-engagement/front/summary-block.json
@@ -1,0 +1,12 @@
+{
+    "apiVersion": 2,
+    "name": "nuclear-engagement/summary-block",
+    "title": "Nuclear Engagement Summary",
+    "category": "widgets",
+    "icon": "excerpt-view",
+    "description": "A block to display the Nuclear Engagement summary.",
+    "supports": {
+      "html": false
+    },
+    "textdomain": "nuclear-engagement"
+}

--- a/nuclear-engagement/modules/toc/block.json
+++ b/nuclear-engagement/modules/toc/block.json
@@ -1,0 +1,12 @@
+{
+    "apiVersion": 2,
+    "name": "nuclear-engagement/toc-block",
+    "title": "Nuclear Engagement Table of Contents",
+    "category": "widgets",
+    "icon": "list-view",
+    "description": "A block to display the Nuclear Engagement table of contents.",
+    "supports": {
+      "html": false
+    },
+    "textdomain": "nuclear-engagement"
+}

--- a/nuclear-engagement/nuclear-engagement.php
+++ b/nuclear-engagement/nuclear-engagement.php
@@ -336,6 +336,96 @@ function nuclen_update_migrate_post_meta() {
 }
 add_action( 'admin_init', 'nuclen_update_migrate_post_meta', 20 );
 
+/**
+ * Render callback for the quiz block.
+ *
+ * Mirrors the [nuclear_engagement_quiz] shortcode.
+ *
+ * @return string
+ */
+function nuclear_engagement_render_quiz_block() {
+       return do_shortcode( '[nuclear_engagement_quiz]' );
+}
+
+/**
+ * Register the front-end quiz block.
+ */
+function nuclear_engagement_register_quiz_block() {
+       if ( ! function_exists( 'register_block_type' ) ) {
+               return;
+       }
+
+       register_block_type(
+               __DIR__ . '/front/block.json',
+               array(
+                       'style'          => array( 'nuclear-engagement', 'nuclear-engagement-theme' ),
+                       'script'         => 'nuclear-engagement-front',
+                       'render_callback' => 'nuclear_engagement_render_quiz_block',
+               )
+       );
+}
+add_action( 'init', 'nuclear_engagement_register_quiz_block' );
+
+/**
+ * Render callback for the summary block.
+ *
+ * Mirrors the [nuclear_engagement_summary] shortcode.
+ *
+ * @return string
+ */
+function nuclear_engagement_render_summary_block() {
+       return do_shortcode( '[nuclear_engagement_summary]' );
+}
+
+/**
+ * Register the front-end summary block.
+ */
+function nuclear_engagement_register_summary_block() {
+       if ( ! function_exists( 'register_block_type' ) ) {
+               return;
+       }
+
+       register_block_type(
+               __DIR__ . '/front/summary-block.json',
+               array(
+                       'style'          => array( 'nuclear-engagement', 'nuclear-engagement-theme' ),
+                       'script'         => 'nuclear-engagement-front',
+                       'render_callback' => 'nuclear_engagement_render_summary_block',
+               )
+       );
+}
+add_action( 'init', 'nuclear_engagement_register_summary_block' );
+
+/**
+ * Render callback for the table of contents block.
+ *
+ * Mirrors the [nuclear_engagement_toc] shortcode.
+ *
+ * @return string
+ */
+function nuclear_engagement_render_toc_block() {
+       return do_shortcode( '[nuclear_engagement_toc]' );
+}
+
+/**
+ * Register the table of contents block.
+ */
+function nuclear_engagement_register_toc_block() {
+       if ( ! function_exists( 'register_block_type' ) ) {
+               return;
+       }
+
+       register_block_type(
+               __DIR__ . '/modules/toc/block.json',
+               array(
+                       'style'          => 'nuclen-toc-front',
+                       'script'         => 'nuclen-toc-front',
+                       'render_callback' => 'nuclear_engagement_render_toc_block',
+               )
+       );
+}
+add_action( 'init', 'nuclear_engagement_register_toc_block' );
+
 /* ──────────────────────────────────────────────────────────
  * ❸ Run the plugin
  * ────────────────────────────────────────────────────────── */


### PR DESCRIPTION
## Summary
- register a front-end quiz block
- mirror the shortcode from the block render callback
- document the block in the README
- add summary and table-of-contents blocks

## Testing
- `composer lint` *(fails: composer not found)*

------
https://chatgpt.com/codex/tasks/task_e_684a54957a708327bd57184a6e5acb2f