### PR TITLE
Fix missing output escaping

### DIFF
--- a/nuclear-engagement/admin/trait-admin-menu.php
+++ b/nuclear-engagement/admin/trait-admin-menu.php
@@ -111,8 +111,8 @@ trait Admin_Menu {
 			if ( $total > 0 ) {
 				$html .= '<tr>';
 				$html .= '<td>' . esc_html( $name ) . '</td>';
-				$html .= '<td>' . $with . '</td>';
-				$html .= '<td>' . $without . '</td>';
+                                $html .= '<td>' . esc_html( $with ) . '</td>';
+                                $html .= '<td>' . esc_html( $without ) . '</td>';
 				$html .= '</tr>';
 			}
 		}


### PR DESCRIPTION
## Summary
- escape stats table cell output in trait-admin-menu.php

## Testing
- `php` not available, cannot run `phpcs`

------
https://chatgpt.com/codex/tasks/task_e_684b8bf00a3c8327945743d123cd1a1b