### PR TITLE
Fix indentation in toc asset and render classes

### DIFF
--- a/nuclear-engagement/modules/toc/includes/class-nuclen-toc-assets.php
+++ b/nuclear-engagement/modules/toc/includes/class-nuclen-toc-assets.php
@@ -17,55 +17,55 @@ use NuclearEngagement\AssetVersions;
  * Front-end assets helper for the TOC module.
  */
 final class Nuclen_TOC_Assets {
-		/** Default vertical offset for scroll-to behaviour. */
+	/** Default vertical offset for scroll-to behaviour. */
 	public const DEFAULT_SCROLL_OFFSET = NUCLEN_TOC_SCROLL_OFFSET_DEFAULT;
 
-        /**
-         * Whether assets have been registered.
-         *
-         * @var bool
-         */
-        private bool $registered = false;
+	/**
+	 * Whether assets have been registered.
+	 *
+	 * @var bool
+	 */
+	private bool $registered = false;
 
-        /**
-         * Current scroll offset in pixels.
-         *
-         * @var int
-         */
-        private int $scroll_offset = self::DEFAULT_SCROLL_OFFSET;
+	/**
+	 * Current scroll offset in pixels.
+	 *
+	 * @var int
+	 */
+	private int $scroll_offset = self::DEFAULT_SCROLL_OFFSET;
 
-		/**
-		 * Enqueue assets and apply runtime tweaks.
-		 *
-		 * @param array $a Shortcode attributes.
-		 */
+	/**
+	 * Enqueue assets and apply runtime tweaks.
+	 *
+	 * @param array $a Shortcode attributes.
+	 */
 	public function enqueue( array $a ): void {
 		if ( ! is_singular() ) {
-				return;
+			return;
 		}
 		if ( ! $this->registered ) {
-				$this->register();
+			$this->register();
 		}
 		wp_enqueue_style( 'nuclen-toc-front' );
 		if ( 'true' === $a['toggle'] || 'true' === $a['highlight'] ) {
-					wp_enqueue_script( 'nuclen-toc-front' );
+			wp_enqueue_script( 'nuclen-toc-front' );
 		}
-				$off = max( 0, min( 500, (int) $a['offset'] ) );
+		$off = max( 0, min( 500, (int) $a['offset'] ) );
 		if ( $this->scroll_offset !== $off ) {
-					wp_add_inline_style( 'nuclen-toc-front', ':root{--nuclen-toc-offset:' . $off . 'px}' );
-					$this->scroll_offset = $off;
+			wp_add_inline_style( 'nuclen-toc-front', ':root{--nuclen-toc-offset:' . $off . 'px}' );
+			$this->scroll_offset = $off;
 		}
 		if ( 'true' === $a['smooth'] ) {
-				wp_add_inline_style( 'nuclen-toc-front', 'html{scroll-behavior:smooth}' );
+			wp_add_inline_style( 'nuclen-toc-front', 'html{scroll-behavior:smooth}' );
 		}
 	}
 
-		/**
-		 * Register scripts and styles.
-		 */
+	/**
+	 * Register scripts and styles.
+	 */
 	private function register(): void {
 		if ( $this->registered ) {
-				return;
+			return;
 		}
 		$this->registered = true;
 

--- a/nuclear-engagement/modules/toc/includes/class-nuclen-toc-render.php
+++ b/nuclear-engagement/modules/toc/includes/class-nuclen-toc-render.php
@@ -15,207 +15,207 @@ if ( ! defined( 'ABSPATH' ) ) {
 
 use NuclearEngagement\SettingsRepository;
 
-		/**
-		 * Handle the [nuclear_engagement_toc] shortcode output.
-		 */
+	/**
+	* Handle the [nuclear_engagement_toc] shortcode output.
+	*/
 final class Nuclen_TOC_Render {
-       /**
-        * Assets manager instance.
-        *
-        * @var Nuclen_TOC_Assets
-        */
-       private Nuclen_TOC_Assets $assets;
+	/**
+	 * Assets manager instance.
+	 *
+	 * @var Nuclen_TOC_Assets
+	 */
+	private Nuclen_TOC_Assets $assets;
 
-       /**
-        * View helper instance.
-        *
-        * @var Nuclen_TOC_View
-        */
-       private Nuclen_TOC_View $view;
+	/**
+	 * View helper instance.
+	 *
+	 * @var Nuclen_TOC_View
+	 */
+	private Nuclen_TOC_View $view;
 
 	/** Class constructor. */
 	public function __construct() {
-			$this->assets = new Nuclen_TOC_Assets();
-			$this->view   = new Nuclen_TOC_View();
+		$this->assets = new Nuclen_TOC_Assets();
+		$this->view   = new Nuclen_TOC_View();
 
-			add_shortcode( 'nuclear_engagement_toc', array( $this, 'nuclen_toc_shortcode' ) );
+		add_shortcode( 'nuclear_engagement_toc', array( $this, 'nuclen_toc_shortcode' ) );
 
-			// i18n for strings inside this class.
-			add_action(
-				'init',
-				static function () {
-						load_plugin_textdomain(
-							'nuclen-toc-shortcode',
-							false,
-							dirname( plugin_basename( NUCLEN_TOC_DIR ) ) . '/languages'
-						);
-				}
-			);
+		// i18n for strings inside this class.
+		add_action(
+			'init',
+			static function () {
+				load_plugin_textdomain(
+					'nuclen-toc-shortcode',
+					false,
+					dirname( plugin_basename( NUCLEN_TOC_DIR ) ) . '/languages'
+				);
+			}
+		);
 	}
 
 	/**
-	 * Sanitize and sort heading levels.
-	 *
-	 * @param array|string $heading_levels Provided heading levels.
-	 * @return array Sanitized heading levels array.
-	 */
+	* Sanitize and sort heading levels.
+	*
+	* @param array|string $heading_levels Provided heading levels.
+	* @return array Sanitized heading levels array.
+	*/
 	private function validate_heading_levels( $heading_levels ): array {
 		if ( ! is_array( $heading_levels ) ) {
-			if ( is_string( $heading_levels ) ) {
-				$heading_levels = explode( ',', $heading_levels );
-			} else {
-					return range( 2, 6 );
-			}
-		}
-			$heading_levels = array_map( 'intval', $heading_levels );
-			$heading_levels = array_filter(
-				$heading_levels,
-				static function ( $level ) {
-						return $level >= 2 && $level <= 6;
-				}
-			);
-		if ( empty( $heading_levels ) ) {
+		if ( is_string( $heading_levels ) ) {
+			$heading_levels = explode( ',', $heading_levels );
+		} else {
 				return range( 2, 6 );
 		}
-			$heading_levels = array_unique( $heading_levels );
-			sort( $heading_levels );
-			return array_values( $heading_levels );
+		}
+		$heading_levels = array_map( 'intval', $heading_levels );
+		$heading_levels = array_filter(
+			$heading_levels,
+			static function ( $level ) {
+				return $level >= 2 && $level <= 6;
+			}
+		);
+		if ( empty( $heading_levels ) ) {
+			return range( 2, 6 );
+		}
+		$heading_levels = array_unique( $heading_levels );
+		sort( $heading_levels );
+		return array_values( $heading_levels );
 	}
 
 	/**
-	 * Sanitize shortcode attributes.
-	 *
-	 * @param array $atts Raw shortcode attributes.
-	 * @return array Validated attributes.
-	 */
+	* Sanitize shortcode attributes.
+	*
+	* @param array $atts Raw shortcode attributes.
+	* @return array Validated attributes.
+	*/
 	private function validate_shortcode_atts( array $atts ): array {
-			$valid_lists    = array( 'ul', 'ol' );
-			$valid_booleans = array( 'true', 'false' );
-			$valid_themes   = array( 'light', 'dark', 'auto' );
+		$valid_lists    = array( 'ul', 'ol' );
+		$valid_booleans = array( 'true', 'false' );
+		$valid_themes   = array( 'light', 'dark', 'auto' );
 
 		if ( isset( $atts['list'] ) && ! in_array( strtolower( $atts['list'] ), $valid_lists, true ) ) {
-				$atts['list'] = 'ul';
+			$atts['list'] = 'ul';
 		}
 		foreach ( array( 'toggle', 'collapsed', 'smooth', 'highlight' ) as $bool_attr ) {
-			if ( isset( $atts[ $bool_attr ] ) && ! in_array( strtolower( $atts[ $bool_attr ] ), $valid_booleans, true ) ) {
-					$atts[ $bool_attr ] = 'true';
-			}
+		if ( isset( $atts[ $bool_attr ] ) && ! in_array( strtolower( $atts[ $bool_attr ] ), $valid_booleans, true ) ) {
+				$atts[ $bool_attr ] = 'true';
+		}
 		}
 		if ( isset( $atts['offset'] ) ) {
-				$atts['offset'] = max( 0, min( 500, intval( $atts['offset'] ) ) );
+			$atts['offset'] = max( 0, min( 500, intval( $atts['offset'] ) ) );
 		}
 		if ( isset( $atts['theme'] ) && ! in_array( strtolower( $atts['theme'] ), $valid_themes, true ) ) {
-				$atts['theme'] = 'light';
+			$atts['theme'] = 'light';
 		}
 		if ( isset( $atts['title'] ) ) {
-				$atts['title'] = sanitize_text_field( $atts['title'] );
+			$atts['title'] = sanitize_text_field( $atts['title'] );
 		}
 		if ( isset( $atts['show_text'] ) ) {
-				$atts['show_text'] = sanitize_text_field( $atts['show_text'] );
+			$atts['show_text'] = sanitize_text_field( $atts['show_text'] );
 		}
 		if ( isset( $atts['hide_text'] ) ) {
-				$atts['hide_text'] = sanitize_text_field( $atts['hide_text'] );
+			$atts['hide_text'] = sanitize_text_field( $atts['hide_text'] );
 		}
-			return $atts;
+		return $atts;
 	}
 
 	/**
-	 * Merge defaults with shortcode attributes and settings.
-	 *
-	 * @param array              $atts     Shortcode attributes.
-	 * @param SettingsRepository $settings Settings API wrapper.
-	 * @return array Prepared attributes.
-	 */
+	* Merge defaults with shortcode attributes and settings.
+	*
+	* @param array              $atts     Shortcode attributes.
+	* @param SettingsRepository $settings Settings API wrapper.
+	* @return array Prepared attributes.
+	*/
 	private function prepare_shortcode_attributes( array $atts, SettingsRepository $settings ): array {
-			$heading_levels = $settings->get_array( 'toc_heading_levels', range( 2, 6 ) );
-			$heading_levels = $this->validate_heading_levels( $heading_levels );
+		$heading_levels = $settings->get_array( 'toc_heading_levels', range( 2, 6 ) );
+		$heading_levels = $this->validate_heading_levels( $heading_levels );
 
-			$defaults = array(
-				'heading_levels' => $heading_levels,
-				'list'           => 'ul',
-				'title'          => '',
-				'toggle'         => 'true',
-				'collapsed'      => 'false',
-				'smooth'         => 'true',
-				'highlight'      => 'true',
-				'offset'         => Nuclen_TOC_Assets::DEFAULT_SCROLL_OFFSET,
-				'theme'          => 'light',
-				'show_text'      => __( 'Show table of contents', 'nuclear-engagement' ),
-				'hide_text'      => __( 'Hide table of contents', 'nuclear-engagement' ),
-			);
+		$defaults = array(
+			'heading_levels' => $heading_levels,
+			'list'           => 'ul',
+			'title'          => '',
+			'toggle'         => 'true',
+			'collapsed'      => 'false',
+			'smooth'         => 'true',
+			'highlight'      => 'true',
+			'offset'         => Nuclen_TOC_Assets::DEFAULT_SCROLL_OFFSET,
+			'theme'          => 'light',
+			'show_text'      => __( 'Show table of contents', 'nuclear-engagement' ),
+			'hide_text'      => __( 'Hide table of contents', 'nuclear-engagement' ),
+		);
 
-			$atts = shortcode_atts( $defaults, array_intersect_key( $atts, $defaults ), 'nuclear_engagement_toc' );
-			$atts = $this->validate_shortcode_atts( $atts );
+		$atts = shortcode_atts( $defaults, array_intersect_key( $atts, $defaults ), 'nuclear_engagement_toc' );
+		$atts = $this->validate_shortcode_atts( $atts );
 
-			if ( isset( $atts['heading_levels'] ) ) {
-					$atts['heading_levels'] = $this->validate_heading_levels( $atts['heading_levels'] );
-			}
-			if ( ! isset( $atts['sticky'] ) ) {
-					$atts['sticky'] = $settings->get_bool( 'toc_sticky' );
-			}
-			return $atts;
+		if ( isset( $atts['heading_levels'] ) ) {
+				$atts['heading_levels'] = $this->validate_heading_levels( $atts['heading_levels'] );
+		}
+		if ( ! isset( $atts['sticky'] ) ) {
+				$atts['sticky'] = $settings->get_bool( 'toc_sticky' );
+		}
+		return $atts;
 	}
 
-		/**
-		 * Shortcode callback for rendering the table of contents.
-		 *
-		 * @param array $atts Shortcode attributes.
-		 * @return string Generated HTML markup.
-		 */
+	/**
+	* Shortcode callback for rendering the table of contents.
+	*
+	* @param array $atts Shortcode attributes.
+	* @return string Generated HTML markup.
+	*/
 	public function nuclen_toc_shortcode( array $atts ): string {
-			global $post;
+		global $post;
 		if ( empty( $post ) ) {
-				return '';
+			return '';
 		}
 
-			$settings = \NuclearEngagement\Container::getInstance()->get( 'settings' );
-			$atts     = $this->prepare_shortcode_attributes( $atts, $settings );
+		$settings = \NuclearEngagement\Container::getInstance()->get( 'settings' );
+		$atts     = $this->prepare_shortcode_attributes( $atts, $settings );
 
-			$list  = ( strtolower( $atts['list'] ) === 'ol' ) ? 'ol' : 'ul';
-			$heads = Nuclen_TOC_Utils::extract( $post->post_content, $atts['heading_levels'] );
+		$list  = ( strtolower( $atts['list'] ) === 'ol' ) ? 'ol' : 'ul';
+		$heads = Nuclen_TOC_Utils::extract( $post->post_content, $atts['heading_levels'] );
 		if ( ! $heads ) {
-				return '';
+			return '';
 		}
 
-			$this->assets->enqueue( $atts );
+		$this->assets->enqueue( $atts );
 
-			$toc_title = $this->view->get_toc_title( $settings );
+		$toc_title = $this->view->get_toc_title( $settings );
 		if ( empty( $atts['title'] ) ) {
-				$atts['title'] = $toc_title;
+			$atts['title'] = $toc_title;
 		}
 
-			$nav_id  = esc_attr( wp_unique_id( 'nuclen-toc-' ) );
-			$wrapper = $this->view->build_wrapper_props( $atts, $settings );
-			$classes = $wrapper['classes'];
-			$sticky  = $wrapper['sticky_attrs'];
-			$show    = $wrapper['show_toggle'];
-			$hidden  = $wrapper['hidden'];
+		$nav_id  = esc_attr( wp_unique_id( 'nuclen-toc-' ) );
+		$wrapper = $this->view->build_wrapper_props( $atts, $settings );
+		$classes = $wrapper['classes'];
+		$sticky  = $wrapper['sticky_attrs'];
+		$show    = $wrapper['show_toggle'];
+		$hidden  = $wrapper['hidden'];
 
-			$out  = '<div class="nuclen-root">';
-			$out .= sprintf(
-				'<section id="%s-wrapper" class="%s"%s>',
-				esc_attr( $nav_id ),
-				esc_attr( implode( ' ', $classes ) ),
-				$sticky
-			);
+		$out  = '<div class="nuclen-root">';
+		$out .= sprintf(
+			'<section id="%s-wrapper" class="%s"%s>',
+			esc_attr( $nav_id ),
+			esc_attr( implode( ' ', $classes ) ),
+			$sticky
+		);
 
 		if ( ! empty( $atts['sticky'] ) ) {
-				$out .= '<div class="nuclen-toc-content">';
+			$out .= '<div class="nuclen-toc-content">';
 		}
 
-			$out .= $this->view->build_toggle_button( $show, $hidden, $atts, $nav_id );
-			$out .= $this->view->build_nav_markup( $heads, $list, $atts, $nav_id, $toc_title, $hidden );
+		$out .= $this->view->build_toggle_button( $show, $hidden, $atts, $nav_id );
+		$out .= $this->view->build_nav_markup( $heads, $list, $atts, $nav_id, $toc_title, $hidden );
 
 		if ( ! empty( $atts['sticky'] ) ) {
-				$out .= '</div>';
+			$out .= '</div>';
 		}
 
-			$out .= '</section></div>';
+		$out .= '</section></div>';
 
 		if ( ! wp_script_is( 'nuclen-toc-front', 'enqueued' ) ) {
-				wp_enqueue_script( 'nuclen-toc-front' );
+			wp_enqueue_script( 'nuclen-toc-front' );
 		}
 
-			return $out;
+		return $out;
 	}
 }


### PR DESCRIPTION
## Summary
- fix mixed indentation styles in `Nuclen_TOC_Assets` and `Nuclen_TOC_Render`
- normalize line endings

## Testing
- `phpunit --version` *(fails: command not found)*
- `composer lint` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685a2e4aec2883278c608608dbd72169