### PR TITLE
Add release script to remove dev packages

### DIFF
--- a/.distignore
+++ b/.distignore
@@ -9,3 +9,12 @@ scripts
 .git
 .gitignore
 .eslintrc
+# dev dependencies removed from production build
+vendor/bin
+vendor/phpunit
+vendor/sebastian
+vendor/phar-io
+vendor/phpcsstandards
+vendor/wp-coding-standards
+vendor/squizlabs
+vendor/dealerdirect

--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,4 @@ dist-ssr
 *.njsproj
 *.sln
 *.sw?
+build

--- a/docs/CI_GUIDELINES.md
+++ b/docs/CI_GUIDELINES.md
@@ -63,3 +63,16 @@ and add `[skip ci]` to the template file. A shell alias can also create the comm
 git config --global alias.cis '!git commit --cleanup=verbatim -m "$1" -m "[skip ci]"'
 ```
 
+
+## Packaging the plugin
+
+The release archive should contain runtime dependencies only. When creating the production zip run:
+
+```bash
+composer install --no-dev --optimize-autoloader
+npm ci
+npm run build
+./scripts/build-release.sh
+```
+
+Running `composer install --no-dev` removes PHPUnit, PHPCS and other development packages from `vendor/` before the files are zipped.

--- a/scripts/build-release.sh
+++ b/scripts/build-release.sh
@@ -1,0 +1,25 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT=$(cd "$(dirname "$0")/.." && pwd)
+PLUGIN_DIR="$ROOT/nuclear-engagement"
+BUILD_DIR="$ROOT/build"
+
+rm -rf "$BUILD_DIR"
+mkdir -p "$BUILD_DIR"
+
+# Install PHP dependencies without dev packages
+composer install --no-dev --optimize-autoloader --no-interaction
+
+# Build front-end assets
+npm ci
+npm run build
+
+# Copy plugin files excluding development artifacts
+rsync -a "$PLUGIN_DIR/" "$BUILD_DIR/nuclear-engagement/" --exclude-from="$ROOT/.distignore"
+
+# Create zip archive
+cd "$BUILD_DIR"
+zip -r nuclear-engagement.zip nuclear-engagement > /dev/null
+
+printf '\nRelease archive created at %s/nuclear-engagement.zip\n' "$BUILD_DIR"


### PR DESCRIPTION
## Summary
- add build-release.sh for packaging the plugin
- ignore build output in git
- exclude PHPUnit and PHPCS packages from production zip
- document release build in CI guidelines

## Testing
- `composer lint` *(fails: composer not installed)*
- `composer test` *(fails: composer not installed)*

------
https://chatgpt.com/codex/tasks/task_e_6859617a3c288327b355e5a24d509594

<!-- Korbit AI PR Description Start -->
## Description by Korbit AI

### What change is being made?

Add a release script to package the plugin by constructing a production-ready build that excludes development dependencies and update `.distignore`, `.gitignore`, and CI guidelines accordingly.

### Why are these changes being made?

The changes enable the creation of a cleaner production build by removing unnecessary development packages, optimizing the deployment package size and performance. This approach outlines a consistent process for preparing the plugin for release while ensuring that only essential runtime dependencies are included.

> Is this description stale? Ask me to generate a new description by commenting `/korbit-generate-pr-description`
<!-- Korbit AI PR Description End -->