### PR TITLE
Refactor: remove jQuery usage in settings display

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -154,3 +154,10 @@ dismissal requests via `fetch`. The PHP loader no longer enqueues the
 `wp-pointer` script or lists jQuery as a dependency—only the style sheet
 remains. This reduces dependencies and keeps the admin bundle lightweight.
 
+## jQuery Removal from Settings Display
+
+The settings page used jQuery to toggle the "Show TOC content" option when
+the toggle button was enabled. To follow the no-jQuery guideline, this inline
+script now uses vanilla JavaScript. The behavior remains the same but without
+relying on the jQuery library.
+

--- a/nuclear-engagement/admin/partials/settings/display.php
+++ b/nuclear-engagement/admin/partials/settings/display.php
@@ -191,18 +191,24 @@ if ( ! defined( 'ABSPATH' ) ) {
 		</div>
 	</div>
 
-	<script>
-	jQuery(document).ready(function($) {
-		function updateTocToggleState() {
-			var showToggle = $('#nuclen_toc_show_toggle').is(':checked');
-			var $showContent = $('#nuclen_toc_show_content');
-			$showContent.prop('disabled', !showToggle);
-			if (!showToggle) {
-				$showContent.prop('checked', true);
-			}
-		}
-		$('#nuclen_toc_show_toggle').on('change', updateTocToggleState);
-		updateTocToggleState();
-	});
-	</script>
+        <script>
+        document.addEventListener('DOMContentLoaded', () => {
+            const toggleEl = document.getElementById('nuclen_toc_show_toggle');
+            const showContentEl = document.getElementById('nuclen_toc_show_content');
+            if (!toggleEl || !showContentEl) {
+                return;
+            }
+
+            const updateTocToggleState = () => {
+                const showToggle = toggleEl.checked;
+                showContentEl.disabled = !showToggle;
+                if (!showToggle) {
+                    showContentEl.checked = true;
+                }
+            };
+
+            toggleEl.addEventListener('change', updateTocToggleState);
+            updateTocToggleState();
+        });
+        </script>
 </div><!-- /#display -->


### PR DESCRIPTION
## Summary
- rewrite TOC visibility toggle script in vanilla JS
- document jQuery removal from settings display

## Testing
- `composer lint` *(fails: command not found)*
- `composer test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684c1ce49e108327b927874c9bb9676f