### PR TITLE
Fix RemoteApiService style issues

### DIFF
--- a/nuclear-engagement/admin/Controller/Ajax/UpdatesController.php
+++ b/nuclear-engagement/admin/Controller/Ajax/UpdatesController.php
@@ -69,7 +69,7 @@ class UpdatesController extends BaseController {
 				$request->generationId = 'gen_' . uniqid( 'auto_', true );
 			}
 
-				$data = $this->api->fetchUpdates( $request->generationId );
+                                $data = $this->api->fetch_updates( $request->generationId );
 				\NuclearEngagement\Services\LoggingService::log( 'Updates response: ' . wp_json_encode( $data ) );
 
 				$response          = new UpdatesResponse();

--- a/nuclear-engagement/admin/trait-admin-autogenerate.php
+++ b/nuclear-engagement/admin/trait-admin-autogenerate.php
@@ -107,7 +107,7 @@ trait Admin_AutoGenerate {
 			$api       = $container->get( 'remote_api' );
 			$storage   = $container->get( 'content_storage' );
 
-			$data = $api->fetchUpdates( $generation_id );
+                        $data = $api->fetch_updates( $generation_id );
 
 			// Check if we have results
 			if ( ! empty( $data['results'] ) && is_array( $data['results'] ) ) {

--- a/nuclear-engagement/front/traits/RestTrait.php
+++ b/nuclear-engagement/front/traits/RestTrait.php
@@ -49,7 +49,7 @@ trait RestTrait {
 		try {
 						$container = $this->get_container();
 						$api       = $container->get( 'remote_api' );
-			return $api->sendPostsToGenerate( $data_to_send );
+                        return $api->send_posts_to_generate( $data_to_send );
 		} catch ( \RuntimeException $e ) {
 			\NuclearEngagement\Services\LoggingService::log( 'Error sending data: ' . $e->getMessage() );
 			return false;

--- a/nuclear-engagement/includes/Services/AutoGenerationService.php
+++ b/nuclear-engagement/includes/Services/AutoGenerationService.php
@@ -152,8 +152,8 @@ class AutoGenerationService {
 				'generation_id' => $generation_id,
 			);
 
-			try {
-				$this->remote_api->sendPostsToGenerate( $data_to_send );
+                        try {
+                                $this->remote_api->send_posts_to_generate( $data_to_send );
 			} catch ( ApiException $e ) {
 				\NuclearEngagement\Services\LoggingService::log(
 					'Failed to start generation: ' . $e->getMessage()

--- a/nuclear-engagement/includes/Services/GenerationPoller.php
+++ b/nuclear-engagement/includes/Services/GenerationPoller.php
@@ -74,7 +74,7 @@ class GenerationPoller {
 				return;
 			}
 
-			$data = $this->remote_api->fetchUpdates( $generation_id );
+                        $data = $this->remote_api->fetch_updates( $generation_id );
 
 			if ( ! empty( $data['results'] ) && is_array( $data['results'] ) ) {
 				$this->content_storage->storeResults( $data['results'], $workflow_type );

--- a/nuclear-engagement/includes/Services/GenerationService.php
+++ b/nuclear-engagement/includes/Services/GenerationService.php
@@ -87,8 +87,8 @@ class GenerationService {
 		);
 
 		// Send to API
-		try {
-			$result = $this->api->sendPostsToGenerate(
+                try {
+                        $result = $this->api->send_posts_to_generate(
 				array(
 					'posts'         => $posts,
 					'workflow'      => $workflow,

--- a/nuclear-engagement/includes/Services/RemoteApiService.php
+++ b/nuclear-engagement/includes/Services/RemoteApiService.php
@@ -1,12 +1,15 @@
 <?php
-declare(strict_types=1);
 /**
  * File: includes/Services/RemoteApiService.php
-
- * Remote API Service
+ *
+ * Remote API Service.
  *
  * @package NuclearEngagement\Services
+ *
+ * phpcs:disable WordPress.Files.FileName.NotHyphenatedLowercase, WordPress.Files.FileName.InvalidClassFileName
  */
+
+declare(strict_types=1);
 
 namespace NuclearEngagement\Services;
 
@@ -50,10 +53,10 @@ class RemoteApiService {
 	/**
 	 * Parse an error response body.
 	 *
-	 * @param string $body
+         * @param string $body HTTP response body.
 	 * @return array{message:string|null,error_code:?string}
 	 */
-	private function parseErrorResponse( string $body ): array {
+    private function parse_error_response( string $body ): array {
 		$data = json_decode( $body, true );
 		$msg  = null;
 		$code = null;
@@ -76,20 +79,20 @@ class RemoteApiService {
 	/**
 	 * Send posts to remote API for content generation
 	 *
-	 * @param array $data
+         * @param array $data Data to send.
 	 * @return array Response data on success
 	 * @throws \RuntimeException On API errors
 	 */
-	public function sendPostsToGenerate( array $data ): array {
-		$apiKey = $this->settings->get_string( 'api_key', '' );
+    public function send_posts_to_generate( array $data ): array {
+        $api_key = $this->settings->get_string( 'api_key', '' );
 
-		if ( empty( $apiKey ) ) {
-			throw new \RuntimeException( 'API key not configured' );
-		}
+        if ( empty( $api_key ) ) {
+            throw new \RuntimeException( 'API key not configured' );
+        }
 
 		$payload = array(
 			'generation_id' => $data['generation_id'] ?? '',
-			'api_key'       => $apiKey,
+                        'api_key'       => $api_key,
 			'siteUrl'       => get_site_url(),
 			'posts'         => array_values(
 				array_filter(
@@ -102,7 +105,7 @@ class RemoteApiService {
 			'workflow'      => $data['workflow'] ?? array(),
 		);
 
-		\NuclearEngagement\Services\LoggingService::log( 'Sending generation request: ' . $data['generation_id'] );
+        \NuclearEngagement\Services\LoggingService::log( 'Sending generation request: ' . $data['generation_id'] ); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
 
 		$response = wp_remote_post(
 			self::API_BASE . '/process-posts',
@@ -110,7 +113,7 @@ class RemoteApiService {
 				'method'             => 'POST',
 				'headers'            => array(
 					'Content-Type' => 'application/json',
-					'X-API-Key'    => $apiKey,
+                                        'X-API-Key'    => $api_key,
 				),
 				'body'               => wp_json_encode( $payload ),
 				'timeout'            => NUCLEN_API_TIMEOUT,
@@ -119,38 +122,37 @@ class RemoteApiService {
 			)
 		);
 
-		if ( is_wp_error( $response ) ) {
-			$error = 'API request failed: ' . $response->get_error_message();
-			\NuclearEngagement\Services\LoggingService::log( $error );
-			throw new ApiException( $error );
-		}
+        if ( is_wp_error( $response ) ) {
+            $error = 'API request failed: ' . $response->get_error_message();
+            \NuclearEngagement\Services\LoggingService::log( $error ); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
+            throw new ApiException( $error );
+        }
 
 		$code = wp_remote_retrieve_response_code( $response );
 		$body = wp_remote_retrieve_body( $response );
 		\NuclearEngagement\Services\LoggingService::debug( "API response body: {$body}" );
 
-		\NuclearEngagement\Services\LoggingService::log( "API response code: {$code}" );
-		\NuclearEngagement\Services\LoggingService::debug( "API response body: {$body}" );
+        \NuclearEngagement\Services\LoggingService::log( "API response code: {$code}" ); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
 
 		// Check for auth errors
-		if ( $code === 401 || $code === 403 ) {
-			$authResult = $this->handleAuthError( $body, $code );
-			throw new ApiException( $authResult['error'], $authResult['status_code'], $authResult['error_code'] ?? null );
-		}
+        if ( 401 === $code || 403 === $code ) {
+            $auth_result = $this->handle_auth_error( $body, $code );
+            throw new ApiException( $auth_result['error'], $auth_result['status_code'], $auth_result['error_code'] ?? null );
+        }
 
-		if ( $code !== 200 ) {
-			\NuclearEngagement\Services\LoggingService::log( "Unexpected response code: {$code}, body: {$body}" );
-			$parsed = $this->parseErrorResponse( $body );
+        if ( 200 !== $code ) {
+                        \NuclearEngagement\Services\LoggingService::log( "Unexpected response code: {$code}, body: {$body}" ); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
+                    $parsed = $this->parse_error_response( $body );
 			$msg    = $parsed['message'] ?? "Failed to fetch updates, code: {$code}";
 			throw new ApiException( $msg, $code, $parsed['error_code'] );
 		}
 
 		$data = json_decode( $body, true );
 		if ( ! is_array( $data ) ) {
-			\NuclearEngagement\Services\LoggingService::log( "Invalid JSON response: {$body}" );
+                        \NuclearEngagement\Services\LoggingService::log( "Invalid JSON response: {$body}" ); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
 			throw new ApiException( 'Invalid data received from API', $code );
 		}
-		if ( isset( $data['success'] ) && $data['success'] === false ) {
+        if ( isset( $data['success'] ) && false === $data['success'] ) {
 			$msg = $data['error'] ?? 'API error';
 			throw new ApiException( $msg, $code, $data['error_code'] ?? null );
 		}
@@ -161,27 +163,27 @@ class RemoteApiService {
 	/**
 	 * Fetch generation updates from remote API
 	 *
-	 * @param string $generationId
-	 * @return array
+         * @param string $generation_id Generation identifier.
+         * @return array API response data.
 	 * @throws \RuntimeException On API errors
 	 */
-	public function fetchUpdates( string $generationId ): array {
-		$apiKey = $this->settings->get_string( 'api_key', '' );
+    public function fetch_updates( string $generation_id ): array {
+        $api_key = $this->settings->get_string( 'api_key', '' );
 
-		if ( empty( $apiKey ) ) {
-			throw new \RuntimeException( 'API key not configured' );
-		}
+        if ( empty( $api_key ) ) {
+            throw new \RuntimeException( 'API key not configured' );
+        }
 
 		$payload = array(
 			'siteUrl'       => get_site_url(),
-			'generation_id' => $generationId,
+                        'generation_id' => $generation_id,
 		);
 
-		if ( empty( $generationId ) ) {
-			\NuclearEngagement\Services\LoggingService::log( 'Fetching credits only (no generation_id)' );
-		} else {
-			\NuclearEngagement\Services\LoggingService::log( "Fetching updates for generation: {$generationId}" );
-		}
+        if ( empty( $generation_id ) ) {
+            \NuclearEngagement\Services\LoggingService::log( 'Fetching credits only (no generation_id)' ); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
+        } else {
+            \NuclearEngagement\Services\LoggingService::log( "Fetching updates for generation: {$generation_id}" ); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
+        }
 
 		$response = wp_remote_post(
 			self::API_BASE . '/updates',
@@ -189,7 +191,7 @@ class RemoteApiService {
 				'method'             => 'POST',
 				'headers'            => array(
 					'Content-Type' => 'application/json',
-					'X-API-Key'    => $apiKey,
+                                        'X-API-Key'    => $api_key,
 				),
 				'body'               => wp_json_encode( $payload ),
 				'timeout'            => NUCLEN_API_TIMEOUT,
@@ -200,7 +202,7 @@ class RemoteApiService {
 
 		if ( is_wp_error( $response ) ) {
 			$error = 'API request failed: ' . $response->get_error_message();
-			\NuclearEngagement\Services\LoggingService::log( $error );
+                    \NuclearEngagement\Services\LoggingService::log( $error ); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
 			throw new ApiException( $error );
 		}
 
@@ -208,24 +210,24 @@ class RemoteApiService {
 		$body = wp_remote_retrieve_body( $response );
 
 		// Check for auth errors
-		if ( $code === 401 || $code === 403 ) {
-			$authResult = $this->handleAuthError( $body, $code );
-			throw new ApiException( $authResult['error'], $authResult['status_code'], $authResult['error_code'] ?? null );
-		}
+        if ( 401 === $code || 403 === $code ) {
+            $auth_result = $this->handle_auth_error( $body, $code );
+            throw new ApiException( $auth_result['error'], $auth_result['status_code'], $auth_result['error_code'] ?? null );
+        }
 
-		if ( $code !== 200 ) {
-			\NuclearEngagement\Services\LoggingService::log( "Unexpected response code: {$code}, body: {$body}" );
-			$parsed = $this->parseErrorResponse( $body );
+        if ( 200 !== $code ) {
+                        \NuclearEngagement\Services\LoggingService::log( "Unexpected response code: {$code}, body: {$body}" ); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
+                    $parsed = $this->parse_error_response( $body );
 			$msg    = $parsed['message'] ?? "Failed to fetch updates, code: {$code}";
 			throw new ApiException( $msg, $code, $parsed['error_code'] );
 		}
 
 		$data = json_decode( $body, true );
 		if ( ! is_array( $data ) ) {
-			\NuclearEngagement\Services\LoggingService::log( "Invalid JSON response: {$body}" );
+                        \NuclearEngagement\Services\LoggingService::log( "Invalid JSON response: {$body}" ); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
 			throw new ApiException( 'Invalid data received from API', $code );
 		}
-		if ( isset( $data['success'] ) && $data['success'] === false ) {
+        if ( isset( $data['success'] ) && false === $data['success'] ) {
 			$msg = $data['error'] ?? 'API error';
 			throw new ApiException( $msg, $code, $data['error_code'] ?? null );
 		}
@@ -236,16 +238,16 @@ class RemoteApiService {
 	/**
 	 * Handle authentication errors from API
 	 *
-	 * @param string $body Response body
-	 * @param int    $code HTTP status code
-	 * @return array Error data
+         * @param string $body Response body.
+         * @param int    $code HTTP status code.
+         * @return array Error data.
 	 */
-	private function handleAuthError( string $body, int $code ): array {
+    private function handle_auth_error( string $body, int $code ): array {
 		$data = json_decode( $body, true );
 
 		if ( is_array( $data ) && isset( $data['error_code'] ) ) {
-			$errorCode = $data['error_code'];
-			if ( $errorCode === 'invalid_api_key' ) {
+            $error_code = $data['error_code'];
+            if ( 'invalid_api_key' === $error_code ) {
 				return array(
 					'error'       => 'Invalid API key. Please update it on the Setup page.',
 					'error_code'  => 'invalid_api_key',
@@ -253,7 +255,7 @@ class RemoteApiService {
 				);
 			}
 
-			if ( $errorCode === 'invalid_wp_app_pass' ) {
+            if ( 'invalid_wp_app_pass' === $error_code ) {
 				return array(
 					'error'       => 'Invalid WP App Password. Please re-generate on the Setup page.',
 					'error_code'  => 'invalid_wp_app_pass',
@@ -262,7 +264,7 @@ class RemoteApiService {
 			}
 		}
 
-		if ( strpos( $body, 'invalid_api_key' ) !== false ) {
+        if ( false !== strpos( $body, 'invalid_api_key' ) ) {
 			return array(
 				'error'       => 'Invalid API key. Please update it on the Setup page.',
 				'error_code'  => 'invalid_api_key',
@@ -270,7 +272,7 @@ class RemoteApiService {
 			);
 		}
 
-		if ( strpos( $body, 'invalid_wp_app_pass' ) !== false ) {
+        if ( false !== strpos( $body, 'invalid_wp_app_pass' ) ) {
 			return array(
 				'error'       => 'Invalid WP App Password. Please re-generate on the Setup page.',
 				'error_code'  => 'invalid_wp_app_pass',

--- a/tests/AutoGenerationServiceTest.php
+++ b/tests/AutoGenerationServiceTest.php
@@ -7,13 +7,13 @@ use NuclearEngagement\Services\ApiException;
 class DummyRemoteApiService {
     public array $updates = [];
     public $generateResponse = [];
-    public function sendPostsToGenerate(array $data): array {
+    public function send_posts_to_generate(array $data): array {
         if ($this->generateResponse instanceof \Exception) {
             throw $this->generateResponse;
         }
         return $this->generateResponse;
     }
-    public function fetchUpdates(string $id): array { return $this->updates[$id] ?? []; }
+    public function fetch_updates(string $id): array { return $this->updates[$id] ?? []; }
 }
 
 class DummyContentStorageService {

--- a/tests/GenerationServiceSingleTest.php
+++ b/tests/GenerationServiceSingleTest.php
@@ -18,13 +18,13 @@ namespace {
     class DummyGenApi {
         public ?\Exception $exception = null;
         public array $response = [];
-        public function sendPostsToGenerate(array $data): array {
+        public function send_posts_to_generate(array $data): array {
             if ($this->exception) {
                 throw $this->exception;
             }
             return $this->response;
         }
-        public function fetchUpdates(string $id): array { return []; }
+        public function fetch_updates(string $id): array { return []; }
     }
 
     class DummyStorage {

--- a/tests/GenerationServiceTest.php
+++ b/tests/GenerationServiceTest.php
@@ -19,10 +19,10 @@ if (!function_exists('get_posts')) {
 }
 
 class GSRemoteApi {
-    public function sendPostsToGenerate(array $data): array {
+    public function send_posts_to_generate(array $data): array {
         throw new ApiException('api fail', 401);
     }
-    public function fetchUpdates(string $id): array { return []; }
+    public function fetch_updates(string $id): array { return []; }
 }
 
 class GSStorage {

--- a/tests/RemoteApiServiceTest.php
+++ b/tests/RemoteApiServiceTest.php
@@ -35,7 +35,7 @@ class RemoteApiServiceTest extends TestCase {
         $svc = $this->makeService();
         $this->expectException(ApiException::class);
         $this->expectExceptionMessage('bad');
-        try { $svc->sendPostsToGenerate(['posts'=>[], 'workflow'=>[]]); } catch (ApiException $e) {
+        try { $svc->send_posts_to_generate(['posts'=>[], 'workflow'=>[]]); } catch (ApiException $e) {
             $this->assertSame(400, $e->getCode());
             throw $e;
         }
@@ -45,7 +45,7 @@ class RemoteApiServiceTest extends TestCase {
         $GLOBALS['test_api_response'] = ['code'=>401,'body'=>json_encode(['error_code'=>'invalid_api_key'])];
         $svc = $this->makeService();
         try {
-            $svc->sendPostsToGenerate(['posts'=>[], 'workflow'=>[]]);
+            $svc->send_posts_to_generate(['posts'=>[], 'workflow'=>[]]);
         } catch (ApiException $e) {
             $this->assertSame(401, $e->getCode());
             $this->assertSame('invalid_api_key', $e->getErrorCode());
@@ -59,7 +59,7 @@ class RemoteApiServiceTest extends TestCase {
         $GLOBALS['test_api_response'] = ['code'=>500,'body'=>json_encode(['error'=>'oops'])];
         $svc = $this->makeService();
         try {
-            $svc->sendPostsToGenerate(['posts'=>[], 'workflow'=>[]]);
+            $svc->send_posts_to_generate(['posts'=>[], 'workflow'=>[]]);
         } catch (ApiException $e) {
             $this->assertSame(500, $e->getCode());
             $this->assertSame('oops', $e->getMessage());


### PR DESCRIPTION
## Summary
- update RemoteApiService to satisfy WordPress Coding Standards
- rename API methods to snake_case
- update call sites and unit tests

## Testing
- `composer lint` *(fails: command not found)*
- `composer test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685a23a853a08327a9032d388acf6e37

<!-- Korbit AI PR Description Start -->
## Description by Korbit AI

### What change is being made?
Refactor method names in RemoteApiService and related classes to adhere to snake_case naming convention.

### Why are these changes being made?
These changes align method names with the codebase's general naming conventions, improving consistency and readability. Additionally, proper PHPDoc comments, refactored variable names, and ignored PHPCS rules for certain lines ensure the code is more maintainable and compliant with project standards.

> Is this description stale? Ask me to generate a new description by commenting `/korbit-generate-pr-description`
<!-- Korbit AI PR Description End -->