### PR TITLE
Fix spacing around ABSPATH guards

### DIFF
--- a/nuclear-engagement/admin/Controller/Ajax/BaseController.php
+++ b/nuclear-engagement/admin/Controller/Ajax/BaseController.php
@@ -10,7 +10,7 @@ declare(strict_types=1);
 
 namespace NuclearEngagement\Admin\Controller\Ajax;
 
-if (!defined('ABSPATH')) {
+if ( ! defined( 'ABSPATH' ) ) {
     exit;
 }
 

--- a/nuclear-engagement/admin/Controller/Ajax/GenerateController.php
+++ b/nuclear-engagement/admin/Controller/Ajax/GenerateController.php
@@ -13,7 +13,7 @@ namespace NuclearEngagement\Admin\Controller\Ajax;
 use NuclearEngagement\Requests\GenerateRequest;
 use NuclearEngagement\Services\GenerationService;
 
-if (!defined('ABSPATH')) {
+if ( ! defined( 'ABSPATH' ) ) {
     exit;
 }
 

--- a/nuclear-engagement/admin/Controller/Ajax/PointerController.php
+++ b/nuclear-engagement/admin/Controller/Ajax/PointerController.php
@@ -12,7 +12,7 @@ namespace NuclearEngagement\Admin\Controller\Ajax;
 
 use NuclearEngagement\Services\PointerService;
 
-if (!defined('ABSPATH')) {
+if ( ! defined( 'ABSPATH' ) ) {
     exit;
 }
 

--- a/nuclear-engagement/admin/Controller/Ajax/PostsCountController.php
+++ b/nuclear-engagement/admin/Controller/Ajax/PostsCountController.php
@@ -13,7 +13,7 @@ namespace NuclearEngagement\Admin\Controller\Ajax;
 use NuclearEngagement\Requests\PostsCountRequest;
 use NuclearEngagement\Services\PostsQueryService;
 
-if (!defined('ABSPATH')) {
+if ( ! defined( 'ABSPATH' ) ) {
     exit;
 }
 

--- a/nuclear-engagement/admin/OnboardingPointers.php
+++ b/nuclear-engagement/admin/OnboardingPointers.php
@@ -10,7 +10,7 @@ declare(strict_types=1);
 
 namespace NuclearEngagement\Admin;
 
-if (!defined('ABSPATH')) {
+if ( ! defined( 'ABSPATH' ) ) {
     exit;
 }
 

--- a/nuclear-engagement/admin/Setup.php
+++ b/nuclear-engagement/admin/Setup.php
@@ -16,7 +16,7 @@ namespace NuclearEngagement\Admin;
 use NuclearEngagement\SettingsRepository;
 use NuclearEngagement\Services\SetupService;
 
-if (!defined('ABSPATH')) {
+if ( ! defined( 'ABSPATH' ) ) {
     exit;
 }
 

--- a/nuclear-engagement/admin/SetupHandlersTrait.php
+++ b/nuclear-engagement/admin/SetupHandlersTrait.php
@@ -17,7 +17,7 @@ namespace NuclearEngagement\Admin;
 use NuclearEngagement\SettingsRepository;
 use NuclearEngagement\Services\SetupService;
 
-if (!defined('ABSPATH')) {
+if ( ! defined( 'ABSPATH' ) ) {
     exit;
 }
 

--- a/nuclear-engagement/bootstrap.php
+++ b/nuclear-engagement/bootstrap.php
@@ -8,7 +8,7 @@ use NuclearEngagement\MetaRegistration;
 use NuclearEngagement\AssetVersions;
 use NuclearEngagement\Plugin;
 
-if (!defined('ABSPATH')) {
+if ( ! defined( 'ABSPATH' ) ) {
     exit;
 }
 

--- a/nuclear-engagement/front/Controller/Rest/ContentController.php
+++ b/nuclear-engagement/front/Controller/Rest/ContentController.php
@@ -14,7 +14,7 @@ use NuclearEngagement\Requests\ContentRequest;
 use NuclearEngagement\Services\ContentStorageService;
 use NuclearEngagement\Utils;
 
-if (!defined('ABSPATH')) {
+if ( ! defined( 'ABSPATH' ) ) {
     exit;
 }
 

--- a/nuclear-engagement/front/QuizShortcode.php
+++ b/nuclear-engagement/front/QuizShortcode.php
@@ -5,7 +5,7 @@ namespace NuclearEngagement\Front;
 use NuclearEngagement\SettingsRepository;
 use NuclearEngagement\Front\FrontClass;
 
-if (!defined('ABSPATH')) {
+if ( ! defined( 'ABSPATH' ) ) {
     exit;
 }
 

--- a/nuclear-engagement/front/QuizView.php
+++ b/nuclear-engagement/front/QuizView.php
@@ -2,7 +2,7 @@
 declare(strict_types=1);
 namespace NuclearEngagement\Front;
 
-if (!defined('ABSPATH')) {
+if ( ! defined( 'ABSPATH' ) ) {
     exit;
 }
 

--- a/nuclear-engagement/front/SummaryShortcode.php
+++ b/nuclear-engagement/front/SummaryShortcode.php
@@ -5,7 +5,7 @@ namespace NuclearEngagement\Front;
 use NuclearEngagement\SettingsRepository;
 use NuclearEngagement\Front\FrontClass;
 
-if (!defined('ABSPATH')) {
+if ( ! defined( 'ABSPATH' ) ) {
     exit;
 }
 

--- a/nuclear-engagement/front/SummaryView.php
+++ b/nuclear-engagement/front/SummaryView.php
@@ -2,7 +2,7 @@
 declare(strict_types=1);
 namespace NuclearEngagement\Front;
 
-if (!defined('ABSPATH')) {
+if ( ! defined( 'ABSPATH' ) ) {
     exit;
 }
 

--- a/nuclear-engagement/front/partials/nuclear-engagement-public-display.php
+++ b/nuclear-engagement/front/partials/nuclear-engagement-public-display.php
@@ -1,6 +1,6 @@
 <?php
 declare(strict_types=1);
-if (!defined('ABSPATH')) {
+if ( ! defined( 'ABSPATH' ) ) {
     exit;
 }
 

--- a/nuclear-engagement/front/traits/RestTrait.php
+++ b/nuclear-engagement/front/traits/RestTrait.php
@@ -14,7 +14,7 @@ declare(strict_types=1);
 
 namespace NuclearEngagement\Front;
 
-if (!defined('ABSPATH')) {
+if ( ! defined( 'ABSPATH' ) ) {
     exit;
 }
 

--- a/nuclear-engagement/front/traits/ShortcodesTrait.php
+++ b/nuclear-engagement/front/traits/ShortcodesTrait.php
@@ -18,7 +18,7 @@ namespace NuclearEngagement\Front;
 use NuclearEngagement\Front\QuizShortcode;
 use NuclearEngagement\Front\SummaryShortcode;
 
-if (!defined('ABSPATH')) {
+if ( ! defined( 'ABSPATH' ) ) {
     exit;
 }
 

--- a/nuclear-engagement/includes/Activator.php
+++ b/nuclear-engagement/includes/Activator.php
@@ -8,7 +8,7 @@ use NuclearEngagement\SettingsRepository;
 use NuclearEngagement\OptinData;
 use NuclearEngagement\AssetVersions;
 
-if (!defined('ABSPATH')) {
+if ( ! defined( 'ABSPATH' ) ) {
     exit;
 }
 

--- a/nuclear-engagement/includes/Container.php
+++ b/nuclear-engagement/includes/Container.php
@@ -10,7 +10,7 @@ declare(strict_types=1);
 
 namespace NuclearEngagement;
 
-if (!defined('ABSPATH')) {
+if ( ! defined( 'ABSPATH' ) ) {
     exit;
 }
 

--- a/nuclear-engagement/includes/Deactivator.php
+++ b/nuclear-engagement/includes/Deactivator.php
@@ -5,7 +5,7 @@ namespace NuclearEngagement;
 
 use NuclearEngagement\SettingsRepository;
 
-if (!defined('ABSPATH')) {
+if ( ! defined( 'ABSPATH' ) ) {
     exit;
 }
 

--- a/nuclear-engagement/includes/Requests/ContentRequest.php
+++ b/nuclear-engagement/includes/Requests/ContentRequest.php
@@ -10,7 +10,7 @@ declare(strict_types=1);
 
 namespace NuclearEngagement\Requests;
 
-if (!defined('ABSPATH')) {
+if ( ! defined( 'ABSPATH' ) ) {
     exit;
 }
 

--- a/nuclear-engagement/includes/Requests/GenerateRequest.php
+++ b/nuclear-engagement/includes/Requests/GenerateRequest.php
@@ -10,7 +10,7 @@ declare(strict_types=1);
 
 namespace NuclearEngagement\Requests;
 
-if (!defined('ABSPATH')) {
+if ( ! defined( 'ABSPATH' ) ) {
     exit;
 }
 

--- a/nuclear-engagement/includes/Requests/PostsCountRequest.php
+++ b/nuclear-engagement/includes/Requests/PostsCountRequest.php
@@ -10,7 +10,7 @@ declare(strict_types=1);
 
 namespace NuclearEngagement\Requests;
 
-if (!defined('ABSPATH')) {
+if ( ! defined( 'ABSPATH' ) ) {
     exit;
 }
 

--- a/nuclear-engagement/includes/Requests/UpdatesRequest.php
+++ b/nuclear-engagement/includes/Requests/UpdatesRequest.php
@@ -10,7 +10,7 @@ declare(strict_types=1);
 
 namespace NuclearEngagement\Requests;
 
-if (!defined('ABSPATH')) {
+if ( ! defined( 'ABSPATH' ) ) {
     exit;
 }
 

--- a/nuclear-engagement/includes/Responses/GenerationResponse.php
+++ b/nuclear-engagement/includes/Responses/GenerationResponse.php
@@ -10,7 +10,7 @@ declare(strict_types=1);
 
 namespace NuclearEngagement\Responses;
 
-if (!defined('ABSPATH')) {
+if ( ! defined( 'ABSPATH' ) ) {
     exit;
 }
 

--- a/nuclear-engagement/includes/Services/ContentStorageService.php
+++ b/nuclear-engagement/includes/Services/ContentStorageService.php
@@ -13,7 +13,7 @@ namespace NuclearEngagement\Services;
 use NuclearEngagement\SettingsRepository;
 use NuclearEngagement\Utils;
 
-if (!defined('ABSPATH')) {
+if ( ! defined( 'ABSPATH' ) ) {
     exit;
 }
 

--- a/nuclear-engagement/includes/Services/GenerationService.php
+++ b/nuclear-engagement/includes/Services/GenerationService.php
@@ -15,7 +15,7 @@ use NuclearEngagement\Responses\GenerationResponse;
 use NuclearEngagement\SettingsRepository;
 use NuclearEngagement\Utils;
 
-if (!defined('ABSPATH')) {
+if ( ! defined( 'ABSPATH' ) ) {
     exit;
 }
 

--- a/nuclear-engagement/includes/Services/LoggingService.php
+++ b/nuclear-engagement/includes/Services/LoggingService.php
@@ -10,7 +10,7 @@ declare(strict_types=1);
 
 namespace NuclearEngagement\Services;
 
-if (!defined('ABSPATH')) {
+if ( ! defined( 'ABSPATH' ) ) {
     exit;
 }
 

--- a/nuclear-engagement/includes/Services/PointerService.php
+++ b/nuclear-engagement/includes/Services/PointerService.php
@@ -10,7 +10,7 @@ declare(strict_types=1);
 
 namespace NuclearEngagement\Services;
 
-if (!defined('ABSPATH')) {
+if ( ! defined( 'ABSPATH' ) ) {
     exit;
 }
 

--- a/nuclear-engagement/includes/Services/PostsQueryService.php
+++ b/nuclear-engagement/includes/Services/PostsQueryService.php
@@ -12,7 +12,7 @@ namespace NuclearEngagement\Services;
 
 use NuclearEngagement\Requests\PostsCountRequest;
 
-if (!defined('ABSPATH')) {
+if ( ! defined( 'ABSPATH' ) ) {
     exit;
 }
 

--- a/nuclear-engagement/includes/Services/RemoteApiService.php
+++ b/nuclear-engagement/includes/Services/RemoteApiService.php
@@ -13,7 +13,7 @@ namespace NuclearEngagement\Services;
 use NuclearEngagement\SettingsRepository;
 use NuclearEngagement\Utils;
 
-if (!defined('ABSPATH')) {
+if ( ! defined( 'ABSPATH' ) ) {
     exit;
 }
 

--- a/nuclear-engagement/includes/Services/SetupService.php
+++ b/nuclear-engagement/includes/Services/SetupService.php
@@ -12,7 +12,7 @@ namespace NuclearEngagement\Services;
 
 use NuclearEngagement\Utils;
 
-if (!defined('ABSPATH')) {
+if ( ! defined( 'ABSPATH' ) ) {
     exit;
 }
 

--- a/nuclear-engagement/includes/SettingsAccessTrait.php
+++ b/nuclear-engagement/includes/SettingsAccessTrait.php
@@ -10,7 +10,7 @@ declare(strict_types=1);
 
 namespace NuclearEngagement;
 
-if (!defined('ABSPATH')) {
+if ( ! defined( 'ABSPATH' ) ) {
     exit;
 }
 

--- a/nuclear-engagement/includes/SettingsRepository.php
+++ b/nuclear-engagement/includes/SettingsRepository.php
@@ -10,7 +10,7 @@ namespace NuclearEngagement;
 use NuclearEngagement\SettingsSanitizer;
 use NuclearEngagement\SettingsCache;
 
-if (!defined('ABSPATH')) {
+if ( ! defined( 'ABSPATH' ) ) {
     exit;
 }
 

--- a/nuclear-engagement/nuclear-engagement.php
+++ b/nuclear-engagement/nuclear-engagement.php
@@ -15,7 +15,7 @@ declare(strict_types=1);
  * Domain Path:       /
  */
 
-if (!defined('ABSPATH')) {
+if ( ! defined( 'ABSPATH' ) ) {
     exit;
 }
 

--- a/tests/TocModuleTest.php
+++ b/tests/TocModuleTest.php
@@ -6,48 +6,48 @@ use NuclearEngagement\Container;
 // ------------------------------------------------------
 // WordPress function stubs
 // ------------------------------------------------------
-if (!defined('HOUR_IN_SECONDS')) {
-    define('HOUR_IN_SECONDS', 3600);
+if ( ! defined( 'HOUR_IN_SECONDS' ) ) {
+    define( 'HOUR_IN_SECONDS', 3600 );
 }
-if (!defined('NUCLEN_TOC_SCROLL_OFFSET_DEFAULT')) {
-    define('NUCLEN_TOC_SCROLL_OFFSET_DEFAULT', 72);
+if ( ! defined( 'NUCLEN_TOC_SCROLL_OFFSET_DEFAULT' ) ) {
+    define( 'NUCLEN_TOC_SCROLL_OFFSET_DEFAULT', 72 );
 }
-if (!defined('NUCLEN_TOC_DIR')) {
-    define('NUCLEN_TOC_DIR', dirname(__DIR__).'/nuclear-engagement/modules/toc/');
+if ( ! defined( 'NUCLEN_TOC_DIR' ) ) {
+    define( 'NUCLEN_TOC_DIR', dirname( __DIR__ ) . '/nuclear-engagement/modules/toc/' );
 }
-if (!defined('NUCLEN_TOC_URL')) {
-    define('NUCLEN_TOC_URL', 'http://example.com/');
+if ( ! defined( 'NUCLEN_TOC_URL' ) ) {
+    define( 'NUCLEN_TOC_URL', 'http://example.com/' );
 }
 
 $GLOBALS['wp_cache'] = [];
 
-if (!function_exists('wp_cache_get')) {
-    function wp_cache_get($key, $group = '') {
-        return $GLOBALS['wp_cache'][$group][$key] ?? false;
+if ( ! function_exists( 'wp_cache_get' ) ) {
+    function wp_cache_get( $key, $group = '' ) {
+        return $GLOBALS['wp_cache'][ $group ][ $key ] ?? false;
     }
 }
-if (!function_exists('wp_cache_set')) {
-    function wp_cache_set($key, $value, $group = '', $ttl = 0) {
-        $GLOBALS['wp_cache'][$group][$key] = $value;
+if ( ! function_exists( 'wp_cache_set' ) ) {
+    function wp_cache_set( $key, $value, $group = '', $ttl = 0 ) {
+        $GLOBALS['wp_cache'][ $group ][ $key ] = $value;
     }
 }
-if (!function_exists('wp_cache_delete')) {
-    function wp_cache_delete($key, $group = '') {
-        unset($GLOBALS['wp_cache'][$group][$key]);
+if ( ! function_exists( 'wp_cache_delete' ) ) {
+    function wp_cache_delete( $key, $group = '' ) {
+        unset( $GLOBALS['wp_cache'][ $group ][ $key ] );
     }
 }
-if (!function_exists('wp_cache_flush_group')) {
-    function wp_cache_flush_group($group) {
-        unset($GLOBALS['wp_cache'][$group]);
+if ( ! function_exists( 'wp_cache_flush_group' ) ) {
+    function wp_cache_flush_group( $group ) {
+        unset( $GLOBALS['wp_cache'][ $group ] );
     }
 }
-if (!function_exists('wp_list_pluck')) {
-    function wp_list_pluck(array $list, string $field) {
+if ( ! function_exists( 'wp_list_pluck' ) ) {
+    function wp_list_pluck( array $list, string $field ) {
         $out = [];
-        foreach ($list as $item) {
-            if (is_array($item) && isset($item[$field])) {
-                $out[] = $item[$field];
-            } elseif (is_object($item) && isset($item->$field)) {
+        foreach ( $list as $item ) {
+            if ( is_array( $item ) && isset( $item[ $field ] ) ) {
+                $out[] = $item[ $field ];
+            } elseif ( is_object( $item ) && isset( $item->$field ) ) {
                 $out[] = $item->$field;
             }
         }
@@ -98,53 +98,53 @@ if (!function_exists('apply_filters')) {
 if (!function_exists('add_filter')) {
     function add_filter(...$args) {}
 }
-if (!function_exists('add_shortcode')) {
-    function add_shortcode(...$args) {}
+if ( ! function_exists( 'add_shortcode' ) ) {
+    function add_shortcode( ...$args ) {}
 }
-if (!function_exists('shortcode_atts')) {
-    function shortcode_atts($pairs, $atts, $shortcode = '') {
+if ( ! function_exists( 'shortcode_atts' ) ) {
+    function shortcode_atts( $pairs, $atts, $shortcode = '' ) {
         $out = $pairs;
-        foreach ($pairs as $name => $default) {
-            if (isset($atts[$name])) {
-                $out[$name] = $atts[$name];
+        foreach ( $pairs as $name => $default ) {
+            if ( isset( $atts[ $name ] ) ) {
+                $out[ $name ] = $atts[ $name ];
             }
         }
-        foreach ($atts as $name => $value) {
-            if (!isset($out[$name])) {
-                $out[$name] = $value;
+        foreach ( $atts as $name => $value ) {
+            if ( ! isset( $out[ $name ] ) ) {
+                $out[ $name ] = $value;
             }
         }
         return $out;
     }
 }
-if (!function_exists('wp_unique_id')) {
-    function wp_unique_id($prefix = '') {
+if ( ! function_exists( 'wp_unique_id' ) ) {
+    function wp_unique_id( $prefix = '' ) {
         static $i = 1;
         return $prefix . $i++;
     }
 }
-if (!function_exists('wp_script_is')) {
-    function wp_script_is($handle, $list = 'enqueued') { return false; }
+if ( ! function_exists( 'wp_script_is' ) ) {
+    function wp_script_is( $handle, $list = 'enqueued' ) { return false; }
 }
-if (!function_exists('wp_enqueue_script')) {
-    function wp_enqueue_script($handle) {}
+if ( ! function_exists( 'wp_enqueue_script' ) ) {
+    function wp_enqueue_script( $handle ) {}
 }
-if (!function_exists('wp_enqueue_style')) {
-    function wp_enqueue_style($handle) {}
+if ( ! function_exists( 'wp_enqueue_style' ) ) {
+    function wp_enqueue_style( $handle ) {}
 }
-if (!function_exists('wp_add_inline_style')) {
-    function wp_add_inline_style($handle, $css) {}
+if ( ! function_exists( 'wp_add_inline_style' ) ) {
+    function wp_add_inline_style( $handle, $css ) {}
 }
-if (!function_exists('wp_register_style')) {
-    function wp_register_style($handle, $src, $deps = [], $ver = '') {}
+if ( ! function_exists( 'wp_register_style' ) ) {
+    function wp_register_style( $handle, $src, $deps = [], $ver = '' ) {}
 }
-if (!function_exists('wp_register_script')) {
-    function wp_register_script($handle, $src, $deps = [], $ver = '', $in_footer = false) {}
+if ( ! function_exists( 'wp_register_script' ) ) {
+    function wp_register_script( $handle, $src, $deps = [], $ver = '', $in_footer = false ) {}
 }
-if (!function_exists('wp_localize_script')) {
-    function wp_localize_script($handle, $object_name, $l10n) {}
+if ( ! function_exists( 'wp_localize_script' ) ) {
+    function wp_localize_script( $handle, $object_name, $l10n ) {}
 }
-if (!function_exists('is_singular')) {
+if ( ! function_exists( 'is_singular' ) ) {
     function is_singular() { return true; }
 }
 

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -1,7 +1,7 @@
 <?php
 // Define ABSPATH to bypass exit calls
-if (!defined('ABSPATH')) {
-    define('ABSPATH', __DIR__ . '/');
+if ( ! defined( 'ABSPATH' ) ) {
+    define( 'ABSPATH', __DIR__ . '/' );
 }
 // Track calls to dbDelta in unit tests
 global $dbDelta_called;


### PR DESCRIPTION
## Summary
- update ABSPATH checks to follow WP coding standards
- tidy spacing in test control structures

## Testing
- `composer lint` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6857e436078c83279a528bc4e705cd7b

<!-- Korbit AI PR Description Start -->
## Description by Korbit AI

### What change is being made?

Standardize the spacing around the `ABSPATH` definition checks and related guard clauses across the codebase for enhanced readability and consistency.

### Why are these changes being made?

The changes improve code readability and adhere to best practice standards for formatting by ensuring consistent spacing around conditions. This helps in maintaining uniformity throughout the codebase, which can simplify future maintenance and development efforts.

> Is this description stale? Ask me to generate a new description by commenting `/korbit-generate-pr-description`
<!-- Korbit AI PR Description End -->