### PR TITLE
Require WP 6.5 and drop module fallback

### DIFF
--- a/nuclear-engagement/README.txt
+++ b/nuclear-engagement/README.txt
@@ -5,7 +5,7 @@ Author: Stefano Lodola
 Author URI: https://www.nuclearengagement.com/about?ref=wp_listing&link=author_uri
 Contributors: stefanolodola
 Tags: AI writer, quiz, summary, table of contents, email optin
-Requires at least: 5.6
+Requires at least: 6.5
 Tested up to: 6.8
 Requires PHP: 7.3
 Stable tag: 1.1

--- a/nuclear-engagement/front/traits/AssetsTrait.php
+++ b/nuclear-engagement/front/traits/AssetsTrait.php
@@ -113,15 +113,14 @@ trait AssetsTrait {
 
 		/* Main bundle */
 
-               wp_enqueue_script(
+               wp_register_script_module(
                        $this->plugin_name . '-front',
                        plugin_dir_url( __FILE__ ) . '../js/nuclen-front.js',
                        array(),
-                       NUCLEN_ASSET_VERSION,
-                       true
+                       NUCLEN_ASSET_VERSION
                );
 
-               wp_script_add_data( $this->plugin_name . '-front', 'type', 'module' );
+               wp_enqueue_script_module( $this->plugin_name . '-front' );
 
 		$settings_repo = $this->nuclen_get_settings_repository();
 

--- a/nuclear-engagement/nuclear-engagement.php
+++ b/nuclear-engagement/nuclear-engagement.php
@@ -8,7 +8,7 @@ if ( ! defined( 'ABSPATH' ) ) {
  * Description:       Bulk generate engaging content for your blog posts with AI in one click.
  * Version:           1.1
  * Author:            Stefano Lodola
- * Requires at least: 5.6
+ * Requires at least: 6.5
  * Tested up to:      6.8
  * Requires PHP:      7.4
  * License:           GPL-2.0+


### PR DESCRIPTION
## Summary
- set minimum WordPress version to 6.5 in plugin files
- remove fallback code for older WordPress releases

## Testing
- `php vendor/bin/phpcs` *(fails: `php: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_684a7889d05083279228afbadba2329d