### PR TITLE
Add Gutenberg blocks for summaries and quizzes

### DIFF
--- a/nuclear-engagement/includes/Blocks.php
+++ b/nuclear-engagement/includes/Blocks.php
@@ -1,0 +1,32 @@
+<?php
+declare(strict_types=1);
+namespace NuclearEngagement;
+
+if ( ! defined( 'ABSPATH' ) ) {
+    exit;
+}
+
+final class Blocks {
+    public static function register(): void {
+        register_block_type(
+            'nuclear-engagement/quiz',
+            [
+                'render_callback' => static function (): string {
+                    return do_shortcode('[nuclear_engagement_quiz]');
+                },
+                'editor_script'   => 'nuclen-admin',
+            ]
+        );
+
+        register_block_type(
+            'nuclear-engagement/summary',
+            [
+                'render_callback' => static function (): string {
+                    return do_shortcode('[nuclear_engagement_summary]');
+                },
+                'editor_script'   => 'nuclen-admin',
+            ]
+        );
+    }
+}
+

--- a/nuclear-engagement/includes/Plugin.php
+++ b/nuclear-engagement/includes/Plugin.php
@@ -150,6 +150,7 @@ class Plugin {
         $this->loader->nuclen_add_action( 'init', $plugin_public, 'nuclen_register_quiz_shortcode' );
         $this->loader->nuclen_add_action( 'init', $plugin_public, 'nuclen_register_summary_shortcode' );
         $this->loader->nuclen_add_filter( 'the_content', $plugin_public, 'nuclen_auto_insert_shortcodes', 50 );
+        $this->loader->nuclen_add_action( 'init', '\\NuclearEngagement\\Blocks', 'register' );
     }
 
     /* ─────────────────────────────────────────────

--- a/src/admin/ts/blocks/nuclen-editor-blocks.ts
+++ b/src/admin/ts/blocks/nuclen-editor-blocks.ts
@@ -1,0 +1,14 @@
+(function(){
+  if (!window.wp || !window.wp.blocks) {
+    return;
+  }
+  const { registerBlockType } = window.wp.blocks;
+  registerBlockType('nuclear-engagement/quiz', {
+    edit: () => null,
+    save: () => null,
+  });
+  registerBlockType('nuclear-engagement/summary', {
+    edit: () => null,
+    save: () => null,
+  });
+})();

--- a/src/admin/ts/nuclen-admin.ts
+++ b/src/admin/ts/nuclen-admin.ts
@@ -17,3 +17,6 @@ import './nuclen-admin-ui';
 
 // Onboardingh
 import './nuclen-admin-onboarding';
+
+// Gutenberg block registrations
+import './blocks/nuclen-editor-blocks';


### PR DESCRIPTION
## Summary
- register new dynamic blocks via `Blocks` class
- hook block registration in plugin
- include block setup in admin bundle

## Testing
- `npm install` *(fails: 403 Forbidden)*
- `npm run build` *(fails: vite not found)*
- `composer lint` *(fails: command not found)*
- `composer test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6857da2899008327be6483715de60415

<!-- Korbit AI PR Description Start -->
## Description by Korbit AI

### What change is being made?

Add Gutenberg blocks for "quiz" and "summary" to the Nuclear Engagement plugin, enabling backend script registration and block initialization for the WordPress editor.

### Why are these changes being made?

These changes facilitate easier content creation and management by introducing dedicated blocks for quizzes and summaries within the WordPress Gutenberg editor, streamlined through shortcodes. This approach is consistent with modular content development, enhancing user experience in content customization without altering the frontend functionality.

> Is this description stale? Ask me to generate a new description by commenting `/korbit-generate-pr-description`
<!-- Korbit AI PR Description End -->