### PR TITLE
Fix whitespace and rename reserved argument

### DIFF
--- a/nuclear-engagement/modules/toc/includes/class-nuclen-toc-utils.php
+++ b/nuclear-engagement/modules/toc/includes/class-nuclen-toc-utils.php
@@ -13,7 +13,7 @@
 declare(strict_types=1);
 
 if ( ! defined( 'ABSPATH' ) ) {
-	exit;
+    exit;
 }
 
 use function nuclen_str_contains;
@@ -23,103 +23,103 @@ use function nuclen_str_contains;
  */
 final class Nuclen_TOC_Utils {
 
-	private const CACHE_GROUP = 'nuclen_toc';
-	private const CACHE_TTL   = 6 * HOUR_IN_SECONDS;          // 6 hours.
+    private const CACHE_GROUP = 'nuclen_toc';
+    private const CACHE_TTL   = 6 * HOUR_IN_SECONDS;          // 6 hours.
 
-		/**
-		 * Track generated IDs to ensure uniqueness within a post.
-		 *
-		 * @var string[]
-		 */
-	private static array $ids_in_post = array();
+        /**
+         * Track generated IDs to ensure uniqueness within a post.
+         *
+         * @var string[]
+         */
+    private static array $ids_in_post = array();
 
-	/**
-	 * Parse H1–H6 headings from raw HTML, respecting heading levels array,
-	 * .no‑toc class, data‑toc="false", and cache the result.
-	 *
-	 * @param string $html The HTML content to parse for headings.
-	 * @param array  $heading_levels Array of specific heading levels to include (e.g., [2, 4] for H2 and H4 only).
-	 *
-	 * @return array[] [
-	 *     'tag'   => 'h2',
-	 *     'level' => 2,
-	 *     'text'  => 'Heading text',
-	 *     'inner' => 'Heading <em>HTML</em>',
-	 *     'id'    => 'slugified-id'
-	 * ]
-	 */
-	public static function extract( string $html, array $heading_levels ): array {
-		// If no specific levels provided, use defaults (2-6).
-		if ( empty( $heading_levels ) ) {
-			$heading_levels = range( 2, 6 );
-		}
+    /**
+     * Parse H1–H6 headings from raw HTML, respecting heading levels array,
+     * .no‑toc class, data‑toc="false", and cache the result.
+     *
+     * @param string $html The HTML content to parse for headings.
+     * @param array  $heading_levels Array of specific heading levels to include (e.g., [2, 4] for H2 and H4 only).
+     *
+     * @return array[] [
+     *     'tag'   => 'h2',
+     *     'level' => 2,
+     *     'text'  => 'Heading text',
+     *     'inner' => 'Heading <em>HTML</em>',
+     *     'id'    => 'slugified-id'
+     * ]
+     */
+    public static function extract( string $html, array $heading_levels ): array {
+        // If no specific levels provided, use defaults (2-6).
+        if ( empty( $heading_levels ) ) {
+            $heading_levels = range( 2, 6 );
+        }
 
-		// Sanitize and validate heading levels.
-		$heading_levels = array_filter(
-			array_map( 'intval', $heading_levels ),
-			function ( $level ) {
-				return $level >= 1 && $level <= 6;
-			}
-		);
+        // Sanitize and validate heading levels.
+        $heading_levels = array_filter(
+            array_map( 'intval', $heading_levels ),
+            function ( $level ) {
+                return $level >= 1 && $level <= 6;
+            }
+        );
 
-		// If still no valid levels, use defaults (2-6).
-		if ( empty( $heading_levels ) ) {
-			$heading_levels = range( 2, 6 );
-		}
+        // If still no valid levels, use defaults (2-6).
+        if ( empty( $heading_levels ) ) {
+            $heading_levels = range( 2, 6 );
+        }
 
-		// Sort and make unique.
-		sort( $heading_levels );
-		$heading_levels = array_unique( $heading_levels );
+        // Sort and make unique.
+        sort( $heading_levels );
+        $heading_levels = array_unique( $heading_levels );
 
-		// Generate cache key based on content and heading levels.
-		$key = md5( $html ) . '_' . implode( '', $heading_levels );
-		$hit = wp_cache_get( $key, self::CACHE_GROUP );
+        // Generate cache key based on content and heading levels.
+        $key = md5( $html ) . '_' . implode( '', $heading_levels );
+        $hit = wp_cache_get( $key, self::CACHE_GROUP );
 
-		if ( false !== $hit ) {
-			self::$ids_in_post = wp_list_pluck( $hit, 'id' );
-			return $hit;
-		}
+        if ( false !== $hit ) {
+            self::$ids_in_post = wp_list_pluck( $hit, 'id' );
+            return $hit;
+        }
 
                 $out = array();
                 self::$ids_in_post = $out;
 
-		if ( preg_match_all( '/<(h[1-6])([^>]*)>(.*?)<\/\1>/is', $html, $m, PREG_SET_ORDER ) ) {
-			foreach ( $m as $row ) {
-				$tag = strtolower( $row[1] );
-				$lvl = (int) substr( $tag, 1 );
+        if ( preg_match_all( '/<(h[1-6])([^>]*)>(.*?)<\/\1>/is', $html, $m, PREG_SET_ORDER ) ) {
+            foreach ( $m as $row ) {
+                $tag = strtolower( $row[1] );
+                $lvl = (int) substr( $tag, 1 );
 
-				// Skip if not in allowed levels or has skip classes/attributes.
-				if ( ! in_array( $lvl, $heading_levels, true ) ) {
-					continue; }
-				if ( preg_match( '/\bno-?toc\b/i', $row[2] ) ) {
-					continue; }
-				if ( preg_match( '/data-toc\s*=\s*["\']?false/i', $row[2] ) ) {
-					continue; }
+                // Skip if not in allowed levels or has skip classes/attributes.
+                if ( ! in_array( $lvl, $heading_levels, true ) ) {
+                    continue; }
+                if ( preg_match( '/\bno-?toc\b/i', $row[2] ) ) {
+                    continue; }
+                if ( preg_match( '/data-toc\s*=\s*["\']?false/i', $row[2] ) ) {
+                    continue; }
 
-				// Process the heading.
-				$inner = $row[3];
-				$text  = wp_strip_all_tags( $inner );
-				if ( '' === $text ) {
-					continue; }
+                // Process the heading.
+                $inner = $row[3];
+                $text  = wp_strip_all_tags( $inner );
+                if ( '' === $text ) {
+                    continue; }
 
-				// Get or generate ID.
-				$id = ( preg_match( '/\bid=["\']([^"\']+)["\']/', $row[2], $id_m ) )
-					? sanitize_html_class( $id_m[1] )
-					: self::unique_id_from_text( $text );
+                // Get or generate ID.
+                $id = ( preg_match( '/\bid=["\']([^"\']+)["\']/', $row[2], $id_m ) )
+                    ? sanitize_html_class( $id_m[1] )
+                    : self::unique_id_from_text( $text );
 
-				$out[] = array(
-					'tag'   => $tag,
-					'level' => $lvl,
-					'text'  => $text,
-					'inner' => $inner,
-					'id'    => $id,
-				);
-			}
-		}
+                $out[] = array(
+                    'tag'   => $tag,
+                    'level' => $lvl,
+                    'text'  => $text,
+                    'inner' => $inner,
+                    'id'    => $id,
+                );
+            }
+        }
 
-		wp_cache_set( $key, $out, self::CACHE_GROUP, self::CACHE_TTL );
-		return $out;
-	}
+        wp_cache_set( $key, $out, self::CACHE_GROUP, self::CACHE_TTL );
+        return $out;
+    }
 
         /*
          * ----------------------------------------------------------
@@ -134,24 +134,24 @@ final class Nuclen_TOC_Utils {
          * @return string Unique slug.
          */
         private static function unique_id_from_text( string $txt ): string {
-		$base = sanitize_title( $txt );
-		$id   = $base;
-		$n    = 2;
-		while ( in_array( $id, self::$ids_in_post, true ) ) {
-			$id = $base . '-' . ( $n++ );
-		}
-		self::$ids_in_post[] = $id;
-		return $id;
-	}
+        $base = sanitize_title( $txt );
+        $id   = $base;
+        $n    = 2;
+        while ( in_array( $id, self::$ids_in_post, true ) ) {
+            $id = $base . '-' . ( $n++ );
+        }
+        self::$ids_in_post[] = $id;
+        return $id;
+    }
 
-		/**
-		 * Tiny wrapper so callers can import just one name.
-		 *
-		 * @param string $haystack The string to search in.
-		 * @param string $needle   The substring to look for.
-		 * @return bool Whether the haystack contains the needle.
-		 */
-	public static function str_contains( string $haystack, string $needle ): bool {
-			return nuclen_str_contains( $haystack, $needle );
-	}
+        /**
+         * Tiny wrapper so callers can import just one name.
+         *
+         * @param string $haystack The string to search in.
+         * @param string $needle   The substring to look for.
+         * @return bool Whether the haystack contains the needle.
+         */
+    public static function str_contains( string $haystack, string $needle ): bool {
+            return nuclen_str_contains( $haystack, $needle );
+    }
 }

--- a/nuclear-engagement/modules/toc/includes/class-nuclen-toc-view.php
+++ b/nuclear-engagement/modules/toc/includes/class-nuclen-toc-view.php
@@ -10,7 +10,7 @@
 declare(strict_types=1);
 
 if ( ! defined( 'ABSPATH' ) ) {
-	exit;
+    exit;
 }
 
 use NuclearEngagement\SettingsRepository;
@@ -19,164 +19,164 @@ use NuclearEngagement\SettingsRepository;
  * Output builder for the front-end table of contents.
  */
 final class Nuclen_TOC_View {
-	private const DEFAULT_STICKY_OFFSET_X  = 20;
-	private const DEFAULT_STICKY_OFFSET_Y  = 20;
-	private const DEFAULT_STICKY_MAX_WIDTH = 300;
+    private const DEFAULT_STICKY_OFFSET_X  = 20;
+    private const DEFAULT_STICKY_OFFSET_Y  = 20;
+    private const DEFAULT_STICKY_MAX_WIDTH = 300;
 
-	/**
-	 * Retrieve the translated TOC title with a fallback.
-	 *
-	 * @param SettingsRepository $settings Plugin settings repository.
-	 * @return string Sanitized title string.
-	 */
-	public function get_toc_title( SettingsRepository $settings ): string {
-		$title = $settings->get_string( 'toc_title' );
-		if ( empty( $title ) ) {
-			return esc_html__( 'Table of Contents', 'nuclen-toc-shortcode' );
-		}
-		return esc_html( $title );
-	}
+    /**
+     * Retrieve the translated TOC title with a fallback.
+     *
+     * @param SettingsRepository $settings Plugin settings repository.
+     * @return string Sanitized title string.
+     */
+    public function get_toc_title( SettingsRepository $settings ): string {
+        $title = $settings->get_string( 'toc_title' );
+        if ( empty( $title ) ) {
+            return esc_html__( 'Table of Contents', 'nuclen-toc-shortcode' );
+        }
+        return esc_html( $title );
+    }
 
-	/**
-	 * Build wrapper classes and sticky attributes.
-	 *
-	 * @param array              $atts     Shortcode attributes.
-	 * @param SettingsRepository $settings Settings repository.
-	 * @return array{classes:array,sticky_attrs:string,show_toggle:bool,hidden:bool}
-	 */
-	public function build_wrapper_props( array $atts, SettingsRepository $settings ): array {
-		$classes = array( 'nuclen-toc-wrapper' );
+    /**
+     * Build wrapper classes and sticky attributes.
+     *
+     * @param array              $atts     Shortcode attributes.
+     * @param SettingsRepository $settings Settings repository.
+     * @return array{classes:array,sticky_attrs:string,show_toggle:bool,hidden:bool}
+     */
+    public function build_wrapper_props( array $atts, SettingsRepository $settings ): array {
+        $classes = array( 'nuclen-toc-wrapper' );
 
-		if ( in_array( $atts['theme'], array( 'dark', 'auto' ), true ) ) {
-			$classes[] = 'nuclen-toc-' . $atts['theme'];
-		}
+        if ( in_array( $atts['theme'], array( 'dark', 'auto' ), true ) ) {
+            $classes[] = 'nuclen-toc-' . $atts['theme'];
+        }
 
-		$show_toggle = $settings->get_bool( 'toc_show_toggle' );
-		$hidden      = $show_toggle && ! $settings->get_bool( 'toc_show_content' );
+        $show_toggle = $settings->get_bool( 'toc_show_toggle' );
+        $hidden      = $show_toggle && ! $settings->get_bool( 'toc_show_content' );
 
-		if ( $show_toggle ) {
-			$classes[] = 'nuclen-toc-has-toggle';
-			if ( $hidden ) {
-				$classes[] = 'nuclen-toc-collapsed';
-			}
-		}
+        if ( $show_toggle ) {
+            $classes[] = 'nuclen-toc-has-toggle';
+            if ( $hidden ) {
+                $classes[] = 'nuclen-toc-collapsed';
+            }
+        }
 
-		$sticky_attrs = '';
-		if ( ! empty( $atts['sticky'] ) ) {
-			$classes[] = 'nuclen-toc-sticky';
+        $sticky_attrs = '';
+        if ( ! empty( $atts['sticky'] ) ) {
+            $classes[] = 'nuclen-toc-sticky';
 
-			$sticky_offset_x  = $settings->get_int( 'toc_sticky_offset_x', self::DEFAULT_STICKY_OFFSET_X );
-			$sticky_offset_y  = $settings->get_int( 'toc_sticky_offset_y', self::DEFAULT_STICKY_OFFSET_Y );
-			$sticky_max_width = $settings->get_int( 'toc_sticky_max_width', self::DEFAULT_STICKY_MAX_WIDTH );
+            $sticky_offset_x  = $settings->get_int( 'toc_sticky_offset_x', self::DEFAULT_STICKY_OFFSET_X );
+            $sticky_offset_y  = $settings->get_int( 'toc_sticky_offset_y', self::DEFAULT_STICKY_OFFSET_Y );
+            $sticky_max_width = $settings->get_int( 'toc_sticky_max_width', self::DEFAULT_STICKY_MAX_WIDTH );
 
-			$sticky_offset_x  = max( 0, min( 1000, $sticky_offset_x ) );
-			$sticky_offset_y  = max( 0, min( 1000, $sticky_offset_y ) );
-			$sticky_max_width = min( 1000, max( 100, $sticky_max_width ) );
+            $sticky_offset_x  = max( 0, min( 1000, $sticky_offset_x ) );
+            $sticky_offset_y  = max( 0, min( 1000, $sticky_offset_y ) );
+            $sticky_max_width = min( 1000, max( 100, $sticky_max_width ) );
 
-			$sticky_attrs = sprintf(
-				' data-offset-x="%d" data-offset-y="%d" data-max-width="%d" data-show-content="%s" data-heading-levels="%s"',
-				$sticky_offset_x,
-				$sticky_offset_y,
-				$sticky_max_width,
-				$settings->get_bool( 'toc_show_content' ) ? 'true' : 'false',
-				esc_attr( implode( ',', $atts['heading_levels'] ) )
-			);
-		}
+            $sticky_attrs = sprintf(
+                ' data-offset-x="%d" data-offset-y="%d" data-max-width="%d" data-show-content="%s" data-heading-levels="%s"',
+                $sticky_offset_x,
+                $sticky_offset_y,
+                $sticky_max_width,
+                $settings->get_bool( 'toc_show_content' ) ? 'true' : 'false',
+                esc_attr( implode( ',', $atts['heading_levels'] ) )
+            );
+        }
 
-		if ( 'true' === $atts['highlight'] ) {
-			$classes[] = 'nuclen-has-highlight';
-		}
+        if ( 'true' === $atts['highlight'] ) {
+            $classes[] = 'nuclen-has-highlight';
+        }
 
-		$z_index = $settings->get_int( 'toc_z_index', 100 );
-		$z_index = max( 1, min( 9999, $z_index ) );
+        $z_index = $settings->get_int( 'toc_z_index', 100 );
+        $z_index = max( 1, min( 9999, $z_index ) );
 
-			return array(
-				'classes'      => $classes,
-				'sticky_attrs' => $sticky_attrs,
-				'show_toggle'  => $show_toggle,
-				'hidden'       => $hidden,
-			);
-	}
+            return array(
+                'classes'      => $classes,
+                'sticky_attrs' => $sticky_attrs,
+                'show_toggle'  => $show_toggle,
+                'hidden'       => $hidden,
+            );
+    }
 
-	/**
-	 * Build the toggle button HTML if toggling is enabled.
-	 *
-	 * @param bool   $show    Whether to show the toggle.
-	 * @param bool   $hidden  Whether the content is hidden.
-	 * @param array  $atts    Shortcode attributes.
-	 * @param string $nav_id  Navigation element ID.
-	 * @return string Button markup or empty string.
-	 */
-	public function build_toggle_button( bool $show, bool $hidden, array $atts, string $nav_id ): string {
-		if ( ! $show ) {
-			return '';
-		}
-		$toggle_text = $hidden ? $atts['show_text'] : $atts['hide_text'];
-		return sprintf(
-			'<button type="button" class="nuclen-toc-toggle" aria-expanded="%s" aria-controls="%s">%s</button>',
-			$hidden ? 'false' : 'true',
-			esc_attr( $nav_id ),
-			esc_html( $toggle_text )
-		);
-	}
+    /**
+     * Build the toggle button HTML if toggling is enabled.
+     *
+     * @param bool   $show    Whether to show the toggle.
+     * @param bool   $hidden  Whether the content is hidden.
+     * @param array  $atts    Shortcode attributes.
+     * @param string $nav_id  Navigation element ID.
+     * @return string Button markup or empty string.
+     */
+    public function build_toggle_button( bool $show, bool $hidden, array $atts, string $nav_id ): string {
+        if ( ! $show ) {
+            return '';
+        }
+        $toggle_text = $hidden ? $atts['show_text'] : $atts['hide_text'];
+        return sprintf(
+            '<button type="button" class="nuclen-toc-toggle" aria-expanded="%s" aria-controls="%s">%s</button>',
+            $hidden ? 'false' : 'true',
+            esc_attr( $nav_id ),
+            esc_html( $toggle_text )
+        );
+    }
 
-	/**
-	 * Render the nested heading list.
-	 *
-	 * @param array  $heads Parsed heading data.
-	 * @param string $list  Tag name for list wrapper.
-	 * @return string HTML list markup.
-	 */
-	public function render_headings_list( array $heads, string $list ): string {
-			$out = '';
-		$stack   = array();
-		foreach ( $heads as $h ) {
-			$l = $h['level'];
-			while ( $stack && end( $stack ) > $l ) {
-				$out .= '</li></' . $list . '>';
-				array_pop( $stack );
-			}
-			if ( ! $stack || end( $stack ) < $l ) {
-				$out    .= '<' . $list . '>';
-				$stack[] = $l;
-			} else {
-				$out .= '</li>';
-			}
-			$out .= '<li><a href="#' . esc_attr( $h['id'] ) . '">' . esc_html( $h['text'] ) . '</a>';
-		}
-		while ( $stack ) {
-			$out .= '</li></' . $list . '>';
-			array_pop( $stack );
-		}
-		return $out;
-	}
+    /**
+     * Render the nested heading list.
+     *
+     * @param array  $heads     Parsed heading data.
+     * @param string $list_tag  Tag name for list wrapper.
+     * @return string HTML list markup.
+     */
+    public function render_headings_list( array $heads, string $list_tag ): string {
+            $out = '';
+        $stack   = array();
+        foreach ( $heads as $h ) {
+            $l = $h['level'];
+            while ( $stack && end( $stack ) > $l ) {
+                $out .= '</li></' . $list_tag . '>';
+                array_pop( $stack );
+            }
+            if ( ! $stack || end( $stack ) < $l ) {
+                $out    .= '<' . $list_tag . '>';
+                $stack[] = $l;
+            } else {
+                $out .= '</li>';
+            }
+            $out .= '<li><a href="#' . esc_attr( $h['id'] ) . '">' . esc_html( $h['text'] ) . '</a>';
+        }
+        while ( $stack ) {
+            $out .= '</li></' . $list_tag . '>';
+            array_pop( $stack );
+        }
+        return $out;
+    }
 
-	/**
-	 * Build the navigation markup containing the heading list.
-	 *
-	 * @param array  $heads     Parsed heading data.
-	 * @param string $list      Tag name for list wrapper.
-	 * @param array  $atts      Shortcode attributes.
-	 * @param string $nav_id    Navigation element ID.
-	 * @param string $toc_title Title for accessibility label.
-	 * @param bool   $hidden    Whether the list starts hidden.
-	 * @return string HTML navigation markup.
-	 */
-	public function build_nav_markup( array $heads, string $list, array $atts, string $nav_id, string $toc_title, bool $hidden ): string {
-			$nav = sprintf(
-				'<nav id="%s" class="nuclen-toc" aria-label="%s"%s%s>',
-				esc_attr( $nav_id ),
-				esc_attr( $toc_title ),
-				$hidden ? ' style="display:none"' : '',
-				'true' === $atts['highlight'] ? ' data-highlight="true"' : ''
-			);
+    /**
+     * Build the navigation markup containing the heading list.
+     *
+     * @param array  $heads     Parsed heading data.
+     * @param string $list_tag  Tag name for list wrapper.
+     * @param array  $atts      Shortcode attributes.
+     * @param string $nav_id    Navigation element ID.
+     * @param string $toc_title Title for accessibility label.
+     * @param bool   $hidden    Whether the list starts hidden.
+     * @return string HTML navigation markup.
+     */
+    public function build_nav_markup( array $heads, string $list_tag, array $atts, string $nav_id, string $toc_title, bool $hidden ): string {
+            $nav = sprintf(
+                '<nav id="%s" class="nuclen-toc" aria-label="%s"%s%s>',
+                esc_attr( $nav_id ),
+                esc_attr( $toc_title ),
+                $hidden ? ' style="display:none"' : '',
+                'true' === $atts['highlight'] ? ' data-highlight="true"' : ''
+            );
 
-		if ( '' !== $atts['title'] ) {
-				$nav .= '<strong class="toc-title">' . esc_html( $atts['title'] ) . '</strong>';
-		}
+        if ( '' !== $atts['title'] ) {
+                $nav .= '<strong class="toc-title">' . esc_html( $atts['title'] ) . '</strong>';
+        }
 
-			$nav .= $this->render_headings_list( $heads, $list ) . '</nav>';
+            $nav .= $this->render_headings_list( $heads, $list_tag ) . '</nav>';
 
-		return $nav;
-	}
+        return $nav;
+    }
 }

--- a/nuclear-engagement/modules/toc/includes/polyfills.php
+++ b/nuclear-engagement/modules/toc/includes/polyfills.php
@@ -11,33 +11,33 @@
 declare(strict_types=1);
 
 if ( ! defined( 'ABSPATH' ) ) {
-	exit;
+    exit;
 }
 
 if ( ! function_exists( 'nuclen_str_contains' ) ) {
-		/**
-		 * Prefixed back‑port of PHP 8 str_contains().
-		 *
-		 * @param string $haystack String to search in.
-		 * @param string $needle   Substring to search for.
-		 *
-		 * @return bool Whether the needle exists in the haystack.
-		 */
-	function nuclen_str_contains( string $haystack, string $needle ): bool {
-			return '' === $needle || false !== strpos( $haystack, $needle );
-	}
+        /**
+         * Prefixed back‑port of PHP 8 str_contains().
+         *
+         * @param string $haystack String to search in.
+         * @param string $needle   Substring to search for.
+         *
+         * @return bool Whether the needle exists in the haystack.
+         */
+    function nuclen_str_contains( string $haystack, string $needle ): bool {
+            return '' === $needle || false !== strpos( $haystack, $needle );
+    }
 }
 
 if ( ! function_exists( 'nuclen_str_ends_with' ) ) {
-		/**
-		 * Prefixed back‑port of PHP 8 str_ends_with().
-		 *
-		 * @param string $haystack String to check.
-		 * @param string $needle   Expected ending.
-		 *
-		 * @return bool Whether the haystack ends with the needle.
-		 */
-	function nuclen_str_ends_with( string $haystack, string $needle ): bool {
-			return '' === $needle || substr( $haystack, -strlen( $needle ) ) === $needle;
-	}
+        /**
+         * Prefixed back‑port of PHP 8 str_ends_with().
+         *
+         * @param string $haystack String to check.
+         * @param string $needle   Expected ending.
+         *
+         * @return bool Whether the haystack ends with the needle.
+         */
+    function nuclen_str_ends_with( string $haystack, string $needle ): bool {
+            return '' === $needle || substr( $haystack, -strlen( $needle ) ) === $needle;
+    }
 }

--- a/nuclear-engagement/modules/toc/loader.php
+++ b/nuclear-engagement/modules/toc/loader.php
@@ -10,7 +10,7 @@
 declare(strict_types=1);
 
 if ( ! defined( 'ABSPATH' ) ) {
-	exit;
+    exit;
 }
 
 /*
@@ -40,12 +40,12 @@ require_once NUCLEN_TOC_DIR . 'includes/class-nuclen-toc-admin.php';
  * ------------------------------------------------------------------
  */
 add_action(
-	'plugins_loaded',
-	static function () {
-		new Nuclen_TOC_Headings();  // filter for heading IDs.
-		new Nuclen_TOC_Render();    // shortcode handler.
-		if ( is_admin() ) {
-			new Nuclen_TOC_Admin();    // settings page.
-		}
-	}
+    'plugins_loaded',
+    static function () {
+        new Nuclen_TOC_Headings();  // filter for heading IDs.
+        new Nuclen_TOC_Render();    // shortcode handler.
+        if ( is_admin() ) {
+            new Nuclen_TOC_Admin();    // settings page.
+        }
+    }
 );

--- a/nuclear-engagement/uninstall.php
+++ b/nuclear-engagement/uninstall.php
@@ -27,12 +27,12 @@
 declare(strict_types=1);
 
 if ( ! defined( 'ABSPATH' ) ) {
-		exit;
+        exit;
 }
 
 // If uninstall not called from WordPress, then exit.
 if ( ! defined( 'WP_UNINSTALL_PLUGIN' ) ) {
-		exit;
+        exit;
 }
 
 // Get plugin settings.
@@ -46,46 +46,46 @@ $delete_css       = ! empty( $settings['delete_custom_css_on_uninstall'] );
 
 // Delete generated content from post meta if requested.
 if ( $delete_generated ) {
-				$meta_keys = array(
-					'nuclen-quiz-data',
-					'nuclen-summary-data',
-					'nuclen_quiz_protected',
-					'nuclen_summary_protected',
-				);
-				foreach ( $meta_keys as $mk ) {
-						delete_post_meta_by_key( $mk );
-				}
+                $meta_keys = array(
+                    'nuclen-quiz-data',
+                    'nuclen-summary-data',
+                    'nuclen_quiz_protected',
+                    'nuclen_summary_protected',
+                );
+                foreach ( $meta_keys as $mk ) {
+                        delete_post_meta_by_key( $mk );
+                }
 }
 
 // Delete plugin settings if requested.
 if ( $delete_settings ) {
-		delete_option( 'nuclear_engagement_settings' );
-		delete_option( 'nuclear_engagement_setup' );
-		delete_option( 'nuclen_custom_css_version' );
+        delete_option( 'nuclear_engagement_settings' );
+        delete_option( 'nuclear_engagement_setup' );
+        delete_option( 'nuclen_custom_css_version' );
 }
 
 // Remove log file if requested.
 if ( $delete_log ) {
-		$info = \NuclearEngagement\Services\LoggingService::get_log_file_info();
-	if ( file_exists( $info['path'] ) ) {
-			wp_delete_file( $info['path'] );
-	}
+        $info = \NuclearEngagement\Services\LoggingService::get_log_file_info();
+    if ( file_exists( $info['path'] ) ) {
+            wp_delete_file( $info['path'] );
+    }
 }
 
 // Remove custom theme file if requested.
 if ( $delete_css ) {
-		$info = \NuclearEngagement\Utils::nuclen_get_custom_css_info();
-	if ( file_exists( $info['path'] ) ) {
-			wp_delete_file( $info['path'] );
-	}
-		delete_option( 'nuclen_custom_css_version' );
+        $info = \NuclearEngagement\Utils::nuclen_get_custom_css_info();
+    if ( file_exists( $info['path'] ) ) {
+            wp_delete_file( $info['path'] );
+    }
+        delete_option( 'nuclen_custom_css_version' );
 }
 
 // Drop opt-in table only when the user opts to delete settings or generated
 // content. This avoids data loss unless a full cleanup was requested.
 if ( $delete_settings || $delete_generated ) {
-		global $wpdb;
-				$table = $wpdb->prefix . 'nuclen_optins';
-				// Remove stored email opt-in submissions on uninstall.
-				$wpdb->query( 'DROP TABLE IF EXISTS ' . esc_sql( $table ) );
+        global $wpdb;
+                $table = $wpdb->prefix . 'nuclen_optins';
+                // Remove stored email opt-in submissions on uninstall.
+                $wpdb->query( 'DROP TABLE IF EXISTS ' . esc_sql( $table ) );
 }


### PR DESCRIPTION
## Summary
- normalize line endings and indentation across TOC module files
- rename reserved `$list` argument to `$list_tag`

## Testing
- `composer lint` *(fails: composer not installed)*
- `composer test` *(fails: composer not installed)*

------
https://chatgpt.com/codex/tasks/task_e_685a2e3da1408327ae9de4061726fa64

<!-- Korbit AI PR Description Start -->
## Description by Korbit AI

### What change is being made?
Standardize whitespace in codebase and update reserved argument name.

### Why are these changes being made?
This change ensures consistency in code indentation and style, improving readability and maintainability. It also involves a minor correction of argument naming to prevent conflicts with reserved keywords.

> Is this description stale? Ask me to generate a new description by commenting `/korbit-generate-pr-description`
<!-- Korbit AI PR Description End -->