### PR TITLE
Refactor fetch helper and add tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,7 @@ lerna-debug.log*
 node_modules
 dist
 dist-ssr
+tests/jsbuild
 *.local
 
 # Editor directories and files

--- a/nuclear-engagement/admin/trait-admin-assets.php
+++ b/nuclear-engagement/admin/trait-admin-assets.php
@@ -76,6 +76,15 @@ trait Admin_Assets {
             )
         );
 
+        wp_localize_script(
+            'nuclen-admin',
+            'nuclenErrorStrings',
+            array(
+                'network_error' => __( 'Network error. Please try again later.', 'nuclear-engagement' ),
+                'server_error'  => __( 'Unexpected server response.', 'nuclear-engagement' ),
+            )
+        );
+
         // This ensures nuclenAjax is available on both the Generate page & single-post editor
         $this->nuclen_enqueue_generate_page_scripts( $hook );
     }

--- a/package.json
+++ b/package.json
@@ -7,7 +7,9 @@
     "dev": "vite",
     "build": "tsc && vite build",
     "preview": "vite preview",
-    "lint": "eslint \"src/**/*.ts\""
+    "lint": "eslint \"src/**/*.ts\"",
+    "build:test": "tsc src/admin/ts/generation/api.ts src/admin/ts/nuclen-globals.d.ts --lib ES2015,DOM --module ES2020 --target ES2020 --outDir tests/jsbuild --skipLibCheck --noEmitOnError false",
+    "test": "npm run build:test && node --test tests/js/*.test.js"
   },
   "devDependencies": {
     "typescript": "~5.6.2",

--- a/src/admin/ts/generate/generate-page-utils.ts
+++ b/src/admin/ts/generate/generate-page-utils.ts
@@ -34,14 +34,17 @@ export async function nuclenCheckCreditsAjax(): Promise<number> {
   if ((window as any).nuclenAjax.nonce) {
     formData.append('security', (window as any).nuclenAjax.nonce);
   }
-  const response = await nuclenFetchWithRetry((window as any).nuclenAjax.ajax_url, {
+  const result = await nuclenFetchWithRetry((window as any).nuclenAjax.ajax_url, {
     method: 'POST',
     body: formData,
     credentials: 'same-origin',
   });
-  const data = await response.json();
-  if (!data.success) {
-    throw new Error(data.data?.message || 'Failed to fetch credits from SaaS');
+  if (!result.ok) {
+    throw new Error(result.error || `HTTP ${result.status}`);
+  }
+  const data = result.data;
+  if (!data?.success) {
+    throw new Error(data?.data?.message || 'Failed to fetch credits from SaaS');
   }
   if (typeof data.data.remaining_credits === 'number') {
     return data.data.remaining_credits;

--- a/src/admin/ts/generate/step1.ts
+++ b/src/admin/ts/generate/step1.ts
@@ -14,7 +14,7 @@ import {
 } from './filters';
 
 export function initStep1(elements: GeneratePageElements): void {
-  elements.getPostsBtn?.addEventListener('click', () => {
+  elements.getPostsBtn?.addEventListener('click', async () => {
     if (!(window as any).nuclenAjax || !(window as any).nuclenAjax.ajax_url) {
       alert('Error: Ajax is not configured properly. Please check the plugin settings.');
       return;
@@ -31,81 +31,83 @@ export function initStep1(elements: GeneratePageElements): void {
     const filters: NuclenFilterValues = nuclenCollectFilters();
     nuclenAppendFilters(formData, filters);
 
-    nuclenFetchWithRetry((window as any).nuclenAjax.ajax_url || '', {
+    const result = await nuclenFetchWithRetry((window as any).nuclenAjax.ajax_url || '', {
       method: 'POST',
       body: formData,
       credentials: 'same-origin',
-    })
-      .then((r) => r.json())
-      .then(async (data) => {
-        if (!data.success) {
-          if (elements.postsCountEl) {
-            elements.postsCountEl.innerText = 'Error retrieving post count.';
-          }
-          if (data.data?.message) {
-            if (data.data.message.includes('Invalid API key')) {
-              alert('Your Gold Code (API key) is invalid. Please create a new one on the NE app and enter it on the plugin Setup page.');
-            } else if (data.data.message.includes('Invalid WP App Password')) {
-              alert('Your WP App Password is invalid. Please go to the plugin Setup page and re-generate it.');
-            } else {
-              alert(data.data.message);
-            }
-          }
-          return;
+    });
+
+    if (!result.ok) {
+      console.error('Error retrieving post count:', result.error);
+      if (elements.postsCountEl) {
+        elements.postsCountEl.innerText =
+          (window as any).nuclenErrorStrings?.network_error || 'Error retrieving post count.';
+      }
+      return;
+    }
+
+    const data = result.data as any;
+    if (!data.success) {
+      if (elements.postsCountEl) {
+        elements.postsCountEl.innerText = 'Error retrieving post count.';
+      }
+      if (data.data?.message) {
+        if (data.data.message.includes('Invalid API key')) {
+          alert('Your Gold Code (API key) is invalid. Please create a new one on the NE app and enter it on the plugin Setup page.');
+        } else if (data.data.message.includes('Invalid WP App Password')) {
+          alert('Your WP App Password is invalid. Please go to the plugin Setup page and re-generate it.');
+        } else {
+          alert(data.data.message);
         }
-        const count = data.data.count as number;
-        const foundPosts = data.data.post_ids;
-        const selectedPostIdsEl = document.getElementById('nuclen_selected_post_ids') as HTMLInputElement | null;
-        if (selectedPostIdsEl) {
-          selectedPostIdsEl.value = JSON.stringify(foundPosts);
+      }
+      return;
+    }
+    const count = data.data.count as number;
+    const foundPosts = data.data.post_ids;
+    const selectedPostIdsEl = document.getElementById('nuclen_selected_post_ids') as HTMLInputElement | null;
+    if (selectedPostIdsEl) {
+      selectedPostIdsEl.value = JSON.stringify(foundPosts);
+    }
+    nuclenStoreFilters(filters);
+    nuclenHideElement(elements.step1);
+    nuclenShowElement(elements.step2);
+    nuclenUpdateProgressBarStep(elements.stepBar1, 'done');
+    nuclenUpdateProgressBarStep(elements.stepBar2, 'current');
+    if (count === 0) {
+      if (elements.postsCountEl) {
+        elements.postsCountEl.innerText = 'No posts found with these filters.';
+      }
+      if (elements.submitBtn) {
+        nuclenHideElement(elements.submitBtn);
+      }
+      return;
+    }
+    if (elements.postsCountEl) {
+      elements.postsCountEl.innerText = `Number of posts to process: ${count}`;
+    }
+    try {
+      const remainingCredits = await nuclenCheckCreditsAjax();
+      const neededCredits = count;
+      if (elements.creditsInfoEl) {
+        elements.creditsInfoEl.textContent = `This will consume ${neededCredits} credit(s). You have ${remainingCredits} left.`;
+      }
+      if (remainingCredits < neededCredits) {
+        alert('Not enough credits. Please top up or reduce the number of posts.');
+        if (elements.submitBtn) {
+          elements.submitBtn.disabled = true;
         }
-        nuclenStoreFilters(filters);
-        nuclenHideElement(elements.step1);
-        nuclenShowElement(elements.step2);
-        nuclenUpdateProgressBarStep(elements.stepBar1, 'done');
-        nuclenUpdateProgressBarStep(elements.stepBar2, 'current');
-        if (count === 0) {
-          if (elements.postsCountEl) {
-            elements.postsCountEl.innerText = 'No posts found with these filters.';
-          }
-          if (elements.submitBtn) {
-            nuclenHideElement(elements.submitBtn);
-          }
-          return;
-        }
-        if (elements.postsCountEl) {
-          elements.postsCountEl.innerText = `Number of posts to process: ${count}`;
-        }
-        try {
-          const remainingCredits = await nuclenCheckCreditsAjax();
-          const neededCredits = count;
-          if (elements.creditsInfoEl) {
-            elements.creditsInfoEl.textContent = `This will consume ${neededCredits} credit(s). You have ${remainingCredits} left.`;
-          }
-          if (remainingCredits < neededCredits) {
-            alert('Not enough credits. Please top up or reduce the number of posts.');
-            if (elements.submitBtn) {
-              elements.submitBtn.disabled = true;
-            }
-          } else if (elements.submitBtn) {
-            nuclenShowElement(elements.submitBtn);
-            elements.submitBtn.disabled = false;
-          }
-        } catch (err: any) {
-          console.error('Error fetching remaining credits:', err);
-          if (elements.creditsInfoEl) {
-            elements.creditsInfoEl.textContent = `Unable to retrieve your credits: ${err.message}`;
-          }
-          if (elements.submitBtn) {
-            elements.submitBtn.disabled = false;
-          }
-        }
-      })
-      .catch((error) => {
-        console.error('Error retrieving post count:', error);
-        if (elements.postsCountEl) {
-          elements.postsCountEl.innerText = 'Error retrieving post count. Please try again later.';
-        }
-      });
+      } else if (elements.submitBtn) {
+        nuclenShowElement(elements.submitBtn);
+        elements.submitBtn.disabled = false;
+      }
+    } catch (err: any) {
+      console.error('Error fetching remaining credits:', err);
+      if (elements.creditsInfoEl) {
+        elements.creditsInfoEl.textContent = `Unable to retrieve your credits: ${err.message}`;
+      }
+      if (elements.submitBtn) {
+        elements.submitBtn.disabled = false;
+      }
+    }
   });
 }

--- a/src/admin/ts/generate/step2.ts
+++ b/src/admin/ts/generate/step2.ts
@@ -30,8 +30,15 @@ export function initStep2(elements: GeneratePageElements): void {
     try {
       const formDataObj = Object.fromEntries(new FormData(elements.generateForm!).entries());
       const startResp = await NuclenStartGeneration(formDataObj);
+      if (!startResp.ok) {
+        throw new Error(
+          startResp.error ||
+            (window as any).nuclenErrorStrings?.server_error ||
+            'Generation start failed'
+        );
+      }
       const generationId =
-        startResp.data?.generation_id || startResp.generation_id || 'gen_' + Math.random().toString(36).substring(2);
+        startResp.data?.generation_id || (startResp as any).generation_id || 'gen_' + Math.random().toString(36).substring(2);
       NuclenPollAndPullUpdates({
         intervalMs: 5000,
         generationId,

--- a/src/admin/ts/generation/api.ts
+++ b/src/admin/ts/generation/api.ts
@@ -1,22 +1,43 @@
-export async function nuclenFetchWithRetry(
+export interface NuclenFetchResult<T = any> {
+  ok: boolean;
+  status: number;
+  data: T | null;
+  error?: string;
+}
+
+export async function nuclenFetchWithRetry<T = any>(
   url: string,
   options: RequestInit,
   retries = 3
-): Promise<Response> {
+): Promise<NuclenFetchResult<T>> {
   try {
     const response = await fetch(url, options);
-    if (!response.ok) {
-      throw new Error(`Network response was not ok (HTTP ${response.status})`);
+    const { status, ok } = response;
+
+    if (ok) {
+      try {
+        const json = (await response.json()) as T;
+        return { ok: true, status, data: json };
+      } catch (err: any) {
+        const text = await response.text().catch(() => '');
+        return { ok: true, status, data: null, error: text || err?.message };
+      }
     }
-    return response;
-  } catch (error) {
+
+    const errText = await response.text().catch(() => '');
+    return { ok: false, status, data: null, error: errText };
+  } catch (error: any) {
     if (retries > 0) {
       console.warn(`Retrying... (${retries} attempts left)`);
       return nuclenFetchWithRetry(url, options, retries - 1);
-    } else {
-      console.error('Max retries reached:', error);
-      throw error;
     }
+    console.error('Max retries reached:', error);
+    return {
+      ok: false,
+      status: 0,
+      data: null,
+      error: error?.message || String(error),
+    };
   }
 }
 
@@ -39,19 +60,29 @@ export async function nuclenFetchUpdates(generationId?: string) {
     formData.append('generation_id', generationId);
   }
 
-  const response = await nuclenFetchWithRetry(window.nuclenAjax.ajax_url, {
+  const result = await nuclenFetchWithRetry(window.nuclenAjax.ajax_url, {
     method: 'POST',
     body: formData,
     credentials: 'same-origin',
   });
 
-  const data = await response.json();
-  return data;
+  if (!result.ok) {
+    throw new Error(result.error || `HTTP ${result.status}`);
+  }
+
+  return result.data;
 }
 
-export async function NuclenStartGeneration(dataToSend: Record<string, any>) {
+export async function NuclenStartGeneration(
+  dataToSend: Record<string, any>
+): Promise<NuclenFetchResult<any>> {
   if (!window.nuclenAdminVars || !window.nuclenAdminVars.ajax_url) {
-    throw new Error('Missing WP Ajax config (nuclenAdminVars.ajax_url).');
+    return {
+      ok: false,
+      status: 0,
+      data: null,
+      error: 'Missing WP Ajax config (nuclenAdminVars.ajax_url).',
+    };
   }
 
   const formData = new FormData();
@@ -59,26 +90,23 @@ export async function NuclenStartGeneration(dataToSend: Record<string, any>) {
   formData.append('payload', JSON.stringify(dataToSend));
   formData.append('security', window.nuclenAjax?.nonce ?? '');
 
-  const response = await fetch(window.nuclenAdminVars.ajax_url, {
+  const result = await nuclenFetchWithRetry(window.nuclenAdminVars.ajax_url, {
     method: 'POST',
     body: formData,
     credentials: 'same-origin',
   });
 
-  if (!response.ok) {
-    throw new Error(`Generation start failed: HTTP ${response.status}`);
+  if (!result.ok) {
+    return result;
   }
 
-  const data = await response.json();
-  if (!data.success) {
-    if (typeof data.data === 'object' && data.data.message) {
-      throw new Error(data.data.message);
-    } else if (data.message) {
-      throw new Error(data.message);
-    } else {
-      throw new Error('Generation start failed (unknown error).');
-    }
+  if (result.data && typeof result.data === 'object' && !result.data.success) {
+    const msg =
+      result.data.data?.message ||
+      result.data.message ||
+      'Generation start failed (unknown error).';
+    return { ok: false, status: result.status, data: result.data, error: msg };
   }
 
-  return data;
+  return result;
 }

--- a/src/admin/ts/single/single-generation-handlers.ts
+++ b/src/admin/ts/single/single-generation-handlers.ts
@@ -31,9 +31,16 @@ export function initSingleGenerationButtons(): void {
         nuclen_selected_post_ids: JSON.stringify([postId]),
         nuclen_selected_generate_workflow: workflow,
       });
+      if (!startResp.ok) {
+        throw new Error(
+          startResp.error ||
+            (window as any).nuclenErrorStrings?.server_error ||
+            'Generation start failed'
+        );
+      }
       const generationId =
         startResp.data?.generation_id ||
-        startResp.generation_id ||
+        (startResp as any).generation_id ||
         'gen_' + Math.random().toString(36).substring(2);
 
       NuclenPollAndPullUpdates({

--- a/tests/js/nuclenFetchWithRetry.test.js
+++ b/tests/js/nuclenFetchWithRetry.test.js
@@ -1,0 +1,46 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { nuclenFetchWithRetry } from '../../tests/jsbuild/api.js';
+
+// Helper to stub global fetch
+function mockFetch(impl) {
+  global.fetch = impl;
+}
+
+test('returns JSON on success', async () => {
+  mockFetch(async () => ({
+    ok: true,
+    status: 200,
+    json: async () => ({ success: true }),
+    text: async () => ''
+  }));
+  const res = await nuclenFetchWithRetry('u', {});
+  assert.equal(res.ok, true);
+  assert.deepEqual(res.data, { success: true });
+});
+
+test('parses error text on HTTP error', async () => {
+  mockFetch(async () => ({
+    ok: false,
+    status: 400,
+    text: async () => 'Bad request'
+  }));
+  const res = await nuclenFetchWithRetry('u', {});
+  assert.equal(res.ok, false);
+  assert.equal(res.status, 400);
+  assert.equal(res.error, 'Bad request');
+});
+
+test('retries on network error', async () => {
+  let calls = 0;
+  mockFetch(async () => {
+    calls++;
+    if (calls < 3) {
+      throw new Error('net');
+    }
+    return { ok: true, status: 200, json: async () => ({ ok: true }), text: async () => '' };
+  });
+  const res = await nuclenFetchWithRetry('u', {}, 2);
+  assert.equal(calls, 3);
+  assert.equal(res.ok, true);
+});


### PR DESCRIPTION
## Summary
- introduce `NuclenFetchResult` and update `nuclenFetchWithRetry`
- adjust admin scripts to consume typed results
- localize common error messages for translation
- add Node based unit tests for fetch helper

## Testing
- `composer lint` *(fails: command not found)*
- `composer test` *(fails: command not found)*
- `npm run build` *(fails: vite not found)*
- `npm run test`

------
https://chatgpt.com/codex/tasks/task_e_6857e337b2fc8327a6db61f2d71bc7f0

<!-- Korbit AI PR Description Start -->
## Description by Korbit AI

### What change is being made?
Refactor `nuclenFetchWithRetry` function to return a custom result interface across multiple modules, introduce asynchronous error handling improvements, and add unit tests for the refactored function.

### Why are these changes being made?
The refactor improves error handling by standardizing the response across different modules and allows for clearer error diagnostics with more informative error messages. The addition of unit tests ensures reliability and correctness of the `nuclenFetchWithRetry` functionality under various conditions, supporting a more robust feature set and easier maintenance.

> Is this description stale? Ask me to generate a new description by commenting `/korbit-generate-pr-description`
<!-- Korbit AI PR Description End -->