### PR TITLE
Handle DB errors during meta migration

### DIFF
--- a/nuclear-engagement/bootstrap.php
+++ b/nuclear-engagement/bootstrap.php
@@ -96,6 +96,12 @@ function nuclen_update_migrate_post_meta() {
             'ne-summary-data'
         )
     );
+    if (!empty($wpdb->last_error)) {
+        \NuclearEngagement\Services\LoggingService::log('Meta migration error: ' . $wpdb->last_error);
+        update_option('nuclen_meta_migration_error', $wpdb->last_error);
+        return;
+    }
+
     $wpdb->query(
         $wpdb->prepare(
             "UPDATE {$wpdb->postmeta} SET meta_key = %s WHERE meta_key = %s",
@@ -103,7 +109,13 @@ function nuclen_update_migrate_post_meta() {
             'ne-quiz-data'
         )
     );
+    if (!empty($wpdb->last_error)) {
+        \NuclearEngagement\Services\LoggingService::log('Meta migration error: ' . $wpdb->last_error);
+        update_option('nuclen_meta_migration_error', $wpdb->last_error);
+        return;
+    }
 
+    delete_option('nuclen_meta_migration_error');
     update_option('nuclen_meta_migration_done', true);
 }
 add_action('admin_init', 'nuclen_update_migrate_post_meta', 20);

--- a/tests/PostMetaMigrationTest.php
+++ b/tests/PostMetaMigrationTest.php
@@ -1,0 +1,58 @@
+<?php
+use PHPUnit\Framework\TestCase;
+
+// Stub LoggingService to capture log messages
+namespace NuclearEngagement\Services {
+    class LoggingService {
+        public static array $logs = [];
+        public static function log(string $msg): void {
+            self::$logs[] = $msg;
+        }
+    }
+}
+
+namespace {
+    use NuclearEngagement\Services\LoggingService;
+
+    class PostMetaMigrationTest extends TestCase {
+        protected function setUp(): void {
+            global $wpdb, $wp_options, $wp_autoload;
+            $wp_options = $wp_autoload = [];
+            $wpdb = new class {
+                public string $last_error = '';
+                public string $postmeta = 'wp_postmeta';
+                public int $queries = 0;
+                public function prepare($q, ...$args) { return $q; }
+                public function query($sql) {
+                    $this->queries++;
+                    $this->last_error = 'fail';
+                    return false;
+                }
+            };
+            LoggingService::$logs = [];
+        }
+
+        private function load_bootstrap(): void {
+            if (!defined('NUCLEN_PLUGIN_FILE')) {
+                define('NUCLEN_PLUGIN_FILE', dirname(__DIR__) . '/nuclear-engagement/nuclear-engagement.php');
+            }
+            // Stub classes used when bootstrap runs
+            if (!class_exists('NuclearEngagement\\MetaRegistration')) {
+                class_alias(\stdClass::class, 'NuclearEngagement\\MetaRegistration');
+            }
+            if (!class_exists('NuclearEngagement\\Plugin')) {
+                class_alias(\stdClass::class, 'NuclearEngagement\\Plugin');
+            }
+            require_once dirname(__DIR__) . '/nuclear-engagement/bootstrap.php';
+        }
+
+        public function test_logs_error_and_sets_option_on_failure(): void {
+            $this->load_bootstrap();
+            \nuclen_update_migrate_post_meta();
+            $this->assertNotEmpty(LoggingService::$logs);
+            $this->assertSame('fail', get_option('nuclen_meta_migration_error'));
+            $this->assertFalse(get_option('nuclen_meta_migration_done'));
+        }
+    }
+}
+

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -13,6 +13,18 @@ if (!function_exists('add_action')) {
 if (!function_exists('absint')) {
     function absint($maybeint) { return abs(intval($maybeint)); }
 }
+if (!function_exists('plugin_dir_path')) {
+    function plugin_dir_path($file) { return dirname($file) . '/'; }
+}
+if (!function_exists('get_plugin_data')) {
+    function get_plugin_data($file) { return ['Version' => '1.0']; }
+}
+if (!function_exists('register_activation_hook')) {
+    function register_activation_hook(...$args) {}
+}
+if (!function_exists('register_deactivation_hook')) {
+    function register_deactivation_hook(...$args) {}
+}
 
 // Simple in-memory storage for options and related autoload flags
 $GLOBALS['wp_options'] = [];


### PR DESCRIPTION
## Summary
- check `$wpdb->last_error` after each migration query
- log the error and store it in the new `nuclen_meta_migration_error` option
- update test bootstrap with new WP stubs
- add a unit test ensuring migration errors are logged

## Testing
- `composer lint` *(fails: command not found)*
- `composer test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6857e32dca7083279abac69688bd2faa


> [!NOTE]
> I'm currently writing a description for your pull request. I should be done shortly (<1 minute). Please don't edit the description field until I'm finished, or we may overwrite each other. If I find nothing to write about, I'll delete this message.
