### PR TITLE
Implement cleanup for active generation tracking

### DIFF
--- a/tests/AutoGenerationServiceTest.php
+++ b/tests/AutoGenerationServiceTest.php
@@ -1,0 +1,61 @@
+<?php
+use PHPUnit\Framework\TestCase;
+use NuclearEngagement\Services\AutoGenerationService;
+use NuclearEngagement\SettingsRepository;
+
+class DummyRemoteApiService {
+    public array $updates = [];
+    public function sendPostsToGenerate(array $data): array { return []; }
+    public function fetchUpdates(string $id): array { return $this->updates[$id] ?? []; }
+}
+
+class DummyContentStorageService {
+    public array $stored = [];
+    public function storeResults(array $results, string $workflowType): void {
+        $this->stored[] = [$results, $workflowType];
+    }
+}
+
+class AutoGenerationServiceTest extends TestCase {
+    protected function setUp(): void {
+        global $wp_options, $wp_autoload, $wp_posts, $wp_meta, $wp_events;
+        $wp_options = $wp_autoload = $wp_posts = $wp_meta = $wp_events = [];
+        SettingsRepository::_reset_for_tests();
+    }
+
+    private function makeService(?DummyRemoteApiService $api = null): AutoGenerationService {
+        $settings = SettingsRepository::get_instance();
+        $api = $api ?: new DummyRemoteApiService();
+        $storage = new DummyContentStorageService();
+        return new AutoGenerationService($settings, $api, $storage);
+    }
+
+    public function test_generate_single_sets_autoload_no(): void {
+        global $wp_autoload, $wp_posts;
+        $wp_posts[1] = (object)[ 'ID' => 1, 'post_title' => 'T', 'post_content' => 'C' ];
+        $service = $this->makeService();
+        $service->generate_single(1, 'quiz');
+        $this->assertSame('no', $wp_autoload['nuclen_active_generations']);
+    }
+
+    public function test_poll_generation_removes_entry_after_success(): void {
+        global $wp_options;
+        $id = 'gen123';
+        $wp_options['nuclen_active_generations'] = [ $id => ['foo'=>'bar'] ];
+        $api = new DummyRemoteApiService();
+        $api->updates[$id] = ['results' => ['1'=>['ok']]];
+        $service = $this->makeService($api);
+        $service->poll_generation($id, 'quiz', 1, 1);
+        $this->assertArrayNotHasKey($id, $wp_options['nuclen_active_generations'] ?? []);
+    }
+
+    public function test_poll_generation_removes_entry_after_final_failure(): void {
+        global $wp_options;
+        $id = 'gen999';
+        $wp_options['nuclen_active_generations'] = [ $id => ['foo'=>'bar'] ];
+        $api = new DummyRemoteApiService();
+        $service = $this->makeService($api);
+        $service->poll_generation($id, 'quiz', 1, AutoGenerationService::MAX_ATTEMPTS);
+        $this->assertArrayNotHasKey($id, $wp_options['nuclen_active_generations'] ?? []);
+    }
+}


### PR DESCRIPTION
## Summary
- disable autoloading when storing `nuclen_active_generations`
- clean up finished or failed generations
- stub more WordPress functions for tests
- add tests for autoload flag and cleanup logic

## Testing
- `vendor/bin/phpcs` *(fails: `php` not found)*
- `vendor/bin/phpunit` *(fails: `php` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6857b6c33d848327bda30ff46a06cdbb

<!-- Korbit AI PR Description Start -->
## Description by Korbit AI

### What change is being made?

Implement a cleanup mechanism for active generation tracking and ensure options are not auto-loaded in the `AutoGenerationService` class.

### Why are these changes being made?

The changes address the need for efficient management of active generations by removing completed or failed entries, thus preventing stale data from accumulating. This approach optimizes memory usage, particularly during autoloading, by updating options with the `autoload='no'` flag. Additionally, the related test cases ensure the correctness of the cleanup process, enhancing the robustness of the service.

> Is this description stale? Ask me to generate a new description by commenting `/korbit-generate-pr-description`
<!-- Korbit AI PR Description End -->