### PR TITLE
Expand logging tests

### DIFF
--- a/tests/LoggingServiceTest.php
+++ b/tests/LoggingServiceTest.php
@@ -66,7 +66,7 @@ namespace {
             LoggingService::debug('debug message');
             $this->assertFileExists($info['path']);
             $contents = file_get_contents($info['path']);
-            $this->assertStringContainsString('debug message', $contents);
+            $this->assertStringContainsString('[DEBUG] debug message', $contents);
         }
     }
 }

--- a/tests/LoggingServiceTest.php
+++ b/tests/LoggingServiceTest.php
@@ -68,5 +68,16 @@ namespace {
             $contents = file_get_contents($info['path']);
             $this->assertStringContainsString('[DEBUG] debug message', $contents);
         }
+
+        public function test_logs_strip_html_and_truncate_long_message(): void {
+            $long = '<p>' . str_repeat('a', 1005) . '</p>';
+            LoggingService::log($long);
+            $info = LoggingService::get_log_file_info();
+            $this->assertFileExists($info['path']);
+            $contents = file_get_contents($info['path']);
+            $expected = str_repeat('a', 1000) . '...';
+            $this->assertStringContainsString($expected, $contents);
+            $this->assertStringNotContainsString('<p>', $contents);
+        }
     }
 }

--- a/tests/LoggingServiceTest.php
+++ b/tests/LoggingServiceTest.php
@@ -46,5 +46,27 @@ namespace {
             $this->assertSame(['test message'], $GLOBALS['ls_errors']);
             $this->assertSame('admin_notices', $GLOBALS['ls_actions'][0][0]);
         }
+
+        public function test_logs_message_to_file_when_writable(): void {
+            LoggingService::log('hello world');
+            $info = LoggingService::get_log_file_info();
+            $this->assertFileExists($info['path']);
+            $contents = file_get_contents($info['path']);
+            $this->assertStringContainsString('hello world', $contents);
+        }
+
+        public function test_debug_logs_only_when_constant_defined(): void {
+            LoggingService::debug('no constant');
+            $info = LoggingService::get_log_file_info();
+            $this->assertFileDoesNotExist($info['path']);
+
+            if (!defined('WP_DEBUG')) {
+                define('WP_DEBUG', true);
+            }
+            LoggingService::debug('debug message');
+            $this->assertFileExists($info['path']);
+            $contents = file_get_contents($info['path']);
+            $this->assertStringContainsString('debug message', $contents);
+        }
     }
 }


### PR DESCRIPTION
## Summary
- expand LoggingServiceTest coverage

## Testing
- `composer lint` *(fails: command not found)*
- `composer test` *(fails: command not found)*
- `vendor/bin/phpcs --version` *(fails: Permission denied)*
- `vendor/bin/phpunit --version` *(fails: Permission denied)*

------
https://chatgpt.com/codex/tasks/task_e_685a13b14b8083278be5cbc18ab516f6

<!-- Korbit AI PR Description Start -->
## Description by Korbit AI

### What change is being made?

Expand the logging tests by adding new test cases to verify logging behavior when the log file is writable and when debug messages are logged only if a specific constant is defined.

### Why are these changes being made?

These changes improve test coverage for the LoggingService by ensuring it behaves correctly in different scenarios, particularly when dealing with writable log files and conditional logging based on a debug constant. This helps ensure the reliability and correctness of the logging functionality under various conditions.

> Is this description stale? Ask me to generate a new description by commenting `/korbit-generate-pr-description`
<!-- Korbit AI PR Description End -->