### PR TITLE
Add CI skip documentation

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -25,6 +25,13 @@ composer lint
 composer test
 ```
 
+## Skipping CI for docs
+
+If your commit only touches documentation or other non-code files, you may avoid
+running the full GitHub Actions workflow by appending `[skip ci]` or
+`skip-checks: true` to the commit message. See
+[docs/CI_GUIDELINES.md](docs/CI_GUIDELINES.md) for details.
+
 If you modify any TypeScript files, rebuild the assets:
 
 ```bash
@@ -40,3 +47,4 @@ npm run dev
 ## Further Reading
 
 For design context and architectural decisions, see [docs/ARCHITECTURE.md](docs/ARCHITECTURE.md).
+For instructions on suppressing unnecessary CI runs, see [docs/CI_GUIDELINES.md](docs/CI_GUIDELINES.md).

--- a/README.md
+++ b/README.md
@@ -64,3 +64,4 @@ npm run dev
 - [User Guide](docs/USER_GUIDE.md)
 - [Translation Guide](docs/TRANSLATION.md)
 - [Hooks Reference](docs/hooks.md)
+- [CI Guidelines](docs/CI_GUIDELINES.md)

--- a/docs/CI_GUIDELINES.md
+++ b/docs/CI_GUIDELINES.md
@@ -1,0 +1,65 @@
+# Continuous Integration Guidelines
+
+This project relies on GitHub Actions for linting, testing and building assets. To keep those checks fast and inexpensive we allow contributors to skip workflows when a change cannot affect production code.
+
+## Ad‑hoc CI skips
+
+- Add **`[skip ci]`** or **`skip-checks: true`** to a commit message when your changes only touch documentation, comments or other non-executable files.
+- Either token is case-insensitive and must appear in the final commit message to take effect.
+- Never use these markers on commits that modify PHP or TypeScript sources—skipped workflows stay pending and can block branch protection rules.
+- Prefer automated path filters inside workflow files whenever a file class is always safe to ignore (for example `docs/**`).
+
+Example commit message:
+
+```
+Fix typo in contributing guide
+
+[skip ci]
+```
+
+## Workflow snippets
+
+Apply path filters at the workflow trigger level:
+
+```yaml
+on:
+  push:
+    paths-ignore:
+      - '**/*.md'
+      - 'docs/**'
+```
+
+Skip individual jobs based on the commit message:
+
+```yaml
+jobs:
+  heavy-tests:
+    if: "!contains(github.event.head_commit.message, '[skip heavy]')"
+```
+
+Cancel duplicate runs when pushing new commits:
+
+```yaml
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+```
+
+## Branch protection
+
+Required checks should point only to jobs that always run. If a workflow is skipped it remains "Pending" and may prevent merging. Align branch protection rules accordingly.
+
+## Local helpers
+
+You may store the marker in a commit template to avoid typing it each time:
+
+```bash
+git config commit.template .gitmessage
+```
+
+and add `[skip ci]` to the template file. A shell alias can also create the commit message automatically:
+
+```bash
+git config --global alias.cis '!git commit --cleanup=verbatim -m "$1" -m "[skip ci]"'
+```
+


### PR DESCRIPTION
## Summary
- document how to skip unnecessary GitHub Action runs
- link to CI doc from README
- mention skip rules in CONTRIBUTING

## Testing
- `composer lint` *(fails: command not found)*
- `composer test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6858e570c8b88327891e77f8b08e6bfe

<!-- Korbit AI PR Description Start -->
## Description by Korbit AI

### What change is being made?

Add documentation on how to skip Continuous Integration (CI) checks for non-code commits by using specific markers in commit messages.

### Why are these changes being made?

These changes are being made to guide contributors on how they can prevent unnecessary CI runs for commits that only affect documentation or other non-executable files, thus optimizing CI resources and improving workflow efficiency. The instruction also aligns with best practices and project guidelines to maintain workflow integrity and ensure that critical checks are not inadvertently bypassed, particularly with PHP or TypeScript source changes.

> Is this description stale? Ask me to generate a new description by commenting `/korbit-generate-pr-description`
<!-- Korbit AI PR Description End -->