### PR TITLE
Add installation guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ Nuclear Engagement stands out with true sitewide automation: process hundreds or
 
 Learn more:
 See [CHANGELOG](docs/CHANGELOG.md) for release notes.
+See [Installation & Workflow Guide](docs/USAGE.md) for setup and usage.
 https://www.nuclearengagement.com
 
 ## Development

--- a/docs/USAGE.md
+++ b/docs/USAGE.md
@@ -1,0 +1,39 @@
+# Installation & Workflow Guide
+
+This guide explains how to install and configure the **Nuclear Engagement** plugin, generate content in bulk and display it on your site.
+
+## Plugin Installation
+
+1. Download the plugin zip from your Nuclear Engagement account.
+2. In WordPress, go to **Plugins → Add New** and upload the zip.
+3. Activate the plugin after the upload completes.
+
+## Initial Setup
+
+Before generating content you need a **Gold Code** (API key).
+
+1. Log into the Nuclear Engagement app and create a new Gold Code.
+2. In WordPress, open **Nuclear Engagement → Setup**.
+3. Paste the Gold Code and follow the prompts to connect your site.
+
+## Typical Workflow
+
+### 1. Bulk Generation
+
+1. Navigate to **Nuclear Engagement → Generate**.
+2. Choose the post types and filters, then retrieve the post count.
+3. Start generation to create summaries and quizzes for the selected posts.
+
+### 2. Shortcode Placement
+
+- `[nuclear_engagement_summary]` – displays the AI summary for the current post.
+- `[nuclear_engagement_quiz]` – outputs the generated quiz.
+- `[nuclear_engagement_toc]` – renders the table of contents if enabled.
+
+Place the shortcodes manually in your content or configure auto insertion under **Settings → Content Placement**.
+
+### 3. Styling
+
+Adjust fonts and colours under **Settings → Styling**. The plugin loads all front‑end markup inside a `.nuclen-root` wrapper so your custom CSS can target only plugin elements.
+
+For general styling conventions see [UI Styling Guidelines](UI-STYLING.md).


### PR DESCRIPTION
## Summary
- create USAGE.md guide under docs
- link to Installation & Workflow Guide from README

## Testing
- `composer lint` *(fails: command not found)*
- `composer test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6857ebfe6a54832785e102563a84d745

<!-- Korbit AI PR Description Start -->
## Description by Korbit AI

### What change is being made?

Add an installation and workflow guide for the Nuclear Engagement plugin to the documentation.

### Why are these changes being made?

The changes are made to provide users with clear instructions on how to install, configure, and use the Nuclear Engagement plugin effectively, improving usability and user experience. This guide fills a gap in the documentation by detailing the installation steps, setup requirements like the Gold Code, and typical workflow processes including shortcode placement and styling.

> Is this description stale? Ask me to generate a new description by commenting `/korbit-generate-pr-description`
<!-- Korbit AI PR Description End -->