### PR TITLE
Fix dark theme variable name

### DIFF
--- a/nuclear-engagement/front/css/nuclen-theme-dark.css
+++ b/nuclear-engagement/front/css/nuclen-theme-dark.css
@@ -25,7 +25,7 @@
 	--nuclen-summary-border-width: 1px;
 	--nuclen-summary-border-radius: 6px;
 	--nuclen-summary-shadow-color: rgba(255,255,255,0.1);
-	--nuclen-summary-shadow_blur: 8px;
+       --nuclen-summary-shadow-blur: 8px;
 
 	/* TOC */
 	--nuclen-toc-font-color:#ffffff;
@@ -50,7 +50,7 @@
 		border: var(--nuclen-summary-border-width) var(--nuclen-summary-border-style) var(--nuclen-summary-border-color);
 		border-radius: var(--nuclen-summary-border-radius);
 		/* Notice the variable name is spelled the same as quiz: summary-shadow-blur => watch for typos */
-		box-shadow: 0 0 var(--nuclen-summary-shadow_blur, 8px) var(--nuclen-summary-shadow-color, rgba(255,255,255,0.1));
+               box-shadow: 0 0 var(--nuclen-summary-shadow-blur, 8px) var(--nuclen-summary-shadow-color, rgba(255,255,255,0.1));
 	}
 
 	section .nuclen-fg {


### PR DESCRIPTION
## Summary
- rename `--nuclen-summary-shadow_blur` to `--nuclen-summary-shadow-blur`
- update reference in the dark theme CSS

## Testing
- `composer lint` *(fails: command not found)*
- `composer test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684e31f45b6483279213c16dab8d1699