### PR TITLE
Fix style issues in PublishGenerationHandler

### DIFF
--- a/nuclear-engagement/includes/Services/PublishGenerationHandler.php
+++ b/nuclear-engagement/includes/Services/PublishGenerationHandler.php
@@ -1,28 +1,40 @@
 <?php
-declare(strict_types=1);
+// phpcs:disable WordPress.Files.FileName.NotHyphenatedLowercase,WordPress.Files.FileName.InvalidClassFileName
 /**
- * File: includes/Services/PublishGenerationHandler.php
+ * PublishGenerationHandler service.
  *
  * Handles auto-generation triggers on post publish.
+ *
+ * @package NuclearEngagement\Services
  */
+
+declare(strict_types=1);
 
 namespace NuclearEngagement\Services;
 
 use NuclearEngagement\SettingsRepository;
 
 if ( ! defined( 'ABSPATH' ) ) {
-	exit;
+        exit;
 }
 
+/**
+ * Handles generation events when a post is published.
+ */
 class PublishGenerationHandler {
 	/**
 	 * @var SettingsRepository
 	 */
 	private SettingsRepository $settings_repository;
 
-	public function __construct( SettingsRepository $settings_repository ) {
-		$this->settings_repository = $settings_repository;
-	}
+       /**
+        * Constructor.
+        *
+        * @param SettingsRepository $settings_repository Repository of plugin settings.
+        */
+       public function __construct( SettingsRepository $settings_repository ) {
+               $this->settings_repository = $settings_repository;
+       }
 
 	/**
 	 * Register the publish transition hook.
@@ -31,22 +43,22 @@ class PublishGenerationHandler {
 		add_action( 'transition_post_status', array( $this, 'handle_post_publish' ), 10, 3 );
 	}
 
-	/**
-	 * Handle post publish transition.
-	 *
-	 * @param string   $new_status New post status
-	 * @param string   $old_status Old post status
-	 * @param \WP_Post $post       Post object
-	 */
-	public function handle_post_publish( $new_status, $old_status, $post ): void {
-		if ( $old_status === 'publish' || $new_status !== 'publish' ) {
-			return;
-		}
+       /**
+        * Handle post publish transition.
+        *
+        * @param string   $new_status New post status.
+        * @param string   $old_status Old post status.
+        * @param \WP_Post $post       Post object.
+        */
+       public function handle_post_publish( $new_status, $old_status, $post ): void {
+               if ( 'publish' === $old_status || 'publish' !== $new_status ) {
+                       return;
+               }
 
-		// Prevent unauthorized users from triggering generation
-		if ( ! wp_doing_cron() && ! current_user_can( 'publish_post', $post->ID ) ) {
-			return;
-		}
+               // Prevent unauthorized users from triggering generation.
+               if ( ! wp_doing_cron() && ! current_user_can( 'publish_post', $post->ID ) ) {
+                       return;
+               }
 
 		$allowed_post_types = $this->settings_repository->get( 'generation_post_types', array( 'post' ) );
 		if ( ! in_array( $post->post_type, (array) $allowed_post_types, true ) ) {


### PR DESCRIPTION
## Summary
- document PublishGenerationHandler service
- add missing constructor and method docs
- use Yoda conditions and punctuation
- ignore filename sniffs for PSR-4 files

## Testing
- `php vendor/bin/phpcs --standard=phpcs.xml -n nuclear-engagement/includes/Services/PublishGenerationHandler.php` *(fails: `php: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_685a239d096c8327b163e4e0998dc60c

<!-- Korbit AI PR Description Start -->
## Description by Korbit AI

### What change is being made?

Fix style issues in `PublishGenerationHandler` by updating comments, aligning PHPDoc blocks, and disabling specific PHP CodeSniffer (phpcs) checks.

### Why are these changes being made?

The changes improve code readability and maintainability by ensuring comments and PHPDoc blocks adhere to common formatting standards. Specific PHP CodeSniffer checks were disabled to accommodate existing naming conventions that deviate from typical guidelines, thereby preventing unnecessary warnings. These style updates enhance the overall quality and consistency of the codebase.

> Is this description stale? Ask me to generate a new description by commenting `/korbit-generate-pr-description`
<!-- Korbit AI PR Description End -->