### PR TITLE
Refactor inline styles into CSS classes

### DIFF
--- a/nuclear-engagement/admin/css/nuclen-admin.css
+++ b/nuclear-engagement/admin/css/nuclen-admin.css
@@ -164,8 +164,27 @@ Classes for form groups, labels, inputs, and buttons.
 }
 
 .nuclen-input:focus {
-	border-color: #007cba;
-	outline: none;
+        border-color: #007cba;
+        outline: none;
+}
+
+/* Utility inputs */
+.nuclen-width-full {
+        width: 100%;
+}
+
+.nuclen-meta-date-input {
+        width: 100%;
+        background: #f9f9f9;
+}
+
+.nuclen-answer-correct {
+        font-weight: bold;
+        background: #e6ffe6;
+}
+
+.nuclen-answer-label {
+        margin-bottom: 0.5em;
 }
 
 /* Buttons */

--- a/nuclear-engagement/admin/trait-admin-metabox-quiz.php
+++ b/nuclear-engagement/admin/trait-admin-metabox-quiz.php
@@ -87,7 +87,7 @@ trait Admin_Quiz_Metabox {
 		</div>';
 
 		echo '<p><strong>Date</strong><br>';
-		echo '<input type="text" name="nuclen_quiz_data[date]" value="' . esc_attr( $date ) . '" readonly style="width:100%;background:#f9f9f9;" />';
+                echo '<input type="text" name="nuclen_quiz_data[date]" value="' . esc_attr( $date ) . '" readonly class="nuclen-meta-date-input" />';
 		echo '</p>';
 
 		/* Render the 10 question blocks */
@@ -105,17 +105,17 @@ trait Admin_Quiz_Metabox {
 			echo '<div class="nuclen-quiz-metabox-question">';
 			echo '<h4>Question ' . ( $q_index + 1 ) . '</h4>';
 
-			echo '<input type="text" name="nuclen_quiz_data[questions][' . $q_index . '][question]" value="' . esc_attr( $q_text ) . '" style="width:100%;" />';
+                        echo '<input type="text" name="nuclen_quiz_data[questions][' . $q_index . '][question]" value="' . esc_attr( $q_text ) . '" class="nuclen-width-full" />';
 
 			echo '<p><strong>Answers</strong></p>';
 			foreach ( $answers as $a_index => $answer ) {
-				$style = $a_index === 0 ? 'font-weight:bold;background:#e6ffe6;' : '';
-				echo '<p style="' . esc_attr( $style ) . '">Answer ' . ( $a_index + 1 ) . '<br>';
-				echo '<input type="text" name="nuclen_quiz_data[questions][' . $q_index . '][answers][' . $a_index . ']" value="' . esc_attr( $answer ) . '" style="width:100%;" /></p>';
+                                $class = $a_index === 0 ? 'nuclen-answer-correct' : '';
+                                echo '<p class="nuclen-answer-label ' . esc_attr( $class ) . '">Answer ' . ( $a_index + 1 ) . '<br>';
+                                echo '<input type="text" name="nuclen_quiz_data[questions][' . $q_index . '][answers][' . $a_index . ']" value="' . esc_attr( $answer ) . '" class="nuclen-width-full" /></p>';
 			}
 
 			echo '<p><strong>Explanation</strong><br>';
-			echo '<textarea name="nuclen_quiz_data[questions][' . $q_index . '][explanation]" rows="3" style="width:100%;">' . esc_textarea( $explan ) . '</textarea></p>';
+                        echo '<textarea name="nuclen_quiz_data[questions][' . $q_index . '][explanation]" rows="3" class="nuclen-width-full">' . esc_textarea( $explan ) . '</textarea></p>';
 			echo '</div>';
 		}
 	}

--- a/nuclear-engagement/admin/trait-admin-metabox-summary.php
+++ b/nuclear-engagement/admin/trait-admin-metabox-summary.php
@@ -77,7 +77,7 @@ trait Admin_Summary_Metabox {
 		</div>';
 
 		echo '<p><strong>Date</strong><br>';
-		echo '<input type="text" name="nuclen_summary_data[date]" value="' . esc_attr( $date ) . '" readonly style="width:100%;background:#f9f9f9;" />';
+                echo '<input type="text" name="nuclen_summary_data[date]" value="' . esc_attr( $date ) . '" readonly class="nuclen-meta-date-input" />';
 		echo '</p>';
 
 		echo '<p><strong>Summary</strong><br>';

--- a/nuclear-engagement/front/css/nuclen-front.css
+++ b/nuclear-engagement/front/css/nuclen-front.css
@@ -238,7 +238,18 @@
 
 /* Utility classes */
 .nuclen-quiz-hidden {
-	display: none;
+        display: none;
+}
+
+.nuclen-optin-btn-row {
+        margin-top: 1em;
+        display: flex;
+        gap: 10px;
+}
+
+.nuclen-optin-skip {
+        margin-top: 0.5em;
+        font-size: .85em;
 }
 
 .nuclen-quiz-pulse {

--- a/src/front/ts/nuclen-quiz-optin.ts
+++ b/src/front/ts/nuclen-quiz-optin.ts
@@ -28,13 +28,13 @@ export function mountOptinBeforeResults(
       <input  type="text"  id="nuclen-optin-name">
       <label for="nuclen-optin-email" class="nuclen-fg">Email *</label>
       <input  type="email" id="nuclen-optin-email" required>
-      <div style="margin-top:1em;display:flex;gap:10px;">
+      <div class="nuclen-optin-btn-row">
         <button type="button" id="nuclen-optin-submit">${ctx.submitLabel}</button>
       </div>
       ${
         ctx.mandatory
           ? ''
-          : '<div style="margin-top:0.5em;"><a href="#" id="nuclen-optin-skip" style="font-size:.85em;">Skip &amp; view results</a></div>'
+          : '<div class="nuclen-optin-skip"><a href="#" id="nuclen-optin-skip">Skip &amp; view results</a></div>'
       }
     </div>`;
 


### PR DESCRIPTION
## Summary
- move inline style rules to CSS classes
- use new classes in quiz and summary metaboxes
- style opt-in template using classes

## Testing
- `npm run build` *(fails: vite not found)*
- `composer lint` *(fails: command not found)*
- `composer test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684d5a935af483278fe78ee2ce5559e5

<!-- Korbit AI PR Description Start -->
## Description by Korbit AI

### What change is being made?

Refactor inline styles into CSS classes across various PHP files and a TypeScript file within the project.

### Why are these changes being made?

The changes improve code maintainability and scalability by centralizing styling in CSS, making it easier to manage and modify styles globally without altering the PHP or TypeScript logic. This refactor aligns with best practices by separating content from presentation, enhancing the readability and maintainability of the codebase.

> Is this description stale? Ask me to generate a new description by commenting `/korbit-generate-pr-description`
<!-- Korbit AI PR Description End -->