### PR TITLE
Continue app refactoring

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -72,3 +72,11 @@ registered all services and controllers. This pushed the class over the
 `ContainerRegistrar` class with a static `register()` method. `Plugin`
 instantiates the container and delegates the registration work to this new
 class, keeping the main class focused on coordinating hooks.
+
+## Pending Changes Trait
+
+The repository still contained several utility methods for managing pending
+settings updates. To simplify the core class and keep the method count below
+15, these helpers now live in a small `PendingSettingsTrait`.
+`SettingsRepository` uses the trait to expose the same public API while keeping
+its own implementation lean. The autoloader maps the new trait.

--- a/nuclear-engagement/includes/PendingSettingsTrait.php
+++ b/nuclear-engagement/includes/PendingSettingsTrait.php
@@ -1,0 +1,50 @@
+<?php
+/**
+ * File: includes/PendingSettingsTrait.php
+ *
+ * Provides helpers for managing pending settings changes.
+ *
+ * @package NuclearEngagement
+ */
+
+namespace NuclearEngagement;
+
+if ( ! defined( 'ABSPATH' ) ) {
+    exit;
+}
+
+trait PendingSettingsTrait {
+    /**
+     * Remove a setting.
+     */
+    public function remove( string $key ): self {
+        if ( isset( $this->pending[ $key ] ) ) {
+            unset( $this->pending[ $key ] );
+        }
+        // Set to null to indicate removal
+        $this->pending[ $key ] = null;
+        return $this;
+    }
+
+    /**
+     * Check if there are pending changes.
+     */
+    public function has_pending(): bool {
+        return ! empty( $this->pending );
+    }
+
+    /**
+     * Get all pending changes.
+     */
+    public function get_pending(): array {
+        return $this->pending;
+    }
+
+    /**
+     * Clear pending changes without saving.
+     */
+    public function clear_pending(): self {
+        $this->pending = [];
+        return $this;
+    }
+}

--- a/nuclear-engagement/includes/SettingsRepository.php
+++ b/nuclear-engagement/includes/SettingsRepository.php
@@ -122,6 +122,7 @@ final class SettingsRepository
     }
 
     use SettingsAccessTrait;
+    use PendingSettingsTrait;
 
 
     /* ===================================================================
@@ -207,40 +208,6 @@ final class SettingsRepository
         return array_key_exists($key, $all);
     }
 
-    /**
-     * Remove a setting.
-     */
-    public function remove(string $key): self {
-        if (isset($this->pending[$key])) {
-            unset($this->pending[$key]);
-        }
-        
-        // Set to null to indicate removal
-        $this->pending[$key] = null;
-        return $this;
-    }
-
-    /**
-     * Check if there are pending changes.
-     */
-    public function has_pending(): bool {
-        return !empty($this->pending);
-    }
-
-    /**
-     * Get all pending changes.
-     */
-    public function get_pending(): array {
-        return $this->pending;
-    }
-
-    /**
-     * Clear pending changes without saving.
-     */
-    public function clear_pending(): self {
-        $this->pending = [];
-        return $this;
-    }
 
     /**
      * Determine if settings should be autoloaded.

--- a/nuclear-engagement/includes/autoload.php
+++ b/nuclear-engagement/includes/autoload.php
@@ -24,6 +24,7 @@ spl_autoload_register(function ($class) {
             'NuclearEngagement\\SettingsSanitizer' => '/includes/SettingsSanitizer.php',
             'NuclearEngagement\\SettingsCache' => '/includes/SettingsCache.php',
             'NuclearEngagement\\SettingsAccessTrait' => '/includes/SettingsAccessTrait.php',
+            'NuclearEngagement\PendingSettingsTrait' => '/includes/PendingSettingsTrait.php',
             'NuclearEngagement\\Container' => '/includes/Container.php',
             'NuclearEngagement\\ContainerRegistrar' => '/includes/ContainerRegistrar.php',
             'NuclearEngagement\\Defaults' => '/includes/Defaults.php',


### PR DESCRIPTION
## Summary
- extract pending settings methods to `PendingSettingsTrait`
- load new trait through autoloader
- update `SettingsRepository` to use the trait
- document trait extraction in `ARCHITECTURE.md`

## Testing
- `composer lint` *(fails: composer not found)*
- `composer test` *(fails: composer not found)*

------
https://chatgpt.com/codex/tasks/task_e_684c02f6211c8327bf29d45535577977