### PR TITLE
Implement caching for post inventory

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -5,6 +5,7 @@ Release notes for the Nuclear Engagement plugin.
 ## 1.1 – 2025-06-13
 - Added: Test infrastructure for improved code quality.
 - Added: Dashboard section showing scheduled content generation tasks.
+- Added: Inventory data caching with auto invalidation.
 - Changed: Architecture refactoring.
 - Changed: Improved security.
 - Changed: Improved performance.

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -6,6 +6,7 @@ Release notes for the Nuclear Engagement plugin.
 - Added: Test infrastructure for improved code quality.
 - Added: Dashboard section showing scheduled content generation tasks.
 - Added: Inventory data caching with auto invalidation.
+- Changed: Expanded cache invalidation to cover more post and term events.
 - Changed: Architecture refactoring.
 - Changed: Improved security.
 - Changed: Improved performance.

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -6,6 +6,7 @@ Release notes for the Nuclear Engagement plugin.
 - Added: Test infrastructure for improved code quality.
 - Added: Dashboard section showing scheduled content generation tasks.
 - Added: Inventory data caching with auto invalidation.
+- Added: Manual refresh control on the dashboard to update cached inventory data.
 - Changed: Expanded cache invalidation to cover more post and term events.
 - Changed: Architecture refactoring.
 - Changed: Improved security.

--- a/nuclear-engagement/admin/Dashboard.php
+++ b/nuclear-engagement/admin/Dashboard.php
@@ -28,9 +28,16 @@ $allowed_post_types = is_array($allowed_post_types) ? $allowed_post_types : arra
 
 /* Attempt to use cached inventory unless refresh requested */
 $inventory_cache = \NuclearEngagement\InventoryCache::get();
-if ( isset( $_GET['nuclen_refresh_inventory'] ) ) {
+if (
+    isset( $_GET['nuclen_refresh_inventory'] ) &&
+    isset( $_GET['nuclen_refresh_inventory_nonce'] ) &&
+    wp_verify_nonce( sanitize_text_field( wp_unslash( $_GET['nuclen_refresh_inventory_nonce'] ) ), 'nuclen_refresh_inventory' ) &&
+    current_user_can( 'manage_options' )
+) {
     \NuclearEngagement\InventoryCache::clear();
     $inventory_cache = null;
+    wp_safe_redirect( remove_query_arg( array( 'nuclen_refresh_inventory', 'nuclen_refresh_inventory_nonce' ) ) );
+    exit;
 }
 
 /* ──────────────────────────────────────────────────────────────

--- a/nuclear-engagement/admin/Dashboard.php
+++ b/nuclear-engagement/admin/Dashboard.php
@@ -26,6 +26,13 @@ $admin = new \NuclearEngagement\Admin\Admin('nuclear-engagement', NUCLEN_PLUGIN_
 $allowed_post_types = $settings_repo->get('generation_post_types', array('post'));
 $allowed_post_types = is_array($allowed_post_types) ? $allowed_post_types : array('post');
 
+/* Attempt to use cached inventory unless refresh requested */
+$inventory_cache = \NuclearEngagement\InventoryCache::get();
+if ( isset( $_GET['nuclen_refresh_inventory'] ) ) {
+    \NuclearEngagement\InventoryCache::clear();
+    $inventory_cache = null;
+}
+
 /* ──────────────────────────────────────────────────────────────
  * 2. Convenience helpers
  * ──────────────────────────────────────────────────────────── */
@@ -108,6 +115,8 @@ function nuclen_get_dual_counts( string $group_by, array $post_types, array $sta
  * 3. Build every stats table we need (quiz + summary)
  * ──────────────────────────────────────────────────────────── */
 $post_statuses = array( 'publish', 'pending', 'draft', 'future' );
+
+if ( null === $inventory_cache ) {
 
 /* — By Post Status — */
 $status_rows    = nuclen_get_dual_counts( 'p.post_status', $allowed_post_types, $post_statuses );
@@ -209,6 +218,29 @@ $by_author_quiz       = $drop_zeros( $by_author_quiz );
 $by_author_summary    = $drop_zeros( $by_author_summary );
 $by_category_quiz     = $drop_zeros( $by_category_quiz );
 $by_category_summary  = $drop_zeros( $by_category_summary );
+
+    \NuclearEngagement\InventoryCache::set(
+        array(
+            'by_status_quiz'       => $by_status_quiz,
+            'by_status_summary'    => $by_status_summary,
+            'by_post_type_quiz'    => $by_post_type_quiz,
+            'by_post_type_summary' => $by_post_type_summary,
+            'by_author_quiz'       => $by_author_quiz,
+            'by_author_summary'    => $by_author_summary,
+            'by_category_quiz'     => $by_category_quiz,
+            'by_category_summary'  => $by_category_summary,
+        )
+    );
+} else {
+    $by_status_quiz       = $inventory_cache['by_status_quiz'] ?? array();
+    $by_status_summary    = $inventory_cache['by_status_summary'] ?? array();
+    $by_post_type_quiz    = $inventory_cache['by_post_type_quiz'] ?? array();
+    $by_post_type_summary = $inventory_cache['by_post_type_summary'] ?? array();
+    $by_author_quiz       = $inventory_cache['by_author_quiz'] ?? array();
+    $by_author_summary    = $inventory_cache['by_author_summary'] ?? array();
+    $by_category_quiz     = $inventory_cache['by_category_quiz'] ?? array();
+    $by_category_summary  = $inventory_cache['by_category_summary'] ?? array();
+}
 
 /* ──────────────────────────────────────────────────────────────
  * 4b. Gather scheduled generation tasks

--- a/nuclear-engagement/admin/partials/dashboard/inventory.php
+++ b/nuclear-engagement/admin/partials/dashboard/inventory.php
@@ -7,6 +7,11 @@ if ( ! defined( 'ABSPATH' ) ) {
 ?>
 <!-- Post inventory -->
 <h2><?php esc_html_e( 'Post Inventory', 'nuclear-engagement' ); ?></h2>
+<p>
+    <a href="<?php echo esc_url( add_query_arg( 'nuclen_refresh_inventory', '1' ) ); ?>" class="button button-secondary">
+        <?php esc_html_e( 'Refresh', 'nuclear-engagement' ); ?>
+    </a>
+</p>
 <!-- Post inventory Navigation Tabs -->
 <div class="nav-tab-wrapper">
     <a href="#post-status" id="post-status-tab" class="nav-tab nav-tab-active"><?php esc_html_e( 'Post Status', 'nuclear-engagement' ); ?></a>

--- a/nuclear-engagement/admin/partials/dashboard/inventory.php
+++ b/nuclear-engagement/admin/partials/dashboard/inventory.php
@@ -7,8 +7,9 @@ if ( ! defined( 'ABSPATH' ) ) {
 ?>
 <!-- Post inventory -->
 <h2><?php esc_html_e( 'Post Inventory', 'nuclear-engagement' ); ?></h2>
+<p><?php esc_html_e( 'Counts are cached for faster page loads.', 'nuclear-engagement' ); ?></p>
 <p>
-    <a href="<?php echo esc_url( add_query_arg( 'nuclen_refresh_inventory', '1' ) ); ?>" class="button button-secondary">
+    <a href="<?php echo esc_url( add_query_arg( array( 'nuclen_refresh_inventory' => '1', 'nuclen_refresh_inventory_nonce' => wp_create_nonce( 'nuclen_refresh_inventory' ) ) ) ); ?>" class="button button-secondary">
         <?php esc_html_e( 'Refresh', 'nuclear-engagement' ); ?>
     </a>
 </p>

--- a/nuclear-engagement/bootstrap.php
+++ b/nuclear-engagement/bootstrap.php
@@ -7,6 +7,7 @@ use NuclearEngagement\Deactivator;
 use NuclearEngagement\MetaRegistration;
 use NuclearEngagement\AssetVersions;
 use NuclearEngagement\Plugin;
+use NuclearEngagement\InventoryCache;
 
 if ( ! defined( 'ABSPATH' ) ) {
     exit;
@@ -143,4 +144,5 @@ function nuclear_engagement_run_plugin() {
     $plugin->nuclen_run();
 }
 
+InventoryCache::register_hooks();
 nuclear_engagement_run_plugin();

--- a/nuclear-engagement/bootstrap.php
+++ b/nuclear-engagement/bootstrap.php
@@ -144,5 +144,16 @@ function nuclear_engagement_run_plugin() {
     $plugin->nuclen_run();
 }
 
-InventoryCache::register_hooks();
-nuclear_engagement_run_plugin();
+function nuclear_engagement_init() {
+    try {
+        InventoryCache::register_hooks();
+    } catch ( \Throwable $e ) {
+        error_log( 'Nuclear Engagement: Cache registration failed - ' . $e->getMessage() );
+        add_action( 'admin_notices', static function () {
+            echo '<div class="error"><p>Nuclear Engagement: Cache system initialization failed.</p></div>';
+        } );
+    }
+
+    nuclear_engagement_run_plugin();
+}
+add_action( 'plugins_loaded', 'nuclear_engagement_init' );

--- a/nuclear-engagement/includes/InventoryCache.php
+++ b/nuclear-engagement/includes/InventoryCache.php
@@ -1,0 +1,70 @@
+<?php
+declare(strict_types=1);
+/**
+ * File: includes/InventoryCache.php
+ *
+ * Cache handler for dashboard post inventory data.
+ *
+ * @package NuclearEngagement
+ */
+
+namespace NuclearEngagement;
+
+if ( ! defined( 'ABSPATH' ) ) {
+    exit;
+}
+
+final class InventoryCache {
+    /** Cache key for inventory data. */
+    public const CACHE_KEY = 'nuclen_inventory_data';
+
+    /** Cache group used for inventory. */
+    public const CACHE_GROUP = 'nuclen_inventory';
+
+    /** Default cache lifetime. */
+    public const CACHE_EXPIRATION = HOUR_IN_SECONDS;
+
+    /**
+     * Register hooks to automatically clear the cache when posts change.
+     */
+    public static function register_hooks(): void {
+        $cb = [ self::class, 'clear' ];
+        foreach ( [ 'save_post', 'deleted_post', 'trashed_post', 'untrashed_post', 'transition_post_status' ] as $hook ) {
+            add_action( $hook, $cb );
+        }
+        foreach ( [ 'added_post_meta', 'updated_post_meta', 'deleted_post_meta' ] as $hook ) {
+            add_action( $hook, $cb );
+        }
+        foreach ( [ 'created_term', 'edited_term', 'delete_term', 'set_object_terms' ] as $hook ) {
+            add_action( $hook, $cb );
+        }
+        add_action( 'switch_blog', $cb );
+    }
+
+    /**
+     * Get cached inventory data.
+     */
+    public static function get(): ?array {
+        $cached = wp_cache_get( self::CACHE_KEY, self::CACHE_GROUP );
+        return is_array( $cached ) ? $cached : null;
+    }
+
+    /**
+     * Store inventory data in cache.
+     */
+    public static function set( array $data ): void {
+        wp_cache_set( self::CACHE_KEY, $data, self::CACHE_GROUP, self::CACHE_EXPIRATION );
+    }
+
+    /**
+     * Clear the inventory cache.
+     */
+    public static function clear(): void {
+        wp_cache_delete( self::CACHE_KEY, self::CACHE_GROUP );
+        if ( function_exists( 'wp_cache_flush_group' ) ) {
+            wp_cache_flush_group( self::CACHE_GROUP );
+        } else {
+            wp_cache_flush();
+        }
+    }
+}

--- a/nuclear-engagement/includes/InventoryCache.php
+++ b/nuclear-engagement/includes/InventoryCache.php
@@ -29,13 +29,21 @@ final class InventoryCache {
      */
     public static function register_hooks(): void {
         $cb = [ self::class, 'clear' ];
-        foreach ( [ 'save_post', 'deleted_post', 'trashed_post', 'untrashed_post', 'transition_post_status' ] as $hook ) {
+        foreach ( [ 'save_post', 'delete_post', 'deleted_post', 'trashed_post', 'untrashed_post', 'transition_post_status' ] as $hook ) {
             add_action( $hook, $cb );
         }
         foreach ( [ 'added_post_meta', 'updated_post_meta', 'deleted_post_meta' ] as $hook ) {
             add_action( $hook, $cb );
         }
-        foreach ( [ 'created_term', 'edited_term', 'delete_term', 'set_object_terms' ] as $hook ) {
+        foreach ( [
+            'create_term',
+            'created_term',
+            'edit_term',
+            'edited_term',
+            'delete_term',
+            'deleted_term',
+            'set_object_terms',
+        ] as $hook ) {
             add_action( $hook, $cb );
         }
         add_action( 'switch_blog', $cb );

--- a/nuclear-engagement/includes/InventoryCache.php
+++ b/nuclear-engagement/includes/InventoryCache.php
@@ -71,8 +71,9 @@ final class InventoryCache {
      * Get cached inventory data.
      */
     public static function get(): ?array {
-        $cached = wp_cache_get( self::get_cache_key(), self::CACHE_GROUP );
-        return is_array( $cached ) ? $cached : null;
+        $found  = false;
+        $cached = wp_cache_get( self::get_cache_key(), self::CACHE_GROUP, false, $found );
+        return $found && is_array( $cached ) ? $cached : null;
     }
 
     /**
@@ -89,8 +90,6 @@ final class InventoryCache {
         wp_cache_delete( self::get_cache_key(), self::CACHE_GROUP );
         if ( function_exists( 'wp_cache_flush_group' ) ) {
             wp_cache_flush_group( self::CACHE_GROUP );
-        } else {
-            wp_cache_flush();
         }
     }
 }


### PR DESCRIPTION
## Summary
- add new `InventoryCache` helper for storing dashboard inventory counts
- register cache hooks in the bootstrap process
- use cached data on the dashboard and allow manual refresh
- add a refresh button to the inventory section
- document inventory caching in the changelog

## Testing
- `composer lint` *(fails: command not found)*
- `composer test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685855e28a188327b289f3e733c14c48

<!-- Korbit AI PR Description Start -->
## Description by Korbit AI

### What change is being made?

Implement caching mechanism for the post inventory data with automatic invalidation to improve performance on the Nuclear Engagement plugin dashboard, and introduce a "Refresh" button for manual cache clearing.

### Why are these changes being made?

The cache implementation enhances dashboard performance by reducing redundant data fetching, which is achieved by storing inventory data temporarily and updating it when relevant changes in posts or metadata are detected. The addition of a refresh button allows users to manually clear and refresh the cache data to ensure the most up-to-date information is retrieved when necessary.

> Is this description stale? Ask me to generate a new description by commenting `/korbit-generate-pr-description`
<!-- Korbit AI PR Description End -->