### PR TITLE
Check for wp_cache_flush_group existence

### DIFF
--- a/nuclear-engagement/includes/SettingsCache.php
+++ b/nuclear-engagement/includes/SettingsCache.php
@@ -43,7 +43,11 @@ final class SettingsCache {
     public function invalidate_cache(): void {
         $key = $this->get_cache_key();
         wp_cache_delete( $key, self::CACHE_GROUP );
-        wp_cache_flush_group( self::CACHE_GROUP );
+        if ( function_exists( 'wp_cache_flush_group' ) ) {
+            wp_cache_flush_group( self::CACHE_GROUP );
+        } else {
+            wp_cache_flush();
+        }
     }
 
     public function maybe_invalidate_cache( $option ): void {


### PR DESCRIPTION
## Summary
- avoid calling wp_cache_flush_group when unavailable
- match SettingsRepository reset logic

## Testing
- `composer lint` *(fails: command not found)*
- `composer test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68596178bc688327afc25cd42730e376

<!-- Korbit AI PR Description Start -->
## Description by Korbit AI

### What change is being made?

Add a check for the existence of the `wp_cache_flush_group` function before attempting to call it, with a fallback to `wp_cache_flush` if it doesn't exist.

### Why are these changes being made?

The change ensures compatibility with environments where `wp_cache_flush_group` may not be available, preventing potential errors and ensuring that the cache invalidation logic still executes by falling back to a more general cache flush method. This increases the robustness and adaptability of the caching mechanism.

> Is this description stale? Ask me to generate a new description by commenting `/korbit-generate-pr-description`
<!-- Korbit AI PR Description End -->