### PR TITLE
Refactor TOC module classes

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -22,4 +22,18 @@ sanitization rules easier to maintain and test in isolation.
 
 To align with the maintainable plugin structure, the plugin entry file now only includes the header and requires `bootstrap.php`. Initialization logic—including constant definitions, autoloader registration and hook setup—resides in the bootstrap file. This keeps `nuclear-engagement.php` under 50 lines for better clarity.
 
+## TOC Module Decomposition
+
+`Nuclen_TOC_Render` originally spanned more than 450 lines and mixed shortcode
+handling with asset management and content filtering. To stay within the
+300 LOC guideline, the functionality has been split into dedicated classes:
+
+- `Nuclen_TOC_Render` – handles the `[nuclear_engagement_toc]` shortcode.
+- `Nuclen_TOC_Assets` – registers and enqueues front-end assets.
+- `Nuclen_TOC_Headings` – injects unique IDs into post headings.
+- `Nuclen_TOC_View` – builds the HTML markup for the TOC.
+
+The loader now requires these files and spins up each class. This keeps
+responsibilities narrow and makes future maintenance easier.
+
 

--- a/nuclear-engagement/modules/toc/includes/class-nuclen-toc-assets.php
+++ b/nuclear-engagement/modules/toc/includes/class-nuclen-toc-assets.php
@@ -1,0 +1,71 @@
+<?php
+/**
+ * File: modules/toc/includes/class-nuclen-toc-assets.php
+ *
+ * Handles front-end asset registration and enqueueing for the TOC module.
+ */
+
+if ( ! defined( 'ABSPATH' ) ) { exit; }
+
+final class Nuclen_TOC_Assets {
+        private bool $registered = false;
+        private int  $scroll_offset = 72;
+
+        /**
+         * Enqueue assets and apply runtime tweaks.
+         */
+        public function enqueue( array $a ) : void {
+                if ( ! is_singular() ) {
+                        return;
+                }
+                if ( ! $this->registered ) {
+                        $this->register();
+                }
+                wp_enqueue_style( 'nuclen-toc-front' );
+                if ( $a['toggle'] === 'true' || $a['highlight'] === 'true' ) {
+                        wp_enqueue_script( 'nuclen-toc-front' );
+                }
+                $off = max( 0, min( 500, (int) $a['offset'] ) );
+                if ( $off !== $this->scroll_offset ) {
+                        wp_add_inline_style( 'nuclen-toc-front', ':root{--nuclen-toc-offset:' . $off . 'px}' );
+                        $this->scroll_offset = $off;
+                }
+                if ( $a['smooth'] === 'true' ) {
+                        wp_add_inline_style( 'nuclen-toc-front', 'html{scroll-behavior:smooth}' );
+                }
+        }
+
+        /** Register scripts and styles. */
+        private function register() : void {
+                if ( $this->registered ) {
+                        return;
+                }
+                $this->registered = true;
+
+                $css_p = NUCLEN_TOC_DIR . 'assets/css/nuclen-toc-front.css';
+                $js_p  = NUCLEN_TOC_DIR . 'assets/js/nuclen-toc-front.js';
+
+                $css_v = file_exists( $css_p ) ? filemtime( $css_p ) : NUCLEN_ASSET_VERSION;
+                $js_v  = file_exists( $js_p )  ? filemtime( $js_p )  : NUCLEN_ASSET_VERSION;
+
+                wp_register_style(
+                        'nuclen-toc-front',
+                        NUCLEN_TOC_URL . 'assets/css/nuclen-toc-front.css',
+                        [],
+                        $css_v
+                );
+
+                wp_register_script(
+                        'nuclen-toc-front',
+                        NUCLEN_TOC_URL . 'assets/js/nuclen-toc-front.js',
+                        [],
+                        $js_v,
+                        true
+                );
+
+                wp_localize_script( 'nuclen-toc-front', 'nuclenTocL10n', [
+                        'hide' => __( 'Hide', 'nuclen-toc-shortcode' ),
+                        'show' => __( 'Show', 'nuclen-toc-shortcode' ),
+                ] );
+        }
+}

--- a/nuclear-engagement/modules/toc/includes/class-nuclen-toc-headings.php
+++ b/nuclear-engagement/modules/toc/includes/class-nuclen-toc-headings.php
@@ -1,0 +1,47 @@
+<?php
+/**
+ * File: modules/toc/includes/class-nuclen-toc-headings.php
+ *
+ * Injects unique IDs into post headings for jump links.
+ */
+
+if ( ! defined( 'ABSPATH' ) ) { exit; }
+
+use function nuclen_str_contains as _nc;
+
+final class Nuclen_TOC_Headings {
+        public function __construct() {
+                add_filter( 'the_content', [ $this, 'nuclen_add_heading_ids' ], 99 );
+        }
+
+        /** Back-compat wrapper for legacy callback name. */
+        public function nuclen_add_heading_ids( string $content ) : string {
+                return $this->add_heading_ids( $content );
+        }
+
+        /**
+         * Inject IDs into headings that lack them.
+         */
+        public function add_heading_ids( string $content ) : string {
+                if ( ! apply_filters( 'nuclen_toc_enable_heading_ids', true ) ) {
+                        return $content;
+                }
+                if ( ! _nc( $content, '<h' ) ) { return $content; }
+
+                foreach ( Nuclen_TOC_Utils::extract( $content, range( 1, 6 ) ) as $h ) {
+                        $pat = sprintf(
+                                '/(<%1$s\b(?![^>]*\bid=)[^>]*>)(%2$s)(<\/%1$s>)/is',
+                                $h['tag'],
+                                preg_quote( $h['inner'], '/' )
+                        );
+                        $rep = sprintf(
+                                '<%1$s id="%2$s">%3$s</%1$s>',
+                                $h['tag'],
+                                esc_attr( $h['id'] ),
+                                $h['inner']
+                        );
+                        $content = preg_replace( $pat, $rep, $content, 1 );
+                }
+                return $content;
+        }
+}

--- a/nuclear-engagement/modules/toc/includes/class-nuclen-toc-render.php
+++ b/nuclear-engagement/modules/toc/includes/class-nuclen-toc-render.php
@@ -2,29 +2,24 @@
 /**
  * File: modules/toc/includes/class-nuclen-toc-render.php
  *
- * Public-facing logic: shortcode, heading-ID filter, asset loading.
+ * Public-facing shortcode handler for the TOC module.
  */
 
 if ( ! defined( 'ABSPATH' ) ) { exit; }
 
-use function nuclen_str_contains as _nc;
 use NuclearEngagement\SettingsRepository;
 
 final class Nuclen_TOC_Render {
+        private Nuclen_TOC_Assets $assets;
+        private Nuclen_TOC_View   $view;
 
-	private const DEFAULT_STICKY_OFFSET_X = 20;
-	private const DEFAULT_STICKY_OFFSET_Y = 20;
-	private const DEFAULT_STICKY_MAX_WIDTH = 300;
+        public function __construct() {
+                $this->assets = new Nuclen_TOC_Assets();
+                $this->view   = new Nuclen_TOC_View();
 
-	private bool $assets_registered = false;
-	private int  $scroll_offset     = 72;
+                add_shortcode( 'nuclear_engagement_toc', [ $this, 'nuclen_toc_shortcode' ] );
 
-	/* ───────────────── bootstrap ─────────────────────────────── */
-	public function __construct() {
-		add_shortcode( 'nuclear_engagement_toc', [ $this, 'nuclen_toc_shortcode' ] );
-		add_filter( 'the_content',               [ $this, 'nuclen_add_heading_ids' ], 99 );
-
-		// i18n for strings inside this class
+                // i18n for strings inside this class
                 add_action( 'init', static function () {
                         load_plugin_textdomain(
                                 'nuclen-toc-shortcode',
@@ -32,113 +27,59 @@ final class Nuclen_TOC_Render {
                                 dirname( plugin_basename( NUCLEN_TOC_DIR ) ) . '/languages'
                         );
                 } );
-	}
+        }
 
-	/**
-	 * Back-compat wrapper for the legacy filter callback name.
-	 *
-	 * @param string $content Post content.
-	 * @return string         Content with injected IDs.
-	 */
-	public function nuclen_add_heading_ids( string $content ) : string {
-		return $this->add_heading_ids( $content );
-	}
+        private function validate_heading_levels( $heading_levels ) : array {
+                if ( ! is_array( $heading_levels ) ) {
+                        if ( is_string( $heading_levels ) ) {
+                                $heading_levels = explode( ',', $heading_levels );
+                        } else {
+                                return range( 2, 6 );
+                        }
+                }
+                $heading_levels = array_map( 'intval', $heading_levels );
+                $heading_levels = array_filter( $heading_levels, static function ( $level ) {
+                        return $level >= 2 && $level <= 6;
+                } );
+                if ( empty( $heading_levels ) ) {
+                        return range( 2, 6 );
+                }
+                $heading_levels = array_unique( $heading_levels );
+                sort( $heading_levels );
+                return array_values( $heading_levels );
+        }
 
-	/**
-	 * Validate and sanitize heading levels array
-	 *
-	 * @param mixed $heading_levels Raw heading levels input
-	 * @return array Validated array of integers between 2-6
-	 */
-	private function validate_heading_levels( $heading_levels ) : array {
-		// If not an array, try to convert it
-		if ( ! is_array( $heading_levels ) ) {
-			// If it's a string like "2,3,4", split it
-			if ( is_string( $heading_levels ) ) {
-				$heading_levels = explode( ',', $heading_levels );
-			} else {
-				// Default fallback
-				return range( 2, 6 );
-			}
-		}
-
-		// Ensure all values are integers
-		$heading_levels = array_map( 'intval', $heading_levels );
-		
-		// Filter to only valid heading levels (2-6)
-		$heading_levels = array_filter( $heading_levels, function( $level ) {
-			return $level >= 2 && $level <= 6;
-		} );
-
-		// If no valid levels after filtering, use defaults
-		if ( empty( $heading_levels ) ) {
-			return range( 2, 6 );
-		}
-
-		// Ensure unique, sorted values
-		$heading_levels = array_unique( $heading_levels );
-		sort( $heading_levels );
-		
-		return array_values( $heading_levels );
-	}
-
-	/**
-	 * Validate and sanitize shortcode attributes
-	 *
-	 * @param array $atts Raw shortcode attributes
-	 * @return array Validated attributes
-	 */
         private function validate_shortcode_atts( array $atts ) : array {
-		// Define valid values for each attribute
-		$valid_lists = [ 'ul', 'ol' ];
-		$valid_booleans = [ 'true', 'false' ];
-		$valid_themes = [ 'light', 'dark', 'auto' ];
+                $valid_lists    = [ 'ul', 'ol' ];
+                $valid_booleans = [ 'true', 'false' ];
+                $valid_themes   = [ 'light', 'dark', 'auto' ];
 
-		// List type validation
-		if ( isset( $atts['list'] ) && ! in_array( strtolower( $atts['list'] ), $valid_lists, true ) ) {
-			$atts['list'] = 'ul';
-		}
-
-		// Boolean validations
-		foreach ( [ 'toggle', 'collapsed', 'smooth', 'highlight' ] as $bool_attr ) {
-			if ( isset( $atts[ $bool_attr ] ) && ! in_array( strtolower( $atts[ $bool_attr ] ), $valid_booleans, true ) ) {
-				$atts[ $bool_attr ] = 'true';
-			}
-		}
-
-		// Offset validation (ensure it's a positive integer)
-		if ( isset( $atts['offset'] ) ) {
-			$atts['offset'] = max( 0, min( 500, intval( $atts['offset'] ) ) );
-		}
-
-		// Theme validation
-		if ( isset( $atts['theme'] ) && ! in_array( strtolower( $atts['theme'] ), $valid_themes, true ) ) {
-			$atts['theme'] = 'light';
-		}
-
-		// Title sanitization
-		if ( isset( $atts['title'] ) ) {
-			$atts['title'] = sanitize_text_field( $atts['title'] );
-		}
-
-		// Show/hide text sanitization
-		if ( isset( $atts['show_text'] ) ) {
-			$atts['show_text'] = sanitize_text_field( $atts['show_text'] );
-		}
-		if ( isset( $atts['hide_text'] ) ) {
-			$atts['hide_text'] = sanitize_text_field( $atts['hide_text'] );
-		}
-
+                if ( isset( $atts['list'] ) && ! in_array( strtolower( $atts['list'] ), $valid_lists, true ) ) {
+                        $atts['list'] = 'ul';
+                }
+                foreach ( [ 'toggle', 'collapsed', 'smooth', 'highlight' ] as $bool_attr ) {
+                        if ( isset( $atts[ $bool_attr ] ) && ! in_array( strtolower( $atts[ $bool_attr ] ), $valid_booleans, true ) ) {
+                                $atts[ $bool_attr ] = 'true';
+                        }
+                }
+                if ( isset( $atts['offset'] ) ) {
+                        $atts['offset'] = max( 0, min( 500, intval( $atts['offset'] ) ) );
+                }
+                if ( isset( $atts['theme'] ) && ! in_array( strtolower( $atts['theme'] ), $valid_themes, true ) ) {
+                        $atts['theme'] = 'light';
+                }
+                if ( isset( $atts['title'] ) ) {
+                        $atts['title'] = sanitize_text_field( $atts['title'] );
+                }
+                if ( isset( $atts['show_text'] ) ) {
+                        $atts['show_text'] = sanitize_text_field( $atts['show_text'] );
+                }
+                if ( isset( $atts['hide_text'] ) ) {
+                        $atts['hide_text'] = sanitize_text_field( $atts['hide_text'] );
+                }
                 return $atts;
         }
 
-        /**
-         * Prepare and sanitize shortcode attributes using plugin settings.
-         *
-         * @param array             $atts     Raw shortcode attributes.
-         * @param SettingsRepository $settings Settings repository instance.
-         * @return array Sanitized attributes.
-         */
         private function prepare_shortcode_attributes( array $atts, SettingsRepository $settings ) : array {
                 $heading_levels = $settings->get_array( 'toc_heading_levels', range( 2, 6 ) );
                 $heading_levels = $this->validate_heading_levels( $heading_levels );
@@ -160,312 +101,65 @@ final class Nuclen_TOC_Render {
                 if ( isset( $atts['heading_levels'] ) ) {
                         $atts['heading_levels'] = $this->validate_heading_levels( $atts['heading_levels'] );
                 }
-
                 if ( ! isset( $atts['sticky'] ) ) {
                         $atts['sticky'] = $settings->get_bool( 'toc_sticky' );
                 }
-
                 return $atts;
         }
 
-        /**
-         * Get the translated TOC title with a fallback.
-         *
-         * @param SettingsRepository $settings Settings repository.
-         * @return string Sanitized title.
-         */
-        private function get_toc_title( SettingsRepository $settings ) : string {
-                $title = $settings->get_string( 'toc_title' );
-                if ( empty( $title ) ) {
-                        return esc_html__( 'Table of Contents', 'nuclen-toc-shortcode' );
-                }
-                return esc_html( $title );
-        }
-
-        /**
-         * Build wrapper classes and sticky attributes for the TOC container.
-         *
-         * @param array             $atts     Shortcode attributes.
-         * @param SettingsRepository $settings Settings repository instance.
-         * @return array {
-         *     @type array  $classes      Array of wrapper classes.
-         *     @type string $sticky_attrs Sticky data attributes string.
-         *     @type bool   $show_toggle  Whether toggle is enabled.
-         *     @type bool   $hidden       Initial hidden state.
-         * }
-         */
-        private function build_wrapper_props( array $atts, SettingsRepository $settings ) : array {
-                $classes = [ 'nuclen-toc-wrapper' ];
-
-                if ( in_array( $atts['theme'], [ 'dark', 'auto' ], true ) ) {
-                        $classes[] = 'nuclen-toc-' . $atts['theme'];
-                }
-
-                $show_toggle = $settings->get_bool( 'toc_show_toggle' );
-                $hidden      = $show_toggle && ! $settings->get_bool( 'toc_show_content' );
-
-                if ( $show_toggle ) {
-                        $classes[] = 'nuclen-toc-has-toggle';
-                        if ( $hidden ) {
-                                $classes[] = 'nuclen-toc-collapsed';
-                        }
-                }
-
-                $sticky_attrs = '';
-                if ( ! empty( $atts['sticky'] ) ) {
-                        $classes[] = 'nuclen-toc-sticky';
-
-                        $sticky_offset_x = $settings->get_int( 'toc_sticky_offset_x', self::DEFAULT_STICKY_OFFSET_X );
-                        $sticky_offset_y = $settings->get_int( 'toc_sticky_offset_y', self::DEFAULT_STICKY_OFFSET_Y );
-                        $sticky_max_width = $settings->get_int( 'toc_sticky_max_width', self::DEFAULT_STICKY_MAX_WIDTH );
-
-                        $sticky_offset_x  = max( 0, min( 1000, $sticky_offset_x ) );
-                        $sticky_offset_y  = max( 0, min( 1000, $sticky_offset_y ) );
-                        $sticky_max_width = min( 1000, max( 100, $sticky_max_width ) );
-
-                        $sticky_attrs = sprintf(
-                                ' data-offset-x="%d" data-offset-y="%d" data-max-width="%d" data-show-content="%s" data-heading-levels="%s"',
-                                $sticky_offset_x,
-                                $sticky_offset_y,
-                                $sticky_max_width,
-                                $settings->get_bool( 'toc_show_content' ) ? 'true' : 'false',
-                                esc_attr( implode( ',', $atts['heading_levels'] ) )
-                        );
-                }
-
-                if ( $atts['highlight'] === 'true' ) {
-                        $classes[] = 'nuclen-has-highlight';
-                }
-
-                // z-index not currently output but preserved for future use.
-                $z_index = $settings->get_int( 'toc_z_index', 100 );
-                $z_index = max( 1, min( 9999, $z_index ) );
-                ( $z_index );
-
-                return [
-                        'classes'      => $classes,
-                        'sticky_attrs' => $sticky_attrs,
-                        'show_toggle'  => $show_toggle,
-                        'hidden'       => $hidden,
-                ];
-        }
-
-        /**
-         * Build the toggle button HTML if toggling is enabled.
-         */
-        private function build_toggle_button( bool $show, bool $hidden, array $atts, string $nav_id ) : string {
-                if ( ! $show ) {
+        public function nuclen_toc_shortcode( array $atts ) : string {
+                global $post;
+                if ( empty( $post ) ) {
                         return '';
                 }
 
-                $toggle_text = $hidden ? $atts['show_text'] : $atts['hide_text'];
-                return sprintf(
-                        '<button type="button" class="nuclen-toc-toggle" aria-expanded="%s" aria-controls="%s">%s</button>',
-                        $hidden ? 'false' : 'true',
-                        esc_attr( $nav_id ),
-                        esc_html( $toggle_text )
-                );
-        }
+                $settings = SettingsRepository::get_instance();
+                $atts     = $this->prepare_shortcode_attributes( $atts, $settings );
 
-        /**
-         * Render the nested heading list.
-         */
-        private function render_headings_list( array $heads, string $list ) : string {
-                $out   = '';
-                $stack = [];
-                foreach ( $heads as $h ) {
-                        $l = $h['level'];
-                        while ( $stack && end( $stack ) > $l ) {
-                                $out .= '</li></' . $list . '>';
-                                array_pop( $stack );
-                        }
-                        if ( ! $stack || end( $stack ) < $l ) {
-                                $out .= '<' . $list . '>';
-                                $stack[] = $l;
-                        } else {
-                                $out .= '</li>';
-                        }
-
-                        $out .= '<li><a href="#' . esc_attr( $h['id'] ) . '">' . esc_html( $h['text'] ) . '</a>';
+                $list  = ( strtolower( $atts['list'] ) === 'ol' ) ? 'ol' : 'ul';
+                $heads = Nuclen_TOC_Utils::extract( $post->post_content, $atts['heading_levels'] );
+                if ( ! $heads ) {
+                        return '';
                 }
-                while ( $stack ) {
-                        $out .= '</li></' . $list . '>';
-                        array_pop( $stack );
+
+                $this->assets->enqueue( $atts );
+
+                $toc_title = $this->view->get_toc_title( $settings );
+                if ( empty( $atts['title'] ) ) {
+                        $atts['title'] = $toc_title;
+                }
+
+                $nav_id  = esc_attr( wp_unique_id( 'nuclen-toc-' ) );
+                $wrapper = $this->view->build_wrapper_props( $atts, $settings );
+                $classes = $wrapper['classes'];
+                $sticky  = $wrapper['sticky_attrs'];
+                $show    = $wrapper['show_toggle'];
+                $hidden  = $wrapper['hidden'];
+
+                $out = sprintf(
+                        '<section id="%s-wrapper" class="%s"%s>',
+                        esc_attr( $nav_id ),
+                        esc_attr( implode( ' ', $classes ) ),
+                        $sticky
+                );
+
+                if ( ! empty( $atts['sticky'] ) ) {
+                        $out .= '<div class="nuclen-toc-content">';
+                }
+
+                $out .= $this->view->build_toggle_button( $show, $hidden, $atts, $nav_id );
+                $out .= $this->view->build_nav_markup( $heads, $list, $atts, $nav_id, $toc_title, $hidden );
+
+                if ( ! empty( $atts['sticky'] ) ) {
+                        $out .= '</div>';
+                }
+
+                $out .= '</section>';
+
+                if ( ! wp_script_is( 'nuclen-toc-front', 'enqueued' ) ) {
+                        wp_enqueue_script( 'nuclen-toc-front' );
                 }
 
                 return $out;
         }
-
-       /* ───────────────── shortcode handler ─────────────────────── */
-       public function nuclen_toc_shortcode( array $atts ) : string {
-               global $post;
-               if ( empty( $post ) ) {
-                       return '';
-               }
-
-               $settings = SettingsRepository::get_instance();
-               $atts     = $this->prepare_shortcode_attributes( $atts, $settings );
-
-               $list  = ( strtolower( $atts['list'] ) === 'ol' ) ? 'ol' : 'ul';
-               $heads = Nuclen_TOC_Utils::extract( $post->post_content, $atts['heading_levels'] );
-               if ( ! $heads ) {
-                       return '';
-               }
-
-               $this->enqueue_assets( $atts );
-
-               $toc_title = $this->get_toc_title( $settings );
-               if ( empty( $atts['title'] ) ) {
-                       $atts['title'] = $toc_title;
-               }
-
-               $nav_id = esc_attr( wp_unique_id( 'nuclen-toc-' ) );
-
-               $wrapper = $this->build_wrapper_props( $atts, $settings );
-               $classes = $wrapper['classes'];
-               $sticky  = $wrapper['sticky_attrs'];
-               $show    = $wrapper['show_toggle'];
-               $hidden  = $wrapper['hidden'];
-
-               $out = sprintf(
-                       '<section id="%s-wrapper" class="%s"%s>',
-                       esc_attr( $nav_id ),
-                       esc_attr( implode( ' ', $classes ) ),
-                       $sticky
-               );
-
-               if ( ! empty( $atts['sticky'] ) ) {
-                       $out .= '<div class="nuclen-toc-content">';
-               }
-
-               $out .= $this->build_toggle_button( $show, $hidden, $atts, $nav_id );
-               $out .= $this->build_nav_markup( $heads, $list, $atts, $nav_id, $toc_title, $hidden );
-
-               if ( ! empty( $atts['sticky'] ) ) {
-                       $out .= '</div>';
-               }
-
-               $out .= '</section>';
-
-               if ( ! wp_script_is( 'nuclen-toc-front', 'enqueued' ) ) {
-                       wp_enqueue_script( 'nuclen-toc-front' );
-               }
-
-               return $out;
-       }
-
-       /**
-        * Build the navigation markup containing the heading list.
-        */
-       private function build_nav_markup( array $heads, string $list, array $atts, string $nav_id, string $toc_title, bool $hidden ) : string {
-               $nav  = sprintf(
-                       '<nav id="%s" class="nuclen-toc" aria-label="%s"%s%s>',
-                       esc_attr( $nav_id ),
-                       esc_attr__( $toc_title, 'nuclen-toc-shortcode' ),
-                       $hidden ? ' style="display:none"' : '',
-                       $atts['highlight'] === 'true' ? ' data-highlight="true"' : ''
-               );
-
-               if ( $atts['title'] !== '' ) {
-                       $nav .= '<strong class="toc-title">' . esc_html__( $atts['title'], 'nuclen-toc-shortcode' ) . '</strong>';
-               }
-
-               $nav .= $this->render_headings_list( $heads, $list ) . '</nav>';
-
-               return $nav;
-       }
-
-	/* ───────────────── heading-ID injector ───────────────────── */
-	public function add_heading_ids( string $content ) : string {
-		// Allow developers to bypass if they want to manage IDs themselves.
-		if ( ! apply_filters( 'nuclen_toc_enable_heading_ids', true ) ) {
-			return $content;
-		}
-
-		if ( ! _nc( $content, '<h' ) ) { return $content; }
-
-		foreach ( Nuclen_TOC_Utils::extract( $content, range( 1, 6 ) ) as $h ) {
-			$pat = sprintf(
-				'/(<%1$s\b(?![^>]*\bid=)[^>]*>)(%2$s)(<\/%1$s>)/is',
-				$h['tag'],
-				preg_quote( $h['inner'], '/' )
-			);
-			$rep = sprintf(
-				'<%1$s id="%2$s">%3$s</%1$s>',
-				$h['tag'],
-				esc_attr( $h['id'] ),
-				$h['inner']
-			);
-
-			$content = preg_replace( $pat, $rep, $content, 1 );
-		}
-		return $content;
-	}
-
-	/* ───────────────── assets ─────────────────────────────────── */
-	private function enqueue_assets( array $a ) : void {
-		// Only proceed if we're on a singular post/page where the TOC is being displayed
-		if ( ! is_singular() ) {
-			return;
-		}
-
-		// Register assets if not already registered
-		if ( ! $this->assets_registered ) {
-			$this->register_assets();
-		}
-
-		// Enqueue the CSS
-		wp_enqueue_style( 'nuclen-toc-front' );
-
-		/* JS only when interactive features are on */
-		if ( $a['toggle'] === 'true' || $a['highlight'] === 'true' ) {
-			wp_enqueue_script( 'nuclen-toc-front' );
-		}
-
-		/* runtime CSS tweaks */
-		$off = max( 0, min( 500, (int) $a['offset'] ) );
-		if ( $off !== $this->scroll_offset ) {
-			wp_add_inline_style( 'nuclen-toc-front', ':root{--nuclen-toc-offset:' . $off . 'px}' );
-			$this->scroll_offset = $off;
-		}
-		if ( $a['smooth'] === 'true' ) {
-			wp_add_inline_style( 'nuclen-toc-front', 'html{scroll-behavior:smooth}' );
-		}
-	}
-
-	private function register_assets() : void {
-		if ( $this->assets_registered ) { 
-			return; 
-		}
-		$this->assets_registered = true;
-
-		$css_p = NUCLEN_TOC_DIR . 'assets/css/nuclen-toc-front.css';
-		$js_p  = NUCLEN_TOC_DIR . 'assets/js/nuclen-toc-front.js';
-
-		$css_v = file_exists( $css_p ) ? filemtime( $css_p ) : NUCLEN_ASSET_VERSION;
-		$js_v  = file_exists( $js_p )  ? filemtime( $js_p )  : NUCLEN_ASSET_VERSION;
-
-		// Register the CSS with a high priority to ensure it loads after theme styles
-		wp_register_style(
-			'nuclen-toc-front',
-			NUCLEN_TOC_URL . 'assets/css/nuclen-toc-front.css',
-			[],
-			$css_v
-		);
-
-		// Register the script in the footer
-		wp_register_script(
-			'nuclen-toc-front',
-			NUCLEN_TOC_URL . 'assets/js/nuclen-toc-front.js',
-			[],
-			$js_v,
-			true // Load in footer
-		);
-
-		// Localize the script with translated strings
-		wp_localize_script( 'nuclen-toc-front', 'nuclenTocL10n', [
-			'hide' => __( 'Hide', 'nuclen-toc-shortcode' ),
-			'show' => __( 'Show', 'nuclen-toc-shortcode' ),
-		] );
-	}
 }

--- a/nuclear-engagement/modules/toc/includes/class-nuclen-toc-view.php
+++ b/nuclear-engagement/modules/toc/includes/class-nuclen-toc-view.php
@@ -1,0 +1,145 @@
+<?php
+/**
+ * File: modules/toc/includes/class-nuclen-toc-view.php
+ *
+ * Generates the HTML markup for the front-end TOC.
+ */
+
+if ( ! defined( 'ABSPATH' ) ) { exit; }
+
+use NuclearEngagement\SettingsRepository;
+
+final class Nuclen_TOC_View {
+        private const DEFAULT_STICKY_OFFSET_X = 20;
+        private const DEFAULT_STICKY_OFFSET_Y = 20;
+        private const DEFAULT_STICKY_MAX_WIDTH = 300;
+
+        /** Retrieve the translated TOC title with a fallback. */
+        public function get_toc_title( SettingsRepository $settings ) : string {
+                $title = $settings->get_string( 'toc_title' );
+                if ( empty( $title ) ) {
+                        return esc_html__( 'Table of Contents', 'nuclen-toc-shortcode' );
+                }
+                return esc_html( $title );
+        }
+
+        /**
+         * Build wrapper classes and sticky attributes.
+         *
+         * @return array{classes:array,sticky_attrs:string,show_toggle:bool,hidden:bool}
+         */
+        public function build_wrapper_props( array $atts, SettingsRepository $settings ) : array {
+                $classes = [ 'nuclen-toc-wrapper' ];
+
+                if ( in_array( $atts['theme'], [ 'dark', 'auto' ], true ) ) {
+                        $classes[] = 'nuclen-toc-' . $atts['theme'];
+                }
+
+                $show_toggle = $settings->get_bool( 'toc_show_toggle' );
+                $hidden      = $show_toggle && ! $settings->get_bool( 'toc_show_content' );
+
+                if ( $show_toggle ) {
+                        $classes[] = 'nuclen-toc-has-toggle';
+                        if ( $hidden ) {
+                                $classes[] = 'nuclen-toc-collapsed';
+                        }
+                }
+
+                $sticky_attrs = '';
+                if ( ! empty( $atts['sticky'] ) ) {
+                        $classes[] = 'nuclen-toc-sticky';
+
+                        $sticky_offset_x = $settings->get_int( 'toc_sticky_offset_x', self::DEFAULT_STICKY_OFFSET_X );
+                        $sticky_offset_y = $settings->get_int( 'toc_sticky_offset_y', self::DEFAULT_STICKY_OFFSET_Y );
+                        $sticky_max_width = $settings->get_int( 'toc_sticky_max_width', self::DEFAULT_STICKY_MAX_WIDTH );
+
+                        $sticky_offset_x  = max( 0, min( 1000, $sticky_offset_x ) );
+                        $sticky_offset_y  = max( 0, min( 1000, $sticky_offset_y ) );
+                        $sticky_max_width = min( 1000, max( 100, $sticky_max_width ) );
+
+                        $sticky_attrs = sprintf(
+                                ' data-offset-x="%d" data-offset-y="%d" data-max-width="%d" data-show-content="%s" data-heading-levels="%s"',
+                                $sticky_offset_x,
+                                $sticky_offset_y,
+                                $sticky_max_width,
+                                $settings->get_bool( 'toc_show_content' ) ? 'true' : 'false',
+                                esc_attr( implode( ',', $atts['heading_levels'] ) )
+                        );
+                }
+
+                if ( $atts['highlight'] === 'true' ) {
+                        $classes[] = 'nuclen-has-highlight';
+                }
+
+                $z_index = $settings->get_int( 'toc_z_index', 100 );
+                $z_index = max( 1, min( 9999, $z_index ) );
+                ( $z_index );
+
+                return [
+                        'classes'      => $classes,
+                        'sticky_attrs' => $sticky_attrs,
+                        'show_toggle'  => $show_toggle,
+                        'hidden'       => $hidden,
+                ];
+        }
+
+        /** Build the toggle button HTML if toggling is enabled. */
+        public function build_toggle_button( bool $show, bool $hidden, array $atts, string $nav_id ) : string {
+                if ( ! $show ) {
+                        return '';
+                }
+                $toggle_text = $hidden ? $atts['show_text'] : $atts['hide_text'];
+                return sprintf(
+                        '<button type="button" class="nuclen-toc-toggle" aria-expanded="%s" aria-controls="%s">%s</button>',
+                        $hidden ? 'false' : 'true',
+                        esc_attr( $nav_id ),
+                        esc_html( $toggle_text )
+                );
+        }
+
+        /** Render the nested heading list. */
+        public function render_headings_list( array $heads, string $list ) : string {
+                $out   = '';
+                $stack = [];
+                foreach ( $heads as $h ) {
+                        $l = $h['level'];
+                        while ( $stack && end( $stack ) > $l ) {
+                                $out .= '</li></' . $list . '>';
+                                array_pop( $stack );
+                        }
+                        if ( ! $stack || end( $stack ) < $l ) {
+                                $out .= '<' . $list . '>';
+                                $stack[] = $l;
+                        } else {
+                                $out .= '</li>';
+                        }
+                        $out .= '<li><a href="#' . esc_attr( $h['id'] ) . '">' . esc_html( $h['text'] ) . '</a>';
+                }
+                while ( $stack ) {
+                        $out .= '</li></' . $list . '>';
+                        array_pop( $stack );
+                }
+                return $out;
+        }
+
+        /**
+         * Build the navigation markup containing the heading list.
+         */
+        public function build_nav_markup( array $heads, string $list, array $atts, string $nav_id, string $toc_title, bool $hidden ) : string {
+                $nav  = sprintf(
+                        '<nav id="%s" class="nuclen-toc" aria-label="%s"%s%s>',
+                        esc_attr( $nav_id ),
+                        esc_attr__( $toc_title, 'nuclen-toc-shortcode' ),
+                        $hidden ? ' style="display:none"' : '',
+                        $atts['highlight'] === 'true' ? ' data-highlight="true"' : ''
+                );
+
+                if ( $atts['title'] !== '' ) {
+                        $nav .= '<strong class="toc-title">' . esc_html__( $atts['title'], 'nuclen-toc-shortcode' ) . '</strong>';
+                }
+
+                $nav .= $this->render_headings_list( $heads, $list ) . '</nav>';
+
+                return $nav;
+        }
+}

--- a/nuclear-engagement/modules/toc/loader.php
+++ b/nuclear-engagement/modules/toc/loader.php
@@ -18,6 +18,9 @@ define( 'NUCLEN_TOC_URL',       plugin_dir_url( __FILE__ ) );
 /* ------------------------------------------------------------------ */
 require_once NUCLEN_TOC_DIR . 'includes/polyfills.php';
 require_once NUCLEN_TOC_DIR . 'includes/class-nuclen-toc-utils.php';
+require_once NUCLEN_TOC_DIR . 'includes/class-nuclen-toc-assets.php';
+require_once NUCLEN_TOC_DIR . 'includes/class-nuclen-toc-view.php';
+require_once NUCLEN_TOC_DIR . 'includes/class-nuclen-toc-headings.php';
 require_once NUCLEN_TOC_DIR . 'includes/class-nuclen-toc-render.php';
 require_once NUCLEN_TOC_DIR . 'includes/class-nuclen-toc-admin.php';
 
@@ -25,8 +28,9 @@ require_once NUCLEN_TOC_DIR . 'includes/class-nuclen-toc-admin.php';
 /*  Spin-up                                                            */
 /* ------------------------------------------------------------------ */
 add_action( 'plugins_loaded', static function () {
-	new Nuclen_TOC_Render();   // public hooks (shortcode, filters, assets)
-	if ( is_admin() ) {
-		new Nuclen_TOC_Admin();    // settings page
-	}
+        new Nuclen_TOC_Headings();  // filter for heading IDs
+        new Nuclen_TOC_Render();    // shortcode handler
+        if ( is_admin() ) {
+                new Nuclen_TOC_Admin();    // settings page
+        }
 } );


### PR DESCRIPTION
## Summary
- split giant `Nuclen_TOC_Render` file into focused classes
- handle asset loading in new `Nuclen_TOC_Assets`
- move heading ID injection to `Nuclen_TOC_Headings`
- add `Nuclen_TOC_View` for markup generation
- update loader to initialize the new classes
- document decomposition in ARCHITECTURE

## Testing
- `composer lint` *(fails: command not found)*
- `composer test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684bf8d895488327bd001094e51dcca4