### PR TITLE
Add font color vars for quiz and summary

### DIFF
--- a/nuclear-engagement/admin/trait-settings-custom-css.php
+++ b/nuclear-engagement/admin/trait-settings-custom-css.php
@@ -28,6 +28,7 @@ trait SettingsPageCustomCSSTrait {
         $css = <<<CSS
 :root{
     /* ───── Quiz container ───── */
+    --nuclen-fg-color: {$s['font_color']};
     --nuclen-quiz-font-color: {$s['font_color']};
     --nuclen-quiz-bg-color: {$s['bg_color']};
     --nuclen-quiz-border-color: {$s['quiz_border_color']};
@@ -72,6 +73,7 @@ trait SettingsPageCustomCSSTrait {
     --nuclen-toc-sticky-max-width: {$s['toc_sticky_max_width']}px;
 
     /* ───── Legacy fallbacks ───── */
+    --nuclen-fg-color: var(--nuclen-quiz-font-color);
     --nuclen-border-color: var(--nuclen-quiz-border-color);
     --nuclen-border-style: var(--nuclen-quiz-border-style);
     --nuclen-border-width: var(--nuclen-quiz-border-width);
@@ -86,7 +88,7 @@ trait SettingsPageCustomCSSTrait {
     border-radius: var(--nuclen-quiz-border-radius);
     box-shadow: 0 0 var(--nuclen-quiz-shadow-blur) var(--nuclen-quiz-shadow-color);
     background: var(--nuclen-quiz-bg-color);
-    color: var(--nuclen-quiz-font-color);
+    color: var(--nuclen-quiz-font-color, var(--nuclen-fg-color));
 }
 
 .nuclen-summary{
@@ -94,7 +96,7 @@ trait SettingsPageCustomCSSTrait {
     border-radius: var(--nuclen-summary-border-radius);
     box-shadow: 0 0 var(--nuclen-summary-shadow-blur) var(--nuclen-summary-shadow-color);
     background: var(--nuclen-summary-bg-color);
-    color: var(--nuclen-summary-font-color);
+    color: var(--nuclen-summary-font-color, var(--nuclen-fg-color));
 }
 
 .nuclen-toc-wrapper{

--- a/nuclear-engagement/front/css/nuclen-front.css
+++ b/nuclear-engagement/front/css/nuclen-front.css
@@ -3,6 +3,14 @@
 * Base styles applied regardless of the theme.
 */
 
+.nuclen-quiz {
+        color: var(--nuclen-quiz-font-color, var(--nuclen-fg-color, #000));
+}
+
+.nuclen-summary {
+        color: var(--nuclen-summary-font-color, var(--nuclen-fg-color, #000));
+}
+
 #nuclen-quiz-container {
 	border-radius: 1em;
 	padding: 1em;

--- a/nuclear-engagement/front/css/nuclen-theme-bright.css
+++ b/nuclear-engagement/front/css/nuclen-theme-bright.css
@@ -1,8 +1,11 @@
 /* front/css/nuclen-theme-bright.css */
 
 :root {
-	--nuclen-fg-color: #333333;
-	--nuclen-bg-color: #ffffff;
+        --nuclen-fg-color: #333333;
+        --nuclen-bg-color: #ffffff;
+
+        --nuclen-quiz-font-color: var(--nuclen-fg-color);
+        --nuclen-summary-font-color: var(--nuclen-fg-color);
 
 	--nuclen-quiz-border-color: #000000;
 	--nuclen-quiz-border-style: solid;

--- a/nuclear-engagement/front/css/nuclen-theme-dark.css
+++ b/nuclear-engagement/front/css/nuclen-theme-dark.css
@@ -1,8 +1,11 @@
 /* front/css/nuclen-theme-dark.css */
 
 :root {
-	--nuclen-fg-color: #ffffff;
-	--nuclen-bg-color: #333333;
+        --nuclen-fg-color: #ffffff;
+        --nuclen-bg-color: #333333;
+
+        --nuclen-quiz-font-color: var(--nuclen-fg-color);
+        --nuclen-summary-font-color: var(--nuclen-fg-color);
 
 	--nuclen-quiz-border-color: #ffffff;
 	--nuclen-quiz-border-style: solid;


### PR DESCRIPTION
## Summary
- allow `.nuclen-quiz` and `.nuclen-summary` to use specific font variables
- default new variables in both themes
- generate `--nuclen-fg-color` alongside quiz and summary font colors
- fallback to `--nuclen-fg-color` when custom colors missing

## Testing
- `composer lint` *(fails: command not found)*
- `composer test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684e323743f4832795a9e721534f5844

<!-- Korbit AI PR Description Start -->
## Description by Korbit AI

### What change is being made?
Add a new CSS variable `--nuclen-fg-color` for default font color usage in quiz and summary sections with a fallback to enhance styling consistency.

### Why are these changes being made?
The changes introduce a consistent fallback font color, `--nuclen-fg-color`, which is referenced in both quiz and summary sections to maintain uniformity and handle cases where specific font color values may not be set directly. This approach reduces the risk of styling discrepancies and ensures a defined default is always applied.

> Is this description stale? Ask me to generate a new description by commenting `/korbit-generate-pr-description`
<!-- Korbit AI PR Description End -->