### PR TITLE
Handle generation API errors

### DIFF
--- a/nuclear-engagement/includes/Services/AutoGenerationService.php
+++ b/nuclear-engagement/includes/Services/AutoGenerationService.php
@@ -160,11 +160,19 @@ class AutoGenerationService {
                 'generation_id' => $generation_id,
             ];
 
-            $result = $this->remote_api->sendPostsToGenerate($data_to_send);
-
-            if (is_wp_error($result)) {
+            try {
+                $result = $this->remote_api->sendPostsToGenerate($data_to_send);
+            } catch (\Exception $e) {
                 \NuclearEngagement\Services\LoggingService::log(
-                    'Failed to start generation: ' . $result->get_error_message()
+                    'Failed to start generation: ' . $e->getMessage()
+                );
+                return;
+            }
+
+            if (is_wp_error($result) || (isset($result['error']) && $result['error'] !== '')) {
+                $message = is_wp_error($result) ? $result->get_error_message() : $result['error'];
+                \NuclearEngagement\Services\LoggingService::log(
+                    'Failed to start generation: ' . $message
                 );
                 return;
             }


### PR DESCRIPTION
## Summary
- catch API exceptions in auto generation
- skip scheduling when API returns an error
- ensure cron events aren't created on failure

## Testing
- `composer lint` *(fails: command not found)*
- `composer test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6857c2ac9cc08327a24ba72409e2b7ad