### PR TITLE
Fix missing output escaping

### DIFF
--- a/nuclear-engagement/admin/trait-admin-menu.php
+++ b/nuclear-engagement/admin/trait-admin-menu.php
@@ -111,8 +111,8 @@ trait Admin_Menu {
 			if ( $total > 0 ) {
 				$html .= '<tr>';
 				$html .= '<td>' . esc_html( $name ) . '</td>';
-				$html .= '<td>' . $with . '</td>';
-				$html .= '<td>' . $without . '</td>';
+                                $html .= '<td>' . esc_html( $with ) . '</td>';
+                                $html .= '<td>' . esc_html( $without ) . '</td>';
 				$html .= '</tr>';
 			}
 		}


### PR DESCRIPTION
## Summary
- escape numeric outputs in admin stats table

## Testing
- `npm test` *(fails: Missing script)*
- `php vendor/bin/phpcs` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684a67e1d35c832795f55d8681b87475