### PR TITLE
Add AJAX error helper

### DIFF
--- a/nuclear-engagement/admin/Controller/Ajax/BaseController.php
+++ b/nuclear-engagement/admin/Controller/Ajax/BaseController.php
@@ -19,6 +19,23 @@ if (!defined('ABSPATH')) {
  */
 abstract class BaseController {
     /**
+     * Send a standardized JSON error response.
+     *
+     * @param string $message Error message.
+     * @param int    $code    HTTP status code.
+     */
+    protected function sendError(string $message, int $code = 500): void {
+        status_header($code);
+        wp_send_json(
+            [
+                'success' => false,
+                'message' => $message,
+            ],
+            $code
+        );
+    }
+
+    /**
      * Verify nonce and permissions.
      *
      * @param string $nonceAction Nonce action.
@@ -32,14 +49,15 @@ abstract class BaseController {
         string $capability = 'manage_options'
     ): bool {
         if (!check_ajax_referer($nonceAction, $nonceField, false)) {
-            status_header(403);
-            wp_send_json_error(['message' => 'Security check failed']);
+            $this->sendError(
+                __('Security check failed', 'nuclear-engagement'),
+                403
+            );
             return false;
         }
 
         if (!current_user_can($capability)) {
-            status_header(403);
-            wp_send_json_error(['message' => 'Not allowed']);
+            $this->sendError(__('Not allowed', 'nuclear-engagement'), 403);
             return false;
         }
 

--- a/nuclear-engagement/admin/Controller/Ajax/GenerateController.php
+++ b/nuclear-engagement/admin/Controller/Ajax/GenerateController.php
@@ -46,8 +46,10 @@ class GenerateController extends BaseController {
             }
 
             if (empty($_POST['payload'])) {
-                status_header(400);
-                wp_send_json_error(['message' => 'Missing payload in request']);
+                $this->sendError(
+                    __('Missing payload in request', 'nuclear-engagement'),
+                    400
+                );
                 return;
             }
 
@@ -64,15 +66,16 @@ class GenerateController extends BaseController {
             \NuclearEngagement\Services\LoggingService::log(
                 'Nuclear Engagement validation error: ' . $e->getMessage()
             );
-            status_header(400);
-            wp_send_json_error(['message' => $e->getMessage()]);
+            $this->sendError($e->getMessage(), 400);
         } catch (\Exception $e) {
             \NuclearEngagement\Services\LoggingService::log(
                 'Nuclear Engagement generation error: ' . $e->getMessage() . ' in ' . $e->getFile() . ':' . $e->getLine()
             );
             \NuclearEngagement\Services\LoggingService::log('Stack trace: ' . $e->getTraceAsString());
-            status_header(500);
-            wp_send_json_error(['message' => 'An unexpected error occurred. Please check your error logs.']);
+            $this->sendError(
+                __('An unexpected error occurred. Please check your error logs.', 'nuclear-engagement'),
+                500
+            );
         }
     }
 }

--- a/nuclear-engagement/admin/Controller/Ajax/PointerController.php
+++ b/nuclear-engagement/admin/Controller/Ajax/PointerController.php
@@ -51,9 +51,9 @@ class PointerController extends BaseController {
             wp_send_json_success(['message' => __('Pointer dismissed.', 'nuclear-engagement')]);
 
         } catch (\InvalidArgumentException $e) {
-            wp_send_json_error(['message' => $e->getMessage()]);
+            $this->sendError($e->getMessage());
         } catch (\Exception $e) {
-            wp_send_json_error(['message' => __('An error occurred', 'nuclear-engagement')]);
+            $this->sendError(__('An error occurred', 'nuclear-engagement'));
         }
     }
 }

--- a/nuclear-engagement/admin/Controller/Ajax/PostsCountController.php
+++ b/nuclear-engagement/admin/Controller/Ajax/PostsCountController.php
@@ -53,7 +53,7 @@ class PostsCountController extends BaseController {
             wp_send_json_success($result);
 
         } catch (\Exception $e) {
-            wp_send_json_error(['message' => $e->getMessage()]);
+            $this->sendError($e->getMessage());
         }
     }
 }

--- a/nuclear-engagement/admin/Controller/Ajax/UpdatesController.php
+++ b/nuclear-engagement/admin/Controller/Ajax/UpdatesController.php
@@ -101,8 +101,8 @@ class UpdatesController extends BaseController {
             wp_send_json_success( $response->toArray() );
 
         } catch ( \Exception $e ) {
-\NuclearEngagement\Services\LoggingService::log( 'Error fetching updates: ' . $e->getMessage() );
-            wp_send_json_error( array( 'message' => $e->getMessage() ) );
+            \NuclearEngagement\Services\LoggingService::log( 'Error fetching updates: ' . $e->getMessage() );
+            $this->sendError( $e->getMessage() );
         }
     }
 }

--- a/src/admin/ts/generate/generate-page-utils.ts
+++ b/src/admin/ts/generate/generate-page-utils.ts
@@ -41,7 +41,7 @@ export async function nuclenCheckCreditsAjax(): Promise<number> {
   });
   const data = await response.json();
   if (!data.success) {
-    throw new Error(data.data?.message || 'Failed to fetch credits from SaaS');
+    throw new Error(data.message || data.data?.message || 'Failed to fetch credits from SaaS');
   }
   if (typeof data.data.remaining_credits === 'number') {
     return data.data.remaining_credits;

--- a/src/admin/ts/generate/step1.ts
+++ b/src/admin/ts/generate/step1.ts
@@ -42,13 +42,14 @@ export function initStep1(elements: GeneratePageElements): void {
           if (elements.postsCountEl) {
             elements.postsCountEl.innerText = 'Error retrieving post count.';
           }
-          if (data.data?.message) {
-            if (data.data.message.includes('Invalid API key')) {
+          const errMsg = data.message || data.data?.message;
+          if (errMsg) {
+            if (errMsg.includes('Invalid API key')) {
               alert('Your Gold Code (API key) is invalid. Please create a new one on the NE app and enter it on the plugin Setup page.');
-            } else if (data.data.message.includes('Invalid WP App Password')) {
+            } else if (errMsg.includes('Invalid WP App Password')) {
               alert('Your WP App Password is invalid. Please go to the plugin Setup page and re-generate it.');
             } else {
-              alert(data.data.message);
+              alert(errMsg);
             }
           }
           return;

--- a/src/admin/ts/generation/api.ts
+++ b/src/admin/ts/generation/api.ts
@@ -71,13 +71,9 @@ export async function NuclenStartGeneration(dataToSend: Record<string, any>) {
 
   const data = await response.json();
   if (!data.success) {
-    if (typeof data.data === 'object' && data.data.message) {
-      throw new Error(data.data.message);
-    } else if (data.message) {
-      throw new Error(data.message);
-    } else {
-      throw new Error('Generation start failed (unknown error).');
-    }
+    const errMsg =
+      data.message || data.data?.message || 'Generation start failed (unknown error).';
+    throw new Error(errMsg);
   }
 
   return data;


### PR DESCRIPTION
## Summary
- add `sendError()` to base AJAX controller
- standardize error responses in AJAX controllers
- translate all AJAX error messages
- update admin scripts to expect new error format

## Testing
- `composer lint` *(fails: command not found)*
- `composer test` *(fails: command not found)*
- `npm run build` *(fails: vite missing)*

------
https://chatgpt.com/codex/tasks/task_e_6857e3307d4c83279dc7714a0e942f47