### PR TITLE
Add GenerationService polling tests

### DIFF
--- a/tests/GenerationServiceSingleTest.php
+++ b/tests/GenerationServiceSingleTest.php
@@ -1,0 +1,96 @@
+<?php
+use PHPUnit\Framework\TestCase;
+use NuclearEngagement\Services\GenerationService;
+use NuclearEngagement\SettingsRepository;
+use RuntimeException;
+
+// Stub LoggingService to avoid filesystem calls
+namespace NuclearEngagement\Services {
+    class LoggingService {
+        public static array $logs = [];
+        public static function log(string $msg): void {
+            self::$logs[] = $msg;
+        }
+    }
+}
+
+namespace {
+    class DummyGenApi {
+        public ?\Exception $exception = null;
+        public array $response = [];
+        public function sendPostsToGenerate(array $data): array {
+            if ($this->exception) {
+                throw $this->exception;
+            }
+            return $this->response;
+        }
+        public function fetchUpdates(string $id): array { return []; }
+    }
+
+    class DummyStorage {
+        public array $stored = [];
+        public function storeResults(array $r, string $t): void {
+            $this->stored[] = [$r, $t];
+        }
+    }
+
+    class GenerationServiceSingleTest extends TestCase {
+        protected function setUp(): void {
+            global $wp_posts, $wp_events, $wp_options, $wp_meta, $wp_autoload;
+            $wp_posts = $wp_events = $wp_options = $wp_meta = $wp_autoload = [];
+            SettingsRepository::_reset_for_tests();
+        }
+
+        private function makeService(?DummyGenApi $api = null, ?DummyStorage $store = null): GenerationService {
+            $settings = SettingsRepository::get_instance();
+            $api = $api ?: new DummyGenApi();
+            $store = $store ?: new DummyStorage();
+            return new GenerationService($settings, $api, $store);
+        }
+
+        public function test_generate_single_schedules_poll_when_no_results(): void {
+            global $wp_posts, $wp_events;
+            $wp_posts[1] = (object)[
+                'ID' => 1,
+                'post_title' => 'T',
+                'post_content' => 'C',
+                'post_type' => 'post',
+                'post_status' => 'publish',
+            ];
+            $api = new DummyGenApi();
+            $api->response = [];
+            $store = new DummyStorage();
+            $service = $this->makeService($api, $store);
+            $service->generateSingle(1, 'quiz');
+            $this->assertEmpty($store->stored);
+            $this->assertCount(1, $wp_events);
+            $event = $wp_events[0];
+            $this->assertSame('nuclen_poll_generation', $event['hook']);
+            $this->assertSame('quiz', $event['args'][1]);
+            $this->assertSame(1, $event['args'][2]);
+            $this->assertSame(1, $event['args'][3]);
+            $this->assertStringStartsWith('auto_1_', $event['args'][0]);
+        }
+
+        public function test_generate_single_rethrows_api_errors(): void {
+            global $wp_posts, $wp_events;
+            $wp_posts[2] = (object)[
+                'ID' => 2,
+                'post_title' => 'T2',
+                'post_content' => 'C2',
+                'post_type' => 'post',
+                'post_status' => 'publish',
+            ];
+            $api = new DummyGenApi();
+            $api->exception = new RuntimeException('fail', 500);
+            $service = $this->makeService($api);
+            $this->expectException(RuntimeException::class);
+            $this->expectExceptionMessage('fail');
+            try {
+                $service->generateSingle(2, 'quiz');
+            } finally {
+                $this->assertEmpty($wp_events);
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- add a new PHPUnit test for GenerationService::generateSingle
- verify poll scheduling and API error bubbling

## Testing
- `composer lint` *(fails: command not found)*
- `composer test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6857c64d00448327a626f81a3af4629b

<!-- Korbit AI PR Description Start -->
## Description by Korbit AI

### What change is being made?

Add unit tests for the `GenerationService` to test its polling behavior and its handling of API errors using dummy classes for API and storage services.

### Why are these changes being made?

The tests are added to ensure that the `GenerationService` correctly schedules a polling event when no results are returned from the API and properly rethrows exceptions from the API, maintaining reliable functionality under different scenarios. This improves the service's robustness by validating its behavior in test environments before deployment.

> Is this description stale? Ask me to generate a new description by commenting `/korbit-generate-pr-description`
<!-- Korbit AI PR Description End -->