### PR TITLE
Add Composer cache to CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,6 +19,14 @@ jobs:
           php-version: '8.1'
           coverage: none
 
+      # Cache Composer packages to speed up dependency installation
+      - name: Cache Composer dependencies
+        uses: actions/cache@v3
+        with:
+          path: vendor
+          key: ${{ runner.os }}-composer-${{ hashFiles('composer.lock') }}
+          restore-keys: ${{ runner.os }}-composer-
+
       - name: Install Composer dependencies
         run: composer install --no-interaction --prefer-dist
 


### PR DESCRIPTION
## Summary
- cache Composer `vendor` directory using `actions/cache`
- document caching step in CI

## Testing
- `composer lint` *(fails: command not found)*
- `composer test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6857c653cf8083278d61fc00d0297277

<!-- Korbit AI PR Description Start -->
## Description by Korbit AI

### What change is being made?

Add Composer cache to the CI workflow to optimize dependency installation.

### Why are these changes being made?

Caching Composer dependencies significantly speeds up the CI process by avoiding redundant downloads, which results in faster build times. This is achieved using the `actions/cache` GitHub Action and leveraging the hash of the `composer.lock` file to ensure cache validity.

> Is this description stale? Ask me to generate a new description by commenting `/korbit-generate-pr-description`
<!-- Korbit AI PR Description End -->