### PR TITLE
Raise minimum WordPress version

### DIFF
--- a/nuclear-engagement/README.txt
+++ b/nuclear-engagement/README.txt
@@ -5,7 +5,7 @@ Author: Stefano Lodola
 Author URI: https://www.nuclearengagement.com/about?ref=wp_listing&link=author_uri
 Contributors: stefanolodola
 Tags: AI writer, quiz, summary, table of contents, email optin
-Requires at least: 5.6
+Requires at least: 6.1
 Tested up to: 6.8
 Requires PHP: 7.3
 Stable tag: 1.1

--- a/nuclear-engagement/includes/SettingsCache.php
+++ b/nuclear-engagement/includes/SettingsCache.php
@@ -42,9 +42,7 @@ final class SettingsCache {
     public function invalidate_cache(): void {
         $key = $this->get_cache_key();
         wp_cache_delete( $key, self::CACHE_GROUP );
-        if ( function_exists( 'wp_cache_flush_group' ) ) {
-            wp_cache_flush_group( self::CACHE_GROUP );
-        }
+        wp_cache_flush_group( self::CACHE_GROUP );
     }
 
     public function maybe_invalidate_cache( $option ): void {

--- a/nuclear-engagement/includes/SettingsRepository.php
+++ b/nuclear-engagement/includes/SettingsRepository.php
@@ -236,8 +236,6 @@ final class SettingsRepository
      */
     public static function _reset_for_tests(): void {
         self::$instance = null;
-        if (function_exists('wp_cache_flush_group')) {
-            wp_cache_flush_group(SettingsCache::CACHE_GROUP);
-        }
+        wp_cache_flush_group( SettingsCache::CACHE_GROUP );
     }
 }

--- a/nuclear-engagement/nuclear-engagement.php
+++ b/nuclear-engagement/nuclear-engagement.php
@@ -5,7 +5,7 @@
  * Description:       Bulk generate engaging content for your blog posts with AI in one click.
  * Version:           1.1
  * Author:            Stefano Lodola
- * Requires at least: 5.6
+ * Requires at least: 6.1
  * Tested up to:      6.8
  * Requires PHP:      7.4
  * License:           GPL-2.0+


### PR DESCRIPTION
## Summary
- require WordPress 6.1
- drop old `wp_cache_flush_group` checks

## Testing
- `composer lint` *(fails: command not found)*
- `composer test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6856cca400f08327b3da8579c3d1b4b9

<!-- Korbit AI PR Description Start -->
## Description by Korbit AI

### What change is being made?

Raise the minimum required WordPress version from 5.6 to 6.1 and remove conditional checks for the existence of the `wp_cache_flush_group` function. 

### Why are these changes being made?

The update reflects dependencies on features available from WordPress 6.1 onwards, ensuring compatibility and leveraging the built-in `wp_cache_flush_group` function, which is guaranteed to exist in the newer WordPress versions. This simplifies the code by removing unnecessary conditional checks for function existence.

> Is this description stale? Ask me to generate a new description by commenting `/korbit-generate-pr-description`
<!-- Korbit AI PR Description End -->