### PR TITLE
Display scheduled generations on dashboard

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -4,6 +4,7 @@ Release notes for the Nuclear Engagement plugin.
 
 ## 1.1 – 2025-06-13
 - Added: Test infrastructure for improved code quality.
+- Added: Dashboard section showing scheduled content generation tasks.
 - Changed: Architecture refactoring.
 - Changed: Improved security.
 - Changed: Improved performance.

--- a/nuclear-engagement/admin/Dashboard.php
+++ b/nuclear-engagement/admin/Dashboard.php
@@ -211,6 +211,30 @@ $by_category_quiz     = $drop_zeros( $by_category_quiz );
 $by_category_summary  = $drop_zeros( $by_category_summary );
 
 /* ──────────────────────────────────────────────────────────────
+ * 4b. Gather scheduled generation tasks
+ * ──────────────────────────────────────────────────────────── */
+$active_generations = get_option( 'nuclen_active_generations', array() );
+$scheduled_tasks    = array();
+
+foreach ( $active_generations as $gen_id => $info ) {
+    $post_id   = (int) ( $info['post_ids'][0] ?? 0 );
+    $title     = $post_id ? get_the_title( $post_id ) : $gen_id;
+    $next_poll = isset( $info['next_poll'] )
+        ? date_i18n(
+            get_option( 'date_format' ) . ' ' . get_option( 'time_format' ),
+            (int) $info['next_poll']
+        )
+        : '';
+
+    $scheduled_tasks[] = array(
+        'post_title'    => $title,
+        'workflow_type' => $info['workflow_type'] ?? '',
+        'attempt'       => (int) ( $info['attempt'] ?? 1 ),
+        'next_poll'     => $next_poll,
+    );
+}
+
+/* ──────────────────────────────────────────────────────────────
  * 5. Render dashboard (same partial as before)
  * ──────────────────────────────────────────────────────────── */
 require plugin_dir_path( __FILE__ ) . 'partials/nuclen-dashboard-page.php';

--- a/nuclear-engagement/admin/partials/dashboard/scheduled.php
+++ b/nuclear-engagement/admin/partials/dashboard/scheduled.php
@@ -1,0 +1,30 @@
+<?php
+declare(strict_types=1);
+// File: admin/partials/dashboard/scheduled.php
+if ( ! defined( 'ABSPATH' ) ) {
+    exit;
+}
+?>
+<h2><?php esc_html_e( 'Scheduled Generations', 'nuclear-engagement' ); ?></h2>
+<div class="nuclen-dashboard-content">
+<?php if ( empty( $scheduled_tasks ) ) : ?>
+    <p><?php esc_html_e( 'No scheduled generation tasks.', 'nuclear-engagement' ); ?></p>
+<?php else : ?>
+    <table class="nuclen-stats-table">
+        <tr>
+            <th><?php esc_html_e( 'Post', 'nuclear-engagement' ); ?></th>
+            <th><?php esc_html_e( 'Type', 'nuclear-engagement' ); ?></th>
+            <th><?php esc_html_e( 'Attempt', 'nuclear-engagement' ); ?></th>
+            <th><?php esc_html_e( 'Next Check', 'nuclear-engagement' ); ?></th>
+        </tr>
+        <?php foreach ( $scheduled_tasks as $t ) : ?>
+        <tr>
+            <td><?php echo esc_html( $t['post_title'] ); ?></td>
+            <td><?php echo esc_html( ucfirst( $t['workflow_type'] ) ); ?></td>
+            <td><?php echo esc_html( $t['attempt'] ); ?></td>
+            <td><?php echo esc_html( $t['next_poll'] ); ?></td>
+        </tr>
+        <?php endforeach; ?>
+    </table>
+<?php endif; ?>
+</div>

--- a/nuclear-engagement/admin/partials/nuclen-dashboard-page.php
+++ b/nuclear-engagement/admin/partials/nuclen-dashboard-page.php
@@ -25,6 +25,7 @@ $utils->display_nuclen_page_header();
         $dash_dir = plugin_dir_path( __FILE__ ) . 'dashboard/';
         require $dash_dir . 'inventory.php';
         require $dash_dir . 'analytics.php';
+        require $dash_dir . 'scheduled.php';
         require $dash_dir . 'credits.php';
     ?>
 </div><!-- .wrap .nuclen-container -->


### PR DESCRIPTION
## Summary
- list scheduled generation tasks in admin dashboard
- link new dashboard section into main dashboard page
- log new feature in changelog

## Testing
- `composer lint` *(fails: command not found)*
- `composer test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6858543cd0d48327a0517c28d145877c

<!-- Korbit AI PR Description Start -->
## Description by Korbit AI

### What change is being made?

Add a dashboard section to display scheduled content generation tasks.

### Why are these changes being made?

This change provides users with visibility of scheduled content generation tasks on the dashboard, enhancing usability and task management. By displaying these tasks, users can better track and manage their scheduled workflows directly from the dashboard interface.

> Is this description stale? Ask me to generate a new description by commenting `/korbit-generate-pr-description`
<!-- Korbit AI PR Description End -->