### PR TITLE
Fix Defaults array indentation

### DIFF
--- a/nuclear-engagement/includes/Defaults.php
+++ b/nuclear-engagement/includes/Defaults.php
@@ -107,14 +107,14 @@ class Defaults {
             'generation_post_types'            => array( 'post' ),
 
             /* ───── Attribution ───── */
-                        'show_attribution'                 => false,
+            'show_attribution'                 => false,
 
-                        /* ───── Uninstall ───── */
-                        'delete_settings_on_uninstall'     => false,
-                        'delete_generated_content_on_uninstall' => false,
-                        'delete_optin_data_on_uninstall'   => false,
-                        'delete_log_file_on_uninstall'     => false,
-                        'delete_custom_css_on_uninstall'   => false,
-                );
+            /* ───── Uninstall ───── */
+            'delete_settings_on_uninstall'     => false,
+            'delete_generated_content_on_uninstall' => false,
+            'delete_optin_data_on_uninstall'   => false,
+            'delete_log_file_on_uninstall'     => false,
+            'delete_custom_css_on_uninstall'   => false,
+        );
         }
 }


### PR DESCRIPTION
## Summary
- fix indentation for the closing section of `Defaults::nuclen_get_default_settings()`

## Testing
- `composer lint` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6859617a6bdc8327b9427a0d7e68cc77