### PR TITLE
Refactor opt‑in export handling

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -80,3 +80,19 @@ settings updates. To simplify the core class and keep the method count below
 15, these helpers now live in a small `PendingSettingsTrait`.
 `SettingsRepository` uses the trait to expose the same public API while keeping
 its own implementation lean. The autoloader maps the new trait.
+
+## Opt-in Export Controller
+
+`OptinData` previously registered its CSV export hooks directly and `Plugin`
+included a proxy method to trigger the export. This duplicated logic and caused
+side effects when the class file loaded. The export hooks now point to a new
+`OptinExportController` class that simply delegates to `OptinData::handle_export()`.
+
+`ContainerRegistrar` registers the controller so `Plugin` can obtain it and
+attach its `handle()` method to both `admin_post_nuclen_export_optin` and
+`wp_ajax_nuclen_export_optin`. The automatic invocation of `OptinData::init()`
+at the end of the file was removed, and hook registration occurs explicitly in
+`Plugin::nuclen_load_dependencies()`.
+
+This keeps responsibilities clear and avoids unintended behavior when files are
+loaded.

--- a/nuclear-engagement/admin/Controller/OptinExportController.php
+++ b/nuclear-engagement/admin/Controller/OptinExportController.php
@@ -1,0 +1,28 @@
+<?php
+/**
+ * File: admin/Controller/OptinExportController.php
+ *
+ * Handles opt-in CSV export requests.
+ *
+ * @package NuclearEngagement\Admin\Controller
+ */
+
+namespace NuclearEngagement\Admin\Controller;
+
+use NuclearEngagement\OptinData;
+
+if ( ! defined( 'ABSPATH' ) ) {
+    exit;
+}
+
+/**
+ * Controller to stream the opt-in CSV file.
+ */
+class OptinExportController {
+    /**
+     * Execute export.
+     */
+    public function handle(): void {
+        OptinData::handle_export();
+    }
+}

--- a/nuclear-engagement/includes/ContainerRegistrar.php
+++ b/nuclear-engagement/includes/ContainerRegistrar.php
@@ -9,6 +9,7 @@ namespace NuclearEngagement;
 
 use NuclearEngagement\Services\{GenerationService, RemoteApiService, ContentStorageService, PointerService, PostsQueryService, AutoGenerationService};
 use NuclearEngagement\Admin\Controller\Ajax\{GenerateController, UpdatesController, PointerController, PostsCountController};
+use NuclearEngagement\Admin\Controller\OptinExportController;
 use NuclearEngagement\Front\Controller\Rest\ContentController;
 
 if ( ! defined( 'ABSPATH' ) ) {
@@ -42,5 +43,6 @@ final class ContainerRegistrar {
         $container->register( 'pointer_controller', static fn( $c ) => new PointerController( $c->get( 'pointer_service' ) ) );
         $container->register( 'posts_count_controller', static fn( $c ) => new PostsCountController( $c->get( 'posts_query_service' ) ) );
         $container->register( 'content_controller', static fn( $c ) => new ContentController( $c->get( 'content_storage' ) ) );
+        $container->register( 'optin_export_controller', static fn() => new OptinExportController() );
     }
 }

--- a/nuclear-engagement/includes/OptinData.php
+++ b/nuclear-engagement/includes/OptinData.php
@@ -30,9 +30,7 @@ class OptinData {
 		add_action( 'wp_ajax_nuclen_save_optin',          [ self::class, 'handle_ajax' ] );
 		add_action( 'wp_ajax_nopriv_nuclen_save_optin',   [ self::class, 'handle_ajax' ] );
 
-		/* Stream CSV – both admin-post & admin-ajax paths */
-		add_action( 'admin_post_nuclen_export_optin',     [ self::class, 'handle_export' ] );
-		add_action( 'wp_ajax_nuclen_export_optin',        [ self::class, 'handle_export' ] );
+                // CSV export handled via OptinExportController
 	}
 
 	/* ---------------------------------------------------------------------
@@ -183,5 +181,3 @@ return (bool) $ok;
 	}
 }
 
-/* Kick-off */
-OptinData::init();

--- a/nuclear-engagement/includes/Plugin.php
+++ b/nuclear-engagement/includes/Plugin.php
@@ -121,16 +121,10 @@ class Plugin {
 		remove_action('wp_ajax_nuclen_dismiss_pointer', [$onboarding, 'nuclen_ajax_dismiss_pointer']);
 		$this->loader->nuclen_add_action('wp_ajax_nuclen_dismiss_pointer', $pointerController, 'dismiss');
 
-		/* Opt-in CSV export (proxy ensures class is loaded) */
-		$this->loader->nuclen_add_action( 'admin_post_nuclen_export_optin', $this, 'nuclen_export_optin_proxy' );
-		$this->loader->nuclen_add_action( 'wp_ajax_nuclen_export_optin',    $this, 'nuclen_export_optin_proxy' );
-	}
-
-	/**
-	 * Proxy: make sure OptinData is available, then stream CSV (exits).
-	 */
-        public function nuclen_export_optin_proxy(): void {
-                OptinData::handle_export();
+                /* Opt-in CSV export */
+                $optinExportController = $this->container->get('optin_export_controller');
+                $this->loader->nuclen_add_action( 'admin_post_nuclen_export_optin', $optinExportController, 'handle' );
+                $this->loader->nuclen_add_action( 'wp_ajax_nuclen_export_optin',    $optinExportController, 'handle' );
         }
 
 	/* ─────────────────────────────────────────────

--- a/nuclear-engagement/includes/autoload.php
+++ b/nuclear-engagement/includes/autoload.php
@@ -36,6 +36,7 @@ spl_autoload_register(function ($class) {
             'NuclearEngagement\\Admin\\Onboarding' => '/admin/Onboarding.php',
             'NuclearEngagement\\Admin\\Settings' => '/admin/Settings.php',
             'NuclearEngagement\\Admin\\Setup' => '/admin/Setup.php',
+            'NuclearEngagement\\Admin\\Controller\\OptinExportController' => '/admin/Controller/OptinExportController.php',
 
             'NuclearEngagement\\Admin\\Controller\\Ajax\\GenerateController' => '/admin/Controller/Ajax/GenerateController.php',
             'NuclearEngagement\\Admin\\Controller\\Ajax\\UpdatesController' => '/admin/Controller/Ajax/UpdatesController.php',


### PR DESCRIPTION
## Summary
- create `OptinExportController` and register it in the container
- remove automatic hook registration from `OptinData`
- wire export actions to the controller in `Plugin`
- update autoloader map
- document export controller extraction in architecture notes

## Testing
- `composer lint` *(fails: command not found)*
- `composer test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684c043ca1448327b108ae5b3a999ad7