### PR TITLE
Fix frontend module loading

### DIFF
--- a/nuclear-engagement/front/traits/AssetsTrait.php
+++ b/nuclear-engagement/front/traits/AssetsTrait.php
@@ -22,15 +22,22 @@ trait AssetsTrait {
 	 *
 	 * @return bool
 	 */
-	private function should_enqueue_assets() : bool {
-	if ( ! is_singular() ) {
-	return false;
-	}
-	
-	$settings_repo   = $this->nuclen_get_settings_repository();
-	$display_summary = $settings_repo->get( 'display_summary', 'manual' );
-	$display_quiz    = $settings_repo->get( 'display_quiz', 'manual' );
-	$display_toc     = $settings_repo->get( 'display_toc', 'manual' );
+        private function should_enqueue_assets() : bool {
+        if ( ! is_singular() ) {
+        return false;
+        }
+
+        $settings_repo   = $this->nuclen_get_settings_repository();
+
+        $allowed_types   = $settings_repo->get( 'generation_post_types', array( 'post' ) );
+        $queried         = get_queried_object();
+        if ( isset( $queried->post_type ) && ! in_array( $queried->post_type, $allowed_types, true ) ) {
+        return false;
+        }
+
+        $display_summary = $settings_repo->get( 'display_summary', 'manual' );
+        $display_quiz    = $settings_repo->get( 'display_quiz', 'manual' );
+        $display_toc     = $settings_repo->get( 'display_toc', 'manual' );
 	
 	if (
 	in_array( $display_summary, array( 'before', 'after' ), true ) ||
@@ -40,9 +47,9 @@ trait AssetsTrait {
 	return true;
 	}
 	
-	$post = get_post();
-	if ( $post && is_string( $post->post_content ) ) {
-	$content = $post->post_content;
+        $post = $queried;
+        if ( $post && is_string( $post->post_content ) ) {
+        $content = $post->post_content;
 	return (
 	has_shortcode( $content, 'nuclear_engagement_summary' ) ||
 	has_shortcode( $content, 'nuclear_engagement_quiz' ) ||
@@ -105,13 +112,14 @@ trait AssetsTrait {
 	public function wp_enqueue_scripts() {
 
 		/* Main bundle */
-		wp_enqueue_script(
-			$this->plugin_name . '-front',
-			plugin_dir_url( dirname( __FILE__ ) ) . 'js/nuclen-front.js',
-			array(),
-			NUCLEN_ASSET_VERSION,
-			true
-		);
+               wp_enqueue_script(
+                       $this->plugin_name . '-front',
+                       plugin_dir_url( __FILE__ ) . '../js/nuclen-front.js',
+                       array(),
+                       NUCLEN_ASSET_VERSION,
+                       true
+               );
+               wp_script_add_data( $this->plugin_name . '-front', 'type', 'module' );
 
 		$settings_repo = $this->nuclen_get_settings_repository();
 


### PR DESCRIPTION
## Summary
- load frontend script as a module so ES imports work
- keep allowed post type check via `get_queried_object`
- correct JS path when enqueuing

## Testing
- `composer lint` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684a7308e438832790afec2cb00b6a01