### PR TITLE
Continue refactor: extract typed settings access

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -46,3 +46,11 @@ responsibilities narrow and makes future maintenance easier.
 - The autoloader maps `NuclearEngagement\SettingsCache`.
 
 This keeps `SettingsRepository` under the 300 LOC limit and reduces its method count for easier maintenance.
+
+## Typed Accessors Extraction
+
+`SettingsRepository` still contained numerous typed getter and setter helpers
+that inflated its line count. These wrappers (`get_string()`, `set_bool()`, etc.)
+now live in a lightweight `SettingsAccessTrait`. The repository simply uses the
+trait, keeping the core persistence logic below 300 lines while preserving the
+public API.

--- a/nuclear-engagement/includes/SettingsAccessTrait.php
+++ b/nuclear-engagement/includes/SettingsAccessTrait.php
@@ -1,0 +1,84 @@
+<?php
+/**
+ * File: includes/SettingsAccessTrait.php
+ *
+ * Provides typed getter and setter helpers for SettingsRepository.
+ *
+ * @package NuclearEngagement
+ */
+
+namespace NuclearEngagement;
+
+if (!defined('ABSPATH')) {
+    exit;
+}
+
+trait SettingsAccessTrait {
+    /**
+     * Get a string setting.
+     */
+    public function get_string(string $key, string $default = ''): string {
+        $value = $this->get($key, $default);
+        return is_string($value) ? $value : (string) $value;
+    }
+
+    /**
+     * Get an integer setting.
+     */
+    public function get_int(string $key, int $default = 0): int {
+        $value = $this->get($key, $default);
+        return is_numeric($value) ? (int) $value : $default;
+    }
+
+    /**
+     * Get a boolean setting.
+     */
+    public function get_bool(string $key, bool $default = false): bool {
+        return (bool) $this->get($key, $default);
+    }
+
+    /**
+     * Get an array setting.
+     */
+    public function get_array(string $key, array $default = []): array {
+        $value = $this->get($key, $default);
+        return is_array($value) ? $value : $default;
+    }
+
+    /**
+     * Set a setting value to be saved later.
+     */
+    public function set(string $key, $value): self {
+        $this->pending[$key] = $value;
+        return $this;
+    }
+
+    /**
+     * Set a string setting.
+     */
+    public function set_string(string $key, string $value): self {
+        return $this->set($key, sanitize_text_field($value));
+    }
+
+    /**
+     * Set an integer setting.
+     */
+    public function set_int(string $key, int $value): self {
+        return $this->set($key, (int) $value);
+    }
+
+    /**
+     * Set a boolean setting.
+     */
+    public function set_bool(string $key, bool $value): self {
+        return $this->set($key, (bool) $value);
+    }
+
+    /**
+     * Set an array setting.
+     */
+    public function set_array(string $key, array $value): self {
+        return $this->set($key, SettingsSanitizer::sanitize_setting($key, $value));
+    }
+}
+

--- a/nuclear-engagement/includes/SettingsRepository.php
+++ b/nuclear-engagement/includes/SettingsRepository.php
@@ -121,76 +121,7 @@ final class SettingsRepository
         return $value;
     }
 
-    /**
-     * Get a string setting.
-     */
-    public function get_string(string $key, string $default = ''): string {
-        $value = $this->get($key, $default);
-        return is_string($value) ? $value : (string) $value;
-    }
-
-    /**
-     * Get an integer setting.
-     */
-    public function get_int(string $key, int $default = 0): int {
-        $value = $this->get($key, $default);
-        return is_numeric($value) ? (int) $value : $default;
-    }
-
-    /**
-     * Get a boolean setting.
-     */
-    public function get_bool(string $key, bool $default = false): bool {
-        return (bool) $this->get($key, $default);
-    }
-
-    /**
-     * Get an array setting.
-     */
-    public function get_array(string $key, array $default = []): array {
-        $value = $this->get($key, $default);
-        return is_array($value) ? $value : $default;
-    }
-
-    /* ===================================================================
-     * SETTERS
-     * =================================================================== */
-
-    /**
-     * Set a setting value to be saved later.
-     */
-    public function set(string $key, $value): self {
-        $this->pending[$key] = $value;
-        return $this;
-    }
-
-    /**
-     * Set a string setting.
-     */
-    public function set_string(string $key, string $value): self {
-        return $this->set($key, sanitize_text_field($value));
-    }
-
-    /**
-     * Set an integer setting.
-     */
-    public function set_int(string $key, int $value): self {
-        return $this->set($key, (int) $value);
-    }
-
-    /**
-     * Set a boolean setting.
-     */
-    public function set_bool(string $key, bool $value): self {
-        return $this->set($key, (bool) $value);
-    }
-
-    /**
-     * Set an array setting.
-     */
-    public function set_array(string $key, array $value): self {
-        return $this->set($key, SettingsSanitizer::sanitize_setting($key, $value));
-    }
+    use SettingsAccessTrait;
 
 
     /* ===================================================================

--- a/nuclear-engagement/includes/autoload.php
+++ b/nuclear-engagement/includes/autoload.php
@@ -23,6 +23,7 @@ spl_autoload_register(function ($class) {
             'NuclearEngagement\\SettingsRepository' => '/includes/SettingsRepository.php',
             'NuclearEngagement\\SettingsSanitizer' => '/includes/SettingsSanitizer.php',
             'NuclearEngagement\\SettingsCache' => '/includes/SettingsCache.php',
+            'NuclearEngagement\\SettingsAccessTrait' => '/includes/SettingsAccessTrait.php',
             'NuclearEngagement\\Container' => '/includes/Container.php',
             'NuclearEngagement\\Defaults' => '/includes/Defaults.php',
             'NuclearEngagement\\OptinData' => '/includes/OptinData.php',


### PR DESCRIPTION
## Summary
- extract typed getters and setters into `SettingsAccessTrait`
- wire autoloader for new trait
- update architecture notes

## Testing
- `composer lint` *(fails: command not found)*
- `composer test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684bfddb3d9c8327bfcdd2c32f74c06c