### PR TITLE
Fix quiz data loading for front assets

### DIFF
--- a/nuclear-engagement/front/traits/AssetsTrait.php
+++ b/nuclear-engagement/front/traits/AssetsTrait.php
@@ -152,7 +152,9 @@ trait AssetsTrait {
                 );
 
 		/* Per-post quiz data - FIXED VERSION */
-		$post_id   = get_the_ID();
+                // Use queried object ID instead of get_the_ID() to ensure
+                // the correct post is referenced even before the loop runs.
+                $post_id   = get_queried_object_id();
 		
 		// get_post_meta with true already unserializes, don't call maybe_unserialize
 		$quiz_meta = get_post_meta( $post_id, 'nuclen-quiz-data', true );


### PR DESCRIPTION
## Summary
- ensure front assets get quiz meta for the correct post

## Testing
- `composer lint` *(fails: composer not installed)*

------
https://chatgpt.com/codex/tasks/task_e_684a93223b508327b767f609fbcbd098