### PR TITLE
Continue refactoring per architecture guidelines

### DIFF
--- a/src/admin/ts/generate/filters.ts
+++ b/src/admin/ts/generate/filters.ts
@@ -1,0 +1,76 @@
+export interface NuclenFilterValues {
+  postStatus: string;
+  category: string;
+  author: string;
+  postType: string;
+  workflow: string;
+  allowRegenerate: boolean;
+  regenerateProtected: boolean;
+  summaryFormat: string;
+  summaryLength: string;
+  summaryNumberOfItems: string;
+}
+
+export function nuclenCollectFilters(): NuclenFilterValues {
+  const postStatusEl = document.getElementById('nuclen_post_status') as HTMLSelectElement | null;
+  const categoryEl = document.getElementById('nuclen_category') as HTMLSelectElement | null;
+  const authorEl = document.getElementById('nuclen_author') as HTMLSelectElement | null;
+  const postTypeEl = document.getElementById('nuclen_post_type') as HTMLSelectElement | null;
+  const workflowEl = document.getElementById('nuclen_generate_workflow') as HTMLSelectElement | null;
+  const allowRegenEl = document.getElementById('nuclen_allow_regenerate_data') as HTMLInputElement | null;
+  const protectRegenEl = document.getElementById('nuclen_regenerate_protected_data') as HTMLInputElement | null;
+  const summaryFormatEl = document.getElementById('nuclen_summary_format') as HTMLSelectElement | null;
+  const summaryLengthEl = document.getElementById('nuclen_summary_length') as HTMLSelectElement | null;
+  const summaryNumberEl = document.getElementById('nuclen_summary_number_of_items') as HTMLSelectElement | null;
+  return {
+    postStatus: postStatusEl ? postStatusEl.value : '',
+    category: categoryEl ? categoryEl.value : '',
+    author: authorEl ? authorEl.value : '',
+    postType: postTypeEl ? postTypeEl.value : '',
+    workflow: workflowEl ? workflowEl.value : '',
+    allowRegenerate: !!allowRegenEl && allowRegenEl.checked,
+    regenerateProtected: !!protectRegenEl && protectRegenEl.checked,
+    summaryFormat: summaryFormatEl ? summaryFormatEl.value : '',
+    summaryLength: summaryLengthEl ? summaryLengthEl.value : '',
+    summaryNumberOfItems: summaryNumberEl ? summaryNumberEl.value : '',
+  };
+}
+
+export function nuclenAppendFilters(formData: FormData, filters: NuclenFilterValues): void {
+  formData.append('nuclen_post_status', filters.postStatus);
+  formData.append('nuclen_category', filters.category);
+  formData.append('nuclen_author', filters.author);
+  formData.append('nuclen_post_type', filters.postType);
+  formData.append('nuclen_generate_workflow', filters.workflow);
+  formData.append('nuclen_allow_regenerate_data', filters.allowRegenerate ? '1' : '0');
+  formData.append('nuclen_regenerate_protected_data', filters.regenerateProtected ? '1' : '0');
+}
+
+export function nuclenStoreFilters(filters: NuclenFilterValues): void {
+  const selectedWorkflowEl = document.getElementById('nuclen_selected_generate_workflow') as HTMLInputElement | null;
+  const selectedSummaryFormatEl = document.getElementById('nuclen_selected_summary_format') as HTMLInputElement | null;
+  const selectedSummaryLengthEl = document.getElementById('nuclen_selected_summary_length') as HTMLInputElement | null;
+  const selectedSummaryNumberEl = document.getElementById('nuclen_selected_summary_number_of_items') as HTMLInputElement | null;
+  const selectedPostStatusEl = document.getElementById('nuclen_selected_post_status') as HTMLInputElement | null;
+  const selectedPostTypeEl = document.getElementById('nuclen_selected_post_type') as HTMLInputElement | null;
+
+  if (selectedWorkflowEl) {
+    selectedWorkflowEl.value = filters.workflow;
+  }
+  if (selectedSummaryFormatEl) {
+    selectedSummaryFormatEl.value = filters.summaryFormat;
+  }
+  if (selectedSummaryLengthEl) {
+    selectedSummaryLengthEl.value = filters.summaryLength;
+  }
+  if (selectedSummaryNumberEl) {
+    selectedSummaryNumberEl.value = filters.summaryNumberOfItems;
+  }
+  if (selectedPostStatusEl) {
+    selectedPostStatusEl.value = filters.postStatus;
+  }
+  if (selectedPostTypeEl) {
+    selectedPostTypeEl.value = filters.postType;
+  }
+}
+

--- a/src/admin/ts/generate/step1.ts
+++ b/src/admin/ts/generate/step1.ts
@@ -6,6 +6,12 @@ import {
   nuclenCheckCreditsAjax,
 } from './generate-page-utils';
 import type { GeneratePageElements } from './elements';
+import {
+  nuclenCollectFilters,
+  nuclenAppendFilters,
+  nuclenStoreFilters,
+  type NuclenFilterValues,
+} from './filters';
 
 export function initStep1(elements: GeneratePageElements): void {
   elements.getPostsBtn?.addEventListener('click', () => {
@@ -22,20 +28,8 @@ export function initStep1(elements: GeneratePageElements): void {
     if ((window as any).nuclenAjax?.nonce) {
       formData.append('security', (window as any).nuclenAjax.nonce);
     }
-    const postStatusEl = document.getElementById('nuclen_post_status') as HTMLSelectElement | null;
-    const categoryEl = document.getElementById('nuclen_category') as HTMLSelectElement | null;
-    const authorEl = document.getElementById('nuclen_author') as HTMLSelectElement | null;
-    const postTypeEl = document.getElementById('nuclen_post_type') as HTMLSelectElement | null;
-    const workflowEl = document.getElementById('nuclen_generate_workflow') as HTMLSelectElement | null;
-    const allowRegenEl = document.getElementById('nuclen_allow_regenerate_data') as HTMLInputElement | null;
-    const protectRegenEl = document.getElementById('nuclen_regenerate_protected_data') as HTMLInputElement | null;
-    formData.append('nuclen_post_status', postStatusEl ? postStatusEl.value : '');
-    formData.append('nuclen_category', categoryEl ? categoryEl.value : '');
-    formData.append('nuclen_author', authorEl ? authorEl.value : '');
-    formData.append('nuclen_post_type', postTypeEl ? postTypeEl.value : '');
-    formData.append('nuclen_generate_workflow', workflowEl ? workflowEl.value : '');
-    formData.append('nuclen_allow_regenerate_data', allowRegenEl && allowRegenEl.checked ? '1' : '0');
-    formData.append('nuclen_regenerate_protected_data', protectRegenEl && protectRegenEl.checked ? '1' : '0');
+    const filters: NuclenFilterValues = nuclenCollectFilters();
+    nuclenAppendFilters(formData, filters);
 
     nuclenFetchWithRetry((window as any).nuclenAjax.ajax_url || '', {
       method: 'POST',
@@ -65,34 +59,7 @@ export function initStep1(elements: GeneratePageElements): void {
         if (selectedPostIdsEl) {
           selectedPostIdsEl.value = JSON.stringify(foundPosts);
         }
-        const workflowEl2 = document.getElementById('nuclen_generate_workflow') as HTMLSelectElement | null;
-        const selectedWorkflowEl = document.getElementById('nuclen_selected_generate_workflow') as HTMLInputElement | null;
-        if (selectedWorkflowEl && workflowEl2) {
-          selectedWorkflowEl.value = workflowEl2.value;
-        }
-        const summaryFormatElStep1 = document.getElementById('nuclen_summary_format') as HTMLSelectElement | null;
-        const summaryLengthElStep1 = document.getElementById('nuclen_summary_length') as HTMLSelectElement | null;
-        const summaryNumberElStep1 = document.getElementById('nuclen_summary_number_of_items') as HTMLSelectElement | null;
-        const selectedSummaryFormatEl = document.getElementById('nuclen_selected_summary_format') as HTMLInputElement | null;
-        const selectedSummaryLengthEl = document.getElementById('nuclen_selected_summary_length') as HTMLInputElement | null;
-        const selectedSummaryNumberEl = document.getElementById('nuclen_selected_summary_number_of_items') as HTMLInputElement | null;
-        if (summaryFormatElStep1 && selectedSummaryFormatEl) {
-          selectedSummaryFormatEl.value = summaryFormatElStep1.value;
-        }
-        if (summaryLengthElStep1 && selectedSummaryLengthEl) {
-          selectedSummaryLengthEl.value = summaryLengthElStep1.value;
-        }
-        if (summaryNumberElStep1 && selectedSummaryNumberEl) {
-          selectedSummaryNumberEl.value = summaryNumberElStep1.value;
-        }
-        const selectedPostStatusEl = document.getElementById('nuclen_selected_post_status') as HTMLInputElement | null;
-        if (selectedPostStatusEl && postStatusEl) {
-          selectedPostStatusEl.value = postStatusEl.value;
-        }
-        const selectedPostTypeEl = document.getElementById('nuclen_selected_post_type') as HTMLInputElement | null;
-        if (selectedPostTypeEl && postTypeEl) {
-          selectedPostTypeEl.value = postTypeEl.value;
-        }
+        nuclenStoreFilters(filters);
         nuclenHideElement(elements.step1);
         nuclenShowElement(elements.step2);
         nuclenUpdateProgressBarStep(elements.stepBar1, 'done');


### PR DESCRIPTION
## Summary
- extract filter utilities used on the generate page
- simplify `initStep1` by delegating form parsing and storage to new helpers

## Testing
- `npm run build` *(fails: vite not found)*
- `composer lint` *(fails: command not found)*
- `composer test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684d47ea53e0832784d6c112f8f1ddd8

<!-- Korbit AI PR Description Start -->
## Description by Korbit AI

### What change is being made?

Refactor `filters.ts` and `step1.ts` to encapsulate filter logic in reusable functions, enhancing code architecture and reducing duplication.

### Why are these changes being made?

These changes are made to conform to established architecture guidelines by encapsulating filter-related logic in `filters.ts`, thereby simplifying `step1.ts`. This approach enhances the maintainability, readability, and testability of the code by reducing redundancy and centralizing filter management.

> Is this description stale? Ask me to generate a new description by commenting `/korbit-generate-pr-description`
<!-- Korbit AI PR Description End -->