### PR TITLE
Fix ESLint config path handling

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -2,8 +2,11 @@ import tsPlugin from '@typescript-eslint/eslint-plugin';
 import tsParser from '@typescript-eslint/parser';
 import js from '@eslint/js';
 import fs from 'fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
 
-const tsconfigPath = new URL('./tsconfig.json', import.meta.url).pathname;
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const tsconfigPath = path.join(__dirname, 'tsconfig.json');
 if (!fs.existsSync(tsconfigPath)) {
   console.error('tsconfig.json not found at', tsconfigPath);
 }
@@ -18,7 +21,7 @@ export default [
     languageOptions: {
       parser: tsParser,
       parserOptions: {
-        project: './tsconfig.json',
+        project: tsconfigPath,
         tsconfigRootDir: __dirname
       }
     },


### PR DESCRIPTION
## Summary
- ensure `eslint.config.js` resolves paths in ESM

## Testing
- `npm run lint` *(fails: Cannot find package '@typescript-eslint/eslint-plugin')*
- `composer lint` *(fails: composer: command not found)*
- `composer test` *(fails: composer: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685a0e3a77848327bc220cf39ad00da2

<!-- Korbit AI PR Description Start -->
## Description by Korbit AI

### What change is being made?

Update ESLint config to correctly resolve the path to `tsconfig.json` using `path` and `fileURLToPath` for compatibility with different environments.

### Why are these changes being made?

The previous implementation of path resolution for `tsconfig.json` was unreliable across different environments that interpret `import.meta.url` differently. By using `path` and `fileURLToPath`, the path handling becomes more robust, ensuring consistent behavior across environments.

> Is this description stale? Ask me to generate a new description by commenting `/korbit-generate-pr-description`
<!-- Korbit AI PR Description End -->