### PR TITLE
Refactor AJAX controllers

### DIFF
--- a/nuclear-engagement/admin/Controller/Ajax/BaseController.php
+++ b/nuclear-engagement/admin/Controller/Ajax/BaseController.php
@@ -1,0 +1,47 @@
+<?php
+/**
+ * File: admin/Controller/Ajax/BaseController.php
+ *
+ * Base class for AJAX controllers.
+ *
+ * @package NuclearEngagement\Admin\Controller\Ajax
+ */
+
+namespace NuclearEngagement\Admin\Controller\Ajax;
+
+if (!defined('ABSPATH')) {
+    exit;
+}
+
+/**
+ * Provides common security helpers for AJAX controllers.
+ */
+abstract class BaseController {
+    /**
+     * Verify nonce and permissions.
+     *
+     * @param string $nonceAction Nonce action.
+     * @param string $nonceField  Nonce field name.
+     * @param string $capability  Capability to check.
+     * @return bool Whether the request is valid.
+     */
+    protected function verifyRequest(
+        string $nonceAction,
+        string $nonceField = 'security',
+        string $capability = 'manage_options'
+    ): bool {
+        if (!check_ajax_referer($nonceAction, $nonceField, false)) {
+            status_header(403);
+            wp_send_json_error(['message' => 'Security check failed']);
+            return false;
+        }
+
+        if (!current_user_can($capability)) {
+            status_header(403);
+            wp_send_json_error(['message' => 'Not allowed']);
+            return false;
+        }
+
+        return true;
+    }
+}

--- a/nuclear-engagement/admin/Controller/Ajax/GenerateController.php
+++ b/nuclear-engagement/admin/Controller/Ajax/GenerateController.php
@@ -19,7 +19,7 @@ if (!defined('ABSPATH')) {
 /**
  * Controller for content generation
  */
-class GenerateController {
+class GenerateController extends BaseController {
     /**
      * @var GenerationService
      */
@@ -39,17 +39,8 @@ class GenerateController {
      */
     public function handle(): void {
         try {
-            
-            // Security check
-            if (!check_ajax_referer('nuclen_admin_ajax_nonce', 'security', false)) {
-                status_header(403);
-                wp_send_json_error(['message' => 'Security check failed: Invalid nonce']);
-                return;
-            }
-            
-            if (!current_user_can('manage_options')) {
-                status_header(403);
-                wp_send_json_error(['message' => 'Not allowed']);
+
+            if (!$this->verifyRequest('nuclen_admin_ajax_nonce')) {
                 return;
             }
             

--- a/nuclear-engagement/admin/Controller/Ajax/PointerController.php
+++ b/nuclear-engagement/admin/Controller/Ajax/PointerController.php
@@ -18,7 +18,7 @@ if (!defined('ABSPATH')) {
 /**
  * Controller for admin pointers
  */
-class PointerController {
+class PointerController extends BaseController {
     /**
      * @var PointerService
      */
@@ -38,11 +38,9 @@ class PointerController {
      */
     public function dismiss(): void {
         try {
-            if (!current_user_can('manage_options')) {
-                wp_send_json_error(['message' => __('No permission', 'nuclear-engagement')]);
+            if (!$this->verifyRequest('nuclen_dismiss_pointer_nonce', 'nonce')) {
+                return;
             }
-            
-            check_ajax_referer('nuclen_dismiss_pointer_nonce', 'nonce');
             
             $pointerId = isset($_POST['pointer']) ? sanitize_text_field(wp_unslash($_POST['pointer'])) : '';
             $userId = get_current_user_id();

--- a/nuclear-engagement/admin/Controller/Ajax/PostsCountController.php
+++ b/nuclear-engagement/admin/Controller/Ajax/PostsCountController.php
@@ -19,7 +19,7 @@ if (!defined('ABSPATH')) {
 /**
  * Controller for getting posts count
  */
-class PostsCountController {
+class PostsCountController extends BaseController {
     /**
      * @var PostsQueryService
      */
@@ -39,9 +39,8 @@ class PostsCountController {
      */
     public function handle(): void {
         try {
-            check_ajax_referer('nuclen_admin_ajax_nonce', 'security');
-            if (!current_user_can('manage_options')) {
-                wp_send_json_error(['message' => 'Not allowed']);
+            if (!$this->verifyRequest('nuclen_admin_ajax_nonce')) {
+                return;
             }
             
             // Parse request

--- a/nuclear-engagement/admin/Controller/Ajax/UpdatesController.php
+++ b/nuclear-engagement/admin/Controller/Ajax/UpdatesController.php
@@ -22,7 +22,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 /**
  * Controller for polling updates
  */
-class UpdatesController {
+class UpdatesController extends BaseController {
 
 	/**
 	 * @var RemoteApiService
@@ -54,12 +54,11 @@ class UpdatesController {
 	/**
 	 * Handle updates request.
 	 */
-	public function handle(): void {
-		try {
-			check_ajax_referer( 'nuclen_admin_ajax_nonce', 'security' );
-			if ( ! current_user_can( 'manage_options' ) ) {
-				wp_send_json_error( array( 'message' => 'Not allowed' ) );
-			}
+        public function handle(): void {
+                try {
+                        if ( ! $this->verifyRequest( 'nuclen_admin_ajax_nonce' ) ) {
+                                return;
+                        }
 
 			$request = UpdatesRequest::fromPost( $_POST );
 

--- a/nuclear-engagement/nuclear-engagement.php
+++ b/nuclear-engagement/nuclear-engagement.php
@@ -101,6 +101,7 @@ spl_autoload_register(function ($class) {
             'NuclearEngagement\\Admin\\Controller\\Ajax\\UpdatesController' => '/admin/Controller/Ajax/UpdatesController.php',
             'NuclearEngagement\\Admin\\Controller\\Ajax\\PointerController' => '/admin/Controller/Ajax/PointerController.php',
             'NuclearEngagement\\Admin\\Controller\\Ajax\\PostsCountController' => '/admin/Controller/Ajax/PostsCountController.php',
+            'NuclearEngagement\\Admin\\Controller\\Ajax\\BaseController' => '/admin/Controller/Ajax/BaseController.php',
             
             // Front classes
             'NuclearEngagement\\Front\\FrontClass' => '/front/FrontClass.php',


### PR DESCRIPTION
## Summary
- add a BaseController for AJAX helpers
- use the new verification method across admin controllers

## Testing
- `composer lint` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684b985970308327b5d8682134e21ff0