### PR TITLE
Fix admin asset loading conditions

### DIFF
--- a/nuclear-engagement/admin/trait-admin-assets.php
+++ b/nuclear-engagement/admin/trait-admin-assets.php
@@ -14,18 +14,33 @@ if ( ! defined( 'ABSPATH' ) ) {
 
 trait Admin_Assets {
 
-	/**
-	 * Enqueue base admin CSS for all plugin admin screens.
-	 */
-	public function wp_enqueue_styles() {
-		wp_enqueue_style(
-			$this->nuclen_get_plugin_name(),
-			plugin_dir_url( __FILE__ ) . 'css/nuclen-admin.css',
-			array(),
-			filemtime( plugin_dir_path( __FILE__ ) . 'css/nuclen-admin.css' ),
-			'all'
-		);
-	}
+        /**
+         * Enqueue base admin CSS on our plugin pages only.
+         *
+         * @param string $hook Current admin page hook suffix.
+         */
+        public function wp_enqueue_styles( $hook ) {
+                $allowed_hooks = array(
+                        'post.php',
+                        'post-new.php',
+                        'toplevel_page_nuclear-engagement',
+                        'nuclear-engagement_page_nuclear-engagement-generate',
+                        'nuclear-engagement_page_nuclear-engagement-settings',
+                        'nuclear-engagement_page_nuclear-engagement-setup',
+                );
+
+                if ( ! in_array( $hook, $allowed_hooks, true ) ) {
+                        return;
+                }
+
+                wp_enqueue_style(
+                        $this->nuclen_get_plugin_name(),
+                        plugin_dir_url( __FILE__ ) . 'css/nuclen-admin.css',
+                        array(),
+                        filemtime( plugin_dir_path( __FILE__ ) . 'css/nuclen-admin.css' ),
+                        'all'
+                );
+        }
 
 	/**
 	 * Enqueue "nuclen-admin.js" for our NE admin pages & post editor.

--- a/nuclear-engagement/front/traits/AssetsTrait.php
+++ b/nuclear-engagement/front/traits/AssetsTrait.php
@@ -17,10 +17,50 @@ if ( ! defined( 'ABSPATH' ) ) {
 
 trait AssetsTrait {
 
+	/**
+	 * Check whether front assets are needed for the current page.
+	 *
+	 * @return bool
+	 */
+	private function should_enqueue_assets() : bool {
+	if ( ! is_singular() ) {
+	return false;
+	}
+	
+	$settings_repo   = $this->get_settings_repository();
+	$display_summary = $settings_repo->get( 'display_summary', 'manual' );
+	$display_quiz    = $settings_repo->get( 'display_quiz', 'manual' );
+	$display_toc     = $settings_repo->get( 'display_toc', 'manual' );
+	
+	if (
+	in_array( $display_summary, array( 'before', 'after' ), true ) ||
+	in_array( $display_quiz, array( 'before', 'after' ), true ) ||
+	in_array( $display_toc, array( 'before', 'after' ), true )
+	) {
+	return true;
+	}
+	
+	$post = get_post();
+	if ( $post && is_string( $post->post_content ) ) {
+	$content = $post->post_content;
+	return (
+	has_shortcode( $content, 'nuclear_engagement_summary' ) ||
+	has_shortcode( $content, 'nuclear_engagement_quiz' ) ||
+	has_shortcode( $content, 'nuclear_engagement_toc' )
+	);
+	}
+	
+	return false;
+	}
+
 	/* ────────────────────────────
 	   STYLES
 	──────────────────────────── */
 	public function wp_enqueue_styles() {
+	
+	if ( ! $this->should_enqueue_assets() ) {
+	return;
+	}
 
 		/* Base CSS */
 		wp_enqueue_style(


### PR DESCRIPTION
## Summary
- restrict admin CSS to load only on Nuclear Engagement pages

## Testing
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_684a6825198c8327b97a90cf337d719c