### PR TITLE
Improve autoloading

### DIFF
--- a/nuclear-engagement/admin/Admin.php
+++ b/nuclear-engagement/admin/Admin.php
@@ -17,11 +17,6 @@ use NuclearEngagement\Utils;
 use NuclearEngagement\SettingsRepository;
 use NuclearEngagement\Container;
 
-require_once __DIR__ . '/trait-admin-metaboxes.php';
-require_once __DIR__ . '/trait-admin-ajax.php';
-require_once __DIR__ . '/trait-admin-menu.php';
-require_once __DIR__ . '/trait-admin-assets.php';
-
 class Admin {
 
 	use Admin_Metaboxes;

--- a/nuclear-engagement/admin/Settings.php
+++ b/nuclear-engagement/admin/Settings.php
@@ -10,13 +10,8 @@
 namespace NuclearEngagement\Admin;
 
 if ( ! defined( 'ABSPATH' ) ) {
-	exit;
+        exit;
 }
-
-// Load trait files – they live in the same folder for simple pathing.
-require_once plugin_dir_path( __FILE__ ) . 'SettingsColorPickerTrait.php';
-require_once plugin_dir_path( __FILE__ ) . 'SettingsSanitizeTrait.php';
-require_once plugin_dir_path( __FILE__ ) . 'SettingsPageTrait.php';
 
 class Settings {
 	use SettingsColorPickerTrait;

--- a/nuclear-engagement/admin/SettingsPageTrait.php
+++ b/nuclear-engagement/admin/SettingsPageTrait.php
@@ -14,10 +14,7 @@ if ( ! defined( 'ABSPATH' ) ) {
     exit;
 }
 
-/* Ensure the helper traits are loaded */
-require_once __DIR__ . '/trait-settings-page-load.php';
-require_once __DIR__ . '/trait-settings-page-save.php';
-require_once __DIR__ . '/trait-settings-custom-css.php';
+/* helper traits are autoloaded */
 
 /**
  * Main trait mixed into the Admin class to drive the Settings screen.

--- a/nuclear-engagement/admin/SettingsSanitizeTrait.php
+++ b/nuclear-engagement/admin/SettingsSanitizeTrait.php
@@ -9,9 +9,6 @@
 
 namespace NuclearEngagement\Admin;
 
-require_once __DIR__ . '/trait-settings-sanitize-core.php';
-require_once __DIR__ . '/trait-settings-sanitize-optin.php';
-
 trait SettingsSanitizeTrait {
 
 	use SettingsSanitizeCoreTrait;

--- a/nuclear-engagement/admin/Setup.php
+++ b/nuclear-engagement/admin/Setup.php
@@ -18,7 +18,6 @@ if (!defined('ABSPATH')) {
     exit;
 }
 
-require_once __DIR__ . '/SetupHandlersTrait.php';
 
 class Setup {
 

--- a/nuclear-engagement/admin/trait-admin-metaboxes.php
+++ b/nuclear-engagement/admin/trait-admin-metaboxes.php
@@ -13,9 +13,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 	exit;
 }
 
-/* Make sure the individual traits are loaded */
-require_once __DIR__ . '/trait-admin-metabox-quiz.php';
-require_once __DIR__ . '/trait-admin-metabox-summary.php';
+
 
 /**
  * Trait Admin_Metaboxes

--- a/nuclear-engagement/admin/trait-settings-sanitize-core.php
+++ b/nuclear-engagement/admin/trait-settings-sanitize-core.php
@@ -9,9 +9,7 @@
 
 namespace NuclearEngagement\Admin;
 
-/* Pull in the granular traits */
-require_once __DIR__ . '/trait-settings-sanitize-general.php';
-require_once __DIR__ . '/trait-settings-sanitize-style.php';
+
 
 trait SettingsSanitizeCoreTrait {
 

--- a/nuclear-engagement/front/FrontClass.php
+++ b/nuclear-engagement/front/FrontClass.php
@@ -23,11 +23,6 @@ if ( ! defined( 'ABSPATH' ) ) {
 use NuclearEngagement\Utils;
 use NuclearEngagement\SettingsRepository;
 
-/* ───── Load traits ───── */
-require_once __DIR__ . '/traits/AssetsTrait.php';
-require_once __DIR__ . '/traits/RestTrait.php';
-require_once __DIR__ . '/traits/ShortcodesTrait.php';
-
 class FrontClass {
 
 	use AssetsTrait;

--- a/nuclear-engagement/includes/Plugin.php
+++ b/nuclear-engagement/includes/Plugin.php
@@ -19,6 +19,7 @@ use NuclearEngagement\Admin\Onboarding;
 use NuclearEngagement\Defaults;
 use NuclearEngagement\SettingsRepository;
 use NuclearEngagement\Container;
+use NuclearEngagement\OptinData;
 use NuclearEngagement\Services\{GenerationService, RemoteApiService, ContentStorageService, PointerService, PostsQueryService, AutoGenerationService};
 use NuclearEngagement\Admin\Controller\Ajax\{GenerateController, UpdatesController, PointerController, PostsCountController};
 use NuclearEngagement\Front\Controller\Rest\ContentController;
@@ -65,19 +66,16 @@ class Plugin {
 	/* ─────────────────────────────────────────────
 	   Dependencies & Loader
 	──────────────────────────────────────────── */
-	private function nuclen_load_dependencies() {
+        private function nuclen_load_dependencies() {
 
-		/* ► ALWAYS load OptinData so its init() runs */
-		require_once plugin_dir_path( __FILE__ ) . 'OptinData.php';
-		// - At the end of that file, OptinData::init() is called,
-		//   registering AJAX actions for every request.
+                /* ► Ensure OptinData hooks are registered */
+                OptinData::init();
 
-		// TOC module
-		require_once plugin_dir_path( __FILE__ ) . '../modules/toc/loader.php';
+                // TOC module
+                require_once plugin_dir_path( __FILE__ ) . '../modules/toc/loader.php';
 
-
-		$this->loader = new Loader();
-	}
+                $this->loader = new Loader();
+        }
 	
 	/**
 	 * Initialize the dependency injection container
@@ -197,12 +195,9 @@ class Plugin {
 	/**
 	 * Proxy: make sure OptinData is available, then stream CSV (exits).
 	 */
-	public function nuclen_export_optin_proxy(): void {
-		if ( ! class_exists( '\NuclearEngagement\OptinData', false ) ) {
-			require_once plugin_dir_path( __FILE__ ) . 'OptinData.php';
-		}
-		\NuclearEngagement\OptinData::handle_export();
-	}
+        public function nuclen_export_optin_proxy(): void {
+                OptinData::handle_export();
+        }
 
 	/* ─────────────────────────────────────────────
 	   Front-end hooks

--- a/nuclear-engagement/nuclear-engagement.php
+++ b/nuclear-engagement/nuclear-engagement.php
@@ -88,7 +88,7 @@ spl_autoload_register(function ($class) {
             'NuclearEngagement\\Defaults' => '/includes/Defaults.php',
             'NuclearEngagement\\OptinData' => '/includes/OptinData.php',
             'NuclearEngagement\\MetaRegistration' => '/includes/MetaRegistration.php',
-            
+
             // Admin classes
             'NuclearEngagement\\Admin\\Admin' => '/admin/Admin.php',
             'NuclearEngagement\\Admin\\Dashboard' => '/admin/Dashboard.php',
@@ -121,6 +121,31 @@ spl_autoload_register(function ($class) {
             'NuclearEngagement\\Requests\\UpdatesRequest' => '/includes/Requests/UpdatesRequest.php',
             'NuclearEngagement\\Responses\\GenerationResponse' => '/includes/Responses/GenerationResponse.php',
             'NuclearEngagement\\Responses\\UpdatesResponse' => '/includes/Responses/UpdatesResponse.php',
+
+            // Admin traits
+            'NuclearEngagement\\Admin\\Admin_Ajax' => '/admin/trait-admin-ajax.php',
+            'NuclearEngagement\\Admin\\Admin_Assets' => '/admin/trait-admin-assets.php',
+            'NuclearEngagement\\Admin\\Admin_AutoGenerate' => '/admin/trait-admin-autogenerate.php',
+            'NuclearEngagement\\Admin\\Admin_Menu' => '/admin/trait-admin-menu.php',
+            'NuclearEngagement\\Admin\\Admin_Quiz_Metabox' => '/admin/trait-admin-metabox-quiz.php',
+            'NuclearEngagement\\Admin\\Admin_Summary_Metabox' => '/admin/trait-admin-metabox-summary.php',
+            'NuclearEngagement\\Admin\\Admin_Metaboxes' => '/admin/trait-admin-metaboxes.php',
+            'NuclearEngagement\\Admin\\SettingsPageCustomCSSTrait' => '/admin/trait-settings-custom-css.php',
+            'NuclearEngagement\\Admin\\SettingsPageLoadTrait' => '/admin/trait-settings-page-load.php',
+            'NuclearEngagement\\Admin\\SettingsPageSaveTrait' => '/admin/trait-settings-page-save.php',
+            'NuclearEngagement\\Admin\\SettingsSanitizeCoreTrait' => '/admin/trait-settings-sanitize-core.php',
+            'NuclearEngagement\\Admin\\SettingsSanitizeGeneralTrait' => '/admin/trait-settings-sanitize-general.php',
+            'NuclearEngagement\\Admin\\SettingsSanitizeOptinTrait' => '/admin/trait-settings-sanitize-optin.php',
+            'NuclearEngagement\\Admin\\SettingsSanitizeStyleTrait' => '/admin/trait-settings-sanitize-style.php',
+            'NuclearEngagement\\Admin\\SettingsColorPickerTrait' => '/admin/SettingsColorPickerTrait.php',
+            'NuclearEngagement\\Admin\\SettingsPageTrait' => '/admin/SettingsPageTrait.php',
+            'NuclearEngagement\\Admin\\SettingsSanitizeTrait' => '/admin/SettingsSanitizeTrait.php',
+            'NuclearEngagement\\Admin\\SetupHandlersTrait' => '/admin/SetupHandlersTrait.php',
+
+            // Front traits
+            'NuclearEngagement\\Front\\AssetsTrait' => '/front/traits/AssetsTrait.php',
+            'NuclearEngagement\\Front\\RestTrait' => '/front/traits/RestTrait.php',
+            'NuclearEngagement\\Front\\ShortcodesTrait' => '/front/traits/ShortcodesTrait.php',
         ];
         
         // Dynamic prefixes for trait loading


### PR DESCRIPTION
## Summary
- extend class map with trait files so the autoloader loads them on demand
- remove manual `require_once` statements in admin and front classes
- initialize `OptinData` via the autoloader

## Testing
- `composer lint` *(fails: composer not installed)*
- `phpcs --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684b8c1f25e083279903221b56f1f675