### PR TITLE
Centralized error handler

### DIFF
--- a/nuclear-engagement/admin/Controller/Ajax/GenerateController.php
+++ b/nuclear-engagement/admin/Controller/Ajax/GenerateController.php
@@ -11,6 +11,7 @@ namespace NuclearEngagement\Admin\Controller\Ajax;
 
 use NuclearEngagement\Requests\GenerateRequest;
 use NuclearEngagement\Services\GenerationService;
+use NuclearEngagement\ErrorHandler;
 
 if (!defined('ABSPATH')) {
     exit;
@@ -69,12 +70,11 @@ class GenerateController {
             wp_send_json_success($response->toArray());
             
         } catch (\InvalidArgumentException $e) {
-            error_log('Nuclear Engagement validation error: ' . $e->getMessage());
+            ErrorHandler::exception($e, 'Nuclear Engagement validation error');
             status_header(400);
             wp_send_json_error(['message' => $e->getMessage()]);
         } catch (\Exception $e) {
-            error_log('Nuclear Engagement generation error: ' . $e->getMessage() . ' in ' . $e->getFile() . ':' . $e->getLine());
-            error_log('Stack trace: ' . $e->getTraceAsString());
+            ErrorHandler::exception($e, 'Nuclear Engagement generation error');
             status_header(500);
             wp_send_json_error(['message' => 'An unexpected error occurred. Please check your error logs.']);
         }

--- a/nuclear-engagement/admin/Controller/Ajax/UpdatesController.php
+++ b/nuclear-engagement/admin/Controller/Ajax/UpdatesController.php
@@ -14,6 +14,7 @@ use NuclearEngagement\Services\RemoteApiService;
 use NuclearEngagement\Services\ContentStorageService;
 use NuclearEngagement\Responses\UpdatesResponse;
 use NuclearEngagement\Utils;
+use NuclearEngagement\ErrorHandler;
 
 if ( ! defined( 'ABSPATH' ) ) {
 	exit;
@@ -100,9 +101,9 @@ class UpdatesController {
 
 			wp_send_json_success( $response->toArray() );
 
-		} catch ( \Exception $e ) {
-			$this->utils->nuclen_log( 'Error fetching updates: ' . $e->getMessage() );
-			wp_send_json_error( array( 'message' => $e->getMessage() ) );
-		}
+                } catch ( \Exception $e ) {
+                        ErrorHandler::exception( $e, 'Error fetching updates' );
+                        wp_send_json_error( array( 'message' => $e->getMessage() ) );
+                }
 	}
 }

--- a/nuclear-engagement/includes/ErrorHandler.php
+++ b/nuclear-engagement/includes/ErrorHandler.php
@@ -1,0 +1,27 @@
+<?php
+namespace NuclearEngagement;
+
+if (!defined('ABSPATH')) {
+    exit;
+}
+
+/**
+ * Centralized error handling utility.
+ */
+final class ErrorHandler {
+    /**
+     * Log a simple message using the plugin logging facility.
+     */
+    public static function log(string $message): void {
+        $utils = new Utils();
+        $utils->nuclen_log($message);
+    }
+
+    /**
+     * Log an exception with optional context information.
+     */
+    public static function exception(\Throwable $e, string $context = ''): void {
+        $message = $context ? $context . ': ' . $e->getMessage() : $e->getMessage();
+        self::log($message);
+    }
+}

--- a/nuclear-engagement/includes/Services/ContentStorageService.php
+++ b/nuclear-engagement/includes/Services/ContentStorageService.php
@@ -11,6 +11,7 @@ namespace NuclearEngagement\Services;
 
 use NuclearEngagement\SettingsRepository;
 use NuclearEngagement\Utils;
+use NuclearEngagement\ErrorHandler;
 
 if (!defined('ABSPATH')) {
     exit;
@@ -75,7 +76,7 @@ class ContentStorageService {
                 $this->utils->nuclen_log("Stored {$workflowType} data for post {$postId}");
                 
             } catch (\Exception $e) {
-                $this->utils->nuclen_log("Error storing {$workflowType} for post {$postId}: " . $e->getMessage());
+                ErrorHandler::exception($e, "Error storing {$workflowType} for post {$postId}");
             }
         }
     }

--- a/nuclear-engagement/includes/Services/GenerationService.php
+++ b/nuclear-engagement/includes/Services/GenerationService.php
@@ -13,6 +13,7 @@ use NuclearEngagement\Requests\GenerateRequest;
 use NuclearEngagement\Responses\GenerationResponse;
 use NuclearEngagement\SettingsRepository;
 use NuclearEngagement\Utils;
+use NuclearEngagement\ErrorHandler;
 
 if (!defined('ABSPATH')) {
     exit;
@@ -164,7 +165,7 @@ class GenerationService {
                 $this->utils->nuclen_log("Scheduled polling for post {$postId}, generation {$response->generationId}");
             }
         } catch (\Exception $e) {
-            $this->utils->nuclen_log("Error generating {$workflowType} for post {$postId}: " . $e->getMessage());
+            ErrorHandler::exception($e, "Error generating {$workflowType} for post {$postId}");
             throw $e;
         }
     }

--- a/nuclear-engagement/nuclear-engagement.php
+++ b/nuclear-engagement/nuclear-engagement.php
@@ -23,6 +23,7 @@ if ( ! defined( 'WPINC' ) ) {
 }
 
 use NuclearEngagement\SettingsRepository;
+use NuclearEngagement\ErrorHandler;
 
 define('NUCLEN_PLUGIN_DIR', plugin_dir_path(__FILE__));
 define('NUCLEN_PLUGIN_VERSION', '1.0.4');
@@ -81,6 +82,7 @@ spl_autoload_register(function ($class) {
             'NuclearEngagement\\Plugin' => '/includes/Plugin.php',
             'NuclearEngagement\\Loader' => '/includes/Loader.php',
             'NuclearEngagement\\Utils' => '/includes/Utils.php',
+            'NuclearEngagement\\ErrorHandler' => '/includes/ErrorHandler.php',
             'NuclearEngagement\\Activator' => '/includes/Activator.php',
             'NuclearEngagement\\Deactivator' => '/includes/Deactivator.php',
             'NuclearEngagement\\SettingsRepository' => '/includes/SettingsRepository.php',
@@ -270,10 +272,10 @@ function nuclen_migrate_app_password() {
 		)
 	);
 
-	if ( is_wp_error( $response ) || wp_remote_retrieve_response_code( $response ) !== 200 ) {
-		// Log but still store locally – user can re‑try from Setup page if needed.
-		error_log( '[Nuclear Engagement] App‑password migration failed to contact SaaS: ' . ( is_wp_error( $response ) ? $response->get_error_message() : wp_remote_retrieve_response_code( $response ) ) );
-	}
+        if ( is_wp_error( $response ) || wp_remote_retrieve_response_code( $response ) !== 200 ) {
+                // Log but still store locally – user can re‑try from Setup page if needed.
+                ErrorHandler::log( '[Nuclear Engagement] App‑password migration failed to contact SaaS: ' . ( is_wp_error( $response ) ? $response->get_error_message() : wp_remote_retrieve_response_code( $response ) ) );
+        }
 
 	/* — Persist new password & UUID — */
 	$app_setup['plugin_password']  = $plugin_password;


### PR DESCRIPTION
## Summary
- add new `ErrorHandler` utility for logging
- register new class in autoloader
- use `ErrorHandler` across services and controllers for consistent logging

## Testing
- `php` or `composer` not available, so no tests were run

------
https://chatgpt.com/codex/tasks/task_e_684a6a1272108327aea59a386edb2dc8