### PR TITLE
Expand unit test coverage

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,3 +26,9 @@ Install dependencies with `composer install` and run linting with:
 ```bash
 composer lint
 ```
+
+Run the PHPUnit test suite with:
+
+```bash
+composer test
+```

--- a/composer.json
+++ b/composer.json
@@ -7,9 +7,11 @@
         }
     },
   "require-dev": {
-    "wp-coding-standards/wpcs": "3.0"
+    "wp-coding-standards/wpcs": "3.0",
+    "phpunit/phpunit": "^9.6"
   },
   "scripts": {
-    "lint": "phpcs"
+    "lint": "phpcs",
+    "test": "phpunit"
   }
 }

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<phpunit bootstrap="tests/bootstrap.php" colors="true" verbose="true">
+    <testsuites>
+        <testsuite name="Plugin Test Suite">
+            <directory>tests</directory>
+        </testsuite>
+    </testsuites>
+</phpunit>

--- a/tests/DefaultsTest.php
+++ b/tests/DefaultsTest.php
@@ -1,0 +1,11 @@
+<?php
+use PHPUnit\Framework\TestCase;
+use NuclearEngagement\Defaults;
+
+class DefaultsTest extends TestCase {
+    public function test_defaults_contains_theme_key() {
+        $defaults = Defaults::nuclen_get_default_settings();
+        $this->assertArrayHasKey('theme', $defaults);
+        $this->assertEquals('bright', $defaults['theme']);
+    }
+}

--- a/tests/OptinDataTest.php
+++ b/tests/OptinDataTest.php
@@ -1,0 +1,21 @@
+<?php
+use PHPUnit\Framework\TestCase;
+use NuclearEngagement\OptinData;
+
+class OptinDataTest extends TestCase {
+    private \ReflectionMethod $escapeMethod;
+
+    protected function setUp(): void {
+        $this->escapeMethod = new \ReflectionMethod(OptinData::class, 'escape_csv_field');
+        $this->escapeMethod->setAccessible(true);
+    }
+
+    public function test_escape_csv_field_prefixes_formula() {
+        $this->assertSame("'=1+1", $this->escapeMethod->invoke(null, '=1+1'));
+        $this->assertSame("'+SUM(A1)", $this->escapeMethod->invoke(null, '+SUM(A1)'));
+    }
+
+    public function test_escape_csv_field_unchanged() {
+        $this->assertSame('plain', $this->escapeMethod->invoke(null, 'plain'));
+    }
+}

--- a/tests/SettingsRepositoryTest.php
+++ b/tests/SettingsRepositoryTest.php
@@ -1,0 +1,53 @@
+<?php
+use PHPUnit\Framework\TestCase;
+use NuclearEngagement\SettingsRepository;
+
+class SettingsRepositoryTest extends TestCase {
+    private \ReflectionMethod $sanitizeMethod;
+
+    protected function setUp(): void {
+        $this->sanitizeMethod = new \ReflectionMethod(SettingsRepository::class, 'sanitize_heading_levels');
+        $this->sanitizeMethod->setAccessible(true);
+    }
+
+    public function test_sanitize_heading_levels_filters_invalid_values() {
+        $input = ['1', '2', '7', 'abc'];
+        $expected = [1,2];
+        $this->assertSame($expected, $this->sanitizeMethod->invoke(null, $input));
+    }
+
+    public function test_singleton_returns_same_instance() {
+        $a = SettingsRepository::get_instance(['theme' => 'dark']);
+        $b = SettingsRepository::get_instance();
+        $this->assertSame($a, $b);
+    }
+
+    public function test_sanitize_post_types_removes_invalid() {
+        SettingsRepository::_reset_for_tests();
+        $ref = new \ReflectionMethod(SettingsRepository::class, 'sanitize_post_types');
+        $ref->setAccessible(true);
+        $input = ['POST', 'page', 'invalid', 'custom?'];
+        $expected = ['post', 'page'];
+        $this->assertSame($expected, $ref->invoke(null, $input));
+    }
+
+    public function test_should_autoload_based_on_size() {
+        SettingsRepository::_reset_for_tests();
+        $instance = SettingsRepository::get_instance();
+        $ref = new \ReflectionMethod(SettingsRepository::class, 'should_autoload');
+        $ref->setAccessible(true);
+        $small = ['a' => 'b'];
+        $this->assertTrue($ref->invoke($instance, $small));
+        $big = ['data' => str_repeat('x', SettingsRepository::MAX_AUTOLOAD_SIZE + 1)];
+        $this->assertFalse($ref->invoke($instance, $big));
+    }
+
+    public function test_get_defaults_includes_custom_values() {
+        SettingsRepository::_reset_for_tests();
+        $instance = SettingsRepository::get_instance(['foo' => 'bar', 'theme' => 'dark']);
+        $defaults = $instance->get_defaults();
+        $this->assertSame('bar', $defaults['foo']);
+        $this->assertSame('dark', $defaults['theme']);
+        $this->assertArrayHasKey('quiz_title', $defaults);
+    }
+}

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -1,0 +1,33 @@
+<?php
+// Define ABSPATH to bypass exit calls
+if (!defined('ABSPATH')) {
+    define('ABSPATH', __DIR__ . '/');
+}
+// Minimal stubs for WordPress functions used in included files
+if (!function_exists('add_action')) {
+    function add_action(...$args) {}
+}
+if (!function_exists('absint')) {
+    function absint($maybeint) { return abs(intval($maybeint)); }
+}
+
+// Include files for tests
+require_once __DIR__ . '/../nuclear-engagement/includes/Defaults.php';
+require_once __DIR__ . '/../nuclear-engagement/includes/OptinData.php';
+require_once __DIR__ . '/../nuclear-engagement/includes/SettingsRepository.php';
+if (!function_exists('sanitize_key')) {
+    function sanitize_key($key) { return strtolower(preg_replace('/[^a-z0-9_]/', '', $key)); }
+}
+if (!function_exists('post_type_exists')) {
+    function post_type_exists($type) { return in_array($type, ['post','page'], true); }
+}
+if (!function_exists('wp_parse_args')) {
+    function wp_parse_args($args, $defaults = []) {
+        if (is_array($args)) {
+            return array_merge($defaults, $args);
+        }
+        parse_str((string) $args, $parsed);
+        return array_merge($defaults, $parsed);
+    }
+}
+


### PR DESCRIPTION
## Summary
- add additional tests for SettingsRepository helpers
- stub WordPress helper functions in test bootstrap

## Testing
- `composer test` *(fails: composer not found)*
- `vendor/bin/phpunit --version` *(fails: phpunit not found)*

------
https://chatgpt.com/codex/tasks/task_e_684b96fb18e88327baf64d240accb4a9