### PR TITLE
Derive plugin version from header

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -169,3 +169,10 @@ fields now use the browser's native `<input type="color">` element. The
 `SettingsColorPickerTrait` no longer enqueues `wp-color-picker` scripts and is
 a no-op kept for backward compatibility.
 
+## Version Constant from Plugin Header
+
+`bootstrap.php` no longer hardcodes the plugin version. Instead it loads the
+plugin header with `get_plugin_data()` and defines `NUCLEN_PLUGIN_VERSION` from
+the returned value. All other code references this constant so updating the
+header automatically propagates the new version.
+

--- a/nuclear-engagement/bootstrap.php
+++ b/nuclear-engagement/bootstrap.php
@@ -12,7 +12,15 @@ if (!defined('ABSPATH')) {
 }
 
 define('NUCLEN_PLUGIN_DIR', plugin_dir_path(NUCLEN_PLUGIN_FILE));
-define('NUCLEN_PLUGIN_VERSION', '1.1');
+
+if ( ! defined( 'NUCLEN_PLUGIN_VERSION' ) ) {
+    if ( ! function_exists( 'get_plugin_data' ) ) {
+        require_once ABSPATH . 'wp-admin/includes/plugin.php';
+    }
+    $data = get_plugin_data( NUCLEN_PLUGIN_FILE );
+    define( 'NUCLEN_PLUGIN_VERSION', $data['Version'] );
+}
+
 define('NUCLEN_ASSET_VERSION', '250613-30');
 
 require_once NUCLEN_PLUGIN_DIR . 'includes/autoload.php';


### PR DESCRIPTION
## Summary
- fetch plugin version using `get_plugin_data` in `bootstrap.php`
- document the dynamic version constant in ARCHITECTURE.md

## Testing
- `composer lint` *(fails: command not found)*
- `composer test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6857c1ccf7c88327971375ebe7f38897


> [!NOTE]
> I'm currently writing a description for your pull request. I should be done shortly (<1 minute). Please don't edit the description field until I'm finished, or we may overwrite each other. If I find nothing to write about, I'll delete this message.
