### PR TITLE
Check table before creating optin table

### DIFF
--- a/nuclear-engagement/includes/OptinData.php
+++ b/nuclear-engagement/includes/OptinData.php
@@ -50,10 +50,14 @@ class OptinData {
     }
 
     /**
-     * Create / migrate the opt-in table.
-     * Safe to run many times – dbDelta() is idempotent.
+     * Create the opt-in table if it doesn't already exist.
+     * Safe to run many times – dbDelta() is idempotent but skipped when not needed.
      */
     public static function maybe_create_table(): void {
+        if ( self::table_exists() ) {
+            return;
+        }
+
         global $wpdb;
 
         $charset = $wpdb->get_charset_collate();
@@ -87,7 +91,9 @@ class OptinData {
         }
 
         /* Make sure the table is present (first-ever submission, etc.) */
-        self::maybe_create_table();
+        if ( ! self::table_exists() ) {
+            self::maybe_create_table();
+        }
 
         global $wpdb;
         $ok = $wpdb->insert(

--- a/tests/OptinDataTest.php
+++ b/tests/OptinDataTest.php
@@ -18,4 +18,20 @@ class OptinDataTest extends TestCase {
     public function test_escape_csv_field_unchanged() {
         $this->assertSame('plain', $this->escapeMethod->invoke(null, 'plain'));
     }
+
+    public function test_dbDelta_not_called_when_table_exists() {
+        global $dbDelta_called, $wpdb;
+
+        $dbDelta_called = false;
+        $wpdb = new class {
+            public $prefix = 'wp_';
+            public function get_charset_collate() { return ''; }
+            public function prepare($query, $param) { return $param; }
+            public function get_var($query) { return 'wp_nuclen_optins'; }
+        };
+
+        OptinData::maybe_create_table();
+
+        $this->assertFalse($dbDelta_called);
+    }
 }

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -3,6 +3,9 @@
 if (!defined('ABSPATH')) {
     define('ABSPATH', __DIR__ . '/');
 }
+// Track calls to dbDelta in unit tests
+global $dbDelta_called;
+$dbDelta_called = false;
 // Minimal stubs for WordPress functions used in included files
 if (!function_exists('add_action')) {
     function add_action(...$args) {}

--- a/tests/wp-admin/includes/upgrade.php
+++ b/tests/wp-admin/includes/upgrade.php
@@ -1,0 +1,5 @@
+<?php
+function dbDelta( $sql ) {
+    global $dbDelta_called;
+    $dbDelta_called = true;
+}


### PR DESCRIPTION
## Summary
- avoid unnecessary dbDelta calls when optin table already exists
- track dbDelta calls in tests
- add test to ensure dbDelta is skipped when the table exists

## Testing
- `composer lint` *(fails: command not found)*
- `composer test` *(fails: command not found)*
- `phpunit` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6857b6ad19788327a903ec300d82fb23

<!-- Korbit AI PR Description Start -->
## Description by Korbit AI

### What change is being made?

Add a pre-check to verify if the opt-in table exists before attempting to create it and introduce corresponding unit tests to ensure `dbDelta()` is not called unnecessarily.

### Why are these changes being made?

This enhancement prevents redundant calls to `dbDelta()`, optimizing database operations by ensuring the table creation process is only initiated when necessary, thereby improving efficiency. This change is particularly useful in reducing overhead, especially when operations are idempotent and the table exists, as already ensured by `dbDelta()`'s behavior.

> Is this description stale? Ask me to generate a new description by commenting `/korbit-generate-pr-description`
<!-- Korbit AI PR Description End -->