### PR TITLE
Fix translation loading timing

### DIFF
--- a/nuclear-engagement/modules/toc/includes/class-nuclen-toc-render.php
+++ b/nuclear-engagement/modules/toc/includes/class-nuclen-toc-render.php
@@ -25,13 +25,13 @@ final class Nuclen_TOC_Render {
 		add_filter( 'the_content',               [ $this, 'nuclen_add_heading_ids' ], 99 );
 
 		// i18n for strings inside this class
-		add_action( 'plugins_loaded', static function () {
-			load_plugin_textdomain(
-				'nuclen-toc-shortcode',
-				false,
-				dirname( plugin_basename( NUCLEN_TOC_DIR ) ) . '/languages'
-			);
-		} );
+                add_action( 'init', static function () {
+                        load_plugin_textdomain(
+                                'nuclen-toc-shortcode',
+                                false,
+                                dirname( plugin_basename( NUCLEN_TOC_DIR ) ) . '/languages'
+                        );
+                } );
 	}
 
 	/**

--- a/nuclear-engagement/nuclear-engagement.php
+++ b/nuclear-engagement/nuclear-engagement.php
@@ -36,10 +36,10 @@ function nuclear_engagement_load_textdomain() {
         dirname(plugin_basename(__FILE__)) . '/languages/'
     );
 }
-add_action('plugins_loaded', 'nuclear_engagement_load_textdomain');
+add_action('init', 'nuclear_engagement_load_textdomain');
 
 // Initialize SettingsRepository with default values
-add_action('plugins_loaded', function() {
+add_action('init', function() {
     $defaults = [
         'theme' => 'bright',
         'font_size' => '16',


### PR DESCRIPTION
## Summary
- load Nuclear Engagement text domain on `init`
- load TOC module translations on `init`
- initialize plugin settings after translations are loaded

## Testing
- `vendor/bin/phpcs` *(fails: php not installed)*

------
https://chatgpt.com/codex/tasks/task_e_684b927001a48327b7204b673b9d6285