### PR TITLE
Continue app refactoring

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -54,3 +54,12 @@ that inflated its line count. These wrappers (`get_string()`, `set_bool()`, etc.
 now live in a lightweight `SettingsAccessTrait`. The repository simply uses the
 trait, keeping the core persistence logic below 300 lines while preserving the
 public API.
+
+## Shortcode Handler Classes
+
+The front-end `ShortcodesTrait` still mixed shortcode rendering logic with
+settings retrieval. To keep responsibilities narrow, this logic now resides in
+two dedicated classes: `QuizShortcode` and `SummaryShortcode`. Each class
+registers its shortcode and builds output using the corresponding view class.
+`ShortcodesTrait` merely instantiates these handlers and delegates calls.
+The autoloader maps the new classes under the `Front` namespace.

--- a/nuclear-engagement/front/QuizShortcode.php
+++ b/nuclear-engagement/front/QuizShortcode.php
@@ -1,0 +1,63 @@
+<?php
+namespace NuclearEngagement\Front;
+
+use NuclearEngagement\SettingsRepository;
+
+if (!defined('ABSPATH')) {
+    exit;
+}
+
+class QuizShortcode {
+    private SettingsRepository $settings;
+    private QuizView $view;
+
+    public function __construct(SettingsRepository $settings) {
+        $this->settings = $settings;
+        $this->view = new QuizView();
+    }
+
+    public function register(): void {
+        add_shortcode('nuclear_engagement_quiz', [$this, 'render']);
+    }
+
+    public function render(): string {
+        $quiz_data = $this->getQuizData();
+        if (!$this->isValidQuizData($quiz_data)) {
+            return '';
+        }
+
+        $settings = $this->getQuizSettings();
+        $html  = $this->view->container($settings);
+        $html .= $this->view->attribution($settings['show_attribution']);
+        return $html;
+    }
+
+    private function getQuizData() {
+        $post_id = get_the_ID();
+        $quiz_meta = get_post_meta($post_id, 'nuclen-quiz-data', true);
+        return maybe_unserialize($quiz_meta);
+    }
+
+    private function isValidQuizData($quiz_data): bool {
+        if (!is_array($quiz_data) || empty($quiz_data['questions'])) {
+            return false;
+        }
+
+        $valid_questions = array_filter(
+            $quiz_data['questions'],
+            static function ($q) {
+                return isset($q['question']) && trim($q['question']) !== '';
+            }
+        );
+
+        return !empty($valid_questions);
+    }
+
+    private function getQuizSettings(): array {
+        return [
+            'quiz_title'       => $this->settings->get_string('quiz_title', __('Test your knowledge', 'nuclear-engagement')),
+            'html_before'      => $this->settings->get_string('custom_quiz_html_before', ''),
+            'show_attribution' => $this->settings->get_bool('show_attribution', false),
+        ];
+    }
+}

--- a/nuclear-engagement/front/SummaryShortcode.php
+++ b/nuclear-engagement/front/SummaryShortcode.php
@@ -1,0 +1,50 @@
+<?php
+namespace NuclearEngagement\Front;
+
+use NuclearEngagement\SettingsRepository;
+
+if (!defined('ABSPATH')) {
+    exit;
+}
+
+class SummaryShortcode {
+    private SettingsRepository $settings;
+    private SummaryView $view;
+
+    public function __construct(SettingsRepository $settings) {
+        $this->settings = $settings;
+        $this->view = new SummaryView();
+    }
+
+    public function register(): void {
+        add_shortcode('nuclear_engagement_summary', [$this, 'render']);
+    }
+
+    public function render(): string {
+        $summary_data = $this->getSummaryData();
+        if (!$this->isValidSummaryData($summary_data)) {
+            return '';
+        }
+
+        $settings = $this->getSummarySettings();
+        $html  = $this->view->container($summary_data, $settings);
+        $html .= $this->view->attribution($settings['show_attribution']);
+        return $html;
+    }
+
+    private function getSummaryData() {
+        $post_id = get_the_ID();
+        return get_post_meta($post_id, 'nuclen-summary-data', true);
+    }
+
+    private function isValidSummaryData($summary_data): bool {
+        return !empty($summary_data) && !empty(trim($summary_data['summary'] ?? ''));
+    }
+
+    private function getSummarySettings(): array {
+        return [
+            'summary_title'    => $this->settings->get_string('summary_title', __('Key Facts', 'nuclear-engagement')),
+            'show_attribution' => $this->settings->get_bool('show_attribution', false),
+        ];
+    }
+}

--- a/nuclear-engagement/front/traits/ShortcodesTrait.php
+++ b/nuclear-engagement/front/traits/ShortcodesTrait.php
@@ -4,235 +4,92 @@
  *
  * Trait: ShortcodesTrait
  *
- * Quiz / summary shortcodes and auto-insertion helpers.
+ * Delegates quiz and summary shortcode handling to dedicated classes
+ * and provides auto-insertion helpers.
  *
  * @package NuclearEngagement\Front
  */
 
 namespace NuclearEngagement\Front;
 
-use NuclearEngagement\SettingsRepository;
-use NuclearEngagement\Front\QuizView;
-use NuclearEngagement\Front\SummaryView;
+use NuclearEngagement\Front\QuizShortcode;
+use NuclearEngagement\Front\SummaryShortcode;
 
 if (!defined('ABSPATH')) {
     exit;
 }
 
 trait ShortcodesTrait {
-        private ?QuizView $quiz_view = null;
-        private ?SummaryView $summary_view = null;
+    private ?QuizShortcode $quiz_shortcode = null;
+    private ?SummaryShortcode $summary_shortcode = null;
 
-        private function get_quiz_view(): QuizView {
-                if ($this->quiz_view === null) {
-                        $this->quiz_view = new QuizView();
-                }
-                return $this->quiz_view;
+    private function get_quiz_shortcode(): QuizShortcode {
+        if ($this->quiz_shortcode === null) {
+            $this->quiz_shortcode = new QuizShortcode($this->nuclen_get_settings_repository());
+        }
+        return $this->quiz_shortcode;
+    }
+
+    private function get_summary_shortcode(): SummaryShortcode {
+        if ($this->summary_shortcode === null) {
+            $this->summary_shortcode = new SummaryShortcode($this->nuclen_get_settings_repository());
+        }
+        return $this->summary_shortcode;
+    }
+
+    /* ---------- Auto-insert into content ---------- */
+    public function nuclen_auto_insert_shortcodes($content) {
+        $settings_repo   = $this->nuclen_get_settings_repository();
+        $summary_position = $settings_repo->get('display_summary', 'none');
+        $quiz_position    = $settings_repo->get('display_quiz', 'none');
+        $toc_position     = $settings_repo->get('display_toc', 'manual');
+
+        $elements = [
+            'summary' => [
+                'position' => $summary_position,
+                'shortcode' => '[nuclear_engagement_summary]',
+            ],
+            'quiz' => [
+                'position' => $quiz_position,
+                'shortcode' => '[nuclear_engagement_quiz]',
+            ],
+            'toc' => [
+                'position' => $toc_position,
+                'shortcode' => '[nuclear_engagement_toc]',
+            ],
+        ];
+
+        $before_content = '';
+        if ($elements['summary']['position'] === 'before') {
+            $before_content .= do_shortcode($elements['summary']['shortcode']);
+        }
+        if ($elements['toc']['position'] === 'before') {
+            $before_content .= do_shortcode($elements['toc']['shortcode']);
+        }
+        if ($elements['quiz']['position'] === 'before') {
+            $before_content .= do_shortcode($elements['quiz']['shortcode']);
         }
 
-        private function get_summary_view(): SummaryView {
-                if ($this->summary_view === null) {
-                        $this->summary_view = new SummaryView();
-                }
-                return $this->summary_view;
+        $after_content = '';
+        if ($elements['summary']['position'] === 'after') {
+            $after_content .= do_shortcode($elements['summary']['shortcode']);
+        }
+        if ($elements['toc']['position'] === 'after') {
+            $after_content .= do_shortcode($elements['toc']['shortcode']);
+        }
+        if ($elements['quiz']['position'] === 'after') {
+            $after_content .= do_shortcode($elements['quiz']['shortcode']);
         }
 
-	/* ---------- Auto-insert into content ---------- */
-	public function nuclen_auto_insert_shortcodes( $content ) {
-		$settings_repo = $this->nuclen_get_settings_repository();
-		$summary_position = $settings_repo->get( 'display_summary', 'none' );
-		$quiz_position    = $settings_repo->get( 'display_quiz', 'none' );
-		$toc_position     = $settings_repo->get( 'display_toc', 'manual' );
+        return $before_content . $content . $after_content;
+    }
 
-		// Collect all elements with their positions
-		$elements = [
-			'summary' => [
-				'position' => $summary_position,
-				'shortcode' => '[nuclear_engagement_summary]',
-			],
-			'quiz' => [
-				'position' => $quiz_position,
-				'shortcode' => '[nuclear_engagement_quiz]',
-			],
-			'toc' => [
-				'position' => $toc_position,
-				'shortcode' => '[nuclear_engagement_toc]',
-			],
-		];
+    /* ---------- Shortcode registrations ---------- */
+    public function nuclen_register_quiz_shortcode() {
+        $this->get_quiz_shortcode()->register();
+    }
 
-		// Process elements that should appear before content
-		$before_content = '';
-		
-		// First add summary if set to before
-		if ( $elements['summary']['position'] === 'before' ) {
-			$before_content .= do_shortcode( $elements['summary']['shortcode'] );
-		}
-		
-		// Then add TOC if set to before (right after summary)
-		if ( $elements['toc']['position'] === 'before' ) {
-			$before_content .= do_shortcode( $elements['toc']['shortcode'] );
-		}
-		
-		// Then add quiz if set to before (after summary and TOC)
-		if ( $elements['quiz']['position'] === 'before' ) {
-			$before_content .= do_shortcode( $elements['quiz']['shortcode'] );
-		}
-
-		// Process elements that should appear after content
-		$after_content = '';
-		
-		// First add summary if set to after
-		if ( $elements['summary']['position'] === 'after' ) {
-			$after_content .= do_shortcode( $elements['summary']['shortcode'] );
-		}
-		
-		// Then add TOC if set to after (right after summary)
-		if ( $elements['toc']['position'] === 'after' ) {
-			$after_content .= do_shortcode( $elements['toc']['shortcode'] );
-		}
-		
-		// Then add quiz if set to after (after summary and TOC)
-		if ( $elements['quiz']['position'] === 'after' ) {
-			$after_content .= do_shortcode( $elements['quiz']['shortcode'] );
-		}
-
-		return $before_content . $content . $after_content;
-	}
-
-	/* ---------- Shortcode registrations ---------- */
-	public function nuclen_register_quiz_shortcode() {
-		add_shortcode( 'nuclear_engagement_quiz', array( $this, 'nuclen_render_quiz_shortcode' ) );
-	}
-
-	public function nuclen_register_summary_shortcode() {
-		add_shortcode( 'nuclear_engagement_summary', array( $this, 'nuclen_render_summary_shortcode' ) );
-	}
-
-	/* ---------- Quiz shortcode methods ---------- */
-	
-	/**
-	 * Main quiz shortcode handler
-	 *
-	 * @return string
-	 */
-        public function nuclen_render_quiz_shortcode() {
-                $quiz_data = $this->getQuizData();
-
-                if (!$this->isValidQuizData($quiz_data)) {
-                        return '';
-                }
-
-                $settings = $this->getQuizSettings();
-
-                $view = $this->get_quiz_view();
-                $html  = $view->container($settings);
-                $html .= $view->attribution($settings['show_attribution']);
-
-                return $html;
-        }
-
-	/**
-	 * Get quiz data for current post
-	 *
-	 * @return array|null
-	 */
-	private function getQuizData() {
-		$post_id = get_the_ID();
-		$quiz_meta = get_post_meta($post_id, 'nuclen-quiz-data', true);
-		return maybe_unserialize($quiz_meta);
-	}
-
-	/**
-	 * Validate quiz data
-	 *
-	 * @param mixed $quiz_data
-	 * @return bool
-	 */
-	private function isValidQuizData($quiz_data) {
-		if (!is_array($quiz_data) || empty($quiz_data['questions'])) {
-			return false;
-		}
-
-		$valid_questions = array_filter(
-			$quiz_data['questions'],
-			static function ($q) {
-				return isset($q['question']) && trim($q['question']) !== '';
-			}
-		);
-
-		return !empty($valid_questions);
-	}
-
-	/**
-	 * Get quiz settings from repository
-	 *
-	 * @return array
-	 */
-	private function getQuizSettings() {
-		$settings = SettingsRepository::get_instance();
-		
-		return [
-			'quiz_title' => $settings->get_string('quiz_title', __('Test your knowledge', 'nuclear-engagement')),
-			'html_before' => $settings->get_string('custom_quiz_html_before', ''),
-			'show_attribution' => $settings->get_bool('show_attribution', false),
-		];
-	}
-
-
-	/* ---------- Summary shortcode methods ---------- */
-	
-	/**
-	 * Main summary shortcode handler
-	 *
-	 * @return string
-	 */
-	public function nuclen_render_summary_shortcode() {
-		$summary_data = $this->getSummaryData();
-		
-		if (!$this->isValidSummaryData($summary_data)) {
-			return '';
-		}
-
-		$settings = $this->getSummarySettings();
-		
-                $view = $this->get_summary_view();
-                $html = $view->container($summary_data, $settings);
-                $html .= $view->attribution($settings['show_attribution']);
-		
-		return $html;
-	}
-
-	/**
-	 * Get summary data for current post
-	 *
-	 * @return array|null
-	 */
-	private function getSummaryData() {
-		$post_id = get_the_ID();
-		return get_post_meta($post_id, 'nuclen-summary-data', true);
-	}
-
-	/**
-	 * Validate summary data
-	 *
-	 * @param mixed $summary_data
-	 * @return bool
-	 */
-	private function isValidSummaryData($summary_data) {
-		return !empty($summary_data) && !empty(trim($summary_data['summary'] ?? ''));
-	}
-
-	/**
-	 * Get summary settings from repository
-	 *
-	 * @return array
-	 */
-	private function getSummarySettings() {
-		$settings = SettingsRepository::get_instance();
-		
-		return [
-			'summary_title' => $settings->get_string('summary_title', __('Key Facts', 'nuclear-engagement')),
-			'show_attribution' => $settings->get_bool('show_attribution', false),
-		];
-	}
+    public function nuclen_register_summary_shortcode() {
+        $this->get_summary_shortcode()->register();
+    }
 }

--- a/nuclear-engagement/includes/autoload.php
+++ b/nuclear-engagement/includes/autoload.php
@@ -42,6 +42,8 @@ spl_autoload_register(function ($class) {
             'NuclearEngagement\\Admin\\Controller\\Ajax\\BaseController' => '/admin/Controller/Ajax/BaseController.php',
 
             'NuclearEngagement\\Front\\FrontClass' => '/front/FrontClass.php',
+            'NuclearEngagement\\Front\\QuizShortcode' => '/front/QuizShortcode.php',
+            'NuclearEngagement\\Front\\SummaryShortcode' => '/front/SummaryShortcode.php',
             'NuclearEngagement\\Front\\Controller\\Rest\\ContentController' => '/front/Controller/Rest/ContentController.php',
 
             'NuclearEngagement\\Services\\GenerationService' => '/includes/Services/GenerationService.php',


### PR DESCRIPTION
## Summary
- move quiz and summary shortcodes into their own classes
- simplify `ShortcodesTrait` to delegate to the new handlers
- wire new classes into the autoloader
- document shortcode handler refactor in ARCHITECTURE.md

## Testing
- `composer lint` *(fails: command not found)*
- `composer test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684bffefb1b8832797f51daaa3a08d01