### PR TITLE
Fix JS style for TOC module

### DIFF
--- a/nuclear-engagement/modules/toc/assets/js/nuclen-toc-front.js
+++ b/nuclear-engagement/modules/toc/assets/js/nuclen-toc-front.js
@@ -1,11 +1,14 @@
-/** ---------- Nuclen TOC – public JS ----------
-File: modules/toc/assets/js/nuclen-toc-front.js
--------------------------------------------------
-Handles:
-• Sticky sidebar behaviour
-• Toggle button (mobile)
-• Scroll‑spy highlighting
-------------------------------------------------- */
+/**
+ * ---------- Nuclen TOC – public JS ----------
+ * File: modules/toc/assets/js/nuclen-toc-front.js
+ * -------------------------------------------------
+ * Handles:
+ * • Sticky sidebar behaviour
+ * • Toggle button ( mobile )
+ * • Scroll‑spy highlighting
+ *
+ * @package NuclearEngagement
+ */
 
 /* =============================================================
    Sticky TOC helper
@@ -14,14 +17,14 @@ const HEADER_OFFSET = 20; /* vertical gap from top */
 const SIDE_MARGIN = 20; /* keep away from viewport edge */
 
 function initStickyToc() {
-	const wrappers = document.querySelectorAll(".nuclen-toc-sticky");
-	if (!wrappers.length) {
+	const wrappers = document.querySelectorAll( ".nuclen-toc-sticky" );
+	if ( ! wrappers.length ) {
 		return;
 	}
 
-	wrappers.forEach((wrapper) => {
-		const toc = wrapper.querySelector(".nuclen-toc");
-		if (!toc) {
+	wrappers.forEach( ( wrapper ) => {
+		const toc = wrapper.querySelector( ".nuclen-toc" );
+		if ( ! toc ) {
 			return;
 		}
 
@@ -34,55 +37,53 @@ function initStickyToc() {
 		let raf = null;
 
 		/* Read per-instance width limit set by PHP */
-		const dataMax = parseInt(wrapper.dataset.maxWidth || "0", 10); // 0 ⇒ unlimited.
+		const dataMax = parseInt( wrapper.dataset.maxWidth || "0", 10 ); // 0 ⇒ unlimited.
 
 		/* Placeholder preserves layout */
-		const ph = document.createElement("div");
+		const ph = document.createElement( "div" );
 		ph.className = "nuclen-toc-placeholder";
 		ph.style.height = `${rect.height}px`;
 		ph.style.width = `${rect.width}px`;
-		wrapper.insertAdjacentElement("afterend", ph);
+		wrapper.insertAdjacentElement( "afterend", ph );
 		ph.style.display = "none";
 
 		/* Smooth snap */
 		wrapper.style.transition = "top 0.25s ease-out";
 
 		/* Helpers */
-		const calcLeft = (w) => {
-			const container = document.querySelector(
-				".entry-content, .post, .content-area, .site-main, main",
-			);
+		const calcLeft = ( w ) => {
+			const container = document.querySelector( ".entry-content, .post, .content-area, .site-main, main", );
 			const contLeft = container
 				? container.getBoundingClientRect().left
 				: originalLeft;
 			const min = SIDE_MARGIN;
 			const max = window.innerWidth - w - SIDE_MARGIN;
-			return Math.max(min, Math.min(contLeft, max));
+			return Math.max( min, Math.min( contLeft, max ));
 		};
 		const availHeight = () => window.innerHeight - HEADER_OFFSET * 2;
 
-		/* Ensure toc participates in layout (some themes set nav absolute) */
+		/* Ensure toc participates in layout ( some themes set nav absolute ) */
 		toc.style.position = "relative";
 		toc.style.width = "100%";
 
 		/* Mode toggle */
-		const setStuck = (stick) => {
-			if (stick === isStuck) {
+		const setStuck = ( stick ) => {
+			if ( stick === isStuck ) {
 				return;
 			}
 			isStuck = stick;
 
-			if (isStuck) {
+			if ( isStuck ) {
 				const h = availHeight();
 				const w =
 					dataMax > 0
-						? Math.min(originalWidth, dataMax)
+						? Math.min( originalWidth, dataMax )
 						: originalWidth;
 
-				wrapper.classList.add("nuclen-toc-stuck");
+				wrapper.classList.add( "nuclen-toc-stuck" );
 				wrapper.style.position = "fixed";
 				wrapper.style.top = `${HEADER_OFFSET}px`;
-				wrapper.style.left = `${calcLeft(w)}px`;
+				wrapper.style.left = `${calcLeft( w )}px`;
 				wrapper.style.width = `${w}px`;
 				wrapper.style.maxHeight = `${h}px`;
 				wrapper.style.overflow = "visible"; // wrapper just positions.
@@ -96,7 +97,7 @@ function initStickyToc() {
 				ph.style.width = `${w}px`;
 				ph.style.height = `${rect.height}px`;
 			} else {
-				wrapper.classList.remove("nuclen-toc-stuck");
+				wrapper.classList.remove( "nuclen-toc-stuck" );
 				wrapper.style.cssText = "transition: top 0.25s ease-out;";
 
 				toc.style.maxHeight = "";
@@ -108,22 +109,22 @@ function initStickyToc() {
 
 		/* Event handlers */
 		const onScroll = () => {
-			if (raf) {
+			if ( raf ) {
 				return;
 			}
-			raf = requestAnimationFrame(() => {
+			raf = requestAnimationFrame( () => {
 				raf = null;
 				const shouldStick =
 					window.pageYOffset + HEADER_OFFSET >= originalTop;
-				setStuck(shouldStick);
-			});
+				setStuck( shouldStick );
+			} );
 		};
 
 		const onResize = () => {
-			if (raf) {
-				cancelAnimationFrame(raf);
+			if ( raf ) {
+				cancelAnimationFrame( raf );
 			}
-			raf = requestAnimationFrame(() => {
+			raf = requestAnimationFrame( () => {
 				raf = null;
 				rect = wrapper.getBoundingClientRect();
 				originalLeft = rect.left;
@@ -131,129 +132,120 @@ function initStickyToc() {
 
 				const w =
 					dataMax > 0
-						? Math.min(originalWidth, dataMax)
+						? Math.min( originalWidth, dataMax )
 						: originalWidth;
 
 				ph.style.width = `${w}px`;
 				ph.style.height = `${rect.height}px`;
 
-				if (isStuck) {
+				if ( isStuck ) {
 					const h = availHeight();
-					wrapper.style.left = `${calcLeft(w)}px`;
+					wrapper.style.left = `${calcLeft( w )}px`;
 					wrapper.style.width = `${w}px`;
 					wrapper.style.maxHeight = `${h}px`;
 					toc.style.maxHeight = `${h}px`;
 				}
-			});
+			} );
 		};
 
-		window.addEventListener("scroll", onScroll, { passive: true });
-		window.addEventListener("resize", onResize);
+		window.addEventListener( "scroll", onScroll, { passive: true } );
+		window.addEventListener( "resize", onResize );
 		onScroll(); // initial determination.
-	});
+	} );
 }
 
 /* =============================================================
-      Toggle button & scroll‑spy
-      ============================================================= */
+	  Toggle button & scroll‑spy
+	  ============================================================= */
 function initTocInteractions() {
 	/* Toggle btn */
-	document.addEventListener("click", (e) => {
-		const btn = e.target.closest(".nuclen-toc-toggle");
-		if (!btn) {
+	document.addEventListener( "click", ( e ) => {
+		const btn = e.target.closest( ".nuclen-toc-toggle" );
+		if ( ! btn ) {
 			return;
 		}
-		const nav = document.getElementById(btn.getAttribute("aria-controls"));
-		const expanded = btn.getAttribute("aria-expanded") === "true";
-		btn.setAttribute("aria-expanded", expanded ? "false" : "true");
-		if (nav) {
+		const nav = document.getElementById( btn.getAttribute( "aria-controls" ));
+		const expanded = btn.getAttribute( "aria-expanded" ) === "true";
+		btn.setAttribute( "aria-expanded", expanded ? "false" : "true" );
+		if ( nav ) {
 			nav.style.display = expanded ? "none" : "";
 		}
 		btn.textContent = expanded ? nuclenTocL10n.show : nuclenTocL10n.hide;
-	});
+	} );
 
-	/* Close on link click (mobile) */
-	document.addEventListener("click", (e) => {
-		const link = e.target.closest(".nuclen-toc a");
-		const wrapper = link ? link.closest(".nuclen-toc-sticky") : null;
-		if (!link || !wrapper) {
+	/* Close on link click ( mobile ) */
+	document.addEventListener( "click", ( e ) => {
+		const link = e.target.closest( ".nuclen-toc a" );
+		const wrapper = link ? link.closest( ".nuclen-toc-sticky" ) : null;
+		if ( ! link || ! wrapper ) {
 			return;
 		}
-		setTimeout(() => {
-			const btn = wrapper.querySelector(
-				'.nuclen-toc-toggle[aria-expanded="true"]',
-			);
-			if (btn) {
+		setTimeout( () => {
+			const btn = wrapper.querySelector( '.nuclen-toc-toggle[aria-expanded="true"]', );
+			if ( btn ) {
 				btn.click();
 			}
-		}, 120);
-	});
+		}, 120 );
+	} );
 
 	/* Click outside closes */
-	document.addEventListener("click", (e) => {
-		const stuck = document.querySelector(
-			".nuclen-toc-sticky.nuclen-toc-stuck",
-		);
-		if (!stuck) {
+	document.addEventListener( "click", ( e ) => {
+		const stuck = document.querySelector( ".nuclen-toc-sticky.nuclen-toc-stuck", );
+		if ( ! stuck ) {
 			return;
 		}
-		if (
-			!stuck.contains(e.target) &&
-			!e.target.closest(".nuclen-toc-toggle")
+		if ( ! stuck.contains( e.target ) &&
+			! e.target.closest( ".nuclen-toc-toggle" )
 		) {
-			const btn = stuck.querySelector(
-				'.nuclen-toc-toggle[aria-expanded="true"]',
-			);
-			if (btn) {
+			const btn = stuck.querySelector( '.nuclen-toc-toggle[aria-expanded="true"]', );
+			if ( btn ) {
 				btn.click();
 			}
 		}
-	});
+	} );
 
 	/* Scroll‑spy */
-	const navs = document.querySelectorAll(
-		'.nuclen-toc[data-highlight="true"]',
-	);
-	if (!navs.length || !("IntersectionObserver" in window)) {
+	const navs = document.querySelectorAll( '.nuclen-toc[data-highlight="true"]', );
+	if ( ! navs.length || !( "IntersectionObserver" in window )) {
 		return;
 	}
 	const ioOpts = { rootMargin: "0px 0px -60%", threshold: 0 };
 
-	navs.forEach((nav) => {
+	navs.forEach( ( nav ) => {
 		const map = new Map();
-		nav.querySelectorAll('a[href^="#"]').forEach((a) => {
-			const id = a.getAttribute("href").slice(1);
-			const tgt = id && document.getElementById(id);
-			if (tgt) map.set(tgt, a);
-		});
-		if (!map.size) {
+		nav.querySelectorAll( 'a[href^="#"]' ).forEach( ( a ) => {
+			const id = a.getAttribute( "href" ).slice( 1 );
+			const tgt = id && document.getElementById( id );
+			if ( tgt ) map.set( tgt, a );
+		} );
+		if ( ! map.size ) {
 			return;
 		}
 
-		const io = new IntersectionObserver((entries) => {
-			entries.forEach((en) => {
-				const link = map.get(en.target);
-				if (!link) {
+		const io = new IntersectionObserver( ( entries ) => {
+			entries.forEach( ( en ) => {
+				const link = map.get( en.target );
+				if ( ! link ) {
 					return;
 				}
-				if (en.isIntersecting) {
-					nav.querySelectorAll("a.is-active").forEach((el) => {
-						el.classList.remove("is-active");
-						el.removeAttribute("aria-current");
-					});
-					link.classList.add("is-active");
-					link.setAttribute("aria-current", "location");
+				if ( en.isIntersecting ) {
+					nav.querySelectorAll( "a.is-active" ).forEach( ( el ) => {
+						el.classList.remove( "is-active" );
+						el.removeAttribute( "aria-current" );
+					} );
+					link.classList.add( "is-active" );
+					link.setAttribute( "aria-current", "location" );
 				}
-			});
-		}, ioOpts);
-		map.forEach((_l, tgt) => io.observe(tgt));
-	});
+			} );
+		}, ioOpts );
+		map.forEach( (_l, tgt ) => io.observe( tgt ));
+	} );
 }
 
 /* =============================================================
-      Boot
-      ============================================================= */
-document.addEventListener("DOMContentLoaded", () => {
+	  Boot
+	  ============================================================= */
+document.addEventListener( "DOMContentLoaded", () => {
 	initStickyToc();
 	initTocInteractions();
-});
+} );


### PR DESCRIPTION
## Summary
- address linting issues in nuclen-toc-front.js

## Testing
- `composer lint` *(fails: command not found)*
- `composer test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685a23ced3b88327ae2ffe5e23234077

<!-- Korbit AI PR Description Start -->
## Description by Korbit AI

### What change is being made?

Refactor JavaScript for the Table of Contents (TOC) module with updates to the code style, including formatting adjustments like spacing, comment updates, and consistent use of parentheses.

### Why are these changes being made?

The changes improve code readability and maintainability by enforcing consistent coding standards and style conventions. No functional changes were made; the updates are purely aesthetic to facilitate easier collaboration and future code reviews.

> Is this description stale? Ask me to generate a new description by commenting `/korbit-generate-pr-description`
<!-- Korbit AI PR Description End -->