### PR TITLE
Add root container for safer styling

### DIFF
--- a/docs/UI-STYLING.md
+++ b/docs/UI-STYLING.md
@@ -26,3 +26,8 @@ Follow these conventions when creating styles for Nuclear Engagement's admin and
 
 - Map accent colours to the WordPress global palette API so users can change them in the editor.
 
+
+## Style Isolation
+
+- The plugin outputs all front-end markup inside a `.nuclen-root` wrapper.
+- Scope any custom or theme overrides under `.nuclen-root` to avoid interfering with non-plugin styles.

--- a/nuclear-engagement/admin/trait-settings-custom-css.php
+++ b/nuclear-engagement/admin/trait-settings-custom-css.php
@@ -83,7 +83,7 @@ trait SettingsPageCustomCSSTrait {
 }
 
 /* ─── Apply variables to actual elements ─── */
-.nuclen-quiz{
+.nuclen-root .nuclen-quiz{
     border: var(--nuclen-quiz-border-width) var(--nuclen-quiz-border-style) var(--nuclen-quiz-border-color);
     border-radius: var(--nuclen-quiz-border-radius);
     box-shadow: 0 0 var(--nuclen-quiz-shadow-blur) var(--nuclen-quiz-shadow-color);
@@ -91,7 +91,7 @@ trait SettingsPageCustomCSSTrait {
     color: var(--nuclen-quiz-font-color, var(--nuclen-fg-color));
 }
 
-.nuclen-summary{
+.nuclen-root .nuclen-summary{
     border: var(--nuclen-summary-border-width) var(--nuclen-summary-border-style) var(--nuclen-summary-border-color);
     border-radius: var(--nuclen-summary-border-radius);
     box-shadow: 0 0 var(--nuclen-summary-shadow-blur) var(--nuclen-summary-shadow-color);
@@ -99,7 +99,7 @@ trait SettingsPageCustomCSSTrait {
     color: var(--nuclen-summary-font-color, var(--nuclen-fg-color));
 }
 
-.nuclen-toc-wrapper{
+.nuclen-root .nuclen-toc-wrapper{
     font-size: var(--nuclen-toc-font-size);
     border: var(--nuclen-toc-border-width) var(--nuclen-toc-border-style) var(--nuclen-toc-border-color);
     border-radius: var(--nuclen-toc-border-radius);
@@ -107,15 +107,15 @@ trait SettingsPageCustomCSSTrait {
     background: var(--nuclen-toc-bg-color);
     color: var(--nuclen-toc-font-color);
 }
-.nuclen-toc-wrapper a{
+.nuclen-root .nuclen-toc-wrapper a{
     color: var(--nuclen-toc-link);
 }
 
-#nuclen-quiz-progress-bar-container{
+.nuclen-root #nuclen-quiz-progress-bar-container{
     background: var(--nuclen-quiz-progress-bg);
     height: var(--nuclen-quiz-progress-height);
 }
-#nuclen-quiz-progress-bar{
+.nuclen-root #nuclen-quiz-progress-bar{
     background: var(--nuclen-quiz-progress-fg);
     height: 100%;
     width: 0;

--- a/nuclear-engagement/front/QuizShortcode.php
+++ b/nuclear-engagement/front/QuizShortcode.php
@@ -27,8 +27,10 @@ class QuizShortcode {
         }
 
         $settings = $this->getQuizSettings();
-        $html  = $this->view->container($settings);
+        $html  = '<div class="nuclen-root">';
+        $html .= $this->view->container($settings);
         $html .= $this->view->attribution($settings['show_attribution']);
+        $html .= '</div>';
         return $html;
     }
 

--- a/nuclear-engagement/front/SummaryShortcode.php
+++ b/nuclear-engagement/front/SummaryShortcode.php
@@ -27,8 +27,10 @@ class SummaryShortcode {
         }
 
         $settings = $this->getSummarySettings();
-        $html  = $this->view->container($summary_data, $settings);
+        $html  = '<div class="nuclen-root">';
+        $html .= $this->view->container($summary_data, $settings);
         $html .= $this->view->attribution($settings['show_attribution']);
+        $html .= '</div>';
         return $html;
     }
 

--- a/nuclear-engagement/front/css/nuclen-front.css
+++ b/nuclear-engagement/front/css/nuclen-front.css
@@ -3,15 +3,15 @@
 * Base styles applied regardless of the theme.
 */
 
-.nuclen-quiz {
+.nuclen-root .nuclen-quiz {
         color: var(--nuclen-quiz-font-color, var(--nuclen-fg-color, #000));
 }
 
-.nuclen-summary {
+.nuclen-root .nuclen-summary {
         color: var(--nuclen-summary-font-color, var(--nuclen-fg-color, #000));
 }
 
-#nuclen-quiz-container {
+.nuclen-root .nuclen-quiz {
 	border-radius: 1em;
 	padding: 1em;
 	text-align: center;
@@ -19,32 +19,32 @@
 	margin: 1em 0;
 }
 
-.nuclen-quiz-title {
+.nuclen-root .nuclen-quiz-title {
 	font-size: 1.5em;
 	margin-bottom: 1em;
 }
 
-#nuclen-quiz-question-number {
+.nuclen-root #nuclen-quiz-question-number {
 	font-size: 1.2em;
 	font-weight: bold;
 }
 
 /* Layout & Grid */
-#nuclen-quiz-answers-container {
+.nuclen-root #nuclen-quiz-answers-container {
 	display: flex;
 	flex-direction: column;
 	gap: 20px;
 }
 
 /* Progress bar container */
-#nuclen-quiz-progress-bar-container {
+.nuclen-root #nuclen-quiz-progress-bar-container {
 	background-color: var(--nuclen-quiz-progress-bg, #e0e0e0);
 	border-radius: 5px;
 	overflow: hidden;
 	margin-bottom: 20px;
 }
 
-#nuclen-quiz-progress-bar {
+.nuclen-root #nuclen-quiz-progress-bar {
 	height: var(--nuclen-quiz-progress-height, 10px);
 	background-color: var(--nuclen-quiz-progress-fg, #1B977D);
 	width: 0%;
@@ -52,9 +52,9 @@
 }
 
 /* Buttons & interactions */
-#nuclen-quiz-next-button,
-#nuclen-quiz-retake-button,
-.nuclen-quiz-result-tab {
+.nuclen-root #nuclen-quiz-next-button,
+.nuclen-root #nuclen-quiz-retake-button,
+.nuclen-root .nuclen-quiz-result-tab {
 	color: var(--nuclen-fg-color, #000);
 	background-color: var(--nuclen-bg-color, #fff);
 	background-image: none;
@@ -63,21 +63,21 @@
 	font-weight: bold;
 }
 
-#nuclen-quiz-next-button,
-#nuclen-quiz-retake-button {
+.nuclen-root #nuclen-quiz-next-button,
+.nuclen-root #nuclen-quiz-retake-button {
 	border: 2px solid var(--nuclen-fg-color, #000);
 }
 
-.nuclen-quiz-result-tab {
+.nuclen-root .nuclen-quiz-result-tab {
 	border: 2px solid #666;
 	border-bottom: 0;
 }
-.nuclen-quiz-result-tab:hover {
+.nuclen-root .nuclen-quiz-result-tab:hover {
 	background-color: #dcdcdc;
 }
 
 /* Answer button (now uses theme-based vars) */
-.nuclen-quiz-answer-button {
+.nuclen-root .nuclen-quiz-answer-button {
 	color: #fff;
 	background-color: var(--nuclen-quiz-button-bg, #94544A);
 	display: block;
@@ -93,74 +93,74 @@
 	background-image: none;
 }
 
-.nuclen-quiz-answer-button:hover {
+.nuclen-root .nuclen-quiz-answer-button:hover {
 	background-color: #dcdcdc;
 	color: #000;
 }
 
-.nuclen-quiz-answer-button:disabled {
+.nuclen-root .nuclen-quiz-answer-button:disabled {
 	cursor: not-allowed;
 }
 
 /* Answer states */
-.nuclen-quiz-answer-correct,
-.nuclen-quiz-answer-correct:hover,
-.nuclen-quiz-answer-correct:active,
-.nuclen-quiz-answer-correct:focus {
+.nuclen-root .nuclen-quiz-answer-correct,
+.nuclen-root .nuclen-quiz-answer-correct:hover,
+.nuclen-root .nuclen-quiz-answer-correct:active,
+.nuclen-root .nuclen-quiz-answer-correct:focus {
 	background-color: #1EA896;
 	color: #fff;
 }
 
-.nuclen-quiz-answer-wrong,
-.nuclen-quiz-answer-wrong:hover {
+.nuclen-root .nuclen-quiz-answer-wrong,
+.nuclen-root .nuclen-quiz-answer-wrong:hover {
 	background-color: #FF715B;
 	color: #fff;
 }
 
-.nuclen-quiz-answer-not-selected,
-.nuclen-quiz-answer-not-selected:hover {
+.nuclen-root .nuclen-quiz-answer-not-selected,
+.nuclen-root .nuclen-quiz-answer-not-selected:hover {
 	background-color: #dcdcdc;
 	opacity: 0.5;
 }
 
 /* Final result & details */
-#nuclen-quiz-final-result-container h2 {
+.nuclen-root #nuclen-quiz-final-result-container h2 {
 	font-size: 24px;
 	margin-bottom: 10px;
 }
 
-#nuclen-quiz-final-result-container p {
+.nuclen-root #nuclen-quiz-final-result-container p {
 	margin: 5px 0;
 }
 
-.nuclen-quiz-question-result.nuclen-quiz-question,
-.nuclen-quiz-question-result.nuclen-quiz-correct-answer {
+.nuclen-root .nuclen-quiz-question-result.nuclen-quiz-question,
+.nuclen-root .nuclen-quiz-question-result.nuclen-quiz-correct-answer {
 	font-size: 16px;
 }
 
-#nuclen-quiz-final-result-container .nuclen-quiz-question-result:last-child {
+.nuclen-root #nuclen-quiz-final-result-container .nuclen-quiz-question-result:last-child {
 	border-bottom: none;
 }
 
-.nuclen-quiz-detail-question {
+.nuclen-root .nuclen-quiz-detail-question {
 	font-weight: bold;
 }
 
-.nuclen-quiz-detail-answer {
+.nuclen-root .nuclen-quiz-detail-answer {
 	font-size: 1.5em;
 	color: #1EA896;
 	font-weight: bold;
 }
 
-.nuclen-quiz-detail-explanation {
+.nuclen-root .nuclen-quiz-detail-explanation {
 	font-size: 1.2em;
 }
 
-.nuclen-quiz-explanation {
+.nuclen-root .nuclen-quiz-explanation {
 	font-size: 14px;
 }
 
-#nuclen-quiz-final-result-container input[type="submit"] {
+.nuclen-root #nuclen-quiz-final-result-container input[type="submit"] {
 	margin-top: 20px;
 	background-color: #4B6542;
 	color: white;
@@ -171,13 +171,13 @@
 	width: 100%;
 }
 
-#nuclen-quiz-final-result-container button:hover,
-#nuclen-quiz-final-result-container input[type="submit"]:hover {
+.nuclen-root #nuclen-quiz-final-result-container button:hover,
+.nuclen-root #nuclen-quiz-final-result-container input[type="submit"]:hover {
 	background-color: #0e2506;
 }
 
-#nuclen-quiz-final-result-container input[type="text"],
-#nuclen-quiz-final-result-container input[type="email"] {
+.nuclen-root #nuclen-quiz-final-result-container input[type="text"],
+.nuclen-root #nuclen-quiz-final-result-container input[type="email"] {
 	width: calc(100% - 20px);
 	padding: 10px;
 	margin: 10px 0;
@@ -186,44 +186,44 @@
 }
 
 /* Score area */
-#nuclen-quiz-results-title {
+.nuclen-root #nuclen-quiz-results-title {
 	font-size: 1.5em;
 }
 
-#nuclen-quiz-results-score {
+.nuclen-root #nuclen-quiz-results-score {
 	font-size: 2em;
 }
 
-#nuclen-quiz-score-comment {
+.nuclen-root #nuclen-quiz-score-comment {
 	font-size: 1.2em;
 	margin-bottom: 1em;
 }
 
-#nuclen-quiz-explanation-container {
+.nuclen-root #nuclen-quiz-explanation-container {
 	font-size: 1.2em;
 	margin: 1em 0;
 }
 
-.nuclen-quiz-question-result.nuclen-quiz-correct-answer {
+.nuclen-root .nuclen-quiz-question-result.nuclen-quiz-correct-answer {
 	font-size: 1.5em;
 }
 
 /* Tabs container for results */
-#nuclen-quiz-result-tabs-container {
+.nuclen-root #nuclen-quiz-result-tabs-container {
 	display: flex;
 	justify-content: center;
 	gap: 4px;
 }
 
-.nuclen-quiz-result-active-tab {
+.nuclen-root .nuclen-quiz-result-active-tab {
 	background-color: #1B977D;
 	color: white;
 }
 
-#nuclen-optin-container,
-#nuclen-quiz-result-details-container,
-#nuclen-quiz-end-message,
-#nuclen-quiz-start-message {
+.nuclen-root #nuclen-optin-container,
+.nuclen-root #nuclen-quiz-result-details-container,
+.nuclen-root #nuclen-quiz-end-message,
+.nuclen-root #nuclen-quiz-start-message {
 	padding: 20px;
 	text-align: left;
 	margin-bottom: 40px;
@@ -232,7 +232,7 @@
 }
 
 /* email optin */
-#nuclen-optin-container {
+.nuclen-root #nuclen-optin-container {
 	display: flex;
 	flex-direction: column;
 	align-items: center;
@@ -240,27 +240,27 @@
 	margin: 0 0 2em 0;
 	width: 300px;
 }
-#nuclen-optin-submit {
+.nuclen-root #nuclen-optin-submit {
 	width: 100%;
 }
 
 /* Utility classes */
-.nuclen-quiz-hidden {
+.nuclen-root .nuclen-quiz-hidden {
         display: none;
 }
 
-.nuclen-optin-btn-row {
+.nuclen-root .nuclen-optin-btn-row {
         margin-top: 1em;
         display: flex;
         gap: 10px;
 }
 
-.nuclen-optin-skip {
+.nuclen-root .nuclen-optin-skip {
         margin-top: 0.5em;
         font-size: .85em;
 }
 
-.nuclen-quiz-pulse {
+.nuclen-root .nuclen-quiz-pulse {
 	animation: nuclen-quiz-pulse-grow 1s;
 }
 
@@ -276,20 +276,20 @@
 	}
 }
 
-.nuclen-quiz-checkmark {
+.nuclen-root .nuclen-quiz-checkmark {
 	color: #4caf50;
 	font-weight: bold;
 	margin-left: 10px;
 }
 
-.nuclen-attribution {
+.nuclen-root .nuclen-attribution {
 	margin-top: 0;
 	margin: 0 0 2em 2em;
 	font-size: x-small;
 }
 
 /* Summary container */
-#nuclen-summary-container {
+.nuclen-root .nuclen-summary {
 	font-size: 1.1em;
 	border-radius: 1em;
 	padding: 1em;

--- a/nuclear-engagement/front/css/nuclen-theme-bright.css
+++ b/nuclear-engagement/front/css/nuclen-theme-bright.css
@@ -32,9 +32,10 @@
 	--nuclen-summary-shadow-blur: 8px;
 
 	/* TOC */
-	--nuclen-toc-font-color:#333333;
-	--nuclen-toc-bg-color:#ffffff;
-	--nuclen-toc-border-color:#000000;
+        --nuclen-toc-font-color:#333333;
+        --nuclen-toc-bg-color:#ffffff;
+        --nuclen-toc-font-size: 0.9em;
+        --nuclen-toc-border-color:#000000;
 	--nuclen-toc-border-style:solid;
 	--nuclen-toc-border-width:1px;
 	--nuclen-toc-border-radius:6px;

--- a/nuclear-engagement/front/css/nuclen-theme-bright.css
+++ b/nuclear-engagement/front/css/nuclen-theme-bright.css
@@ -42,14 +42,14 @@
 	--nuclen-toc-shadow-blur:8px;
 	}
 
-	#nuclen-quiz-container {
+ .nuclen-root .nuclen-quiz {
 		background-color: var(--nuclen-bg-color);
 		border: var(--nuclen-quiz-border-width) var(--nuclen-quiz-border-style) var(--nuclen-quiz-border-color);
 		border-radius: var(--nuclen-quiz-border-radius);
 		box-shadow: 0 0 var(--nuclen-quiz-shadow-blur) var(--nuclen-quiz-shadow-color);
 	}
 
-	#nuclen-summary-container {
+ .nuclen-root .nuclen-summary {
 		background-color: var(--nuclen-bg-color);
 		border: var(--nuclen-summary-border-width) var(--nuclen-summary-border-style) var(--nuclen-summary-border-color);
 		border-radius: var(--nuclen-summary-border-radius);

--- a/nuclear-engagement/front/css/nuclen-theme-dark.css
+++ b/nuclear-engagement/front/css/nuclen-theme-dark.css
@@ -41,14 +41,14 @@
 	--nuclen-toc-shadow-blur:8px;
 	}
 
-	#nuclen-quiz-container {
+ .nuclen-root .nuclen-quiz {
 		background-color: var(--nuclen-bg-color);
 		border: var(--nuclen-quiz-border-width) var(--nuclen-quiz-border-style) var(--nuclen-quiz-border-color);
 		border-radius: var(--nuclen-quiz-border-radius);
 		box-shadow: 0 0 var(--nuclen-quiz-shadow-blur) var(--nuclen-quiz-shadow-color);
 	}
 
-	#nuclen-summary-container {
+ .nuclen-root .nuclen-summary {
 		background-color: var(--nuclen-bg-color);
 		border: var(--nuclen-summary-border-width) var(--nuclen-summary-border-style) var(--nuclen-summary-border-color);
 		border-radius: var(--nuclen-summary-border-radius);

--- a/nuclear-engagement/front/css/nuclen-theme-dark.css
+++ b/nuclear-engagement/front/css/nuclen-theme-dark.css
@@ -31,9 +31,10 @@
        --nuclen-summary-shadow-blur: 8px;
 
 	/* TOC */
-	--nuclen-toc-font-color:#ffffff;
-	--nuclen-toc-bg-color:#333333;
-	--nuclen-toc-border-color:#ffffff;
+        --nuclen-toc-font-color:#ffffff;
+        --nuclen-toc-bg-color:#333333;
+        --nuclen-toc-font-size: 0.9em;
+        --nuclen-toc-border-color:#ffffff;
 	--nuclen-toc-border-style:solid;
 	--nuclen-toc-border-width:1px;
 	--nuclen-toc-border-radius:6px;

--- a/nuclear-engagement/front/css/nuclen-theme-dark.css
+++ b/nuclear-engagement/front/css/nuclen-theme-dark.css
@@ -53,7 +53,6 @@
 		background-color: var(--nuclen-bg-color);
 		border: var(--nuclen-summary-border-width) var(--nuclen-summary-border-style) var(--nuclen-summary-border-color);
 		border-radius: var(--nuclen-summary-border-radius);
-		/* Notice the variable name is spelled the same as quiz: summary-shadow-blur => watch for typos */
                box-shadow: 0 0 var(--nuclen-summary-shadow-blur, 8px) var(--nuclen-summary-shadow-color, rgba(255,255,255,0.1));
 	}
 

--- a/nuclear-engagement/modules/toc/assets/css/nuclen-toc-front.css
+++ b/nuclear-engagement/modules/toc/assets/css/nuclen-toc-front.css
@@ -11,16 +11,16 @@
 	--nuclen-toc-offset:72px;
 }
 
-.nuclen-toc {
+ .nuclen-root .nuclen-toc {
         font-size: var(--nuclen-toc-font-size, 0.9em);
 }
-.nuclen-toc li{margin:.25em 0}
+ .nuclen-root .nuclen-toc li{margin:.25em 0}
 
-.nuclen-toc a{
+ .nuclen-root .nuclen-toc a{
 	text-decoration:none;
 	color:var(--nuclen-toc-link);
 }
-.nuclen-toc a.is-active[aria-current="location"]{
+ .nuclen-root .nuclen-toc a.is-active[aria-current="location"]{
 	font-weight:700;
 }
 
@@ -32,7 +32,7 @@
 /* Front-end TOC styles (leveraging root variables) */
 
 /* Sticky TOC styles */
-.nuclen-toc-wrapper.nuclen-toc-sticky {
+ .nuclen-root .nuclen-toc-wrapper.nuclen-toc-sticky {
     position: relative;
     z-index: 100;
     transition: all 0.3s ease;
@@ -45,7 +45,7 @@
 }
 
 /* Toggle button styles */
-.nuclen-toc-toggle {
+ .nuclen-root .nuclen-toc-toggle {
     background: none;
     color: inherit;
     cursor: pointer;
@@ -55,7 +55,7 @@
 }
 
 /* Toggle icon */
-.nuclen-toc-toggle:after {
+ .nuclen-root .nuclen-toc-toggle:after {
     content: '▼';
     display: inline-block;
     margin-left: 8px;
@@ -63,24 +63,24 @@
     transition: transform 0.2s ease;
 }
 
-.nuclen-toc-wrapper.nuclen-toc-collapsed .nuclen-toc-toggle:after {
+ .nuclen-root .nuclen-toc-wrapper.nuclen-toc-collapsed .nuclen-toc-toggle:after {
     transform: rotate(-90deg);
 }
 
 /* TOC content transitions */
-.nuclen-toc {
+ .nuclen-root .nuclen-toc {
     transition: opacity 0.2s ease-in-out;
 }
 
 /* Ensure TOC content respects container width */
-.nuclen-toc-sticky .nuclen-toc {
+ .nuclen-root .nuclen-toc-sticky .nuclen-toc {
     width: 100%;
     overflow: hidden;
 }
 
 /* Ensure TOC list items don't overflow */
-.nuclen-toc-sticky .nuclen-toc ul,
-.nuclen-toc-sticky .nuclen-toc ol {
+ .nuclen-root .nuclen-toc-sticky .nuclen-toc ul,
+ .nuclen-root .nuclen-toc-sticky .nuclen-toc ol {
     margin: 0;
     padding-left: 0.5em;
     overflow: hidden;
@@ -88,7 +88,7 @@
 }
 
 /* Make sure links don't cause horizontal overflow */
-.nuclen-toc-sticky .nuclen-toc a {
+ .nuclen-root .nuclen-toc-sticky .nuclen-toc a {
     display: inline-block;
     max-width: 100%;
     white-space: nowrap;
@@ -98,7 +98,7 @@
 }
 
 /* Stuck state – applied by JavaScript */
-.nuclen-toc-wrapper.nuclen-toc-sticky.nuclen-toc-stuck .nuclen-toc {
+ .nuclen-root .nuclen-toc-wrapper.nuclen-toc-sticky.nuclen-toc-stuck .nuclen-toc {
 	position: fixed;
 	top: 20px;                     /* offset from top (overridden in JS if needed) */
 	overflow-y: auto;
@@ -108,7 +108,7 @@
 }
 
 /* Collapsed state */
-.nuclen-toc-sticky.nuclen-toc-collapsed {
+ .nuclen-root .nuclen-toc-sticky.nuclen-toc-collapsed {
     width: 40px;
     height: 40px;
     opacity: 0.8;
@@ -119,15 +119,15 @@
     cursor: pointer;
 }
 
-.nuclen-toc-sticky.nuclen-toc-collapsed .nuclen-toc-toggle {
+ .nuclen-root .nuclen-toc-sticky.nuclen-toc-collapsed .nuclen-toc-toggle {
     display: none;
 }
 
-.nuclen-toc-sticky.nuclen-toc-collapsed .nuclen-toc-content {
+ .nuclen-root .nuclen-toc-sticky.nuclen-toc-collapsed .nuclen-toc-content {
     display: none;
 }
 
-.nuclen-toc-sticky .nuclen-toc-content {
+ .nuclen-root .nuclen-toc-sticky .nuclen-toc-content {
     flex: 1;
     overflow-y: auto;
     max-height: calc(90vh - 50px);
@@ -138,26 +138,26 @@
 }
 
 /* Webkit scrollbar styling */
-.nuclen-toc-sticky .nuclen-toc-content::-webkit-scrollbar {
+ .nuclen-root .nuclen-toc-sticky .nuclen-toc-content::-webkit-scrollbar {
     width: 6px;
 }
 
-.nuclen-toc-sticky .nuclen-toc-content::-webkit-scrollbar-track {
+ .nuclen-root .nuclen-toc-sticky .nuclen-toc-content::-webkit-scrollbar-track {
     background: transparent;
     margin: 5px 0;
 }
 
-.nuclen-toc-sticky .nuclen-toc-content::-webkit-scrollbar-thumb {
+ .nuclen-root .nuclen-toc-sticky .nuclen-toc-content::-webkit-scrollbar-thumb {
     background-color: rgba(0,0,0,0.2);
     border-radius: 3px;
 }
 
-.nuclen-toc-sticky .nuclen-toc-content::-webkit-scrollbar-thumb:hover {
+ .nuclen-root .nuclen-toc-sticky .nuclen-toc-content::-webkit-scrollbar-thumb:hover {
     background-color: rgba(0,0,0,0.3);
 }
 
 /* Toggle button */
-.nuclen-toc-collapse-toggle {
+ .nuclen-root .nuclen-toc-collapse-toggle {
     display: none;
     position: absolute;
     top: 0;
@@ -172,37 +172,37 @@
     color: #333;
 }
 
-.nuclen-toc-sticky .nuclen-toc-collapse-toggle {
+ .nuclen-root .nuclen-toc-sticky .nuclen-toc-collapse-toggle {
     display: block;
 }
 
-.nuclen-toc-collapse-toggle:before {
+ .nuclen-root .nuclen-toc-collapse-toggle:before {
     content: '\2630';
     font-size: 24px;
     line-height: 40px;
 }
 
-.nuclen-toc-sticky:not(.nuclen-toc-collapsed) .nuclen-toc-collapse-toggle:before {
+ .nuclen-root .nuclen-toc-sticky:not(.nuclen-toc-collapsed) .nuclen-toc-collapse-toggle:before {
     content: '×';
     font-size: 32px;
     line-height: 36px;
 }
 
 /* TOC content wrapper */
-.nuclen-toc-content {
+ .nuclen-root .nuclen-toc-content {
     transition: all 0.3s ease;
 }
 
-.nuclen-toc-wrapper.nuclen-toc-sticky .nuclen-toc {
+ .nuclen-root .nuclen-toc-wrapper.nuclen-toc-sticky .nuclen-toc {
     position: relative;
 }
 
 /* Ensure the TOC stays within its parent width when sticky */
-.nuclen-toc-stuck {
+ .nuclen-root .nuclen-toc-stuck {
     max-width: 100% !important;
 }
 
-.nuclen-toc-wrapper{
+ .nuclen-root .nuclen-toc-wrapper{
 	background:var(--nuclen-toc-bg-color);
 	color:var(--nuclen-toc-font-color);
 	border:var(--nuclen-toc-border-width) var(--nuclen-toc-border-style) var(--nuclen-toc-border-color);
@@ -213,21 +213,21 @@
         font-size: var(--nuclen-toc-font-size, 0.9em);
 }
 
-.nuclen-toc ul,
-.nuclen-toc ol{
+ .nuclen-root .nuclen-toc ul,
+ .nuclen-root .nuclen-toc ol{
 	list-style: none;
 	margin:0;
 	padding:0;
 }
 
-.nuclen-toc a:hover,
-.nuclen-toc a:focus{
+ .nuclen-root .nuclen-toc a:hover,
+ .nuclen-root .nuclen-toc a:focus{
 	text-decoration:underline;
 }
 
 
-.nuclen-has-highlight [data-highlight="true"] a.nuclen-current,
-.nuclen-has-highlight [data-highlight="true"] a.nuclen-current:hover{
+ .nuclen-root .nuclen-has-highlight [data-highlight="true"] a.nuclen-current,
+ .nuclen-root .nuclen-has-highlight [data-highlight="true"] a.nuclen-current:hover{
 	font-weight:bold;
 	text-decoration:underline;
 }

--- a/nuclear-engagement/modules/toc/includes/class-nuclen-toc-render.php
+++ b/nuclear-engagement/modules/toc/includes/class-nuclen-toc-render.php
@@ -138,7 +138,8 @@ final class Nuclen_TOC_Render {
                 $show    = $wrapper['show_toggle'];
                 $hidden  = $wrapper['hidden'];
 
-                $out = sprintf(
+                $out  = '<div class="nuclen-root">';
+                $out .= sprintf(
                         '<section id="%s-wrapper" class="%s"%s>',
                         esc_attr( $nav_id ),
                         esc_attr( implode( ' ', $classes ) ),
@@ -156,7 +157,7 @@ final class Nuclen_TOC_Render {
                         $out .= '</div>';
                 }
 
-                $out .= '</section>';
+                $out .= '</section></div>';
 
                 if ( ! wp_script_is( 'nuclen-toc-front', 'enqueued' ) ) {
                         wp_enqueue_script( 'nuclen-toc-front' );


### PR DESCRIPTION
## Summary
- isolate frontend sections under a `.nuclen-root` wrapper
- prefix CSS selectors with `.nuclen-root`
- wrap shortcode output (quiz, summary, TOC) in the new wrapper

## Testing
- `composer lint` *(fails: command not found)*
- `composer test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684e3014048883278016988f1bd380f8

<!-- Korbit AI PR Description Start -->
## Description by Korbit AI

### What change is being made?

Wrap HTML output in a new root `<div>` with the class `nuclen-root` for the `QuizShortcode`, `SummaryShortcode`, and Table of Contents modules.

### Why are these changes being made?

These changes establish a consistent root container class for styling purposes, ensuring safer and more predictable CSS management across various components within the `nuclear-engagement` project. This adjustment aims to alleviate potential CSS conflicts by encapsulating styling within a well-defined container.

> Is this description stale? Ask me to generate a new description by commenting `/korbit-generate-pr-description`
<!-- Korbit AI PR Description End -->