### PR TITLE
Unify API error handling

### DIFF
--- a/nuclear-engagement/front/traits/RestTrait.php
+++ b/nuclear-engagement/front/traits/RestTrait.php
@@ -49,7 +49,7 @@ trait RestTrait {
                         $container = $this->get_container();
                         $api = $container->get('remote_api');
             return $api->sendPostsToGenerate($data_to_send);
-        } catch (\Exception $e) {
+        } catch (\RuntimeException $e) {
 \NuclearEngagement\Services\LoggingService::log('Error sending data: ' . $e->getMessage());
             return false;
         }

--- a/nuclear-engagement/includes/Services/AutoGenerationService.php
+++ b/nuclear-engagement/includes/Services/AutoGenerationService.php
@@ -161,18 +161,10 @@ class AutoGenerationService {
             ];
 
             try {
-                $result = $this->remote_api->sendPostsToGenerate($data_to_send);
-            } catch (\Exception $e) {
+                $this->remote_api->sendPostsToGenerate($data_to_send);
+            } catch (\RuntimeException $e) {
                 \NuclearEngagement\Services\LoggingService::log(
                     'Failed to start generation: ' . $e->getMessage()
-                );
-                return;
-            }
-
-            if (is_wp_error($result) || (isset($result['error']) && $result['error'] !== '')) {
-                $message = is_wp_error($result) ? $result->get_error_message() : $result['error'];
-                \NuclearEngagement\Services\LoggingService::log(
-                    'Failed to start generation: ' . $message
                 );
                 return;
             }

--- a/tests/AutoGenerationServiceTest.php
+++ b/tests/AutoGenerationServiceTest.php
@@ -2,11 +2,17 @@
 use PHPUnit\Framework\TestCase;
 use NuclearEngagement\Services\AutoGenerationService;
 use NuclearEngagement\SettingsRepository;
+use RuntimeException;
 
 class DummyRemoteApiService {
     public array $updates = [];
-    public array $generateResponse = [];
-    public function sendPostsToGenerate(array $data): array { return $this->generateResponse; }
+    public $generateResponse = [];
+    public function sendPostsToGenerate(array $data): array {
+        if ($this->generateResponse instanceof \Exception) {
+            throw $this->generateResponse;
+        }
+        return $this->generateResponse;
+    }
     public function fetchUpdates(string $id): array { return $this->updates[$id] ?? []; }
 }
 
@@ -43,7 +49,7 @@ class AutoGenerationServiceTest extends TestCase {
         global $wp_posts, $wp_events, $wp_options;
         $wp_posts[1] = (object)[ 'ID' => 1, 'post_title' => 'T', 'post_content' => 'C' ];
         $api = new DummyRemoteApiService();
-        $api->generateResponse = ['error' => 'nope'];
+        $api->generateResponse = new RuntimeException('nope');
         $service = $this->makeService($api);
         $service->generate_single(1, 'quiz');
         $this->assertEmpty($wp_events);

--- a/tests/GenerationServiceTest.php
+++ b/tests/GenerationServiceTest.php
@@ -1,0 +1,69 @@
+<?php
+use PHPUnit\Framework\TestCase;
+use NuclearEngagement\Services\GenerationService;
+use NuclearEngagement\SettingsRepository;
+use NuclearEngagement\Requests\GenerateRequest;
+use RuntimeException;
+
+if (!function_exists('get_posts')) {
+    function get_posts($args) {
+        $ids = $args['post__in'] ?? [];
+        $posts = [];
+        foreach ($ids as $id) {
+            if (isset($GLOBALS['wp_posts'][$id])) {
+                $posts[] = $GLOBALS['wp_posts'][$id];
+            }
+        }
+        return $posts;
+    }
+}
+
+class GSRemoteApi {
+    public function sendPostsToGenerate(array $data): array {
+        throw new RuntimeException('api fail', 401);
+    }
+    public function fetchUpdates(string $id): array { return []; }
+}
+
+class GSStorage {
+    public array $stored = [];
+    public function storeResults(array $r, string $t): void { $this->stored[] = [$r,$t]; }
+}
+
+class GenerationServiceTest extends TestCase {
+    protected function setUp(): void {
+        global $wp_posts, $wp_options, $wp_autoload;
+        $wp_posts = $wp_options = $wp_autoload = [];
+        SettingsRepository::_reset_for_tests();
+    }
+
+    private function makeService(): GenerationService {
+        $settings = SettingsRepository::get_instance();
+        $api = new GSRemoteApi();
+        $storage = new GSStorage();
+        return new GenerationService($settings, $api, $storage);
+    }
+
+    public function test_generate_content_returns_error_response_on_exception(): void {
+        global $wp_posts;
+        $wp_posts[1] = (object)[
+            'ID' => 1,
+            'post_title' => 'T',
+            'post_content' => 'C',
+            'post_type' => 'post',
+            'post_status' => 'publish',
+        ];
+        $req = new GenerateRequest();
+        $req->postIds = [1];
+        $req->workflowType = 'quiz';
+        $req->generationId = 'gid';
+        $req->postType = 'post';
+        $req->postStatus = 'publish';
+
+        $service = $this->makeService();
+        $res = $service->generateContent($req);
+        $this->assertFalse($res->success);
+        $this->assertSame('api fail', $res->error);
+        $this->assertSame(401, $res->statusCode);
+    }
+}


### PR DESCRIPTION
## Summary
- throw `RuntimeException` from `RemoteApiService::sendPostsToGenerate`
- adapt services and trait to catch `RuntimeException`
- update tests for new behaviour and add `GenerationServiceTest`

## Testing
- `composer lint`
- `composer test`

------
https://chatgpt.com/codex/tasks/task_e_6857c4606f008327b7c16fa22f3920dc

<!-- Korbit AI PR Description Start -->
## Description by Korbit AI

### What change is being made?

Unify error handling for the API by replacing all instances of generic exceptions with more specific `\RuntimeException`; remove redundant error handling logic throughout services and update test cases accordingly.

### Why are these changes being made?

The previous implementation had inconsistent error handling using generic exceptions and manual error checking on API responses. Standardizing on `\RuntimeException` simplifies and centralizes error handling, leading to cleaner code and fewer redundant checks. This approach also enhances the robustness and readability of the service code. Additionally, updating the test cases ensures the code is validated against the new error handling approach.

> Is this description stale? Ask me to generate a new description by commenting `/korbit-generate-pr-description`
<!-- Korbit AI PR Description End -->