### PR TITLE
Add strict types declarations

### DIFF
--- a/nuclear-engagement/admin/Admin.php
+++ b/nuclear-engagement/admin/Admin.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 /**
  * File: admin/Admin.php
  *

--- a/nuclear-engagement/admin/Controller/Ajax/BaseController.php
+++ b/nuclear-engagement/admin/Controller/Ajax/BaseController.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 /**
  * File: admin/Controller/Ajax/BaseController.php
  *

--- a/nuclear-engagement/admin/Controller/Ajax/GenerateController.php
+++ b/nuclear-engagement/admin/Controller/Ajax/GenerateController.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 /**
  * File: admin/Controller/Ajax/GenerateController.php
 

--- a/nuclear-engagement/admin/Controller/Ajax/PointerController.php
+++ b/nuclear-engagement/admin/Controller/Ajax/PointerController.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 /**
  * File: admin/Controller/Ajax/PointerController.php
 

--- a/nuclear-engagement/admin/Controller/Ajax/PostsCountController.php
+++ b/nuclear-engagement/admin/Controller/Ajax/PostsCountController.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 /**
  * File: admin/Controller/Ajax/PostsCountController.php
 

--- a/nuclear-engagement/admin/Controller/Ajax/UpdatesController.php
+++ b/nuclear-engagement/admin/Controller/Ajax/UpdatesController.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 /**
  * File: admin/Controller/Ajax/UpdatesController.php
  *

--- a/nuclear-engagement/admin/Controller/OptinExportController.php
+++ b/nuclear-engagement/admin/Controller/OptinExportController.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 /**
  * File: admin/Controller/OptinExportController.php
  *

--- a/nuclear-engagement/admin/Dashboard.php
+++ b/nuclear-engagement/admin/Dashboard.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 /**
  * admin/Dashboard.php
  *

--- a/nuclear-engagement/admin/Onboarding.php
+++ b/nuclear-engagement/admin/Onboarding.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 /**
  * File: admin/Onboarding.php
  *

--- a/nuclear-engagement/admin/OnboardingPointers.php
+++ b/nuclear-engagement/admin/OnboardingPointers.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 /**
  * File: admin/OnboardingPointers.php
  *

--- a/nuclear-engagement/admin/Settings.php
+++ b/nuclear-engagement/admin/Settings.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 /**
  * File: admin/Settings.php
  *

--- a/nuclear-engagement/admin/SettingsColorPickerTrait.php
+++ b/nuclear-engagement/admin/SettingsColorPickerTrait.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 /**
  * File: admin/SettingsColorPickerTrait.php
  *

--- a/nuclear-engagement/admin/SettingsPageTrait.php
+++ b/nuclear-engagement/admin/SettingsPageTrait.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 /**
  * File: admin/SettingsPageTrait.php
  *

--- a/nuclear-engagement/admin/SettingsSanitizeTrait.php
+++ b/nuclear-engagement/admin/SettingsSanitizeTrait.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 /**
  * File: admin/SettingsSanitizeTrait.php
  *

--- a/nuclear-engagement/admin/Setup.php
+++ b/nuclear-engagement/admin/Setup.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 /**
  * File: admin/Setup.php
  *

--- a/nuclear-engagement/admin/SetupHandlersTrait.php
+++ b/nuclear-engagement/admin/SetupHandlersTrait.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 /**
  * File: admin/SetupHandlersTrait.php
  *

--- a/nuclear-engagement/admin/index.php
+++ b/nuclear-engagement/admin/index.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 if ( ! defined( 'ABSPATH' ) ) {
     exit;
 } // Silence is golden

--- a/nuclear-engagement/admin/partials/dashboard/analytics.php
+++ b/nuclear-engagement/admin/partials/dashboard/analytics.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 // File: admin/partials/dashboard/analytics.php
 if ( ! defined( 'ABSPATH' ) ) {
     exit;

--- a/nuclear-engagement/admin/partials/dashboard/credits.php
+++ b/nuclear-engagement/admin/partials/dashboard/credits.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 // File: admin/partials/dashboard/credits.php
 if ( ! defined( 'ABSPATH' ) ) {
     exit;

--- a/nuclear-engagement/admin/partials/dashboard/inventory.php
+++ b/nuclear-engagement/admin/partials/dashboard/inventory.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 // File: admin/partials/dashboard/inventory.php
 if ( ! defined( 'ABSPATH' ) ) {
     exit;

--- a/nuclear-engagement/admin/partials/nuclen-admin-display.php
+++ b/nuclear-engagement/admin/partials/nuclen-admin-display.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 if ( ! defined( 'ABSPATH' ) ) {
     exit;
 }

--- a/nuclear-engagement/admin/partials/nuclen-admin-generate.php
+++ b/nuclear-engagement/admin/partials/nuclen-admin-generate.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 if ( ! defined( 'ABSPATH' ) ) {
     exit;
 }

--- a/nuclear-engagement/admin/partials/nuclen-admin-settings.php
+++ b/nuclear-engagement/admin/partials/nuclen-admin-settings.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 // File: admin/partials/nuclen-admin-settings.php
 if ( ! defined( 'ABSPATH' ) ) {
     exit;

--- a/nuclear-engagement/admin/partials/nuclen-dashboard-page.php
+++ b/nuclear-engagement/admin/partials/nuclen-dashboard-page.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 if ( ! defined( 'ABSPATH' ) ) {
     exit;
 }

--- a/nuclear-engagement/admin/partials/settings/display.php
+++ b/nuclear-engagement/admin/partials/settings/display.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 // File: admin/partials/settings/display.php
 if ( ! defined( 'ABSPATH' ) ) {
     exit;

--- a/nuclear-engagement/admin/partials/settings/display/attribution.php
+++ b/nuclear-engagement/admin/partials/settings/display/attribution.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 // File: admin/partials/settings/display/attribution.php
 if ( ! defined( 'ABSPATH' ) ) {
     exit;

--- a/nuclear-engagement/admin/partials/settings/display/counts.php
+++ b/nuclear-engagement/admin/partials/settings/display/counts.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 // File: admin/partials/settings/display/counts.php
 if ( ! defined( 'ABSPATH' ) ) {
     exit;

--- a/nuclear-engagement/admin/partials/settings/display/custom-quiz.php
+++ b/nuclear-engagement/admin/partials/settings/display/custom-quiz.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 // File: admin/partials/settings/display/custom-quiz.php
 if ( ! defined( 'ABSPATH' ) ) {
     exit;

--- a/nuclear-engagement/admin/partials/settings/display/labels.php
+++ b/nuclear-engagement/admin/partials/settings/display/labels.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 // File: admin/partials/settings/display/labels.php
 if ( ! defined( 'ABSPATH' ) ) {
     exit;

--- a/nuclear-engagement/admin/partials/settings/display/titles.php
+++ b/nuclear-engagement/admin/partials/settings/display/titles.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 // File: admin/partials/settings/display/titles.php
 if ( ! defined( 'ABSPATH' ) ) {
     exit;

--- a/nuclear-engagement/admin/partials/settings/display/toc.php
+++ b/nuclear-engagement/admin/partials/settings/display/toc.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 // File: admin/partials/settings/display/toc.php
 if ( ! defined( 'ABSPATH' ) ) {
     exit;

--- a/nuclear-engagement/admin/partials/settings/generation.php
+++ b/nuclear-engagement/admin/partials/settings/generation.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 // File: admin/partials/settings-tabs/generation.php
 if ( ! defined( 'ABSPATH' ) ) {
     exit;

--- a/nuclear-engagement/admin/partials/settings/optin.php
+++ b/nuclear-engagement/admin/partials/settings/optin.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 // File: admin/partials/settings/optin.php
 if ( ! defined( 'ABSPATH' ) ) {
     exit;

--- a/nuclear-engagement/admin/partials/settings/placement.php
+++ b/nuclear-engagement/admin/partials/settings/placement.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 // File: admin/partials/settings/placement.php
 if ( ! defined( 'ABSPATH' ) ) {
         exit;

--- a/nuclear-engagement/admin/partials/settings/theme.php
+++ b/nuclear-engagement/admin/partials/settings/theme.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 // File: admin/partials/settings/theme.php
 if ( ! defined( 'ABSPATH' ) ) {
         exit;

--- a/nuclear-engagement/admin/partials/settings/theme/progress-bar.php
+++ b/nuclear-engagement/admin/partials/settings/theme/progress-bar.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 // File: admin/partials/settings/theme/progress-bar.php
 if ( ! defined( 'ABSPATH' ) ) {
     exit;

--- a/nuclear-engagement/admin/partials/settings/theme/quiz-buttons.php
+++ b/nuclear-engagement/admin/partials/settings/theme/quiz-buttons.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 // File: admin/partials/settings/theme/quiz-buttons.php
 if ( ! defined( 'ABSPATH' ) ) {
     exit;

--- a/nuclear-engagement/admin/partials/settings/theme/quiz-container.php
+++ b/nuclear-engagement/admin/partials/settings/theme/quiz-container.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 // File: admin/partials/settings/theme/quiz-container.php
 if ( ! defined( 'ABSPATH' ) ) {
     exit;

--- a/nuclear-engagement/admin/partials/settings/theme/summary-container.php
+++ b/nuclear-engagement/admin/partials/settings/theme/summary-container.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 // File: admin/partials/settings/theme/summary-container.php
 if ( ! defined( 'ABSPATH' ) ) {
     exit;

--- a/nuclear-engagement/admin/partials/settings/theme/toc-container.php
+++ b/nuclear-engagement/admin/partials/settings/theme/toc-container.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 // File: admin/partials/settings/theme/toc-container.php
 if ( ! defined( 'ABSPATH' ) ) {
     exit;

--- a/nuclear-engagement/admin/partials/settings/uninstall.php
+++ b/nuclear-engagement/admin/partials/settings/uninstall.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 // File: admin/partials/settings/uninstall.php
 if ( ! defined( 'ABSPATH' ) ) {
         exit;

--- a/nuclear-engagement/admin/partials/setup/credits.php
+++ b/nuclear-engagement/admin/partials/setup/credits.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 if ( ! defined( 'ABSPATH' ) ) {
     exit;
 }

--- a/nuclear-engagement/admin/partials/setup/header.php
+++ b/nuclear-engagement/admin/partials/setup/header.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 if ( ! defined( 'ABSPATH' ) ) {
     exit;
 }

--- a/nuclear-engagement/admin/partials/setup/step1.php
+++ b/nuclear-engagement/admin/partials/setup/step1.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 if ( ! defined( 'ABSPATH' ) ) {
     exit;
 }

--- a/nuclear-engagement/admin/partials/setup/step2.php
+++ b/nuclear-engagement/admin/partials/setup/step2.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 if ( ! defined( 'ABSPATH' ) ) {
     exit;
 }

--- a/nuclear-engagement/admin/partials/setup/support.php
+++ b/nuclear-engagement/admin/partials/setup/support.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 if ( ! defined( 'ABSPATH' ) ) {
     exit;
 }

--- a/nuclear-engagement/admin/trait-admin-ajax.php
+++ b/nuclear-engagement/admin/trait-admin-ajax.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 /**
  * File: admin/trait-admin-ajax.php
  *

--- a/nuclear-engagement/admin/trait-admin-assets.php
+++ b/nuclear-engagement/admin/trait-admin-assets.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 /**
  * File: admin/trait-admin-assets.php
  *

--- a/nuclear-engagement/admin/trait-admin-autogenerate.php
+++ b/nuclear-engagement/admin/trait-admin-autogenerate.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 /**
  * File: admin/trait-admin-autogenerate.php
  *

--- a/nuclear-engagement/admin/trait-admin-menu.php
+++ b/nuclear-engagement/admin/trait-admin-menu.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 /**
  * File: admin/trait-admin-menu.php
  *

--- a/nuclear-engagement/admin/trait-admin-metabox-quiz.php
+++ b/nuclear-engagement/admin/trait-admin-metabox-quiz.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 /**
  * File: admin/trait-admin-metabox-quiz.php
  *

--- a/nuclear-engagement/admin/trait-admin-metabox-summary.php
+++ b/nuclear-engagement/admin/trait-admin-metabox-summary.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 /**
  * File: admin/trait-admin-metabox-summary.php
  *

--- a/nuclear-engagement/admin/trait-admin-metaboxes.php
+++ b/nuclear-engagement/admin/trait-admin-metaboxes.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 /**
  * File: admin/trait-admin-metaboxes.php
  *

--- a/nuclear-engagement/admin/trait-settings-custom-css.php
+++ b/nuclear-engagement/admin/trait-settings-custom-css.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 /**
  * File: admin/trait-settings-custom-css.php
  *

--- a/nuclear-engagement/admin/trait-settings-page-load.php
+++ b/nuclear-engagement/admin/trait-settings-page-load.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 /**
  * File: admin/trait-settings-page-load.php
  *

--- a/nuclear-engagement/admin/trait-settings-page-save.php
+++ b/nuclear-engagement/admin/trait-settings-page-save.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 /**
  * File: admin/trait-settings-page-save.php
  *

--- a/nuclear-engagement/admin/trait-settings-sanitize-core.php
+++ b/nuclear-engagement/admin/trait-settings-sanitize-core.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 /**
  * File: admin/trait-settings-sanitize-core.php
  *

--- a/nuclear-engagement/admin/trait-settings-sanitize-general.php
+++ b/nuclear-engagement/admin/trait-settings-sanitize-general.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 /**
  * File: admin/trait-settings-sanitize-general.php
  *

--- a/nuclear-engagement/admin/trait-settings-sanitize-optin.php
+++ b/nuclear-engagement/admin/trait-settings-sanitize-optin.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 /**
  * File: admin/trait-settings-sanitize-optin.php
  *

--- a/nuclear-engagement/admin/trait-settings-sanitize-style.php
+++ b/nuclear-engagement/admin/trait-settings-sanitize-style.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 /**
  * File: admin/trait-settings-sanitize-style.php
  *

--- a/nuclear-engagement/bootstrap.php
+++ b/nuclear-engagement/bootstrap.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 use NuclearEngagement\SettingsRepository;
 use NuclearEngagement\Defaults;
 use NuclearEngagement\Activator;

--- a/nuclear-engagement/front/Controller/Rest/ContentController.php
+++ b/nuclear-engagement/front/Controller/Rest/ContentController.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 /**
  * File: front/Controller/Rest/ContentController.php
  *

--- a/nuclear-engagement/front/FrontClass.php
+++ b/nuclear-engagement/front/FrontClass.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 /**
  * File: front/FrontClass.php
  *

--- a/nuclear-engagement/front/QuizShortcode.php
+++ b/nuclear-engagement/front/QuizShortcode.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 namespace NuclearEngagement\Front;
 
 use NuclearEngagement\SettingsRepository;

--- a/nuclear-engagement/front/QuizView.php
+++ b/nuclear-engagement/front/QuizView.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 namespace NuclearEngagement\Front;
 
 if (!defined('ABSPATH')) {

--- a/nuclear-engagement/front/SummaryShortcode.php
+++ b/nuclear-engagement/front/SummaryShortcode.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 namespace NuclearEngagement\Front;
 
 use NuclearEngagement\SettingsRepository;

--- a/nuclear-engagement/front/SummaryView.php
+++ b/nuclear-engagement/front/SummaryView.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 namespace NuclearEngagement\Front;
 
 if (!defined('ABSPATH')) {

--- a/nuclear-engagement/front/index.php
+++ b/nuclear-engagement/front/index.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 if ( ! defined( 'ABSPATH' ) ) {
     exit;
 } // Silence is golden

--- a/nuclear-engagement/front/partials/nuclear-engagement-public-display.php
+++ b/nuclear-engagement/front/partials/nuclear-engagement-public-display.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 if (!defined('ABSPATH')) {
     exit;
 }

--- a/nuclear-engagement/front/traits/AssetsTrait.php
+++ b/nuclear-engagement/front/traits/AssetsTrait.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 /**
  * File: front/traits/assets-trait.php
  *

--- a/nuclear-engagement/front/traits/RestTrait.php
+++ b/nuclear-engagement/front/traits/RestTrait.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 /**
  * File: front/traits/RestTrait.php
  *

--- a/nuclear-engagement/front/traits/ShortcodesTrait.php
+++ b/nuclear-engagement/front/traits/ShortcodesTrait.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 /**
  * File: front/traits/ShortcodesTrait.php
  *

--- a/nuclear-engagement/includes/Activator.php
+++ b/nuclear-engagement/includes/Activator.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 // Activator.php
 
 namespace NuclearEngagement;

--- a/nuclear-engagement/includes/AssetVersions.php
+++ b/nuclear-engagement/includes/AssetVersions.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 namespace NuclearEngagement;
 
 if ( ! defined( 'ABSPATH' ) ) {

--- a/nuclear-engagement/includes/Container.php
+++ b/nuclear-engagement/includes/Container.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 /**
  * File: includes/Container.php
 

--- a/nuclear-engagement/includes/ContainerRegistrar.php
+++ b/nuclear-engagement/includes/ContainerRegistrar.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 /**
  * File: includes/ContainerRegistrar.php
  *

--- a/nuclear-engagement/includes/Deactivator.php
+++ b/nuclear-engagement/includes/Deactivator.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 
 namespace NuclearEngagement;
 

--- a/nuclear-engagement/includes/Defaults.php
+++ b/nuclear-engagement/includes/Defaults.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 /**
  * File: includes/Defaults.php
  *

--- a/nuclear-engagement/includes/Loader.php
+++ b/nuclear-engagement/includes/Loader.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 namespace NuclearEngagement;
 
 if ( ! defined( 'ABSPATH' ) ) {

--- a/nuclear-engagement/includes/MetaRegistration.php
+++ b/nuclear-engagement/includes/MetaRegistration.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 /**
  * File: includes/MetaRegistration.php
  *

--- a/nuclear-engagement/includes/OptinData.php
+++ b/nuclear-engagement/includes/OptinData.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 /**
  * file: includes/OptinData.php
  * Class: NuclearEngagement\OptinData

--- a/nuclear-engagement/includes/PendingSettingsTrait.php
+++ b/nuclear-engagement/includes/PendingSettingsTrait.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 /**
  * File: includes/PendingSettingsTrait.php
  *

--- a/nuclear-engagement/includes/Plugin.php
+++ b/nuclear-engagement/includes/Plugin.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 /**
  * File: includes/Plugin.php
  *

--- a/nuclear-engagement/includes/Requests/ContentRequest.php
+++ b/nuclear-engagement/includes/Requests/ContentRequest.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 /**
  * File: includes/Requests/ContentRequest.php
  *

--- a/nuclear-engagement/includes/Requests/GenerateRequest.php
+++ b/nuclear-engagement/includes/Requests/GenerateRequest.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 /**
  * File: includes/Requests/GenerateRequest.php
 

--- a/nuclear-engagement/includes/Requests/PostsCountRequest.php
+++ b/nuclear-engagement/includes/Requests/PostsCountRequest.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 /**
  * File: includes/Requests/PostsCountRequest.php
 

--- a/nuclear-engagement/includes/Requests/UpdatesRequest.php
+++ b/nuclear-engagement/includes/Requests/UpdatesRequest.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 /**
  * File: includes/Requests/UpdatesRequest.php
 

--- a/nuclear-engagement/includes/Responses/GenerationResponse.php
+++ b/nuclear-engagement/includes/Responses/GenerationResponse.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 /**
  * File: includes/Responses/GenerationResponse.php
  *

--- a/nuclear-engagement/includes/Responses/UpdatesResponse.php
+++ b/nuclear-engagement/includes/Responses/UpdatesResponse.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 /**
  * File: includes/Responses/UpdatesResponse.php
  *

--- a/nuclear-engagement/includes/Services/AutoGenerationService.php
+++ b/nuclear-engagement/includes/Services/AutoGenerationService.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 /**
  * File: includes/Services/AutoGenerationService.php
  *

--- a/nuclear-engagement/includes/Services/ContentStorageService.php
+++ b/nuclear-engagement/includes/Services/ContentStorageService.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 /**
  * File: includes/Services/ContentStorageService.php
  *

--- a/nuclear-engagement/includes/Services/GenerationService.php
+++ b/nuclear-engagement/includes/Services/GenerationService.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 /**
  * File: includes/Services/GenerationService.php
 

--- a/nuclear-engagement/includes/Services/LoggingService.php
+++ b/nuclear-engagement/includes/Services/LoggingService.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 /**
  * File: includes/Services/LoggingService.php
  *

--- a/nuclear-engagement/includes/Services/PointerService.php
+++ b/nuclear-engagement/includes/Services/PointerService.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 /**
  * File: includes/Services/PointerService.php
  *

--- a/nuclear-engagement/includes/Services/PostsQueryService.php
+++ b/nuclear-engagement/includes/Services/PostsQueryService.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 /**
  * File: includes/Services/PostsQueryService.php
  *

--- a/nuclear-engagement/includes/Services/RemoteApiService.php
+++ b/nuclear-engagement/includes/Services/RemoteApiService.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 /**
  * File: includes/Services/RemoteApiService.php
 

--- a/nuclear-engagement/includes/Services/SetupService.php
+++ b/nuclear-engagement/includes/Services/SetupService.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 /**
  * File: includes/Services/SetupService.php
  *

--- a/nuclear-engagement/includes/SettingsAccessTrait.php
+++ b/nuclear-engagement/includes/SettingsAccessTrait.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 /**
  * File: includes/SettingsAccessTrait.php
  *

--- a/nuclear-engagement/includes/SettingsCache.php
+++ b/nuclear-engagement/includes/SettingsCache.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 /**
  * File: includes/SettingsCache.php
  *

--- a/nuclear-engagement/includes/SettingsRepository.php
+++ b/nuclear-engagement/includes/SettingsRepository.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 /**
  * File: includes/SettingsRepository.php
  *

--- a/nuclear-engagement/includes/SettingsSanitizer.php
+++ b/nuclear-engagement/includes/SettingsSanitizer.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 /**
  * File: includes/SettingsSanitizer.php
  *

--- a/nuclear-engagement/includes/Utils.php
+++ b/nuclear-engagement/includes/Utils.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 /**
  * File: includes/Utils.php
  * Implementation of changes required by WordPress.org guidelines.

--- a/nuclear-engagement/includes/constants.php
+++ b/nuclear-engagement/includes/constants.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 if ( ! defined( 'ABSPATH' ) ) {
     exit;
 }

--- a/nuclear-engagement/includes/helpers.php
+++ b/nuclear-engagement/includes/helpers.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 /**
  * Global helper functions for Nuclear Engagement plugin.
  *

--- a/nuclear-engagement/includes/index.php
+++ b/nuclear-engagement/includes/index.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 if ( ! defined( 'ABSPATH' ) ) {
     exit;
 } // Silence is golden

--- a/nuclear-engagement/index.php
+++ b/nuclear-engagement/index.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 if ( ! defined( 'ABSPATH' ) ) {
     exit;
 } // Silence is golden

--- a/nuclear-engagement/modules/toc/includes/class-nuclen-toc-admin.php
+++ b/nuclear-engagement/modules/toc/includes/class-nuclen-toc-admin.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 /**
  * File: modules/toc/includes/class-nuclen-toc-admin.php
  *

--- a/nuclear-engagement/modules/toc/includes/class-nuclen-toc-assets.php
+++ b/nuclear-engagement/modules/toc/includes/class-nuclen-toc-assets.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 /**
  * File: modules/toc/includes/class-nuclen-toc-assets.php
  *

--- a/nuclear-engagement/modules/toc/includes/class-nuclen-toc-headings.php
+++ b/nuclear-engagement/modules/toc/includes/class-nuclen-toc-headings.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 /**
  * File: modules/toc/includes/class-nuclen-toc-headings.php
  *

--- a/nuclear-engagement/modules/toc/includes/class-nuclen-toc-render.php
+++ b/nuclear-engagement/modules/toc/includes/class-nuclen-toc-render.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 /**
  * File: modules/toc/includes/class-nuclen-toc-render.php
  *

--- a/nuclear-engagement/modules/toc/includes/class-nuclen-toc-utils.php
+++ b/nuclear-engagement/modules/toc/includes/class-nuclen-toc-utils.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 /**
  * File: modules/toc/includes/class-nuclen-toc-utils.php
  *

--- a/nuclear-engagement/modules/toc/includes/class-nuclen-toc-view.php
+++ b/nuclear-engagement/modules/toc/includes/class-nuclen-toc-view.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 /**
  * File: modules/toc/includes/class-nuclen-toc-view.php
  *

--- a/nuclear-engagement/modules/toc/includes/polyfills.php
+++ b/nuclear-engagement/modules/toc/includes/polyfills.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 /**
  * File: modules/toc/includes/polyfills.php
  *

--- a/nuclear-engagement/modules/toc/loader.php
+++ b/nuclear-engagement/modules/toc/loader.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 /**
  * File: modules/toc/loader.php
  *

--- a/nuclear-engagement/nuclear-engagement.php
+++ b/nuclear-engagement/nuclear-engagement.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 /**
  * Plugin Name:       Nuclear Engagement
  * Plugin URI:        https://www.nuclearengagement.com

--- a/nuclear-engagement/uninstall.php
+++ b/nuclear-engagement/uninstall.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 if ( ! defined( 'ABSPATH' ) ) {
     exit;
 }


### PR DESCRIPTION
## Summary
- enable strict_types across the plugin

## Testing
- `composer lint` *(fails: command not found)*
- `composer test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6857d5f9f3708327a918294a2f9fd3d3

<!-- Korbit AI PR Description Start -->
## Description by Korbit AI

### What change is being made?

Add strict types declarations to all PHP files across the `nuclear-engagement` plugin codebase.

### Why are these changes being made?

These changes ensure that PHP will enforce type compatibility, leading to more robust and predictable code by catching type errors at an earlier stage such as during development, rather than at runtime. This approach aligns the codebase with modern PHP best practices, improving overall code quality and maintainability.

> Is this description stale? Ask me to generate a new description by commenting `/korbit-generate-pr-description`
<!-- Korbit AI PR Description End -->