### PR TITLE
Fix onboarding comment typo

### DIFF
--- a/src/admin/ts/nuclen-admin.ts
+++ b/src/admin/ts/nuclen-admin.ts
@@ -15,7 +15,7 @@ import './nuclen-admin-generate-page';
 // Admin UI (tabs, color pickers, theme toggles)
 import './nuclen-admin-ui';
 
-// Onboardingh
+// Onboarding
 import './nuclen-admin-onboarding';
 
 // Gutenberg block registrations


### PR DESCRIPTION
## Summary
- fix a typo in `nuclen-admin.ts`

## Testing
- `composer install` *(fails: command not found)*
- `npm install` *(fails: E403 Forbidden)*
- `composer lint` *(fails: command not found)*
- `composer test` *(fails: command not found)*
- `npm run build` *(fails: vite not found)*


------
https://chatgpt.com/codex/tasks/task_e_6857fc48e3dc8327873e0f16ef52ad3a