### PR TITLE
Add translation docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ Nuclear Engagement stands out with true sitewide automation: process hundreds or
 
 Learn more:
 See [CHANGELOG](docs/CHANGELOG.md) for release notes.
+See [TRANSLATION](docs/TRANSLATION.md) for localization instructions.
 https://www.nuclearengagement.com
 
 ## Development

--- a/docs/TRANSLATION.md
+++ b/docs/TRANSLATION.md
@@ -1,0 +1,25 @@
+# Translation Guide
+
+This plugin ships with a translation template located at `nuclear-engagement/languages/nuclear-engagement.pot`.
+Follow the steps below to create or update `.po` and `.mo` files for your locale.
+
+## Creating a New Translation
+
+1. Open the POT file in Poedit (or any gettext editor).
+2. Choose **Create new translation** and select your language.
+3. Translate the strings and save the file as `nuclear-engagement-<locale>.po`.
+4. Poedit will automatically compile the corresponding `nuclear-engagement-<locale>.mo` file.
+5. Copy both files to the plugin's `languages/` directory.
+
+WordPress will load translations from this folder when the site language matches the locale code.
+
+## Updating the POT File
+
+After adding new translatable strings in the plugin code, regenerate the template using WP‑CLI:
+
+```bash
+wp i18n make-pot nuclear-engagement nuclear-engagement/languages/nuclear-engagement.pot
+```
+
+Then refresh your `.po` files in Poedit ("Update from POT") and recompile the `.mo` files.
+


### PR DESCRIPTION
## Summary
- document how to create .po/.mo files from `nuclear-engagement.pot`
- link the translation guide from the main README

## Testing
- `php vendor/bin/phpcs` *(fails: command not found)*


------
https://chatgpt.com/codex/tasks/task_e_6857ec032da88327aa60bc08dda15b5b

<!-- Korbit AI PR Description Start -->
## Description by Korbit AI

### What change is being made?

Add a new translation guide document and reference it in the README file for localization instructions.

### Why are these changes being made?

This change provides comprehensive instructions on how to create and update translation files for plugin localization, enhancing user experience for non-English speakers. By including the translation documentation, developers and contributors are guided in maintaining and supporting multilingual capabilities effectively.

> Is this description stale? Ask me to generate a new description by commenting `/korbit-generate-pr-description`
<!-- Korbit AI PR Description End -->