### PR TITLE
Fix API key checks in setup

### DIFF
--- a/nuclear-engagement/admin/SetupHandlersTrait.php
+++ b/nuclear-engagement/admin/SetupHandlersTrait.php
@@ -185,10 +185,13 @@ trait SetupHandlersTrait {
 	/*--------------------------------------------------------------
 	 #  Helpers
 	 --------------------------------------------------------------*/
-	private function nuclen_validate_api_key_with_app( $api_key ) {
-		$url      = 'https://app.nuclearengagement.com/api/check-api-key';
-		$response = wp_remote_post(
-			$url,
+        private function nuclen_validate_api_key_with_app( $api_key ) {
+                if ( empty( $api_key ) ) {
+                        return false;
+                }
+                $url      = 'https://app.nuclearengagement.com/api/check-api-key';
+                $response = wp_remote_post(
+                        $url,
 			array(
 				'method'  => 'POST',
 				'headers' => array( 'Content-Type' => 'application/json' ),
@@ -206,10 +209,13 @@ trait SetupHandlersTrait {
 		return wp_remote_retrieve_response_code( $response ) === 200;
 	}
 
-	private function nuclen_send_app_password_to_app( $data ) {
-		$url      = 'https://app.nuclearengagement.com/api/store-wp-creds';
-		$response = wp_remote_post(
-			$url,
+        private function nuclen_send_app_password_to_app( $data ) {
+                if ( empty( $data['appApiKey'] ) ) {
+                        return false;
+                }
+                $url      = 'https://app.nuclearengagement.com/api/store-wp-creds';
+                $response = wp_remote_post(
+                        $url,
 			array(
 				'method'  => 'POST',
 				'headers' => array( 'Content-Type' => 'application/json' ),

--- a/nuclear-engagement/admin/partials/setup/step1.php
+++ b/nuclear-engagement/admin/partials/setup/step1.php
@@ -51,7 +51,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 		<span class="dashicons dashicons-plugins-checked"></span>
 		<h2 class="nuclen-subheading"><?php esc_html_e( 'Step 1 complete – Site authorised', 'nuclear-engagement' ); ?></h2>
 		<p class="nuclen-paragraph" style="color:green;"><?php esc_html_e( 'Your site is connected.', 'nuclear-engagement' ); ?></p>
-		<?php $short_key = substr( $app_setup['api_key'], 0, 6 ); ?>
+                <?php $short_key = isset( $app_setup['api_key'] ) ? substr( $app_setup['api_key'], 0, 6 ) : ''; ?>
 		<p class="nuclen-paragraph">
 			<?php esc_html_e( 'Current Gold Code:', 'nuclear-engagement' ); ?>
 			<input type="text" readonly style="width:80px;color:#888;" value="<?php echo esc_attr( $short_key ); ?>">


### PR DESCRIPTION
## Summary
- avoid undefined key warning by verifying `api_key` before display
- guard SaaS requests from running when `api_key` is missing

## Testing
- `php vendor/bin/phpcs` *(fails: `php` not found)*

------
https://chatgpt.com/codex/tasks/task_e_684b94d37b248327a66aea67f7f77a50