### PR TITLE
Optimize dashboard queries

### DIFF
--- a/nuclear-engagement/admin/Dashboard.php
+++ b/nuclear-engagement/admin/Dashboard.php
@@ -65,6 +65,42 @@ function nuclen_get_group_counts( string $group_by, string $meta_key, array $pos
 	);
 
 	return $wpdb->get_results( $sql, ARRAY_A );
+
+}
+
+/**
+ * Run a grouped count query for both quiz and summary meta in one go.
+ *
+ * @param string $group_by   Column to group by.
+ * @param array  $post_types Allowed post types.
+ * @param array  $statuses   Allowed post statuses.
+ * @return array             Rows with counts for quiz and summary.
+ */
+function nuclen_get_dual_counts( string $group_by, array $post_types, array $statuses ): array {
+       global $wpdb;
+
+       $post_types = array_map( 'sanitize_key', $post_types );
+       $statuses   = array_map( 'sanitize_key', $statuses );
+
+       $placeholders_pt = implode( ',', array_fill( 0, count( $post_types ), '%s' ) );
+       $placeholders_st = implode( ',', array_fill( 0, count( $statuses ), '%s' ) );
+
+       $sql = $wpdb->prepare(
+               "SELECT $group_by AS g,
+                       SUM(CASE WHEN pm_q.meta_id IS NULL THEN 0 ELSE 1 END) AS quiz_with,
+                       SUM(CASE WHEN pm_q.meta_id IS NULL THEN 1 ELSE 0 END) AS quiz_without,
+                       SUM(CASE WHEN pm_s.meta_id IS NULL THEN 0 ELSE 1 END) AS summary_with,
+                       SUM(CASE WHEN pm_s.meta_id IS NULL THEN 1 ELSE 0 END) AS summary_without
+                FROM {$wpdb->posts} p
+                LEFT JOIN {$wpdb->postmeta} pm_q ON pm_q.post_id = p.ID AND pm_q.meta_key = 'nuclen-quiz-data'
+                LEFT JOIN {$wpdb->postmeta} pm_s ON pm_s.post_id = p.ID AND pm_s.meta_key = 'nuclen-summary-data'
+                WHERE p.post_type  IN ($placeholders_pt)
+                  AND p.post_status IN ($placeholders_st)
+                GROUP BY $group_by",
+               array_merge( $post_types, $statuses )
+       );
+
+       return $wpdb->get_results( $sql, ARRAY_A );
 }
 
 /* ──────────────────────────────────────────────────────────────
@@ -73,49 +109,41 @@ function nuclen_get_group_counts( string $group_by, string $meta_key, array $pos
 $post_statuses = array( 'publish', 'pending', 'draft', 'future' );
 
 /* — By Post Status — */
-$status_quiz_rows    = nuclen_get_group_counts( 'p.post_status', 'nuclen-quiz-data',    $allowed_post_types, $post_statuses );
-$status_summary_rows = nuclen_get_group_counts( 'p.post_status', 'nuclen-summary-data', $allowed_post_types, $post_statuses );
+$status_rows    = nuclen_get_dual_counts( 'p.post_status', $allowed_post_types, $post_statuses );
+$status_objects = get_post_stati( array(), 'objects' );
+$by_status_quiz = $by_status_summary = array();
 
-$status_objects      = get_post_stati( array(), 'objects' );
-$by_status_quiz      = $by_status_summary = array();
-
-foreach ( $status_quiz_rows as $r ) {
-	$label = $status_objects[ $r['g'] ]->label ?? ucfirst( $r['g'] );
-	$by_status_quiz[ $label ][ $r['w'] ] = (int) $r['c'];
-}
-foreach ( $status_summary_rows as $r ) {
-	$label = $status_objects[ $r['g'] ]->label ?? ucfirst( $r['g'] );
-	$by_status_summary[ $label ][ $r['w'] ] = (int) $r['c'];
+foreach ( $status_rows as $r ) {
+        $label = $status_objects[ $r['g'] ]->label ?? ucfirst( $r['g'] );
+        $by_status_quiz[ $label ]['with']    = (int) $r['quiz_with'];
+        $by_status_quiz[ $label ]['without'] = (int) $r['quiz_without'];
+        $by_status_summary[ $label ]['with']    = (int) $r['summary_with'];
+        $by_status_summary[ $label ]['without'] = (int) $r['summary_without'];
 }
 
 /* — By Post Type — */
-$ptype_quiz_rows    = nuclen_get_group_counts( 'p.post_type', 'nuclen-quiz-data',    $allowed_post_types, $post_statuses );
-$ptype_summary_rows = nuclen_get_group_counts( 'p.post_type', 'nuclen-summary-data', $allowed_post_types, $post_statuses );
+$ptype_rows = nuclen_get_dual_counts( 'p.post_type', $allowed_post_types, $post_statuses );
 
-$by_post_type_quiz    = $by_post_type_summary = array();
-foreach ( $ptype_quiz_rows as $r ) {
-	$pt_obj = get_post_type_object( $r['g'] );
-	$label  = $pt_obj->labels->name ?? ucfirst( $r['g'] );
-	$by_post_type_quiz[ $label ][ $r['w'] ] = (int) $r['c'];
-}
-foreach ( $ptype_summary_rows as $r ) {
-	$pt_obj = get_post_type_object( $r['g'] );
-	$label  = $pt_obj->labels->name ?? ucfirst( $r['g'] );
-	$by_post_type_summary[ $label ][ $r['w'] ] = (int) $r['c'];
+$by_post_type_quiz = $by_post_type_summary = array();
+foreach ( $ptype_rows as $r ) {
+        $pt_obj = get_post_type_object( $r['g'] );
+        $label  = $pt_obj->labels->name ?? ucfirst( $r['g'] );
+        $by_post_type_quiz[ $label ]['with']    = (int) $r['quiz_with'];
+        $by_post_type_quiz[ $label ]['without'] = (int) $r['quiz_without'];
+        $by_post_type_summary[ $label ]['with']    = (int) $r['summary_with'];
+        $by_post_type_summary[ $label ]['without'] = (int) $r['summary_without'];
 }
 
 /* — By Author — */
-$author_quiz_rows    = nuclen_get_group_counts( 'p.post_author', 'nuclen-quiz-data',    $allowed_post_types, $post_statuses );
-$author_summary_rows = nuclen_get_group_counts( 'p.post_author', 'nuclen-summary-data', $allowed_post_types, $post_statuses );
+$author_rows = nuclen_get_dual_counts( 'p.post_author', $allowed_post_types, $post_statuses );
 
-$by_author_quiz    = $by_author_summary = array();
-foreach ( $author_quiz_rows as $r ) {
-	$name = get_the_author_meta( 'display_name', (int) $r['g'] ) ?: __( 'Unknown Author', 'nuclear-engagement' );
-	$by_author_quiz[ $name ][ $r['w'] ] = (int) $r['c'];
-}
-foreach ( $author_summary_rows as $r ) {
-	$name = get_the_author_meta( 'display_name', (int) $r['g'] ) ?: __( 'Unknown Author', 'nuclear-engagement' );
-	$by_author_summary[ $name ][ $r['w'] ] = (int) $r['c'];
+$by_author_quiz = $by_author_summary = array();
+foreach ( $author_rows as $r ) {
+        $name = get_the_author_meta( 'display_name', (int) $r['g'] ) ?: __( 'Unknown Author', 'nuclear-engagement' );
+        $by_author_quiz[ $name ]['with']    = (int) $r['quiz_with'];
+        $by_author_quiz[ $name ]['without'] = (int) $r['quiz_without'];
+        $by_author_summary[ $name ]['with']    = (int) $r['summary_with'];
+        $by_author_summary[ $name ]['without'] = (int) $r['summary_without'];
 }
 
 /* — By Category — (only for post-types that use the “category” taxonomy) */
@@ -128,29 +156,31 @@ $by_category_quiz = $by_category_summary = array();
 if ( $with_cat_pt ) {
 	$in_cat_pt  = "'" . implode( "','", array_map( 'esc_sql', $with_cat_pt ) ) . "'";
 	$in_st      = "'" . implode( "','", $post_statuses ) . "'";
-	$sql_cat = "
-		SELECT t.term_id,
-		       t.name               AS cat_name,
-		       CASE WHEN pm.meta_id IS NULL THEN 'without' ELSE 'with' END AS w,
-		       COUNT(*)             AS c
-		FROM {$wpdb->posts} p
-		JOIN {$wpdb->term_relationships} tr ON tr.object_id = p.ID
-		JOIN {$wpdb->term_taxonomy}  tt ON tt.term_taxonomy_id = tr.term_taxonomy_id AND tt.taxonomy = 'category'
-		JOIN {$wpdb->terms}          t  ON t.term_id = tt.term_id
-		LEFT JOIN {$wpdb->postmeta}  pm ON pm.post_id = p.ID AND pm.meta_key = %s
-		WHERE p.post_type  IN ($in_cat_pt)
-		  AND p.post_status IN ($in_st)
-		GROUP BY t.term_id, w
-	";
-	$cat_quiz_rows    = $wpdb->get_results( $wpdb->prepare( $sql_cat, 'nuclen-quiz-data' ),    ARRAY_A );
-	$cat_summary_rows = $wpdb->get_results( $wpdb->prepare( $sql_cat, 'nuclen-summary-data' ), ARRAY_A );
+        $sql_cat = "
+                SELECT t.term_id,
+                       t.name AS cat_name,
+                       SUM(CASE WHEN pm_q.meta_id IS NULL THEN 0 ELSE 1 END) AS quiz_with,
+                       SUM(CASE WHEN pm_q.meta_id IS NULL THEN 1 ELSE 0 END) AS quiz_without,
+                       SUM(CASE WHEN pm_s.meta_id IS NULL THEN 0 ELSE 1 END) AS summary_with,
+                       SUM(CASE WHEN pm_s.meta_id IS NULL THEN 1 ELSE 0 END) AS summary_without
+                FROM {$wpdb->posts} p
+                JOIN {$wpdb->term_relationships} tr ON tr.object_id = p.ID
+                JOIN {$wpdb->term_taxonomy}  tt ON tt.term_taxonomy_id = tr.term_taxonomy_id AND tt.taxonomy = 'category'
+                JOIN {$wpdb->terms}          t  ON t.term_id = tt.term_id
+                LEFT JOIN {$wpdb->postmeta}  pm_q ON pm_q.post_id = p.ID AND pm_q.meta_key = 'nuclen-quiz-data'
+                LEFT JOIN {$wpdb->postmeta}  pm_s ON pm_s.post_id = p.ID AND pm_s.meta_key = 'nuclen-summary-data'
+                WHERE p.post_type  IN ($in_cat_pt)
+                  AND p.post_status IN ($in_st)
+                GROUP BY t.term_id
+        ";
+        $cat_rows = $wpdb->get_results( $sql_cat, ARRAY_A );
 
-	foreach ( $cat_quiz_rows as $r ) {
-		$by_category_quiz[ $r['cat_name'] ][ $r['w'] ] = (int) $r['c'];
-	}
-	foreach ( $cat_summary_rows as $r ) {
-		$by_category_summary[ $r['cat_name'] ][ $r['w'] ] = (int) $r['c'];
-	}
+        foreach ( $cat_rows as $r ) {
+                $by_category_quiz[ $r['cat_name'] ]['with']    = (int) $r['quiz_with'];
+                $by_category_quiz[ $r['cat_name'] ]['without'] = (int) $r['quiz_without'];
+                $by_category_summary[ $r['cat_name'] ]['with']    = (int) $r['summary_with'];
+                $by_category_summary[ $r['cat_name'] ]['without'] = (int) $r['summary_without'];
+        }
 }
 
 /* ──────────────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary
- add `nuclen_get_dual_counts()` to query quiz & summary counts together
- refactor dashboard stats to use the combined query
- consolidate category stats query

## Testing
- `php vendor/bin/phpcs` *(fails: `php: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_684b8c09fe1c8327b10c7f750a238ff3