### PR TITLE
Add explicit return types to setup handlers

### DIFF
--- a/nuclear-engagement/admin/SetupHandlersTrait.php
+++ b/nuclear-engagement/admin/SetupHandlersTrait.php
@@ -25,7 +25,7 @@ trait SetupHandlersTrait {
     /*--------------------------------------------------------------
      #  STEP 1 – Store the Gold Code
      --------------------------------------------------------------*/
-    public function nuclen_handle_connect_app() {
+    public function nuclen_handle_connect_app(): void {
 
         if ( ! isset( $_POST['nuclen_connect_app_nonce'], $_POST['nuclen_api_key'] ) ||
              ! wp_verify_nonce( sanitize_text_field( wp_unslash( $_POST['nuclen_connect_app_nonce'] ) ), 'nuclen_connect_app_action' )
@@ -66,7 +66,7 @@ trait SetupHandlersTrait {
     /*--------------------------------------------------------------
      #  STEP 2 – Generate & store plugin App Password
      --------------------------------------------------------------*/
-    public function nuclen_handle_generate_app_password( $bypass_nonce = false ) {
+    public function nuclen_handle_generate_app_password( $bypass_nonce = false ): void {
 
         if ( ! $bypass_nonce ) {
             if ( ! isset( $_POST['nuclen_generate_app_password_nonce'] ) ||
@@ -139,7 +139,7 @@ trait SetupHandlersTrait {
     /*--------------------------------------------------------------
      #  Reset handlers
      --------------------------------------------------------------*/
-    public function nuclen_handle_reset_api_key() {
+    public function nuclen_handle_reset_api_key(): void {
 
         if ( ! isset( $_POST['nuclen_reset_api_key_nonce'] ) ||
              ! wp_verify_nonce( sanitize_text_field( wp_unslash( $_POST['nuclen_reset_api_key_nonce'] ) ), 'nuclen_reset_api_key_action' )
@@ -161,7 +161,7 @@ trait SetupHandlersTrait {
         $this->nuclen_redirect_with_success( 'Gold Code reset. Site disconnected.' );
     }
 
-    public function nuclen_handle_reset_wp_app_connection() {
+    public function nuclen_handle_reset_wp_app_connection(): void {
 
         if ( ! isset( $_POST['nuclen_reset_wp_app_nonce'] ) ||
              ! wp_verify_nonce( sanitize_text_field( wp_unslash( $_POST['nuclen_reset_wp_app_nonce'] ) ), 'nuclen_reset_wp_app_action' )
@@ -188,7 +188,7 @@ trait SetupHandlersTrait {
        }
 
 
-    private function nuclen_redirect_with_error( $msg ) {
+    private function nuclen_redirect_with_error( $msg ): void {
         wp_redirect(
             add_query_arg(
                 array(
@@ -202,7 +202,7 @@ trait SetupHandlersTrait {
         exit;
     }
 
-    private function nuclen_redirect_with_success( $msg ) {
+    private function nuclen_redirect_with_success( $msg ): void {
         wp_redirect(
             add_query_arg(
                 array(


### PR DESCRIPTION
## Summary
- declare void return types for setup handler methods and redirect helpers

## Testing
- `php vendor/bin/phpcs` *(fails: php command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6857c6515c788327af97598a3e71f8b9

<!-- Korbit AI PR Description Start -->
## Description by Korbit AI

### What change is being made?

Add explicit return types to the functions in the `SetupHandlersTrait` class in the `nuclear-engagement/admin/SetupHandlersTrait.php` file.

### Why are these changes being made?

These changes clarify the intended return type of each function, which enhances code readability and maintainability. By specifying `void` as the return type, it is clear that these functions do not return any value, reducing potential misunderstandings and improving type safety in the codebase.

> Is this description stale? Ask me to generate a new description by commenting `/korbit-generate-pr-description`
<!-- Korbit AI PR Description End -->