### PR TITLE
Improve generation security

### DIFF
--- a/nuclear-engagement/includes/Services/LoggingService.php
+++ b/nuclear-engagement/includes/Services/LoggingService.php
@@ -72,6 +72,12 @@ class LoggingService {
             return;
         }
 
+        // Strip any HTML and limit length to avoid leaking sensitive data
+        $message = wp_strip_all_tags($message);
+        if (strlen($message) > 1000) {
+            $message = substr($message, 0, 1000) . '...';
+        }
+
         $info       = self::get_log_file_info();
         $log_folder = $info['dir'];
         $log_file   = $info['path'];

--- a/nuclear-engagement/includes/Services/PublishGenerationHandler.php
+++ b/nuclear-engagement/includes/Services/PublishGenerationHandler.php
@@ -43,6 +43,11 @@ class PublishGenerationHandler {
             return;
         }
 
+        // Prevent unauthorized users from triggering generation
+        if (!wp_doing_cron() && !current_user_can('publish_post', $post->ID)) {
+            return;
+        }
+
         $allowed_post_types = $this->settings_repository->get('generation_post_types', ['post']);
         if (! in_array($post->post_type, (array) $allowed_post_types, true)) {
             return;

--- a/src/admin/ts/generation/api.ts
+++ b/src/admin/ts/generation/api.ts
@@ -57,7 +57,10 @@ export async function NuclenStartGeneration(dataToSend: Record<string, any>) {
   const formData = new FormData();
   formData.append('action', 'nuclen_trigger_generation');
   formData.append('payload', JSON.stringify(dataToSend));
-  formData.append('security', window.nuclenAjax?.nonce ?? '');
+  if (!window.nuclenAjax?.nonce) {
+    throw new Error('Missing security nonce.');
+  }
+  formData.append('security', window.nuclenAjax.nonce);
 
   const response = await fetch(window.nuclenAdminVars.ajax_url, {
     method: 'POST',

--- a/src/admin/ts/generation/results.ts
+++ b/src/admin/ts/generation/results.ts
@@ -6,14 +6,15 @@ export const REST_NONCE = (window as any).nuclenAdminVars?.rest_nonce || '';
 import { displayError } from '../utils/displayError';
 
 export function nuclenAlertApiError(errMsg: string): void {
-  if (errMsg.includes('Invalid API key')) {
+  const cleanMsg = errMsg.replace(/<[^>]+>/g, '');
+  if (cleanMsg.includes('Invalid API key')) {
     displayError('Your API key is invalid. Please go to the Setup page and enter a new one.');
-  } else if (errMsg.includes('Invalid WP App Password')) {
+  } else if (cleanMsg.includes('Invalid WP App Password')) {
     displayError('Your WP App Password is invalid. Please re-generate it on the Setup page.');
-  } else if (errMsg.includes('Not enough credits')) {
+  } else if (cleanMsg.includes('Not enough credits')) {
     displayError('Not enough credits. Please top up your account or reduce the number of posts.');
   } else {
-    displayError(`Error: ${errMsg}`);
+    displayError(`Error: ${cleanMsg}`);
   }
 }
 


### PR DESCRIPTION
## Summary
- sanitize log messages to avoid leaking sensitive info
- restrict content generation to authorized users only
- enforce nonce presence before generation requests
- sanitize API error messages before display

## Testing
- `npm run build` *(fails: vite not found)*
- `composer lint` *(fails: command not found)*
- `composer test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685804cb14908327b29494fef37e7608