### PR TITLE
Cache asset versions at activation

### DIFF
--- a/nuclear-engagement/admin/Onboarding.php
+++ b/nuclear-engagement/admin/Onboarding.php
@@ -13,6 +13,7 @@
 namespace NuclearEngagement\Admin;
 
 use NuclearEngagement\Admin\OnboardingPointers;
+use NuclearEngagement\AssetVersions;
 
 if ( ! defined( 'ABSPATH' ) ) {
     exit;
@@ -85,7 +86,7 @@ class Onboarding {
                         'nuclen-onboarding',
                         plugin_dir_url( __DIR__ ) . 'admin/js/onboarding-pointers.js',
                         array( 'wp-util' ),
-                        defined( 'NUCLEN_ASSET_VERSION' ) ? NUCLEN_ASSET_VERSION : '1',
+                        AssetVersions::get( 'onboarding_js' ),
                         true
                 );
 

--- a/nuclear-engagement/admin/trait-admin-assets.php
+++ b/nuclear-engagement/admin/trait-admin-assets.php
@@ -7,6 +7,8 @@
 
 namespace NuclearEngagement\Admin;
 
+use NuclearEngagement\AssetVersions;
+
 if ( ! defined( 'ABSPATH' ) ) {
     exit;
 }
@@ -22,7 +24,7 @@ trait Admin_Assets {
             $this->nuclen_get_plugin_name(),
             plugin_dir_url( __FILE__ ) . 'css/nuclen-admin.css',
             array(),
-            filemtime( plugin_dir_path( __FILE__ ) . 'css/nuclen-admin.css' ),
+            AssetVersions::get( 'admin_css' ),
             'all'
         );
     }
@@ -54,7 +56,7 @@ trait Admin_Assets {
                         'nuclen-admin',
                         plugin_dir_url( __DIR__ ) . 'admin/js/nuclen-admin.js',
                         array(),
-                        NUCLEN_ASSET_VERSION,
+                        AssetVersions::get( 'admin_js' ),
                         true
                 );
 

--- a/nuclear-engagement/bootstrap.php
+++ b/nuclear-engagement/bootstrap.php
@@ -4,6 +4,7 @@ use NuclearEngagement\Defaults;
 use NuclearEngagement\Activator;
 use NuclearEngagement\Deactivator;
 use NuclearEngagement\MetaRegistration;
+use NuclearEngagement\AssetVersions;
 use NuclearEngagement\Plugin;
 
 if (!defined('ABSPATH')) {
@@ -16,6 +17,8 @@ define('NUCLEN_ASSET_VERSION', '250613-30');
 
 require_once NUCLEN_PLUGIN_DIR . 'includes/autoload.php';
 require_once NUCLEN_PLUGIN_DIR . 'includes/constants.php';
+
+AssetVersions::init();
 
 function nuclear_engagement_load_textdomain() {
     load_plugin_textdomain(

--- a/nuclear-engagement/front/traits/AssetsTrait.php
+++ b/nuclear-engagement/front/traits/AssetsTrait.php
@@ -13,6 +13,8 @@
 
 namespace NuclearEngagement\Front;
 
+use NuclearEngagement\AssetVersions;
+
 if ( ! defined( 'ABSPATH' ) ) {
     exit;
 }
@@ -29,7 +31,7 @@ trait AssetsTrait {
             $this->plugin_name,
             plugin_dir_url( __FILE__ ) . '../css/nuclen-front.css',
             array(),
-            filemtime( plugin_dir_path( __FILE__ ) . '../css/nuclen-front.css' ),
+            AssetVersions::get( 'front_css' ),
             'all'
         );
 
@@ -43,20 +45,24 @@ trait AssetsTrait {
 
         if ( $theme_choice === 'bright' ) {
             $theme_url = plugin_dir_url( __FILE__ ) . '../css/nuclen-theme-bright.css';
+            $theme_v   = AssetVersions::get( 'theme_bright_css' );
         } elseif ( $theme_choice === 'dark' ) {
             $theme_url = plugin_dir_url( __FILE__ ) . '../css/nuclen-theme-dark.css';
+            $theme_v   = AssetVersions::get( 'theme_dark_css' );
         } elseif ( $theme_choice === 'custom' ) {
             $css_info  = \NuclearEngagement\Utils::nuclen_get_custom_css_info();
             $theme_url = $css_info['url'];
+            $theme_v   = get_option( 'nuclen_custom_css_version', AssetVersions::get( 'theme_bright_css' ) );
         } else {
             $theme_url = plugin_dir_url( __FILE__ ) . '../css/nuclen-theme-bright.css';
+            $theme_v   = AssetVersions::get( 'theme_bright_css' );
         }
 
         wp_enqueue_style(
             $this->plugin_name . '-theme',
             $theme_url,
             array(),
-            filemtime( str_replace( content_url(), WP_CONTENT_DIR, $theme_url ) ),
+            $theme_v,
             'all'
         );
     }
@@ -71,7 +77,7 @@ trait AssetsTrait {
             $this->plugin_name . '-front',
             plugin_dir_url( dirname( __FILE__ ) ) . 'js/nuclen-front.js',
             array(),
-            NUCLEN_ASSET_VERSION,
+            AssetVersions::get( 'front_js' ),
             true
         );
 

--- a/nuclear-engagement/includes/Activator.php
+++ b/nuclear-engagement/includes/Activator.php
@@ -4,6 +4,8 @@
 namespace NuclearEngagement;
 
 use NuclearEngagement\SettingsRepository;
+use NuclearEngagement\OptinData;
+use NuclearEngagement\AssetVersions;
 
 if (!defined('ABSPATH')) {
     exit;
@@ -32,5 +34,8 @@ class Activator {
 
         // Ensure opt-in table exists on activation
         OptinData::maybe_create_table();
+
+        // Generate asset version strings for cache busting
+        AssetVersions::update_versions();
     }
 }

--- a/nuclear-engagement/includes/AssetVersions.php
+++ b/nuclear-engagement/includes/AssetVersions.php
@@ -1,0 +1,66 @@
+<?php
+namespace NuclearEngagement;
+
+if ( ! defined( 'ABSPATH' ) ) {
+    exit;
+}
+
+/**
+ * Handles versioning for compiled plugin assets.
+ */
+final class AssetVersions {
+    private const OPTION = 'nuclen_asset_versions';
+    private const PLUGIN_OPTION = 'nuclen_asset_versions_build';
+
+    /**
+     * Recompute asset versions when the stored plugin version differs.
+     */
+    public static function init(): void {
+        $stored = get_option( self::PLUGIN_OPTION );
+        if ( $stored !== NUCLEN_PLUGIN_VERSION ) {
+            self::update_versions();
+        }
+    }
+
+    /**
+     * Compute and store asset version strings.
+     */
+    public static function update_versions(): void {
+        update_option( self::OPTION, self::compute() );
+        update_option( self::PLUGIN_OPTION, NUCLEN_PLUGIN_VERSION );
+    }
+
+    /**
+     * Retrieve a version string for the given key.
+     */
+    public static function get( string $key ): string {
+        $versions = get_option( self::OPTION, array() );
+        return isset( $versions[ $key ] ) ? $versions[ $key ] : NUCLEN_ASSET_VERSION;
+    }
+
+    /**
+     * Build the version map based on file modification times.
+     */
+    private static function compute(): array {
+        $files = array(
+            'admin_css'         => NUCLEN_PLUGIN_DIR . 'admin/css/nuclen-admin.css',
+            'admin_dashboard'   => NUCLEN_PLUGIN_DIR . 'admin/css/nuclen-admin-dashboard.css',
+            'admin_js'          => NUCLEN_PLUGIN_DIR . 'admin/js/nuclen-admin.js',
+            'onboarding_js'     => NUCLEN_PLUGIN_DIR . 'admin/js/onboarding-pointers.js',
+            'front_css'         => NUCLEN_PLUGIN_DIR . 'front/css/nuclen-front.css',
+            'front_js'          => NUCLEN_PLUGIN_DIR . 'front/js/nuclen-front.js',
+            'theme_bright_css'  => NUCLEN_PLUGIN_DIR . 'front/css/nuclen-theme-bright.css',
+            'theme_dark_css'    => NUCLEN_PLUGIN_DIR . 'front/css/nuclen-theme-dark.css',
+            'toc_admin_css'     => NUCLEN_PLUGIN_DIR . 'modules/toc/assets/css/nuclen-toc-admin.css',
+            'toc_admin_js'      => NUCLEN_PLUGIN_DIR . 'modules/toc/assets/js/nuclen-toc-admin.js',
+            'toc_front_css'     => NUCLEN_PLUGIN_DIR . 'modules/toc/assets/css/nuclen-toc-front.css',
+            'toc_front_js'      => NUCLEN_PLUGIN_DIR . 'modules/toc/assets/js/nuclen-toc-front.js',
+        );
+
+        $versions = array();
+        foreach ( $files as $key => $path ) {
+            $versions[ $key ] = file_exists( $path ) ? (string) filemtime( $path ) : (string) time();
+        }
+        return $versions;
+    }
+}

--- a/nuclear-engagement/includes/Utils.php
+++ b/nuclear-engagement/includes/Utils.php
@@ -41,11 +41,11 @@ class Utils {
         $custom_css_path    = $custom_dir . '/' . $base_css_file_name;
 
         // Get the stored version hash or generate a new one if the file exists
-        $version = get_option('nuclen_custom_css_version', '');
-        if (file_exists($custom_css_path)) {
-            $file_mtime = filemtime($custom_css_path);
-            $file_hash = md5_file($custom_css_path);
-            $version = $file_mtime . '-' . substr($file_hash, 0, 8);
+        $version = get_option( 'nuclen_custom_css_version', '' );
+        if ( $version === '' && file_exists( $custom_css_path ) ) {
+            $file_mtime = filemtime( $custom_css_path );
+            $file_hash  = md5_file( $custom_css_path );
+            $version    = $file_mtime . '-' . substr( $file_hash, 0, 8 );
         }
 
         $custom_css_url = $upload_dir['baseurl'] . '/nuclear-engagement/' . $base_css_file_name . '?v=' . $version;

--- a/nuclear-engagement/includes/autoload.php
+++ b/nuclear-engagement/includes/autoload.php
@@ -30,6 +30,7 @@ spl_autoload_register(function ($class) {
             'NuclearEngagement\\Defaults' => '/includes/Defaults.php',
             'NuclearEngagement\\OptinData' => '/includes/OptinData.php',
             'NuclearEngagement\\MetaRegistration' => '/includes/MetaRegistration.php',
+            'NuclearEngagement\\AssetVersions' => '/includes/AssetVersions.php',
 
             'NuclearEngagement\\Admin\\Admin' => '/admin/Admin.php',
             'NuclearEngagement\\Admin\\Dashboard' => '/admin/Dashboard.php',

--- a/nuclear-engagement/modules/toc/includes/class-nuclen-toc-admin.php
+++ b/nuclear-engagement/modules/toc/includes/class-nuclen-toc-admin.php
@@ -9,6 +9,8 @@ if ( ! defined( 'ABSPATH' ) ) {
     exit;
 }
 
+use NuclearEngagement\AssetVersions;
+
 final class Nuclen_TOC_Admin {
 
     private string $hook = '';
@@ -36,8 +38,8 @@ final class Nuclen_TOC_Admin {
         $css_p = NUCLEN_TOC_DIR . 'assets/css/nuclen-toc-admin.css';
         $js_p  = NUCLEN_TOC_DIR . 'assets/js/nuclen-toc-admin.js';
 
-        $css_v = file_exists( $css_p ) ? filemtime( $css_p ) : NUCLEN_ASSET_VERSION;
-        $js_v  = file_exists( $js_p )  ? filemtime( $js_p )  : NUCLEN_ASSET_VERSION;
+        $css_v = AssetVersions::get( 'toc_admin_css' );
+        $js_v  = AssetVersions::get( 'toc_admin_js' );
 
         wp_register_style(
             'nuclen-toc-admin',

--- a/nuclear-engagement/modules/toc/includes/class-nuclen-toc-assets.php
+++ b/nuclear-engagement/modules/toc/includes/class-nuclen-toc-assets.php
@@ -9,6 +9,8 @@ if ( ! defined( 'ABSPATH' ) ) {
     exit;
 }
 
+use NuclearEngagement\AssetVersions;
+
 final class Nuclen_TOC_Assets {
         /** Default vertical offset for scroll-to behaviour. */
         public const DEFAULT_SCROLL_OFFSET = NUCLEN_TOC_SCROLL_OFFSET_DEFAULT;
@@ -50,8 +52,8 @@ final class Nuclen_TOC_Assets {
                 $css_p = NUCLEN_TOC_DIR . 'assets/css/nuclen-toc-front.css';
                 $js_p  = NUCLEN_TOC_DIR . 'assets/js/nuclen-toc-front.js';
 
-                $css_v = file_exists( $css_p ) ? filemtime( $css_p ) : NUCLEN_ASSET_VERSION;
-                $js_v  = file_exists( $js_p )  ? filemtime( $js_p )  : NUCLEN_ASSET_VERSION;
+                $css_v = AssetVersions::get( 'toc_front_css' );
+                $js_v  = AssetVersions::get( 'toc_front_js' );
 
                 wp_register_style(
                         'nuclen-toc-front',


### PR DESCRIPTION
## Summary
- add new `AssetVersions` helper to store precomputed file hashes
- update activation routine to refresh cached asset versions
- fetch cached versions when enqueueing assets
- pull custom CSS version from option instead of recomputing

## Testing
- `composer lint` *(fails: command not found)*
- `composer test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6857b6d652588327b81941b8667b43d7