### PR TITLE
Prefix get_settings_repository methods

### DIFF
--- a/nuclear-engagement/admin/Admin.php
+++ b/nuclear-engagement/admin/Admin.php
@@ -88,7 +88,7 @@ class Admin {
 	 *
 	 * @return SettingsRepository
 	 */
-	public function get_settings_repository() {
+	public function nuclen_get_settings_repository() {
 		return $this->settings_repository;
 	}
 

--- a/nuclear-engagement/admin/Settings.php
+++ b/nuclear-engagement/admin/Settings.php
@@ -41,7 +41,7 @@ class Settings {
 	 *
 	 * @return SettingsRepository
 	 */
-	public function get_settings_repository() {
+	public function nuclen_get_settings_repository() {
 		return $this->settings_repository;
 	}
 }

--- a/nuclear-engagement/admin/trait-admin-autogenerate.php
+++ b/nuclear-engagement/admin/trait-admin-autogenerate.php
@@ -35,7 +35,7 @@ trait Admin_AutoGenerate {
         }
 
         // Get settings from repository
-        $settings_repo = $this->get_settings_repository();
+        $settings_repo = $this->nuclen_get_settings_repository();
         $allowed_post_types = $settings_repo->get( 'generation_post_types', array( 'post' ) );
         if ( ! in_array( $post->post_type, (array) $allowed_post_types, true ) ) {
             return;
@@ -88,7 +88,7 @@ trait Admin_AutoGenerate {
         
         try {
             // Check if auto-generation is enabled for this post type.
-            $settings_repo = $this->get_settings_repository();
+            $settings_repo = $this->nuclen_get_settings_repository();
             $connected = $settings_repo->get( 'connected', false );
             $wp_app_pass_created = $settings_repo->get( 'wp_app_pass_created', false );
             if ( ! $connected || ! $wp_app_pass_created ) {

--- a/nuclear-engagement/admin/trait-admin-menu.php
+++ b/nuclear-engagement/admin/trait-admin-menu.php
@@ -72,7 +72,7 @@ trait Admin_Menu {
 	 * Shows only an admin notice until **both** setup steps are done.
 	 */
 	public function nuclen_display_generate_page() {
-		$settings_repo = $this->get_settings_repository();
+		$settings_repo = $this->nuclen_get_settings_repository();
 		$connected = $settings_repo->get( 'connected', false );
 		$wp_app_pass_created = $settings_repo->get( 'wp_app_pass_created', false );
 

--- a/nuclear-engagement/admin/trait-admin-metabox-quiz.php
+++ b/nuclear-engagement/admin/trait-admin-metabox-quiz.php
@@ -18,7 +18,7 @@ trait Admin_Quiz_Metabox {
 	 * ---------------------------------------------------------------------- */
 
 	public function nuclen_add_quiz_data_meta_box() {
-		$settings_repo = $this->get_settings_repository();
+		$settings_repo = $this->nuclen_get_settings_repository();
 		$post_types = $settings_repo->get( 'generation_post_types', array( 'post' ) );
 		$post_types = is_array( $post_types ) ? $post_types : array( 'post' );
 
@@ -174,7 +174,7 @@ trait Admin_Quiz_Metabox {
 		clean_post_cache( $post_id );
 
 		/* ---- Update post_modified if enabled ----------------------------- */
-		$settings_repo = $this->get_settings_repository();
+		$settings_repo = $this->nuclen_get_settings_repository();
 		$update_last_modified = $settings_repo->get( 'update_last_modified', 0 );
 		if ( ! empty( $update_last_modified ) && (int) $update_last_modified === 1 ) {
 			remove_action( 'save_post', array( $this, 'nuclen_save_quiz_data_meta' ), 10 );

--- a/nuclear-engagement/admin/trait-admin-metabox-summary.php
+++ b/nuclear-engagement/admin/trait-admin-metabox-summary.php
@@ -18,7 +18,7 @@ trait Admin_Summary_Metabox {
 	 * ---------------------------------------------------------------------- */
 
 	public function nuclen_add_summary_data_meta_box() {
-		$settings_repo = $this->get_settings_repository();
+		$settings_repo = $this->nuclen_get_settings_repository();
 		$post_types = $settings_repo->get( 'generation_post_types', array( 'post' ) );
 		$post_types = is_array( $post_types ) ? $post_types : array( 'post' );
 
@@ -127,7 +127,7 @@ trait Admin_Summary_Metabox {
 		clean_post_cache( $post_id );
 
 		/* ---- Update post_modified if enabled ----------------------------- */
-		$settings_repo = $this->get_settings_repository();
+		$settings_repo = $this->nuclen_get_settings_repository();
 		$settings = $settings_repo->get( 'update_last_modified', 0 );
 		if ( ! empty( $settings ) && (int) $settings === 1 ) {
 			remove_action( 'save_post', array( $this, 'nuclen_save_quiz_data_meta' ), 10 );

--- a/nuclear-engagement/admin/trait-settings-page-load.php
+++ b/nuclear-engagement/admin/trait-settings-page-load.php
@@ -21,7 +21,7 @@ trait SettingsPageLoadTrait {
 	 * @return array [ $settings , $defaults ]
 	 */
 	protected function nuclen_get_current_settings(): array {
-		$settings_repo = $this->get_settings_repository();
+		$settings_repo = $this->nuclen_get_settings_repository();
 		$defaults = \NuclearEngagement\Defaults::nuclen_get_default_settings();
 
 		// Get all settings from the repository

--- a/nuclear-engagement/admin/trait-settings-page-save.php
+++ b/nuclear-engagement/admin/trait-settings-page-save.php
@@ -186,7 +186,7 @@ trait SettingsPageSaveTrait {
 		}
 
 		// Get the settings repository and save all settings
-		$settings_repo = $this->get_settings_repository();
+		$settings_repo = $this->nuclen_get_settings_repository();
 		foreach ($new_settings as $key => $value) {
 			$settings_repo->set($key, $value);
 		}

--- a/nuclear-engagement/front/FrontClass.php
+++ b/nuclear-engagement/front/FrontClass.php
@@ -72,7 +72,7 @@ class FrontClass {
 	 *
 	 * @return SettingsRepository
 	 */
-	public function get_settings_repository() {
+	public function nuclen_get_settings_repository() {
 		return $this->settings_repository;
 	}
 }

--- a/nuclear-engagement/front/traits/AssetsTrait.php
+++ b/nuclear-engagement/front/traits/AssetsTrait.php
@@ -27,7 +27,7 @@ trait AssetsTrait {
 	return false;
 	}
 	
-	$settings_repo   = $this->get_settings_repository();
+	$settings_repo   = $this->nuclen_get_settings_repository();
 	$display_summary = $settings_repo->get( 'display_summary', 'manual' );
 	$display_quiz    = $settings_repo->get( 'display_quiz', 'manual' );
 	$display_toc     = $settings_repo->get( 'display_toc', 'manual' );
@@ -72,7 +72,7 @@ trait AssetsTrait {
 		);
 
 		/* Theme CSS (bright / dark / custom / none) */
-		$settings_repo = $this->get_settings_repository();
+		$settings_repo = $this->nuclen_get_settings_repository();
 		$theme_choice = $settings_repo->get( 'theme', 'bright' );
 
 		if ( $theme_choice === 'none' ) {
@@ -113,7 +113,7 @@ trait AssetsTrait {
 			true
 		);
 
-		$settings_repo = $this->get_settings_repository();
+		$settings_repo = $this->nuclen_get_settings_repository();
 
 		/* ───── Inline scalars (booleans & strings) ───── */
 		$inline_js = '';

--- a/nuclear-engagement/front/traits/ShortcodesTrait.php
+++ b/nuclear-engagement/front/traits/ShortcodesTrait.php
@@ -21,7 +21,7 @@ trait ShortcodesTrait {
 
 	/* ---------- Auto-insert into content ---------- */
 	public function nuclen_auto_insert_shortcodes( $content ) {
-		$settings_repo = $this->get_settings_repository();
+		$settings_repo = $this->nuclen_get_settings_repository();
 		$summary_position = $settings_repo->get( 'display_summary', 'none' );
 		$quiz_position    = $settings_repo->get( 'display_quiz', 'none' );
 		$toc_position     = $settings_repo->get( 'display_toc', 'manual' );

--- a/nuclear-engagement/includes/Plugin.php
+++ b/nuclear-engagement/includes/Plugin.php
@@ -252,7 +252,7 @@ class Plugin {
 	 *
 	 * @return SettingsRepository
 	 */
-	public function get_settings_repository() {
+	public function nuclen_get_settings_repository() {
 		return $this->settings_repository;
 	}
 	


### PR DESCRIPTION
## Summary
- prefix the `get_settings_repository` method and references with `nuclen_`

## Testing
- `php vendor/bin/phpcs` *(fails: `php: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_684a6dc190ec8327969244f6dcaa31dd