### PR TITLE
Improve logging resilience

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -130,6 +130,11 @@ resides in a dedicated `LoggingService` under `includes/Services/`.
   service method.
 - The autoloader maps `NuclearEngagement\Services\LoggingService`.
 
+The service now checks that the uploads directory and log file are writable
+before attempting to write. When writing fails, it falls back to PHP's
+`error_log()` and registers an admin notice via the `admin_notices` hook so
+administrators are alerted to permission issues.
+
 This keeps `Utils` slim while ensuring logging responsibilities are centralized.
 
 ## Posts Query Service

--- a/tests/LoggingServiceTest.php
+++ b/tests/LoggingServiceTest.php
@@ -1,0 +1,50 @@
+<?php
+use PHPUnit\Framework\TestCase;
+use NuclearEngagement\Services\LoggingService;
+
+namespace NuclearEngagement\Services {
+    function wp_upload_dir() {
+        return [
+            'basedir' => $GLOBALS['ls_base'],
+            'baseurl'  => 'http://example.com/uploads',
+        ];
+    }
+    function wp_mkdir_p($dir) {
+        return mkdir($dir, 0777, true);
+    }
+    function add_action(...$args) {
+        $GLOBALS['ls_actions'][] = $args;
+    }
+    function error_log($msg) {
+        $GLOBALS['ls_errors'][] = $msg;
+    }
+    if (!function_exists('esc_html')) {
+        function esc_html($text) { return $text; }
+    }
+}
+
+namespace {
+    class LoggingServiceTest extends TestCase {
+        protected function setUp(): void {
+            $GLOBALS['ls_actions'] = [];
+            $GLOBALS['ls_errors'] = [];
+            $GLOBALS['ls_base'] = sys_get_temp_dir() . '/ls_' . uniqid();
+            mkdir($GLOBALS['ls_base']);
+        }
+
+        protected function tearDown(): void {
+            $base = $GLOBALS['ls_base'];
+            foreach (glob("$base/*") as $file) {
+                @unlink($file);
+            }
+            @rmdir($base);
+        }
+
+        public function test_unwritable_directory_triggers_fallback(): void {
+            chmod($GLOBALS['ls_base'], 0555);
+            LoggingService::log('test message');
+            $this->assertSame(['test message'], $GLOBALS['ls_errors']);
+            $this->assertSame('admin_notices', $GLOBALS['ls_actions'][0][0]);
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- add writable checks and fallback in LoggingService
- surface logging failures as admin notices and log to PHP error log
- document the new behaviour
- add tests for unwritable directories

## Testing
- `composer lint` *(fails: command not found)*
- `composer test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6857e329f30c83279cb3766ed399bc6c


> [!NOTE]
> I'm currently writing a description for your pull request. I should be done shortly (<1 minute). Please don't edit the description field until I'm finished, or we may overwrite each other. If I find nothing to write about, I'll delete this message.
