### PR TITLE
Refactor AutoGenerationService

### DIFF
--- a/nuclear-engagement/includes/ContainerRegistrar.php
+++ b/nuclear-engagement/includes/ContainerRegistrar.php
@@ -8,7 +8,7 @@ declare(strict_types=1);
 
 namespace NuclearEngagement;
 
-use NuclearEngagement\Services\{GenerationService, RemoteApiService, ContentStorageService, PointerService, PostsQueryService, AutoGenerationService};
+use NuclearEngagement\Services\{GenerationService, RemoteApiService, ContentStorageService, PointerService, PostsQueryService, AutoGenerationService, GenerationPoller, PublishGenerationHandler};
 use NuclearEngagement\Admin\Controller\Ajax\{GenerateController, UpdatesController, PointerController, PostsCountController};
 use NuclearEngagement\Admin\Controller\OptinExportController;
 use NuclearEngagement\Front\Controller\Rest\ContentController;
@@ -24,10 +24,22 @@ final class ContainerRegistrar {
         $container->register( 'remote_api', static fn( $c ) => new RemoteApiService( $c->get( 'settings' ) ) );
         $container->register( 'content_storage', static fn( $c ) => new ContentStorageService( $c->get( 'settings' ) ) );
 
-        $container->register( 'auto_generation_service', static fn( $c ) => new AutoGenerationService(
+        $container->register( 'generation_poller', static fn( $c ) => new GenerationPoller(
             $c->get( 'settings' ),
             $c->get( 'remote_api' ),
             $c->get( 'content_storage' )
+        ) );
+
+        $container->register( 'publish_generation_handler', static fn( $c ) => new PublishGenerationHandler(
+            $c->get( 'settings' )
+        ) );
+
+        $container->register( 'auto_generation_service', static fn( $c ) => new AutoGenerationService(
+            $c->get( 'settings' ),
+            $c->get( 'remote_api' ),
+            $c->get( 'content_storage' ),
+            $c->get( 'generation_poller' ),
+            $c->get( 'publish_generation_handler' )
         ) );
 
         $container->register( 'generation_service', static fn( $c ) => new GenerationService(

--- a/nuclear-engagement/includes/Services/GenerationPoller.php
+++ b/nuclear-engagement/includes/Services/GenerationPoller.php
@@ -1,0 +1,134 @@
+<?php
+declare(strict_types=1);
+/**
+ * File: includes/Services/GenerationPoller.php
+ *
+ * Polls the remote API for generation results.
+ */
+
+namespace NuclearEngagement\Services;
+
+use NuclearEngagement\SettingsRepository;
+use NuclearEngagement\Services\RemoteApiService;
+use NuclearEngagement\Services\ContentStorageService;
+use NuclearEngagement\Services\ApiException;
+
+if ( ! defined( 'ABSPATH' ) ) {
+    exit;
+}
+
+class GenerationPoller {
+    /**
+     * @var SettingsRepository
+     */
+    private SettingsRepository $settings_repository;
+
+    /**
+     * @var RemoteApiService
+     */
+    private RemoteApiService $remote_api;
+
+    /**
+     * @var ContentStorageService
+     */
+    private ContentStorageService $content_storage;
+
+    public function __construct(
+        SettingsRepository $settings_repository,
+        RemoteApiService $remote_api,
+        ContentStorageService $content_storage
+    ) {
+        $this->settings_repository = $settings_repository;
+        $this->remote_api = $remote_api;
+        $this->content_storage = $content_storage;
+    }
+
+    /**
+     * Register WordPress hook for polling events.
+     */
+    public function register_hooks(): void {
+        add_action(
+            'nuclen_poll_generation',
+            [ $this, 'poll_generation' ],
+            10,
+            4 // generation_id, workflow_type, post_id, attempt
+        );
+    }
+
+    /**
+     * Poll for generation updates.
+     *
+     * @param string $generation_id Generation ID
+     * @param string $workflow_type  Type of workflow (quiz/summary)
+     * @param int    $post_id        Post ID
+     * @param int    $attempt        Current attempt number
+     */
+    public function poll_generation(string $generation_id, string $workflow_type, int $post_id, int $attempt): void {
+        $max_attempts = AutoGenerationService::MAX_ATTEMPTS;
+        $retry_delay  = AutoGenerationService::RETRY_DELAY;
+
+        try {
+            $connected        = $this->settings_repository->get('connected', false);
+            $wp_app_created   = $this->settings_repository->get('wp_app_pass_created', false);
+            if ( ! $connected || ! $wp_app_created ) {
+                return;
+            }
+
+            $data = $this->remote_api->fetchUpdates($generation_id);
+
+            if ( ! empty($data['results']) && is_array($data['results']) ) {
+                $this->content_storage->storeResults($data['results'], $workflow_type);
+                \NuclearEngagement\Services\LoggingService::log(
+                    "Poll success for post {$post_id} ({$workflow_type}), generation {$generation_id}"
+                );
+                $this->cleanup_generation($generation_id);
+                return;
+            }
+
+            if ( isset($data['success']) && $data['success'] === true ) {
+                \NuclearEngagement\Services\LoggingService::log(
+                    "Still processing post {$post_id} ({$workflow_type}), attempt {$attempt}/{$max_attempts}"
+                );
+            }
+        } catch (ApiException $e) {
+            \NuclearEngagement\Services\LoggingService::log(
+                "Polling error for post {$post_id} ({$workflow_type}): " . $e->getMessage()
+            );
+        } catch (\Exception $e) {
+            \NuclearEngagement\Services\LoggingService::log(
+                "Polling error for post {$post_id} ({$workflow_type}): " . $e->getMessage()
+            );
+        }
+
+        if ( $attempt < $max_attempts ) {
+            $event_args = [ $generation_id, $workflow_type, $post_id, $attempt + 1 ];
+            wp_schedule_single_event(
+                time() + $retry_delay,
+                'nuclen_poll_generation',
+                $event_args
+            );
+        } else {
+            \NuclearEngagement\Services\LoggingService::log(
+                "Polling aborted after {$max_attempts} attempts for post {$post_id} ({$workflow_type})"
+            );
+            $this->cleanup_generation($generation_id);
+        }
+    }
+
+    /**
+     * Remove a completed or failed generation from the tracking option.
+     *
+     * @param string $generation_id Generation ID to remove
+     */
+    private function cleanup_generation(string $generation_id): void {
+        $generations = get_option('nuclen_active_generations', []);
+        if ( isset($generations[$generation_id]) ) {
+            unset($generations[$generation_id]);
+            if ( empty($generations) ) {
+                delete_option('nuclen_active_generations');
+            } else {
+                update_option('nuclen_active_generations', $generations, 'no');
+            }
+        }
+    }
+}

--- a/nuclear-engagement/includes/Services/PublishGenerationHandler.php
+++ b/nuclear-engagement/includes/Services/PublishGenerationHandler.php
@@ -1,0 +1,78 @@
+<?php
+declare(strict_types=1);
+/**
+ * File: includes/Services/PublishGenerationHandler.php
+ *
+ * Handles auto-generation triggers on post publish.
+ */
+
+namespace NuclearEngagement\Services;
+
+use NuclearEngagement\SettingsRepository;
+
+if ( ! defined( 'ABSPATH' ) ) {
+    exit;
+}
+
+class PublishGenerationHandler {
+    /**
+     * @var SettingsRepository
+     */
+    private SettingsRepository $settings_repository;
+
+    public function __construct(SettingsRepository $settings_repository) {
+        $this->settings_repository = $settings_repository;
+    }
+
+    /**
+     * Register the publish transition hook.
+     */
+    public function register_hooks(): void {
+        add_action('transition_post_status', [ $this, 'handle_post_publish' ], 10, 3);
+    }
+
+    /**
+     * Handle post publish transition.
+     *
+     * @param string  $new_status New post status
+     * @param string  $old_status Old post status
+     * @param \WP_Post $post       Post object
+     */
+    public function handle_post_publish($new_status, $old_status, $post): void {
+        if ($old_status === 'publish' || $new_status !== 'publish') {
+            return;
+        }
+
+        $allowed_post_types = $this->settings_repository->get('generation_post_types', ['post']);
+        if (! in_array($post->post_type, (array) $allowed_post_types, true)) {
+            return;
+        }
+
+        $gen_quiz    = (bool) $this->settings_repository->get('auto_generate_quiz_on_publish', false);
+        $gen_summary = (bool) $this->settings_repository->get('auto_generate_summary_on_publish', false);
+
+        if (!$gen_quiz && !$gen_summary) {
+            return;
+        }
+
+        if ($gen_quiz) {
+            $protected = get_post_meta($post->ID, 'nuclen_quiz_protected', true);
+            if (!$protected) {
+                $args = [ $post->ID, 'quiz' ];
+                if (! wp_next_scheduled(AutoGenerationService::START_HOOK, $args)) {
+                    wp_schedule_single_event(time(), AutoGenerationService::START_HOOK, $args);
+                }
+            }
+        }
+
+        if ($gen_summary) {
+            $protected = get_post_meta($post->ID, 'nuclen_summary_protected', true);
+            if (!$protected) {
+                $args = [ $post->ID, 'summary' ];
+                if (! wp_next_scheduled(AutoGenerationService::START_HOOK, $args)) {
+                    wp_schedule_single_event(time(), AutoGenerationService::START_HOOK, $args);
+                }
+            }
+        }
+    }
+}

--- a/tests/AutoGenerationServiceTest.php
+++ b/tests/AutoGenerationServiceTest.php
@@ -32,9 +32,13 @@ class AutoGenerationServiceTest extends TestCase {
 
     private function makeService(?DummyRemoteApiService $api = null): AutoGenerationService {
         $settings = SettingsRepository::get_instance();
-        $api = $api ?: new DummyRemoteApiService();
-        $storage = new DummyContentStorageService();
-        return new AutoGenerationService($settings, $api, $storage);
+        $api      = $api ?: new DummyRemoteApiService();
+        $storage  = new DummyContentStorageService();
+
+        $poller  = new \NuclearEngagement\Services\GenerationPoller($settings, $api, $storage);
+        $handler = new \NuclearEngagement\Services\PublishGenerationHandler($settings);
+
+        return new AutoGenerationService($settings, $api, $storage, $poller, $handler);
     }
 
     public function test_generate_single_sets_autoload_no(): void {


### PR DESCRIPTION
## Summary
- extract PublishGenerationHandler for post publish hooks
- create GenerationPoller class for polling logic
- update ContainerRegistrar to register new services
- delegate AutoGenerationService to the new classes
- adapt unit tests

## Testing
- `composer lint` *(fails: composer not installed)*
- `composer test` *(fails: composer not installed)*

------
https://chatgpt.com/codex/tasks/task_e_6857fc4d2d808327a612f17d485c0af6

<!-- Korbit AI PR Description Start -->
## Description by Korbit AI

### What change is being made?

Refactor `AutoGenerationService` by extracting `GenerationPoller` and `PublishGenerationHandler` into separate classes to handle polling and publish event registration, respectively.

### Why are these changes being made?

These changes improve code maintainability and readability by organizing responsibilities into distinct classes. This modular approach makes the code easier to manage and test, adhering to the single responsibility principle and allowing for future scalability.

> Is this description stale? Ask me to generate a new description by commenting `/korbit-generate-pr-description`
<!-- Korbit AI PR Description End -->