### PR TITLE
Improve error handling and constants

### DIFF
--- a/nuclear-engagement/admin/Controller/Ajax/BaseController.php
+++ b/nuclear-engagement/admin/Controller/Ajax/BaseController.php
@@ -26,9 +26,8 @@ abstract class BaseController {
      */
     protected function sendError(string $message, int $code = 500): void {
         status_header($code);
-        wp_send_json(
+        wp_send_json_error(
             [
-                'success' => false,
                 'message' => $message,
             ],
             $code

--- a/nuclear-engagement/admin/Controller/Ajax/UpdatesController.php
+++ b/nuclear-engagement/admin/Controller/Ajax/UpdatesController.php
@@ -102,17 +102,12 @@ class UpdatesController extends BaseController {
             wp_send_json_success( $response->toArray() );
 
         } catch ( ApiException $e ) {
-\NuclearEngagement\Services\LoggingService::log( 'Error fetching updates: ' . $e->getMessage() );
-            $res = new UpdatesResponse();
-            $res->success = false;
-            $res->message = $e->getMessage();
-            if ($e->getCode()) {
-                $res->statusCode = $e->getCode();
-            }
-            wp_send_json_error( $res->toArray() );
-        } catch ( \Exception $e ) {
             \NuclearEngagement\Services\LoggingService::log( 'Error fetching updates: ' . $e->getMessage() );
-            $this->sendError( $e->getMessage() );
+            $message = __( 'Failed to fetch updates. Please try again later.', 'nuclear-engagement' );
+            $this->sendError( $message, $e->getCode() ?: 500 );
+        } catch ( \Throwable $e ) {
+            \NuclearEngagement\Services\LoggingService::log( 'Error fetching updates: ' . $e->getMessage() );
+            $this->sendError( __( 'An unexpected error occurred.', 'nuclear-engagement' ) );
         }
     }
 }

--- a/nuclear-engagement/bootstrap.php
+++ b/nuclear-engagement/bootstrap.php
@@ -89,6 +89,15 @@ function nuclen_update_migrate_post_meta() {
 
     global $wpdb;
 
+    $check_error = static function () use ( $wpdb ) {
+        if ( ! empty( $wpdb->last_error ) ) {
+            \NuclearEngagement\Services\LoggingService::log( 'Meta migration error: ' . $wpdb->last_error );
+            update_option( 'nuclen_meta_migration_error', $wpdb->last_error );
+            return false;
+        }
+        return true;
+    };
+
     $wpdb->query(
         $wpdb->prepare(
             "UPDATE {$wpdb->postmeta} SET meta_key = %s WHERE meta_key = %s",
@@ -96,9 +105,7 @@ function nuclen_update_migrate_post_meta() {
             'ne-summary-data'
         )
     );
-    if (!empty($wpdb->last_error)) {
-        \NuclearEngagement\Services\LoggingService::log('Meta migration error: ' . $wpdb->last_error);
-        update_option('nuclen_meta_migration_error', $wpdb->last_error);
+    if ( ! $check_error() ) {
         return;
     }
 
@@ -109,9 +116,7 @@ function nuclen_update_migrate_post_meta() {
             'ne-quiz-data'
         )
     );
-    if (!empty($wpdb->last_error)) {
-        \NuclearEngagement\Services\LoggingService::log('Meta migration error: ' . $wpdb->last_error);
-        update_option('nuclen_meta_migration_error', $wpdb->last_error);
+    if ( ! $check_error() ) {
         return;
     }
 

--- a/nuclear-engagement/includes/Blocks.php
+++ b/nuclear-engagement/includes/Blocks.php
@@ -8,11 +8,20 @@ if ( ! defined( 'ABSPATH' ) ) {
 
 final class Blocks {
     public static function register(): void {
+        if ( ! function_exists( 'register_block_type' ) ) {
+            error_log( 'Nuclear Engagement: block registration unavailable.' );
+            return;
+        }
+
         register_block_type(
             'nuclear-engagement/quiz',
             [
                 'render_callback' => static function (): string {
-                    return do_shortcode('[nuclear_engagement_quiz]');
+                    $out = do_shortcode('[nuclear_engagement_quiz]');
+                    if ( ! is_string( $out ) || trim( $out ) === '' ) {
+                        return '<p>' . esc_html__( 'Quiz unavailable.', 'nuclear-engagement' ) . '</p>';
+                    }
+                    return $out;
                 },
                 'editor_script'   => 'nuclen-admin',
             ]
@@ -22,7 +31,11 @@ final class Blocks {
             'nuclear-engagement/summary',
             [
                 'render_callback' => static function (): string {
-                    return do_shortcode('[nuclear_engagement_summary]');
+                    $out = do_shortcode('[nuclear_engagement_summary]');
+                    if ( ! is_string( $out ) || trim( $out ) === '' ) {
+                        return '<p>' . esc_html__( 'Summary unavailable.', 'nuclear-engagement' ) . '</p>';
+                    }
+                    return $out;
                 },
                 'editor_script'   => 'nuclen-admin',
             ]

--- a/nuclear-engagement/includes/Services/ApiException.php
+++ b/nuclear-engagement/includes/Services/ApiException.php
@@ -15,7 +15,7 @@ if (!defined('ABSPATH')) {
 class ApiException extends \RuntimeException {
     private ?string $errorCode;
 
-    public function __construct(string $message, int $code = 0, ?string $errorCode = null) {
+    public function __construct(string $message, int $code = 500, ?string $errorCode = null) {
         parent::__construct($message, $code);
         $this->errorCode = $errorCode;
     }

--- a/nuclear-engagement/includes/Services/AutoGenerationService.php
+++ b/nuclear-engagement/includes/Services/AutoGenerationService.php
@@ -158,6 +158,15 @@ class AutoGenerationService {
                 \NuclearEngagement\Services\LoggingService::log(
                     'Failed to start generation: ' . $e->getMessage()
                 );
+                $gens = get_option('nuclen_active_generations', []);
+                if (isset($gens[$generation_id])) {
+                    unset($gens[$generation_id]);
+                    if (empty($gens)) {
+                        delete_option('nuclen_active_generations');
+                    } else {
+                        update_option('nuclen_active_generations', $gens, 'no');
+                    }
+                }
                 return;
             }
 

--- a/nuclear-engagement/includes/Services/GenerationPoller.php
+++ b/nuclear-engagement/includes/Services/GenerationPoller.php
@@ -94,10 +94,18 @@ class GenerationPoller {
             \NuclearEngagement\Services\LoggingService::log(
                 "Polling error for post {$post_id} ({$workflow_type}): " . $e->getMessage()
             );
-        } catch (\Exception $e) {
+            if ( $attempt >= $max_attempts ) {
+                $this->cleanup_generation( $generation_id );
+                return;
+            }
+        } catch (\Throwable $e) {
             \NuclearEngagement\Services\LoggingService::log(
                 "Polling error for post {$post_id} ({$workflow_type}): " . $e->getMessage()
             );
+            if ( $attempt >= $max_attempts ) {
+                $this->cleanup_generation( $generation_id );
+                return;
+            }
         }
 
         if ( $attempt < $max_attempts ) {

--- a/nuclear-engagement/includes/Services/GenerationService.php
+++ b/nuclear-engagement/includes/Services/GenerationService.php
@@ -93,7 +93,7 @@ class GenerationService {
                 'workflow' => $workflow,
                 'generation_id' => $request->generationId,
             ]);
-        } catch (ApiException $e) {
+        } catch (\Throwable $e) {
             $response = new GenerationResponse();
             $response->generationId = $request->generationId;
             $response->success = false;
@@ -102,18 +102,8 @@ class GenerationService {
             if ($code) {
                 $response->statusCode = (int) $code;
             }
-            if (method_exists($e, 'getErrorCode')) {
+            if ($e instanceof ApiException) {
                 $response->errorCode = $e->getErrorCode();
-            }
-            return $response;
-        } catch (\RuntimeException $e) {
-            $response = new GenerationResponse();
-            $response->generationId = $request->generationId;
-            $response->success = false;
-            $response->error = $e->getMessage();
-            $code = $e->getCode();
-            if ($code) {
-                $response->statusCode = (int) $code;
             }
             return $response;
         }

--- a/nuclear-engagement/includes/constants.php
+++ b/nuclear-engagement/includes/constants.php
@@ -4,7 +4,14 @@ if ( ! defined( 'ABSPATH' ) ) {
     exit;
 }
 
-/** Plugin-wide constants for numeric values. */
+/**
+ * Plugin-wide numeric configuration.
+ *
+ * These constants centralize all tunable numeric values used across the
+ * plugin. Keeping them in one place avoids "magic numbers" sprinkled in
+ * the codebase and makes it easier to tweak behaviour without hunting
+ * through multiple files.
+ */
 
 /** Maximum log file size in bytes. */
 define( 'NUCLEN_LOG_FILE_MAX_SIZE', MB_IN_BYTES );


### PR DESCRIPTION
## Summary
- add context to constants file
- return JSON errors consistently
- clean up active generation tracking on failures
- handle shortcode edge cases for blocks
- default `ApiException` to HTTP 500
- log & clean up generation polling failures
- broaden exception catch in `GenerationService`
- DRY database migration error handling

## Testing
- `php vendor/bin/phpcs` *(fails: `php` command not found)*
- `php vendor/bin/phpunit` *(fails: `php` command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685801371f9883278887e1d97b51cf90