### PR TITLE
Load assets only when plugin output is used

### DIFF
--- a/nuclear-engagement/front/QuizShortcode.php
+++ b/nuclear-engagement/front/QuizShortcode.php
@@ -3,6 +3,7 @@ declare(strict_types=1);
 namespace NuclearEngagement\Front;
 
 use NuclearEngagement\SettingsRepository;
+use NuclearEngagement\Front\FrontClass;
 
 if (!defined('ABSPATH')) {
     exit;
@@ -11,10 +12,12 @@ if (!defined('ABSPATH')) {
 class QuizShortcode {
     private SettingsRepository $settings;
     private QuizView $view;
+    private FrontClass $front;
 
-    public function __construct(SettingsRepository $settings) {
+    public function __construct(SettingsRepository $settings, FrontClass $front) {
         $this->settings = $settings;
-        $this->view = new QuizView();
+        $this->front    = $front;
+        $this->view     = new QuizView();
     }
 
     public function register(): void {
@@ -22,6 +25,7 @@ class QuizShortcode {
     }
 
     public function render(): string {
+        $this->front->nuclen_force_enqueue_assets();
         $quiz_data = $this->getQuizData();
         if (!$this->isValidQuizData($quiz_data)) {
             return '';

--- a/nuclear-engagement/front/SummaryShortcode.php
+++ b/nuclear-engagement/front/SummaryShortcode.php
@@ -3,6 +3,7 @@ declare(strict_types=1);
 namespace NuclearEngagement\Front;
 
 use NuclearEngagement\SettingsRepository;
+use NuclearEngagement\Front\FrontClass;
 
 if (!defined('ABSPATH')) {
     exit;
@@ -11,10 +12,12 @@ if (!defined('ABSPATH')) {
 class SummaryShortcode {
     private SettingsRepository $settings;
     private SummaryView $view;
+    private FrontClass $front;
 
-    public function __construct(SettingsRepository $settings) {
+    public function __construct(SettingsRepository $settings, FrontClass $front) {
         $this->settings = $settings;
-        $this->view = new SummaryView();
+        $this->front    = $front;
+        $this->view     = new SummaryView();
     }
 
     public function register(): void {
@@ -22,6 +25,7 @@ class SummaryShortcode {
     }
 
     public function render(): string {
+        $this->front->nuclen_force_enqueue_assets();
         $summary_data = $this->getSummaryData();
         if (!$this->isValidSummaryData($summary_data)) {
             return '';

--- a/nuclear-engagement/front/traits/AssetsTrait.php
+++ b/nuclear-engagement/front/traits/AssetsTrait.php
@@ -22,12 +22,18 @@ if ( ! defined( 'ABSPATH' ) ) {
 
 trait AssetsTrait {
 
+    /** Force asset enqueue regardless of detection checks. */
+    private bool $force_assets = false;
+
     /**
      * Determine if front-end assets should load on the current request.
      *
      * @return bool
      */
     private function should_load_assets(): bool {
+        if ( $this->force_assets ) {
+            return true;
+        }
         if ( is_admin() || ! is_singular() ) {
             return false;
         }
@@ -193,5 +199,15 @@ trait AssetsTrait {
             'your_answer'   => $settings_repo->get( 'quiz_label_your_answer', __( 'Your answer:', 'nuclear-engagement' ) ),
         );
         wp_localize_script( $this->plugin_name . '-front', 'NuclenStrings', $ne_strings );
+    }
+
+    /**
+     * Force asset enqueue when shortcodes run outside post content.
+     */
+    public function nuclen_force_enqueue_assets(): void {
+        $this->force_assets = true;
+        $this->wp_enqueue_styles();
+        $this->wp_enqueue_scripts();
+        $this->force_assets = false;
     }
 }

--- a/nuclear-engagement/front/traits/AssetsTrait.php
+++ b/nuclear-engagement/front/traits/AssetsTrait.php
@@ -40,6 +40,12 @@ trait AssetsTrait {
         $post    = get_post( $post_id );
         $content = $post ? $post->post_content : '';
 
+        if ( function_exists( 'has_block' ) && $post ) {
+            if ( has_block( 'nuclear-engagement/quiz', $post ) || has_block( 'nuclear-engagement/summary', $post ) ) {
+                return true;
+            }
+        }
+
         if ( has_shortcode( $content, 'nuclear_engagement_quiz' ) || has_shortcode( $content, 'nuclear_engagement_summary' ) ) {
             return true;
         }

--- a/nuclear-engagement/front/traits/ShortcodesTrait.php
+++ b/nuclear-engagement/front/traits/ShortcodesTrait.php
@@ -28,14 +28,20 @@ trait ShortcodesTrait {
 
     private function get_quiz_shortcode(): QuizShortcode {
         if ($this->quiz_shortcode === null) {
-            $this->quiz_shortcode = new QuizShortcode($this->nuclen_get_settings_repository());
+            $this->quiz_shortcode = new QuizShortcode(
+                $this->nuclen_get_settings_repository(),
+                $this
+            );
         }
         return $this->quiz_shortcode;
     }
 
     private function get_summary_shortcode(): SummaryShortcode {
         if ($this->summary_shortcode === null) {
-            $this->summary_shortcode = new SummaryShortcode($this->nuclen_get_settings_repository());
+            $this->summary_shortcode = new SummaryShortcode(
+                $this->nuclen_get_settings_repository(),
+                $this
+            );
         }
         return $this->summary_shortcode;
     }


### PR DESCRIPTION
## Summary
- add `should_load_assets()` helper
- load styles/scripts only when shortcodes or auto-inserted content are present

## Testing
- `composer lint` *(fails: command not found)*
- `composer test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6857e03521b08327b56efff81c09ad2e

<!-- Korbit AI PR Description Start -->
## Description by Korbit AI

### What change is being made?

Add a method to conditionally load front-end assets only when the plugin output is used on a page, ensuring assets are loaded when specific conditions are met, such as the presence of certain shortcodes or specific metadata.

### Why are these changes being made?

The purpose of these changes is to optimize asset loading, enhancing page load performance by preventing unnecessary asset inclusion on pages where plugin features are not utilized. This approach avoids bloating pages with unused styles and scripts, aligning asset loading with actual content requirements and user settings.

> Is this description stale? Ask me to generate a new description by commenting `/korbit-generate-pr-description`
<!-- Korbit AI PR Description End -->