### PR TITLE
Fix PHP linter issues

### DIFF
--- a/nuclear-engagement/modules/toc/includes/polyfills.php
+++ b/nuclear-engagement/modules/toc/includes/polyfills.php
@@ -1,30 +1,40 @@
 <?php
-declare(strict_types=1);
 /**
  * File: modules/toc/includes/polyfills.php
  *
  * Poly‑fills for PHP 7.4 and name‑spaced helpers.
  * All helpers are prefixed `nuclen_` to avoid collisions in large stacks.
  */
+declare(strict_types=1);
 
 if ( ! defined( 'ABSPATH' ) ) {
 	exit;
 }
 
 if ( ! function_exists( 'nuclen_str_contains' ) ) {
-	/**
-	 * Prefixed back‑port of PHP 8 str_contains().
-	 */
-	function nuclen_str_contains( string $haystack, string $needle ): bool {
-		return $needle === '' || strpos( $haystack, $needle ) !== false;
-	}
+        /**
+         * Prefixed back‑port of PHP 8 str_contains().
+         *
+         * @param string $haystack String to search in.
+         * @param string $needle   Substring to search for.
+         *
+         * @return bool Whether the needle exists in the haystack.
+         */
+        function nuclen_str_contains( string $haystack, string $needle ): bool {
+                return '' === $needle || false !== strpos( $haystack, $needle );
+        }
 }
 
 if ( ! function_exists( 'nuclen_str_ends_with' ) ) {
-	/**
-	 * Prefixed back‑port of PHP 8 str_ends_with().
-	 */
-	function nuclen_str_ends_with( string $haystack, string $needle ): bool {
-		return $needle === '' || substr( $haystack, -strlen( $needle ) ) === $needle;
-	}
+        /**
+         * Prefixed back‑port of PHP 8 str_ends_with().
+         *
+         * @param string $haystack String to check.
+         * @param string $needle   Expected ending.
+         *
+         * @return bool Whether the haystack ends with the needle.
+         */
+        function nuclen_str_ends_with( string $haystack, string $needle ): bool {
+                return '' === $needle || substr( $haystack, -strlen( $needle ) ) === $needle;
+        }
 }

--- a/nuclear-engagement/modules/toc/loader.php
+++ b/nuclear-engagement/modules/toc/loader.php
@@ -1,28 +1,28 @@
 <?php
-declare(strict_types=1);
 /**
  * File: modules/toc/loader.php
  *
  * Loads the Nuclen TOC sub-module.
  */
+declare(strict_types=1);
 
 if ( ! defined( 'ABSPATH' ) ) {
 	exit;
 }
 
 /*
------------------------------------------------------------------- */
-/*
-	Local constants (prefixed, module-scoped)                         */
-/* ------------------------------------------------------------------ */
+ * ------------------------------------------------------------------
+ * Local constants (prefixed, module-scoped)
+ * ------------------------------------------------------------------
+ */
 define( 'NUCLEN_TOC_DIR', __DIR__ . '/' );
 define( 'NUCLEN_TOC_URL', plugin_dir_url( __FILE__ ) );
 
 /*
------------------------------------------------------------------- */
-/*
-	Includes                                                          */
-/* ------------------------------------------------------------------ */
+ * ------------------------------------------------------------------
+ * Includes
+ * ------------------------------------------------------------------
+ */
 require_once NUCLEN_TOC_DIR . 'includes/polyfills.php';
 require_once NUCLEN_TOC_DIR . 'includes/class-nuclen-toc-utils.php';
 require_once NUCLEN_TOC_DIR . 'includes/class-nuclen-toc-assets.php';
@@ -32,17 +32,17 @@ require_once NUCLEN_TOC_DIR . 'includes/class-nuclen-toc-render.php';
 require_once NUCLEN_TOC_DIR . 'includes/class-nuclen-toc-admin.php';
 
 /*
------------------------------------------------------------------- */
-/*
-	Spin-up                                                            */
-/* ------------------------------------------------------------------ */
+ * ------------------------------------------------------------------
+ * Spin-up
+ * ------------------------------------------------------------------
+ */
 add_action(
 	'plugins_loaded',
 	static function () {
-		new Nuclen_TOC_Headings();  // filter for heading IDs
-		new Nuclen_TOC_Render();    // shortcode handler
+		new Nuclen_TOC_Headings();  // filter for heading IDs.
+		new Nuclen_TOC_Render();    // shortcode handler.
 		if ( is_admin() ) {
-			new Nuclen_TOC_Admin();    // settings page
+			new Nuclen_TOC_Admin();    // settings page.
 		}
 	}
 );

--- a/nuclear-engagement/nuclear-engagement.php
+++ b/nuclear-engagement/nuclear-engagement.php
@@ -1,5 +1,4 @@
 <?php
-declare(strict_types=1);
 /**
  * Plugin Name:       Nuclear Engagement
  * Plugin URI:        https://www.nuclearengagement.com
@@ -14,6 +13,7 @@ declare(strict_types=1);
  * Text Domain:       nuclear-engagement
  * Domain Path:       /
  */
+declare(strict_types=1);
 
 if ( ! defined( 'ABSPATH' ) ) {
 	exit;

--- a/nuclear-engagement/uninstall.php
+++ b/nuclear-engagement/uninstall.php
@@ -1,9 +1,4 @@
 <?php
-declare(strict_types=1);
-if ( ! defined( 'ABSPATH' ) ) {
-	exit;
-}
-
 /**
  * Fired when the plugin is uninstalled.
  *
@@ -28,13 +23,18 @@ if ( ! defined( 'ABSPATH' ) ) {
  *
  * @package    Nuclear_Engagement
  */
+declare(strict_types=1);
+
+if ( ! defined( 'ABSPATH' ) ) {
+        exit;
+}
 
 // If uninstall not called from WordPress, then exit.
 if ( ! defined( 'WP_UNINSTALL_PLUGIN' ) ) {
 		exit;
 }
 
-// Get plugin settings
+// Get plugin settings.
 $settings = get_option( 'nuclear_engagement_settings', array() );
 
 $delete_settings  = ! empty( $settings['delete_settings_on_uninstall'] );
@@ -43,35 +43,39 @@ $delete_optins    = ! empty( $settings['delete_optin_data_on_uninstall'] );
 $delete_log       = ! empty( $settings['delete_log_file_on_uninstall'] );
 $delete_css       = ! empty( $settings['delete_custom_css_on_uninstall'] );
 
-// Delete generated content from post meta if requested
+// Delete generated content from post meta if requested.
 if ( $delete_generated ) {
-		global $wpdb;
-		$meta_keys = array( 'nuclen-quiz-data', 'nuclen-summary-data', 'nuclen_quiz_protected', 'nuclen_summary_protected' );
-	foreach ( $meta_keys as $mk ) {
-			$wpdb->query( $wpdb->prepare( "DELETE FROM {$wpdb->postmeta} WHERE meta_key = %s", $mk ) );
-	}
+                $meta_keys = array(
+                        'nuclen-quiz-data',
+                        'nuclen-summary-data',
+                        'nuclen_quiz_protected',
+                        'nuclen_summary_protected'
+                );
+                foreach ( $meta_keys as $mk ) {
+                        delete_post_meta_by_key( $mk );
+                }
 }
 
-// Delete plugin settings if requested
+// Delete plugin settings if requested.
 if ( $delete_settings ) {
 		delete_option( 'nuclear_engagement_settings' );
 		delete_option( 'nuclear_engagement_setup' );
 		delete_option( 'nuclen_custom_css_version' );
 }
 
-// Remove log file if requested
+// Remove log file if requested.
 if ( $delete_log ) {
 		$info = \NuclearEngagement\Services\LoggingService::get_log_file_info();
 	if ( file_exists( $info['path'] ) ) {
-			unlink( $info['path'] );
+			wp_delete_file( $info['path'] );
 	}
 }
 
-// Remove custom theme file if requested
+// Remove custom theme file if requested.
 if ( $delete_css ) {
 		$info = \NuclearEngagement\Utils::nuclen_get_custom_css_info();
 	if ( file_exists( $info['path'] ) ) {
-			unlink( $info['path'] );
+			wp_delete_file( $info['path'] );
 	}
 		delete_option( 'nuclen_custom_css_version' );
 }
@@ -80,7 +84,7 @@ if ( $delete_css ) {
 // content. This avoids data loss unless a full cleanup was requested.
 if ( $delete_settings || $delete_generated ) {
 		global $wpdb;
-		$table = $wpdb->prefix . 'nuclen_optins';
-		// Remove stored email opt-in submissions on uninstall
-		$wpdb->query( "DROP TABLE IF EXISTS {$table}" );
+                $table = $wpdb->prefix . "nuclen_optins";
+                // Remove stored email opt-in submissions on uninstall.
+                $wpdb->query( "DROP TABLE IF EXISTS " . esc_sql( $table ) );
 }


### PR DESCRIPTION
## Summary
- add missing file headers and follow WordPress docblock rules
- clean up comment formatting in the TOC module loader
- use Yoda conditions and document parameters for polyfill functions
- fix uninstall routine comments and replace direct meta deletions
- use `wp_delete_file()` when removing files

## Testing
- `composer lint` *(fails: command not found)*
- `composer test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685a105ca0b48327a619db970f5d0adf


> [!NOTE]
> I'm currently writing a description for your pull request. I should be done shortly (<1 minute). Please don't edit the description field until I'm finished, or we may overwrite each other. If I find nothing to write about, I'll delete this message.
