### PR TITLE
Continue refactoring per docs

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -145,3 +145,12 @@ These routines now reside in a dedicated `PostsQueryService` used by
 
 This keeps query logic contained while leaving `Utils` focused on rendering tasks.
 
+## jQuery Removal from Onboarding
+
+The original onboarding pointer script relied on jQuery and the `wp-pointer` plugin.
+To meet the "no jQuery" guideline, the logic now uses vanilla TypeScript.
+`onboarding-pointers.js` manually positions `.wp-pointer` elements and sends
+dismissal requests via `fetch`. The PHP loader no longer enqueues the
+`wp-pointer` script or lists jQuery as a dependency—only the style sheet
+remains. This reduces dependencies and keeps the admin bundle lightweight.
+

--- a/nuclear-engagement/admin/Onboarding.php
+++ b/nuclear-engagement/admin/Onboarding.php
@@ -79,16 +79,15 @@ class Onboarding {
 		}
 
 		/* ───── 4. Enqueue pointer assets ───── */
-		wp_enqueue_style(  'wp-pointer' );
-		wp_enqueue_script( 'wp-pointer' );
+                wp_enqueue_style(  'wp-pointer' );
 
-		wp_enqueue_script(
-			'nuclen-onboarding',
-			plugin_dir_url( __DIR__ ) . 'admin/js/onboarding-pointers.js',
-			array( 'jquery', 'wp-pointer', 'wp-util' ),
-			defined( 'NUCLEN_ASSET_VERSION' ) ? NUCLEN_ASSET_VERSION : '1',
-			true
-		);
+                wp_enqueue_script(
+                        'nuclen-onboarding',
+                        plugin_dir_url( __DIR__ ) . 'admin/js/onboarding-pointers.js',
+                        array( 'wp-util' ),
+                        defined( 'NUCLEN_ASSET_VERSION' ) ? NUCLEN_ASSET_VERSION : '1',
+                        true
+                );
 
 		/* ───── 5. Inject payload via wp_add_inline_script() ───── */
 		$payload = array(

--- a/nuclear-engagement/admin/js/onboarding-pointers.js
+++ b/nuclear-engagement/admin/js/onboarding-pointers.js
@@ -4,27 +4,100 @@
  * Nuclear Engagement – onboarding pointers
  * Handles per-screen WP Pointer display & dismissal.
  */
-jQuery( function ( $ ) {
-	if ( typeof window.nePointerData === 'undefined' ) {
-		return;
-	}
+( function () {
+       if ( typeof window.nePointerData === 'undefined' ) {
+               return;
+       }
 
-	const { pointers, ajaxurl, nonce } = window.nePointerData;
-	if ( ! Array.isArray( pointers ) || ! pointers.length ) {
-		return;
-	}
+       const { pointers, ajaxurl, nonce } = window.nePointerData;
+       if ( ! Array.isArray( pointers ) || ! pointers.length ) {
+               return;
+       }
 
-	pointers.forEach( ( p ) => {
-		$( p.target ).pointer( {
-			content  : `<h3>${ p.title }</h3><p>${ p.content }</p>`,
-			position : p.position,
-			close    : function () {
-				// Persist dismissal
-				wp.ajax.post( 'nuclen_dismiss_pointer', {
-					pointer  : p.id,
-					nonce,
-				} );
-			},
-		} ).pointer( 'open' );
-	} );
-} );
+       let index = 0;
+
+       function showNext() {
+               if ( index >= pointers.length ) {
+                       return;
+               }
+
+               const ptr    = pointers[ index ];
+               const target = document.querySelector( ptr.target );
+               if ( ! target ) {
+                       index++;
+                       showNext();
+                       return;
+               }
+
+               const wrapper = document.createElement( 'div' );
+               wrapper.className = 'wp-pointer pointer-' + ptr.position.edge;
+               wrapper.style.position = 'absolute';
+               wrapper.innerHTML =
+                       '<div class="wp-pointer-content"><h3>' +
+                       ptr.title +
+                       '</h3><p>' +
+                       ptr.content +
+                       '</p><a class="close" href="#">Dismiss</a></div>';
+               document.body.appendChild( wrapper );
+
+               const rect = target.getBoundingClientRect();
+               let top    = window.scrollY + rect.top;
+               let left   = window.scrollX + rect.left;
+
+               switch ( ptr.position.edge ) {
+                       case 'top':
+                               top -= wrapper.offsetHeight;
+                               break;
+                       case 'bottom':
+                               top += rect.height;
+                               break;
+                       case 'left':
+                               left -= wrapper.offsetWidth;
+                               break;
+                       case 'right':
+                               left += rect.width;
+                               break;
+               }
+
+               if ( ptr.position.align === 'center' ) {
+                       if ( ptr.position.edge === 'top' || ptr.position.edge === 'bottom' ) {
+                               left += ( rect.width - wrapper.offsetWidth ) / 2;
+                       } else {
+                               top += ( rect.height - wrapper.offsetHeight ) / 2;
+                       }
+               } else if ( ptr.position.align === 'right' || ptr.position.align === 'bottom' ) {
+                       if ( ptr.position.edge === 'top' || ptr.position.edge === 'bottom' ) {
+                               left += rect.width - wrapper.offsetWidth;
+                       } else {
+                               top += rect.height - wrapper.offsetHeight;
+                       }
+               }
+
+               wrapper.style.top  = Math.max( top, 0 ) + 'px';
+               wrapper.style.left = Math.max( left, 0 ) + 'px';
+
+               const close = wrapper.querySelector( '.close' );
+               close.addEventListener( 'click', function ( e ) {
+                       e.preventDefault();
+                       const params = new URLSearchParams( {
+                               action  : 'nuclen_dismiss_pointer',
+                               pointer : ptr.id,
+                       } );
+                       if ( nonce ) {
+                               params.append( 'nonce', nonce );
+                       }
+                       fetch( ajaxurl, {
+                               method      : 'POST',
+                               credentials : 'same-origin',
+                               headers     : { 'Content-Type': 'application/x-www-form-urlencoded' },
+                               body        : params.toString(),
+                       } );
+
+                       wrapper.remove();
+                       index++;
+                       showNext();
+               } );
+       }
+
+       document.addEventListener( 'DOMContentLoaded', showNext );
+} )();


### PR DESCRIPTION
## Summary
- drop jQuery dependency from onboarding pointer script
- update loader to enqueue only wp-pointer CSS
- document jQuery removal in ARCHITECTURE.md

## Testing
- `composer lint` *(fails: `composer` not found)*
- `composer test` *(fails: `composer` not found)*
- `npm run build` *(fails: `vite: not found`)*

------
https://chatgpt.com/codex/tasks/task_e_684c1b39096c8327a688735bb4424815