### PR TITLE
Fix cron args and robust auth error parsing

### DIFF
--- a/nuclear-engagement/includes/Services/RemoteApiService.php
+++ b/nuclear-engagement/includes/Services/RemoteApiService.php
@@ -198,6 +198,27 @@ class RemoteApiService {
      * @return array Error data
      */
     private function handleAuthError(string $body, int $code): array {
+        $data = json_decode($body, true);
+
+        if (is_array($data) && isset($data['error_code'])) {
+            $errorCode = $data['error_code'];
+            if ($errorCode === 'invalid_api_key') {
+                return [
+                    'error' => 'Invalid API key. Please update it on the Setup page.',
+                    'error_code' => 'invalid_api_key',
+                    'status_code' => $code,
+                ];
+            }
+
+            if ($errorCode === 'invalid_wp_app_pass') {
+                return [
+                    'error' => 'Invalid WP App Password. Please re-generate on the Setup page.',
+                    'error_code' => 'invalid_wp_app_pass',
+                    'status_code' => $code,
+                ];
+            }
+        }
+
         if (strpos($body, 'invalid_api_key') !== false) {
             return [
                 'error' => 'Invalid API key. Please update it on the Setup page.',
@@ -205,7 +226,7 @@ class RemoteApiService {
                 'status_code' => $code,
             ];
         }
-        
+
         if (strpos($body, 'invalid_wp_app_pass') !== false) {
             return [
                 'error' => 'Invalid WP App Password. Please re-generate on the Setup page.',
@@ -213,7 +234,7 @@ class RemoteApiService {
                 'status_code' => $code,
             ];
         }
-        
+
         return [
             'error' => 'Authentication error (API key or WP App Password may be invalid).',
             'status_code' => $code,


### PR DESCRIPTION
## Summary
- avoid duplicate cron jobs by using consistent argument arrays
- parse API responses for authentication errors before falling back to string matching

## Testing
- `composer lint` *(fails: command not found)*
- `composer test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684d4dc66f54832785b772db25fc6a5c


> [!NOTE]
> I'm currently writing a description for your pull request. I should be done shortly (<1 minute). Please don't edit the description field until I'm finished, or we may overwrite each other. If I find nothing to write about, I'll delete this message.
