### PR TITLE
Refactor AJAX controllers with common base class

### DIFF
--- a/nuclear-engagement/admin/Controller/Ajax/GenerateController.php
+++ b/nuclear-engagement/admin/Controller/Ajax/GenerateController.php
@@ -12,6 +12,7 @@ namespace NuclearEngagement\Admin\Controller\Ajax;
 use NuclearEngagement\Requests\GenerateRequest;
 use NuclearEngagement\Services\GenerationService;
 use NuclearEngagement\ErrorHandler;
+use NuclearEngagement\Includes\BaseAjaxController;
 
 if (!defined('ABSPATH')) {
     exit;
@@ -20,7 +21,7 @@ if (!defined('ABSPATH')) {
 /**
  * Controller for content generation
  */
-class GenerateController {
+class GenerateController extends BaseAjaxController {
     /**
      * @var GenerationService
      */
@@ -40,17 +41,7 @@ class GenerateController {
      */
     public function handle(): void {
         try {
-            
-            // Security check
-            if (!check_ajax_referer('nuclen_admin_ajax_nonce', 'security', false)) {
-                status_header(403);
-                wp_send_json_error(['message' => 'Security check failed: Invalid nonce']);
-                return;
-            }
-            
-            if (!current_user_can('manage_options')) {
-                status_header(403);
-                wp_send_json_error(['message' => 'Not allowed']);
+            if ( ! $this->verify_request( 'nuclen_admin_ajax_nonce' ) ) {
                 return;
             }
             

--- a/nuclear-engagement/admin/Controller/Ajax/PointerController.php
+++ b/nuclear-engagement/admin/Controller/Ajax/PointerController.php
@@ -10,6 +10,7 @@
 namespace NuclearEngagement\Admin\Controller\Ajax;
 
 use NuclearEngagement\Services\PointerService;
+use NuclearEngagement\Includes\BaseAjaxController;
 
 if (!defined('ABSPATH')) {
     exit;
@@ -18,7 +19,7 @@ if (!defined('ABSPATH')) {
 /**
  * Controller for admin pointers
  */
-class PointerController {
+class PointerController extends BaseAjaxController {
     /**
      * @var PointerService
      */
@@ -38,11 +39,9 @@ class PointerController {
      */
     public function dismiss(): void {
         try {
-            if (!current_user_can('manage_options')) {
-                wp_send_json_error(['message' => __('No permission', 'nuclear-engagement')]);
+            if ( ! $this->verify_request( 'nuclen_dismiss_pointer_nonce', 'nonce' ) ) {
+                return;
             }
-            
-            check_ajax_referer('nuclen_dismiss_pointer_nonce', 'nonce');
             
             $pointerId = isset($_POST['pointer']) ? sanitize_text_field(wp_unslash($_POST['pointer'])) : '';
             $userId = get_current_user_id();

--- a/nuclear-engagement/admin/Controller/Ajax/PostsCountController.php
+++ b/nuclear-engagement/admin/Controller/Ajax/PostsCountController.php
@@ -11,6 +11,7 @@ namespace NuclearEngagement\Admin\Controller\Ajax;
 
 use NuclearEngagement\Requests\PostsCountRequest;
 use NuclearEngagement\Services\PostsQueryService;
+use NuclearEngagement\Includes\BaseAjaxController;
 
 if (!defined('ABSPATH')) {
     exit;
@@ -19,7 +20,7 @@ if (!defined('ABSPATH')) {
 /**
  * Controller for getting posts count
  */
-class PostsCountController {
+class PostsCountController extends BaseAjaxController {
     /**
      * @var PostsQueryService
      */
@@ -39,9 +40,8 @@ class PostsCountController {
      */
     public function handle(): void {
         try {
-            check_ajax_referer('nuclen_admin_ajax_nonce', 'security');
-            if (!current_user_can('manage_options')) {
-                wp_send_json_error(['message' => 'Not allowed']);
+            if ( ! $this->verify_request( 'nuclen_admin_ajax_nonce' ) ) {
+                return;
             }
             
             // Parse request

--- a/nuclear-engagement/admin/Controller/Ajax/UpdatesController.php
+++ b/nuclear-engagement/admin/Controller/Ajax/UpdatesController.php
@@ -15,6 +15,7 @@ use NuclearEngagement\Services\ContentStorageService;
 use NuclearEngagement\Responses\UpdatesResponse;
 use NuclearEngagement\Utils;
 use NuclearEngagement\ErrorHandler;
+use NuclearEngagement\Includes\BaseAjaxController;
 
 if ( ! defined( 'ABSPATH' ) ) {
 	exit;
@@ -23,7 +24,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 /**
  * Controller for polling updates
  */
-class UpdatesController {
+class UpdatesController extends BaseAjaxController {
 
 	/**
 	 * @var RemoteApiService
@@ -55,12 +56,11 @@ class UpdatesController {
 	/**
 	 * Handle updates request.
 	 */
-	public function handle(): void {
-		try {
-			check_ajax_referer( 'nuclen_admin_ajax_nonce', 'security' );
-			if ( ! current_user_can( 'manage_options' ) ) {
-				wp_send_json_error( array( 'message' => 'Not allowed' ) );
-			}
+        public function handle(): void {
+                try {
+                        if ( ! $this->verify_request( 'nuclen_admin_ajax_nonce' ) ) {
+                                return;
+                        }
 
 			$request = UpdatesRequest::fromPost( $_POST );
 

--- a/nuclear-engagement/includes/BaseAjaxController.php
+++ b/nuclear-engagement/includes/BaseAjaxController.php
@@ -1,0 +1,45 @@
+<?php
+/**
+ * File: includes/BaseAjaxController.php
+ *
+ * Abstract controller providing common AJAX helpers.
+ *
+ * @package NuclearEngagement\Includes
+ */
+
+namespace NuclearEngagement\Includes;
+
+if ( ! defined( 'ABSPATH' ) ) {
+    exit;
+}
+
+/**
+ * Base class for AJAX controllers.
+ */
+abstract class BaseAjaxController {
+
+    /**
+     * Verify nonce and permissions for an AJAX request.
+     *
+     * @param string $nonceAction Action name for nonce verification.
+     * @param string $nonceField  Optional. Nonce field name. Default 'security'.
+     * @param string $capability  Optional. Required capability. Default 'manage_options'.
+     *
+     * @return bool True on success, false if verification failed and a JSON response was sent.
+     */
+    protected function verify_request( string $nonceAction, string $nonceField = 'security', string $capability = 'manage_options' ): bool {
+        if ( ! check_ajax_referer( $nonceAction, $nonceField, false ) ) {
+            status_header( 403 );
+            wp_send_json_error( array( 'message' => 'Security check failed: Invalid nonce' ) );
+            return false;
+        }
+
+        if ( ! current_user_can( $capability ) ) {
+            status_header( 403 );
+            wp_send_json_error( array( 'message' => 'Not allowed' ) );
+            return false;
+        }
+
+        return true;
+    }
+}

--- a/nuclear-engagement/nuclear-engagement.php
+++ b/nuclear-engagement/nuclear-engagement.php
@@ -90,6 +90,7 @@ spl_autoload_register(function ($class) {
             'NuclearEngagement\\Defaults' => '/includes/Defaults.php',
             'NuclearEngagement\\OptinData' => '/includes/OptinData.php',
             'NuclearEngagement\\MetaRegistration' => '/includes/MetaRegistration.php',
+            'NuclearEngagement\\Includes\\BaseAjaxController' => '/includes/BaseAjaxController.php',
             
             // Admin classes
             'NuclearEngagement\\Admin\\Admin' => '/admin/Admin.php',


### PR DESCRIPTION
## Summary
- add `BaseAjaxController` with nonce and permission helpers
- refactor AJAX controllers to use the new base class
- register the base class in the plugin autoloader

## Testing
- `php vendor/bin/phpcs -q` *(fails: `php` not found)*

------
https://chatgpt.com/codex/tasks/task_e_684a6f1f0130832780e0b4aafb717a04