### PR TITLE
Fix REST nonce validation

### DIFF
--- a/nuclear-engagement/front/Controller/Rest/ContentController.php
+++ b/nuclear-engagement/front/Controller/Rest/ContentController.php
@@ -49,6 +49,12 @@ class ContentController {
      */
     public function handle(\WP_REST_Request $request) {
         try {
+            // Verify REST nonce before processing any data
+            $nonce = $request->get_header('X-WP-Nonce');
+            if (!wp_verify_nonce($nonce, 'wp_rest')) {
+                return new \WP_Error('rest_invalid_nonce', __('Invalid nonce', 'nuclear-engagement'), ['status' => 403]);
+            }
+
             $data = $request->get_json_params();
             
             $this->utils->nuclen_log('Received content via REST: ' . json_encode([


### PR DESCRIPTION
## Summary
- verify nonce for REST `/receive-content` handler

## Testing
- `composer run-script lint` *(fails: composer not found)*

------
https://chatgpt.com/codex/tasks/task_e_684b8bfc70e08327a77e4904eb18ae12