### PR TITLE
Fix PHPCS doc comment errors

### DIFF
--- a/nuclear-engagement/modules/toc/includes/class-nuclen-toc-render.php
+++ b/nuclear-engagement/modules/toc/includes/class-nuclen-toc-render.php
@@ -1,10 +1,10 @@
 <?php
-declare(strict_types=1);
 /**
  * File: modules/toc/includes/class-nuclen-toc-render.php
  *
  * Public-facing shortcode handler for the TOC module.
  */
+declare(strict_types=1);
 
 if ( ! defined( 'ABSPATH' ) ) {
 	exit;
@@ -12,17 +12,23 @@ if ( ! defined( 'ABSPATH' ) ) {
 
 use NuclearEngagement\SettingsRepository;
 
+		/**
+	 * Handle the [nuclear_engagement_toc] shortcode output.
+	 */
 final class Nuclen_TOC_Render {
+	/** Assets manager instance. */
 	private Nuclen_TOC_Assets $assets;
+	/** View helper instance. */
 	private Nuclen_TOC_View $view;
 
+	/** Class constructor. */
 	public function __construct() {
 			$this->assets = new Nuclen_TOC_Assets();
 			$this->view   = new Nuclen_TOC_View();
 
 			add_shortcode( 'nuclear_engagement_toc', array( $this, 'nuclen_toc_shortcode' ) );
 
-			// i18n for strings inside this class
+			// i18n for strings inside this class.
 			add_action(
 				'init',
 				static function () {
@@ -35,7 +41,13 @@ final class Nuclen_TOC_Render {
 			);
 	}
 
-	private function validate_heading_levels( $heading_levels ): array {
+	/**
+	 * Sanitize and sort heading levels.
+	 *
+	 * @param array|string $heading_levels Provided heading levels.
+	 * @return array Sanitized heading levels array.
+	 */
+private function validate_heading_levels( $heading_levels ): array {
 		if ( ! is_array( $heading_levels ) ) {
 			if ( is_string( $heading_levels ) ) {
 				$heading_levels = explode( ',', $heading_levels );
@@ -58,7 +70,13 @@ final class Nuclen_TOC_Render {
 			return array_values( $heading_levels );
 	}
 
-	private function validate_shortcode_atts( array $atts ): array {
+	/**
+	 * Sanitize shortcode attributes.
+	 *
+	 * @param array $atts Raw shortcode attributes.
+	 * @return array Validated attributes.
+	 */
+private function validate_shortcode_atts( array $atts ): array {
 			$valid_lists    = array( 'ul', 'ol' );
 			$valid_booleans = array( 'true', 'false' );
 			$valid_themes   = array( 'light', 'dark', 'auto' );
@@ -89,7 +107,14 @@ final class Nuclen_TOC_Render {
 			return $atts;
 	}
 
-	private function prepare_shortcode_attributes( array $atts, SettingsRepository $settings ): array {
+	/**
+	 * Merge defaults with shortcode attributes and settings.
+	 *
+	 * @param array              $atts     Shortcode attributes.
+	 * @param SettingsRepository $settings Settings API wrapper.
+	 * @return array Prepared attributes.
+	 */
+private function prepare_shortcode_attributes( array $atts, SettingsRepository $settings ): array {
 			$heading_levels = $settings->get_array( 'toc_heading_levels', range( 2, 6 ) );
 			$heading_levels = $this->validate_heading_levels( $heading_levels );
 
@@ -119,7 +144,13 @@ final class Nuclen_TOC_Render {
 			return $atts;
 	}
 
-	public function nuclen_toc_shortcode( array $atts ): string {
+		/**
+		 * Shortcode callback for rendering the table of contents.
+		 *
+		 * @param array $atts Shortcode attributes.
+		 * @return string Generated HTML markup.
+		 */
+public function nuclen_toc_shortcode( array $atts ): string {
 			global $post;
 		if ( empty( $post ) ) {
 				return '';

--- a/nuclear-engagement/modules/toc/includes/class-nuclen-toc-view.php
+++ b/nuclear-engagement/modules/toc/includes/class-nuclen-toc-view.php
@@ -1,10 +1,10 @@
 <?php
-declare(strict_types=1);
 /**
  * File: modules/toc/includes/class-nuclen-toc-view.php
  *
  * Generates the HTML markup for the front-end TOC.
  */
+declare(strict_types=1);
 
 if ( ! defined( 'ABSPATH' ) ) {
 	exit;
@@ -12,13 +12,22 @@ if ( ! defined( 'ABSPATH' ) ) {
 
 use NuclearEngagement\SettingsRepository;
 
+/**
+ * Output builder for the front-end table of contents.
+ */
+
 final class Nuclen_TOC_View {
 	private const DEFAULT_STICKY_OFFSET_X  = 20;
 	private const DEFAULT_STICKY_OFFSET_Y  = 20;
 	private const DEFAULT_STICKY_MAX_WIDTH = 300;
 
-	/** Retrieve the translated TOC title with a fallback. */
-	public function get_toc_title( SettingsRepository $settings ): string {
+	/**
+	 * Retrieve the translated TOC title with a fallback.
+	 *
+	 * @param SettingsRepository $settings Plugin settings repository.
+	 * @return string Sanitized title string.
+	 */
+public function get_toc_title( SettingsRepository $settings ): string {
 		$title = $settings->get_string( 'toc_title' );
 		if ( empty( $title ) ) {
 			return esc_html__( 'Table of Contents', 'nuclen-toc-shortcode' );
@@ -29,9 +38,11 @@ final class Nuclen_TOC_View {
 	/**
 	 * Build wrapper classes and sticky attributes.
 	 *
+	 * @param array              $atts     Shortcode attributes.
+	 * @param SettingsRepository $settings Settings repository.
 	 * @return array{classes:array,sticky_attrs:string,show_toggle:bool,hidden:bool}
 	 */
-	public function build_wrapper_props( array $atts, SettingsRepository $settings ): array {
+public function build_wrapper_props( array $atts, SettingsRepository $settings ): array {
 		$classes = array( 'nuclen-toc-wrapper' );
 
 		if ( in_array( $atts['theme'], array( 'dark', 'auto' ), true ) ) {
@@ -70,15 +81,14 @@ final class Nuclen_TOC_View {
 			);
 		}
 
-		if ( $atts['highlight'] === 'true' ) {
+		if ( 'true' === $atts['highlight'] ) {
 			$classes[] = 'nuclen-has-highlight';
 		}
 
-		$z_index = $settings->get_int( 'toc_z_index', 100 );
-		$z_index = max( 1, min( 9999, $z_index ) );
-		( $z_index );
-
-		return array(
+$z_index = $settings->get_int( 'toc_z_index', 100 );
+$z_index = max( 1, min( 9999, $z_index ) );
+	
+			return array(
 			'classes'      => $classes,
 			'sticky_attrs' => $sticky_attrs,
 			'show_toggle'  => $show_toggle,
@@ -86,9 +96,17 @@ final class Nuclen_TOC_View {
 		);
 	}
 
-	/** Build the toggle button HTML if toggling is enabled. */
+/**
+	 * Build the toggle button HTML if toggling is enabled.
+	 *
+	 * @param bool   $show    Whether to show the toggle.
+	 * @param bool   $hidden  Whether the content is hidden.
+	 * @param array  $atts    Shortcode attributes.
+	 * @param string $nav_id  Navigation element ID.
+	 * @return string Button markup or empty string.
+	 */
 	public function build_toggle_button( bool $show, bool $hidden, array $atts, string $nav_id ): string {
-		if ( ! $show ) {
+			if ( ! $show ) {
 			return '';
 		}
 		$toggle_text = $hidden ? $atts['show_text'] : $atts['hide_text'];
@@ -100,9 +118,15 @@ final class Nuclen_TOC_View {
 		);
 	}
 
-	/** Render the nested heading list. */
+/**
+	 * Render the nested heading list.
+	 *
+	 * @param array  $heads Parsed heading data.
+	 * @param string $list  Tag name for list wrapper.
+	 * @return string HTML list markup.
+	 */
 	public function render_headings_list( array $heads, string $list ): string {
-		$out   = '';
+			$out   = '';
 		$stack = array();
 		foreach ( $heads as $h ) {
 			$l = $h['level'];
@@ -127,22 +151,30 @@ final class Nuclen_TOC_View {
 
 	/**
 	 * Build the navigation markup containing the heading list.
+	 *
+	 * @param array  $heads     Parsed heading data.
+	 * @param string $list      Tag name for list wrapper.
+	 * @param array  $atts      Shortcode attributes.
+		 * @param string $nav_id    Navigation element ID.
+		 * @param string $toc_title Title for accessibility label.
+		 * @param bool   $hidden    Whether the list starts hidden.
+		 * @return string HTML navigation markup.
 	 */
-	public function build_nav_markup( array $heads, string $list, array $atts, string $nav_id, string $toc_title, bool $hidden ): string {
-		$nav = sprintf(
-			'<nav id="%s" class="nuclen-toc" aria-label="%s"%s%s>',
-			esc_attr( $nav_id ),
-			esc_attr__( $toc_title, 'nuclen-toc-shortcode' ),
-			$hidden ? ' style="display:none"' : '',
-			$atts['highlight'] === 'true' ? ' data-highlight="true"' : ''
-		);
+		public function build_nav_markup( array $heads, string $list, array $atts, string $nav_id, string $toc_title, bool $hidden ): string {
+				$nav = sprintf(
+				'<nav id="%s" class="nuclen-toc" aria-label="%s"%s%s>',
+				esc_attr( $nav_id ),
+				esc_attr( $toc_title ),
+				$hidden ? ' style="display:none"' : '',
+				'true' === $atts['highlight'] ? ' data-highlight="true"' : ''
+				);
 
-		if ( $atts['title'] !== '' ) {
-			$nav .= '<strong class="toc-title">' . esc_html__( $atts['title'], 'nuclen-toc-shortcode' ) . '</strong>';
-		}
+		if ( '' !== $atts['title'] ) {
+				$nav .= '<strong class="toc-title">' . esc_html( $atts['title'] ) . '</strong>';
+}
 
-		$nav .= $this->render_headings_list( $heads, $list ) . '</nav>';
+				$nav .= $this->render_headings_list( $heads, $list ) . '</nav>';
 
-		return $nav;
+			return $nav;
 	}
 }


### PR DESCRIPTION
## Summary
- add file headers and class docblocks for TOC classes
- document member variables and methods
- clean up inline comment punctuation and Yoda conditions

## Testing
- `composer lint` *(fails: composer not found)*
- `composer test` *(fails: composer not found)*

------
https://chatgpt.com/codex/tasks/task_e_685a104b88c48327ad98d55333a71fb1