### PR TITLE
Add caching flags to PostsQueryService

### DIFF
--- a/nuclear-engagement/includes/Services/PostsQueryService.php
+++ b/nuclear-engagement/includes/Services/PostsQueryService.php
@@ -75,6 +75,11 @@ class PostsQueryService {
             $queryArgs['meta_query'] = $metaQuery;
         }
 
+        // Disable caching for performance during counts
+        $queryArgs['update_post_meta_cache'] = false;
+        $queryArgs['update_post_term_cache'] = false;
+        $queryArgs['cache_results'] = false;
+
         return $queryArgs;
     }
 


### PR DESCRIPTION
## Summary
- disable caching in `PostsQueryService::buildQueryArgs()` to speed count queries

## Testing
- `composer lint` *(fails: command not found)*
- `composer test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6857dfeaac6883278bf94006549b178c

<!-- Korbit AI PR Description Start -->
## Description by Korbit AI

### What change is being made?

Add caching flags to the `PostsQueryService` to disable post meta, term cache, and result cache during post count queries.

### Why are these changes being made?

These changes are implemented to improve the performance of post count operations by avoiding unnecessary caching during these specific queries, which can otherwise slow down the service. This approach assumes that caching is not beneficial in scenarios where only counts are retrieved without needing additional metadata or terms.

> Is this description stale? Ask me to generate a new description by commenting `/korbit-generate-pr-description`
<!-- Korbit AI PR Description End -->