### PR TITLE
Fix quiz data loading for front assets

### DIFF
--- a/nuclear-engagement/front/traits/AssetsTrait.php
+++ b/nuclear-engagement/front/traits/AssetsTrait.php
@@ -152,7 +152,9 @@ trait AssetsTrait {
                 );
 
 		/* Per-post quiz data - FIXED VERSION */
-		$post_id   = get_the_ID();
+                // Use queried object ID instead of get_the_ID() to ensure
+                // the correct post is referenced even before the loop runs.
+                $post_id   = get_queried_object_id();
 		
 		// get_post_meta with true already unserializes, don't call maybe_unserialize
 		$quiz_meta = get_post_meta( $post_id, 'nuclen-quiz-data', true );

--- a/nuclear-engagement/includes/MetaRegistration.php
+++ b/nuclear-engagement/includes/MetaRegistration.php
@@ -38,7 +38,8 @@ class MetaRegistration {
         // Register quiz data meta
         foreach ( $post_types as $post_type ) {
             register_post_meta( $post_type, 'nuclen-quiz-data', [
-                'type' => 'string',
+                // Store structured quiz info as an array
+                'type' => 'array',
                 'description' => 'Nuclear Engagement quiz data',
                 'single' => true,
                 'show_in_rest' => false,
@@ -58,7 +59,8 @@ class MetaRegistration {
             
             // Register summary data meta
             register_post_meta( $post_type, 'nuclen-summary-data', [
-                'type' => 'string',
+                // Summary data also uses structured arrays
+                'type' => 'array',
                 'description' => 'Nuclear Engagement summary data',
                 'single' => true,
                 'show_in_rest' => false,


### PR DESCRIPTION
## Summary
- ensure front assets get quiz meta for the correct post
- register quiz and summary meta to return arrays

## Testing
- `composer lint` *(fails: composer not installed)*

------
https://chatgpt.com/codex/tasks/task_e_684a93223b508327b767f609fbcbd098