### PR TITLE
Fix PHPCS issues in TOC module

### DIFF
--- a/nuclear-engagement/modules/toc/includes/class-nuclen-toc-admin.php
+++ b/nuclear-engagement/modules/toc/includes/class-nuclen-toc-admin.php
@@ -1,10 +1,11 @@
 <?php
-declare(strict_types=1);
 /**
- * File: modules/toc/includes/class-nuclen-toc-admin.php
+ * Settings→Nuclen TOC — live shortcode generator.
  *
- * Settings→Nuclen TOC  — live shortcode generator.
+ * @package NuclearEngagement
  */
+
+declare(strict_types=1);
 
 if ( ! defined( 'ABSPATH' ) ) {
 	exit;
@@ -12,17 +13,26 @@ if ( ! defined( 'ABSPATH' ) ) {
 
 use NuclearEngagement\AssetVersions;
 
+/**
+ * Admin page for generating TOC shortcodes.
+ */
 final class Nuclen_TOC_Admin {
 
-	private string $hook = '';
+       /** Hook suffix for the options page. */
+       private string $hook = '';
 
-	public function __construct() {
-		add_action( 'admin_menu', array( $this, 'menu' ) );
-		add_action( 'admin_enqueue_scripts', array( $this, 'assets' ) );
-	}
+       /**
+        * Register admin hooks.
+        */
+       public function __construct() {
+               add_action( 'admin_menu', array( $this, 'menu' ) );
+               add_action( 'admin_enqueue_scripts', array( $this, 'assets' ) );
+       }
 
-	/* ───────────────── menu item ─────────────────────────────── */
-	public function menu(): void {
+       /**
+        * Register the settings page.
+        */
+       public function menu(): void {
 		$this->hook = add_options_page(
 			__( 'Nuclen TOC', 'nuclen-toc-shortcode' ),
 			__( 'Nuclen TOC', 'nuclen-toc-shortcode' ),
@@ -32,8 +42,12 @@ final class Nuclen_TOC_Admin {
 		);
 	}
 
-	/* ───────────────── admin assets ──────────────────────────── */
-	public function assets( string $hook ): void {
+       /**
+        * Enqueue scripts and styles for the admin page.
+        *
+        * @param string $hook Current admin page hook.
+        */
+       public function assets( string $hook ): void {
 		if ( $hook !== $this->hook ) {
 			return; }
 
@@ -70,8 +84,10 @@ final class Nuclen_TOC_Admin {
 		wp_enqueue_script( 'nuclen-toc-admin' );
 	}
 
-	/* ───────────────── page HTML ─────────────────────────────── */
-	public function page(): void {
+       /**
+        * Render the settings page markup.
+        */
+       public function page(): void {
 		if ( ! current_user_can( 'manage_options' ) ) {
 			return; }
 
@@ -109,18 +125,33 @@ final class Nuclen_TOC_Admin {
 			'</button></p></div>';
 	}
 
-	/* helpers */
-	private function select_row( string $id, string $label, int $def ): void {
+       /* helpers */
+
+       /**
+        * Output a select row for heading levels.
+        *
+        * @param string $id    DOM id for the select element.
+        * @param string $label Row label.
+        * @param int    $def   Default selected heading level.
+        */
+       private function select_row( string $id, string $label, int $def ): void {
 		echo '<tr><th><label for="' . esc_attr( $id ) . '">' . esc_html( $label ) .
 			'</label></th><td><select id="' . esc_attr( $id ) . '">';
-		for ( $i = 1; $i <= 6; $i++ ) {
-			echo '<option value="' . $i . '"' . selected( $def, $i, false ) . '>H' . $i . '</option>';
-		}
-		echo '</select></td></tr>';
-	}
-	private function checkbox_row( string $id, string $label, bool $checked ): void {
-		echo '<tr><th>' . esc_html( $label ) . '</th><td><label><input type="checkbox" id="' .
-			esc_attr( $id ) . '"' . checked( $checked, true, false ) . '> ' .
-			esc_html( $label ) . '</label></td></tr>';
-	}
+               for ( $i = 1; $i <= 6; $i++ ) {
+                       echo '<option value="' . esc_attr( $i ) . '"' . selected( $def, $i, false ) . '>H' . esc_html( $i ) . '</option>';
+               }
+               echo '</select></td></tr>';
+       }
+       /**
+        * Output a checkbox row.
+        *
+        * @param string $id      DOM id for the checkbox.
+        * @param string $label   Row label.
+        * @param bool   $checked Whether the checkbox should be checked.
+        */
+       private function checkbox_row( string $id, string $label, bool $checked ): void {
+               echo '<tr><th>' . esc_html( $label ) . '</th><td><label><input type="checkbox" id="' .
+                       esc_attr( $id ) . '"' . checked( $checked, true, false ) . '> ' .
+                       esc_html( $label ) . '</label></td></tr>';
+       }
 }

--- a/nuclear-engagement/modules/toc/includes/class-nuclen-toc-assets.php
+++ b/nuclear-engagement/modules/toc/includes/class-nuclen-toc-assets.php
@@ -1,10 +1,11 @@
 <?php
-declare(strict_types=1);
 /**
- * File: modules/toc/includes/class-nuclen-toc-assets.php
+ * Front-end asset registration and enqueueing for the TOC module.
  *
- * Handles front-end asset registration and enqueueing for the TOC module.
+ * @package NuclearEngagement
  */
+
+declare(strict_types=1);
 
 if ( ! defined( 'ABSPATH' ) ) {
 	exit;
@@ -12,39 +13,48 @@ if ( ! defined( 'ABSPATH' ) ) {
 
 use NuclearEngagement\AssetVersions;
 
+/**
+ * Front-end assets helper for the TOC module.
+ */
 final class Nuclen_TOC_Assets {
-		/** Default vertical offset for scroll-to behaviour. */
-	public const DEFAULT_SCROLL_OFFSET = NUCLEN_TOC_SCROLL_OFFSET_DEFAULT;
+       /** Default vertical offset for scroll-to behaviour. */
+       public const DEFAULT_SCROLL_OFFSET = NUCLEN_TOC_SCROLL_OFFSET_DEFAULT;
 
-	private bool $registered   = false;
-	private int $scroll_offset = self::DEFAULT_SCROLL_OFFSET;
+       /** Whether assets have been registered. */
+       private bool $registered   = false;
+       /** Current scroll offset in pixels. */
+       private int $scroll_offset = self::DEFAULT_SCROLL_OFFSET;
 
-		/**
-		 * Enqueue assets and apply runtime tweaks.
-		 */
-	public function enqueue( array $a ): void {
+       /**
+        * Enqueue assets and apply runtime tweaks.
+        *
+        * @param array $a Shortcode attributes.
+        */
+       public function enqueue( array $a ): void {
 		if ( ! is_singular() ) {
 				return;
 		}
-		if ( ! $this->registered ) {
-				$this->register();
-		}
+               if ( ! $this->registered ) {
+                       $this->register();
+               }
 			wp_enqueue_style( 'nuclen-toc-front' );
-		if ( $a['toggle'] === 'true' || $a['highlight'] === 'true' ) {
-				wp_enqueue_script( 'nuclen-toc-front' );
-		}
+               if ( 'true' === $a['toggle'] || 'true' === $a['highlight'] ) {
+                       wp_enqueue_script( 'nuclen-toc-front' );
+               }
 			$off = max( 0, min( 500, (int) $a['offset'] ) );
-		if ( $off !== $this->scroll_offset ) {
-				wp_add_inline_style( 'nuclen-toc-front', ':root{--nuclen-toc-offset:' . $off . 'px}' );
-				$this->scroll_offset = $off;
-		}
-		if ( $a['smooth'] === 'true' ) {
-				wp_add_inline_style( 'nuclen-toc-front', 'html{scroll-behavior:smooth}' );
-		}
+               if ( $this->scroll_offset !== $off ) {
+                       wp_add_inline_style( 'nuclen-toc-front', ':root{--nuclen-toc-offset:' . $off . 'px}' );
+                       $this->scroll_offset = $off;
+               }
+               if ( 'true' === $a['smooth'] ) {
+                       wp_add_inline_style( 'nuclen-toc-front', 'html{scroll-behavior:smooth}' );
+               }
 	}
 
-		/** Register scripts and styles. */
-	private function register(): void {
+       /**
+        * Register scripts and styles.
+        */
+       private function register(): void {
 		if ( $this->registered ) {
 				return;
 		}

--- a/nuclear-engagement/modules/toc/includes/class-nuclen-toc-headings.php
+++ b/nuclear-engagement/modules/toc/includes/class-nuclen-toc-headings.php
@@ -1,35 +1,50 @@
 <?php
-declare(strict_types=1);
 /**
- * File: modules/toc/includes/class-nuclen-toc-headings.php
- *
  * Injects unique IDs into post headings for jump links.
+ *
+ * @package NuclearEngagement
  */
+
+declare(strict_types=1);
 
 if ( ! defined( 'ABSPATH' ) ) {
 	exit;
 }
 
-use function nuclen_str_contains as _nc;
+use function nuclen_str_contains;
 
+/**
+ * Adds unique IDs to headings within post content.
+ */
 final class Nuclen_TOC_Headings {
-	public function __construct() {
-			add_filter( 'the_content', array( $this, 'nuclen_add_heading_ids' ), 99 );
-	}
+       /**
+        * Hook into content filters.
+        */
+       public function __construct() {
+               add_filter( 'the_content', array( $this, 'nuclen_add_heading_ids' ), 99 );
+       }
 
-		/** Back-compat wrapper for legacy callback name. */
-	public function nuclen_add_heading_ids( string $content ): string {
-			return $this->add_heading_ids( $content );
-	}
+       /**
+        * Back-compat wrapper for legacy callback name.
+        *
+        * @param string $content Post content to filter.
+        * @return string Filtered content.
+        */
+       public function nuclen_add_heading_ids( string $content ): string {
+               return $this->add_heading_ids( $content );
+       }
 
-		/**
-		 * Inject IDs into headings that lack them.
-		 */
-	public function add_heading_ids( string $content ): string {
+       /**
+        * Inject IDs into headings that lack them.
+        *
+        * @param string $content HTML content to modify.
+        * @return string Modified HTML content.
+        */
+       public function add_heading_ids( string $content ): string {
 		if ( ! apply_filters( 'nuclen_toc_enable_heading_ids', true ) ) {
 				return $content;
 		}
-		if ( ! _nc( $content, '<h' ) ) {
+               if ( ! nuclen_str_contains( $content, '<h' ) ) {
 			return $content; }
 
 		foreach ( Nuclen_TOC_Utils::extract( $content, range( 1, 6 ) ) as $h ) {


### PR DESCRIPTION
## Summary
- add file and function docblocks
- sanitize dynamic output in admin markup
- use Yoda conditions and docblocks in asset loader
- document TOC heading injector and stop using deprecated alias

## Testing
- `composer lint` *(fails: command not found)*
- `composer test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685a103a53988327b94b0e211786731e


> [!NOTE]
> I'm currently writing a description for your pull request. I should be done shortly (<1 minute). Please don't edit the description field until I'm finished, or we may overwrite each other. If I find nothing to write about, I'll delete this message.
