### PR TITLE
Normalize indentation in TOC view

### DIFF
--- a/nuclear-engagement/modules/toc/includes/class-nuclen-toc-view.php
+++ b/nuclear-engagement/modules/toc/includes/class-nuclen-toc-view.php
@@ -13,136 +13,136 @@ if ( ! defined( 'ABSPATH' ) ) {
 use NuclearEngagement\SettingsRepository;
 
 final class Nuclen_TOC_View {
-        private const DEFAULT_STICKY_OFFSET_X = 20;
-        private const DEFAULT_STICKY_OFFSET_Y = 20;
-        private const DEFAULT_STICKY_MAX_WIDTH = 300;
+    private const DEFAULT_STICKY_OFFSET_X = 20;
+    private const DEFAULT_STICKY_OFFSET_Y = 20;
+    private const DEFAULT_STICKY_MAX_WIDTH = 300;
 
-        /** Retrieve the translated TOC title with a fallback. */
-        public function get_toc_title( SettingsRepository $settings ) : string {
-                $title = $settings->get_string( 'toc_title' );
-                if ( empty( $title ) ) {
-                        return esc_html__( 'Table of Contents', 'nuclen-toc-shortcode' );
-                }
-                return esc_html( $title );
+    /** Retrieve the translated TOC title with a fallback. */
+    public function get_toc_title( SettingsRepository $settings ) : string {
+        $title = $settings->get_string( 'toc_title' );
+        if ( empty( $title ) ) {
+            return esc_html__( 'Table of Contents', 'nuclen-toc-shortcode' );
+        }
+        return esc_html( $title );
+    }
+
+    /**
+    * Build wrapper classes and sticky attributes.
+    *
+    * @return array{classes:array,sticky_attrs:string,show_toggle:bool,hidden:bool}
+    */
+    public function build_wrapper_props( array $atts, SettingsRepository $settings ) : array {
+        $classes = [ 'nuclen-toc-wrapper' ];
+
+        if ( in_array( $atts['theme'], [ 'dark', 'auto' ], true ) ) {
+            $classes[] = 'nuclen-toc-' . $atts['theme'];
         }
 
-        /**
-         * Build wrapper classes and sticky attributes.
-         *
-         * @return array{classes:array,sticky_attrs:string,show_toggle:bool,hidden:bool}
-         */
-        public function build_wrapper_props( array $atts, SettingsRepository $settings ) : array {
-                $classes = [ 'nuclen-toc-wrapper' ];
+        $show_toggle = $settings->get_bool( 'toc_show_toggle' );
+        $hidden      = $show_toggle && ! $settings->get_bool( 'toc_show_content' );
 
-                if ( in_array( $atts['theme'], [ 'dark', 'auto' ], true ) ) {
-                        $classes[] = 'nuclen-toc-' . $atts['theme'];
-                }
-
-                $show_toggle = $settings->get_bool( 'toc_show_toggle' );
-                $hidden      = $show_toggle && ! $settings->get_bool( 'toc_show_content' );
-
-                if ( $show_toggle ) {
-                        $classes[] = 'nuclen-toc-has-toggle';
-                        if ( $hidden ) {
-                                $classes[] = 'nuclen-toc-collapsed';
-                        }
-                }
-
-                $sticky_attrs = '';
-                if ( ! empty( $atts['sticky'] ) ) {
-                        $classes[] = 'nuclen-toc-sticky';
-
-                        $sticky_offset_x = $settings->get_int( 'toc_sticky_offset_x', self::DEFAULT_STICKY_OFFSET_X );
-                        $sticky_offset_y = $settings->get_int( 'toc_sticky_offset_y', self::DEFAULT_STICKY_OFFSET_Y );
-                        $sticky_max_width = $settings->get_int( 'toc_sticky_max_width', self::DEFAULT_STICKY_MAX_WIDTH );
-
-                        $sticky_offset_x  = max( 0, min( 1000, $sticky_offset_x ) );
-                        $sticky_offset_y  = max( 0, min( 1000, $sticky_offset_y ) );
-                        $sticky_max_width = min( 1000, max( 100, $sticky_max_width ) );
-
-                        $sticky_attrs = sprintf(
-                                ' data-offset-x="%d" data-offset-y="%d" data-max-width="%d" data-show-content="%s" data-heading-levels="%s"',
-                                $sticky_offset_x,
-                                $sticky_offset_y,
-                                $sticky_max_width,
-                                $settings->get_bool( 'toc_show_content' ) ? 'true' : 'false',
-                                esc_attr( implode( ',', $atts['heading_levels'] ) )
-                        );
-                }
-
-                if ( $atts['highlight'] === 'true' ) {
-                        $classes[] = 'nuclen-has-highlight';
-                }
-
-                $z_index = $settings->get_int( 'toc_z_index', 100 );
-                $z_index = max( 1, min( 9999, $z_index ) );
-                ( $z_index );
-
-                return [
-                        'classes'      => $classes,
-                        'sticky_attrs' => $sticky_attrs,
-                        'show_toggle'  => $show_toggle,
-                        'hidden'       => $hidden,
-                ];
+        if ( $show_toggle ) {
+            $classes[] = 'nuclen-toc-has-toggle';
+            if ( $hidden ) {
+                $classes[] = 'nuclen-toc-collapsed';
+            }
         }
 
-        /** Build the toggle button HTML if toggling is enabled. */
-        public function build_toggle_button( bool $show, bool $hidden, array $atts, string $nav_id ) : string {
-                if ( ! $show ) {
-                        return '';
-                }
-                $toggle_text = $hidden ? $atts['show_text'] : $atts['hide_text'];
-                return sprintf(
-                        '<button type="button" class="nuclen-toc-toggle" aria-expanded="%s" aria-controls="%s">%s</button>',
-                        $hidden ? 'false' : 'true',
-                        esc_attr( $nav_id ),
-                        esc_html( $toggle_text )
-                );
+        $sticky_attrs = '';
+        if ( ! empty( $atts['sticky'] ) ) {
+            $classes[] = 'nuclen-toc-sticky';
+
+            $sticky_offset_x = $settings->get_int( 'toc_sticky_offset_x', self::DEFAULT_STICKY_OFFSET_X );
+            $sticky_offset_y = $settings->get_int( 'toc_sticky_offset_y', self::DEFAULT_STICKY_OFFSET_Y );
+            $sticky_max_width = $settings->get_int( 'toc_sticky_max_width', self::DEFAULT_STICKY_MAX_WIDTH );
+
+            $sticky_offset_x  = max( 0, min( 1000, $sticky_offset_x ) );
+            $sticky_offset_y  = max( 0, min( 1000, $sticky_offset_y ) );
+            $sticky_max_width = min( 1000, max( 100, $sticky_max_width ) );
+
+            $sticky_attrs = sprintf(
+                ' data-offset-x="%d" data-offset-y="%d" data-max-width="%d" data-show-content="%s" data-heading-levels="%s"',
+                $sticky_offset_x,
+                $sticky_offset_y,
+                $sticky_max_width,
+                $settings->get_bool( 'toc_show_content' ) ? 'true' : 'false',
+                esc_attr( implode( ',', $atts['heading_levels'] ) )
+            );
         }
 
-        /** Render the nested heading list. */
-        public function render_headings_list( array $heads, string $list ) : string {
-                $out   = '';
-                $stack = [];
-                foreach ( $heads as $h ) {
-                        $l = $h['level'];
-                        while ( $stack && end( $stack ) > $l ) {
-                                $out .= '</li></' . $list . '>';
-                                array_pop( $stack );
-                        }
-                        if ( ! $stack || end( $stack ) < $l ) {
-                                $out .= '<' . $list . '>';
-                                $stack[] = $l;
-                        } else {
-                                $out .= '</li>';
-                        }
-                        $out .= '<li><a href="#' . esc_attr( $h['id'] ) . '">' . esc_html( $h['text'] ) . '</a>';
-                }
-                while ( $stack ) {
-                        $out .= '</li></' . $list . '>';
-                        array_pop( $stack );
-                }
-                return $out;
+        if ( $atts['highlight'] === 'true' ) {
+            $classes[] = 'nuclen-has-highlight';
         }
 
-        /**
-         * Build the navigation markup containing the heading list.
-         */
-        public function build_nav_markup( array $heads, string $list, array $atts, string $nav_id, string $toc_title, bool $hidden ) : string {
-                $nav  = sprintf(
-                        '<nav id="%s" class="nuclen-toc" aria-label="%s"%s%s>',
-                        esc_attr( $nav_id ),
-                        esc_attr__( $toc_title, 'nuclen-toc-shortcode' ),
-                        $hidden ? ' style="display:none"' : '',
-                        $atts['highlight'] === 'true' ? ' data-highlight="true"' : ''
-                );
+        $z_index = $settings->get_int( 'toc_z_index', 100 );
+        $z_index = max( 1, min( 9999, $z_index ) );
+        ( $z_index );
 
-                if ( $atts['title'] !== '' ) {
-                        $nav .= '<strong class="toc-title">' . esc_html__( $atts['title'], 'nuclen-toc-shortcode' ) . '</strong>';
-                }
+        return [
+            'classes'      => $classes,
+            'sticky_attrs' => $sticky_attrs,
+            'show_toggle'  => $show_toggle,
+            'hidden'       => $hidden,
+        ];
+    }
 
-                $nav .= $this->render_headings_list( $heads, $list ) . '</nav>';
-
-                return $nav;
+    /** Build the toggle button HTML if toggling is enabled. */
+    public function build_toggle_button( bool $show, bool $hidden, array $atts, string $nav_id ) : string {
+        if ( ! $show ) {
+            return '';
         }
+        $toggle_text = $hidden ? $atts['show_text'] : $atts['hide_text'];
+        return sprintf(
+            '<button type="button" class="nuclen-toc-toggle" aria-expanded="%s" aria-controls="%s">%s</button>',
+            $hidden ? 'false' : 'true',
+            esc_attr( $nav_id ),
+            esc_html( $toggle_text )
+        );
+    }
+
+    /** Render the nested heading list. */
+    public function render_headings_list( array $heads, string $list ) : string {
+        $out   = '';
+        $stack = [];
+        foreach ( $heads as $h ) {
+            $l = $h['level'];
+            while ( $stack && end( $stack ) > $l ) {
+                $out .= '</li></' . $list . '>';
+                array_pop( $stack );
+            }
+            if ( ! $stack || end( $stack ) < $l ) {
+                $out .= '<' . $list . '>';
+                $stack[] = $l;
+            } else {
+                $out .= '</li>';
+            }
+            $out .= '<li><a href="#' . esc_attr( $h['id'] ) . '">' . esc_html( $h['text'] ) . '</a>';
+        }
+        while ( $stack ) {
+            $out .= '</li></' . $list . '>';
+            array_pop( $stack );
+        }
+        return $out;
+    }
+
+    /**
+    * Build the navigation markup containing the heading list.
+    */
+    public function build_nav_markup( array $heads, string $list, array $atts, string $nav_id, string $toc_title, bool $hidden ) : string {
+        $nav  = sprintf(
+            '<nav id="%s" class="nuclen-toc" aria-label="%s"%s%s>',
+            esc_attr( $nav_id ),
+            esc_attr__( $toc_title, 'nuclen-toc-shortcode' ),
+            $hidden ? ' style="display:none"' : '',
+            $atts['highlight'] === 'true' ? ' data-highlight="true"' : ''
+        );
+
+        if ( $atts['title'] !== '' ) {
+            $nav .= '<strong class="toc-title">' . esc_html__( $atts['title'], 'nuclen-toc-shortcode' ) . '</strong>';
+        }
+
+        $nav .= $this->render_headings_list( $heads, $list ) . '</nav>';
+
+        return $nav;
+    }
 }


### PR DESCRIPTION
## Summary
- fix indentation in `class-nuclen-toc-view.php`

## Testing
- `phpcs` *(fails: `php` not found)*
- `phpunit` *(fails: `php` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6857e434b55c8327b61c6c66d83773c4

<!-- Korbit AI PR Description Start -->
## Description by Korbit AI

### What change is being made?

Normalize indentation in the `Nuclen_TOC_View` class to use consistent tabulation.

### Why are these changes being made?

The inconsistent indentation was affecting the readability and maintainability of the `Nuclen_TOC_View` class code. By normalizing the indentation, we ensure that the code is cleaner and easier for developers to navigate and understand. This standardization aligns with coding best practices for uniform formatting.

> Is this description stale? Ask me to generate a new description by commenting `/korbit-generate-pr-description`
<!-- Korbit AI PR Description End -->