### PR TITLE
Fix PHP docblock styles

### DIFF
--- a/nuclear-engagement/modules/toc/includes/class-nuclen-toc-assets.php
+++ b/nuclear-engagement/modules/toc/includes/class-nuclen-toc-assets.php
@@ -20,10 +20,19 @@ final class Nuclen_TOC_Assets {
 		/** Default vertical offset for scroll-to behaviour. */
 	public const DEFAULT_SCROLL_OFFSET = NUCLEN_TOC_SCROLL_OFFSET_DEFAULT;
 
-		/** Whether assets have been registered. */
-	private bool $registered = false;
-		/** Current scroll offset in pixels. */
-	private int $scroll_offset = self::DEFAULT_SCROLL_OFFSET;
+        /**
+         * Whether assets have been registered.
+         *
+         * @var bool
+         */
+        private bool $registered = false;
+
+        /**
+         * Current scroll offset in pixels.
+         *
+         * @var int
+         */
+        private int $scroll_offset = self::DEFAULT_SCROLL_OFFSET;
 
 		/**
 		 * Enqueue assets and apply runtime tweaks.

--- a/nuclear-engagement/modules/toc/includes/class-nuclen-toc-render.php
+++ b/nuclear-engagement/modules/toc/includes/class-nuclen-toc-render.php
@@ -3,7 +3,10 @@
  * File: modules/toc/includes/class-nuclen-toc-render.php
  *
  * Public-facing shortcode handler for the TOC module.
+ *
+ * @package NuclearEngagement
  */
+
 declare(strict_types=1);
 
 if ( ! defined( 'ABSPATH' ) ) {
@@ -16,10 +19,19 @@ use NuclearEngagement\SettingsRepository;
 		 * Handle the [nuclear_engagement_toc] shortcode output.
 		 */
 final class Nuclen_TOC_Render {
-	/** Assets manager instance. */
-	private Nuclen_TOC_Assets $assets;
-	/** View helper instance. */
-	private Nuclen_TOC_View $view;
+       /**
+        * Assets manager instance.
+        *
+        * @var Nuclen_TOC_Assets
+        */
+       private Nuclen_TOC_Assets $assets;
+
+       /**
+        * View helper instance.
+        *
+        * @var Nuclen_TOC_View
+        */
+       private Nuclen_TOC_View $view;
 
 	/** Class constructor. */
 	public function __construct() {

--- a/nuclear-engagement/modules/toc/includes/class-nuclen-toc-utils.php
+++ b/nuclear-engagement/modules/toc/includes/class-nuclen-toc-utils.php
@@ -6,7 +6,10 @@
  *   ▸ heading extraction with skip‑rules
  *   ▸ slug deduplication
  *   ▸ object‑cache wrapper
+ *
+ * @package NuclearEngagement
  */
+
 declare(strict_types=1);
 
 if ( ! defined( 'ABSPATH' ) ) {
@@ -77,7 +80,8 @@ final class Nuclen_TOC_Utils {
 			return $hit;
 		}
 
-		self::$ids_in_post = $out = array();
+                $out = array();
+                self::$ids_in_post = $out;
 
 		if ( preg_match_all( '/<(h[1-6])([^>]*)>(.*?)<\/\1>/is', $html, $m, PREG_SET_ORDER ) ) {
 			foreach ( $m as $row ) {
@@ -117,13 +121,19 @@ final class Nuclen_TOC_Utils {
 		return $out;
 	}
 
-	/*
-	---------------------------------------------------------- */
-	/*
-		Helpers                                                   */
-	/* ---------------------------------------------------------- */
+        /*
+         * ----------------------------------------------------------
+         * Helpers
+         * ----------------------------------------------------------
+         */
 
-	private static function unique_id_from_text( string $txt ): string {
+        /**
+         * Generate a unique slug from heading text.
+         *
+         * @param string $txt Heading text.
+         * @return string Unique slug.
+         */
+        private static function unique_id_from_text( string $txt ): string {
 		$base = sanitize_title( $txt );
 		$id   = $base;
 		$n    = 2;

--- a/nuclear-engagement/modules/toc/includes/class-nuclen-toc-view.php
+++ b/nuclear-engagement/modules/toc/includes/class-nuclen-toc-view.php
@@ -3,7 +3,10 @@
  * File: modules/toc/includes/class-nuclen-toc-view.php
  *
  * Generates the HTML markup for the front-end TOC.
+ *
+ * @package NuclearEngagement
  */
+
 declare(strict_types=1);
 
 if ( ! defined( 'ABSPATH' ) ) {
@@ -15,7 +18,6 @@ use NuclearEngagement\SettingsRepository;
 /**
  * Output builder for the front-end table of contents.
  */
-
 final class Nuclen_TOC_View {
 	private const DEFAULT_STICKY_OFFSET_X  = 20;
 	private const DEFAULT_STICKY_OFFSET_Y  = 20;

--- a/nuclear-engagement/modules/toc/includes/polyfills.php
+++ b/nuclear-engagement/modules/toc/includes/polyfills.php
@@ -4,7 +4,10 @@
  *
  * Poly‑fills for PHP 7.4 and name‑spaced helpers.
  * All helpers are prefixed `nuclen_` to avoid collisions in large stacks.
+ *
+ * @package NuclearEngagement
  */
+
 declare(strict_types=1);
 
 if ( ! defined( 'ABSPATH' ) ) {

--- a/nuclear-engagement/modules/toc/loader.php
+++ b/nuclear-engagement/modules/toc/loader.php
@@ -3,7 +3,10 @@
  * File: modules/toc/loader.php
  *
  * Loads the Nuclen TOC sub-module.
+ *
+ * @package NuclearEngagement
  */
+
 declare(strict_types=1);
 
 if ( ! defined( 'ABSPATH' ) ) {

--- a/nuclear-engagement/uninstall.php
+++ b/nuclear-engagement/uninstall.php
@@ -23,6 +23,7 @@
  *
  * @package    Nuclear_Engagement
  */
+
 declare(strict_types=1);
 
 if ( ! defined( 'ABSPATH' ) ) {


### PR DESCRIPTION
## Summary
- fix missing `@package` tags in PHP headers
- fix property docblocks in TOC classes
- tidy up helper comments
- minor whitespace fixes

## Testing
- `composer lint` *(fails: composer not found)*
- `composer test` *(fails: composer not found)*

------
https://chatgpt.com/codex/tasks/task_e_685a23d6bf18832784512b00f056b456


> [!NOTE]
> I'm currently writing a description for your pull request. I should be done shortly (<1 minute). Please don't edit the description field until I'm finished, or we may overwrite each other. If I find nothing to write about, I'll delete this message.
