### PR TITLE
Refactor SettingsRepository into traits

### DIFF
--- a/nuclear-engagement/includes/class-settings-cache-trait.php
+++ b/nuclear-engagement/includes/class-settings-cache-trait.php
@@ -1,0 +1,64 @@
+<?php
+/**
+ * File: includes/class-settings-cache-trait.php
+ *
+ * Provides cache management helpers for SettingsRepository.
+ *
+ * @package NuclearEngagement
+ * @subpackage Traits
+ * @since 1.0.0
+ */
+
+declare( strict_types = 1 );
+
+namespace NuclearEngagement;
+
+// If this file is called directly, abort.
+if ( ! defined( 'ABSPATH' ) ) {
+    exit;
+}
+
+trait SettingsCacheTrait {
+    /**
+     * Invalidate the settings cache.
+     *
+     * @since 1.0.0
+     */
+    public function invalidate_cache(): void {
+        $this->cache->invalidate_cache();
+    }
+
+    /**
+     * Handle option updates to invalidate cache.
+     *
+     * @since 1.0.0
+     *
+     * @param string $option    The option name being updated.
+     * @param mixed  $old_value The old option value.
+     * @param mixed  $value     The new option value.
+     */
+    public function maybe_invalidate_cache( $option, $old_value, $value ): void {
+        unset( $old_value, $value );
+        $this->cache->maybe_invalidate_cache( $option );
+    }
+
+    /**
+     * Handle option deletion to invalidate cache.
+     *
+     * @since 1.0.0
+     *
+     * @param string $option The option name being deleted.
+     */
+    public function maybe_invalidate_cache_on_delete( $option ): void {
+        $this->cache->maybe_invalidate_cache( $option );
+    }
+
+    /**
+     * Clear all cached data (for testing).
+     *
+     * @since 1.0.0
+     */
+    public function clear_cache(): void {
+        $this->cache->clear();
+    }
+}

--- a/nuclear-engagement/includes/class-settings-getters-trait.php
+++ b/nuclear-engagement/includes/class-settings-getters-trait.php
@@ -1,0 +1,92 @@
+<?php
+/**
+ * File: includes/class-settings-getters-trait.php
+ *
+ * Provides getter helpers for SettingsRepository.
+ *
+ * @package NuclearEngagement
+ * @subpackage Traits
+ * @since 1.0.0
+ */
+
+declare( strict_types = 1 );
+
+namespace NuclearEngagement;
+
+// If this file is called directly, abort.
+if ( ! defined( 'ABSPATH' ) ) {
+    exit;
+}
+
+trait SettingsGettersTrait {
+    /**
+     * Get all settings with defaults merged in.
+     *
+     * @since 1.0.0
+     *
+     * @return array The complete settings array with defaults merged in.
+     */
+    public function all(): array {
+        $cached = $this->cache->get();
+        if ( null !== $cached ) {
+            return $cached;
+        }
+
+        // Not in cache, fetch from database.
+        $saved    = get_option( self::OPTION, array() );
+        $settings = wp_parse_args(
+            is_array( $saved ) ? $saved : array(),
+            $this->defaults
+        );
+
+        // Store in cache.
+        $this->cache->set( $settings );
+
+        return $settings;
+    }
+
+    /**
+     * Get all settings from database (bypasses cache).
+     *
+     * @since 1.0.0
+     *
+     * @return array The complete settings array.
+     */
+    public function get_all(): array {
+        return $this->all();
+    }
+
+    /**
+     * Get a specific setting by key.
+     *
+     * @since 1.0.0
+     *
+     * @param string $key      The setting key to retrieve.
+     * @param mixed  $fallback Optional. Fallback value if the setting doesn't exist.
+     * @return mixed The setting value, or fallback if not found.
+     */
+    public function get( string $key, $fallback = null ) {
+        $all   = $this->all();
+        $value = $all[ $key ] ?? $fallback;
+
+        // Allow filtering of individual settings.
+        if ( 1 === func_num_args() ) {
+            $value = apply_filters( "nuclen_setting_{$key}", $value, $key );
+        }
+
+        return $value;
+    }
+
+    /**
+     * Check if a setting exists.
+     *
+     * @since 1.0.0
+     *
+     * @param string $key The setting key to check.
+     * @return bool True if the setting exists, false otherwise.
+     */
+    public function has( string $key ): bool {
+        $all = $this->all();
+        return array_key_exists( $key, $all );
+    }
+}

--- a/nuclear-engagement/includes/class-settings-persistence-trait.php
+++ b/nuclear-engagement/includes/class-settings-persistence-trait.php
@@ -1,0 +1,81 @@
+<?php
+/**
+ * File: includes/class-settings-persistence-trait.php
+ *
+ * Handles saving logic for SettingsRepository.
+ *
+ * @package NuclearEngagement
+ * @subpackage Traits
+ * @since 1.0.0
+ */
+
+declare( strict_types = 1 );
+
+namespace NuclearEngagement;
+
+use NuclearEngagement\SettingsSanitizer;
+
+// If this file is called directly, abort.
+if ( ! defined( 'ABSPATH' ) ) {
+    exit;
+}
+
+trait SettingsPersistenceTrait {
+    /**
+     * Save pending settings to database.
+     *
+     * @since 1.0.0
+     *
+     * @return bool True if settings were saved, false otherwise.
+     */
+    public function save(): bool {
+        if ( empty( $this->pending ) ) {
+            return false;
+        }
+
+        $current   = $this->all();
+        $sanitized = SettingsSanitizer::sanitize_settings( $this->pending );
+        $merged    = wp_parse_args( $sanitized, $current );
+
+        // Clear pending settings.
+        $this->pending = array();
+
+        // Invalidate cache before save.
+        $this->invalidate_cache();
+
+        // Only update if settings have changed.
+        if ( $merged !== $current ) {
+            $autoload = $this->should_autoload( $merged );
+            $result   = update_option( self::OPTION, $merged, $autoload ? 'yes' : 'no' );
+
+            // Also update legacy option for backward compatibility.
+            if ( $result && false !== get_option( 'nuclear_engagement_setup' ) ) {
+                $legacy_data = array(
+                    'api_key'             => $merged['api_key'] ?? '',
+                    'connected'           => $merged['connected'] ?? false,
+                    'wp_app_pass_created' => $merged['wp_app_pass_created'] ?? false,
+                    'wp_app_pass_uuid'    => $merged['wp_app_pass_uuid'] ?? '',
+                    'plugin_password'     => $merged['plugin_password'] ?? '',
+                );
+                update_option( 'nuclear_engagement_setup', $legacy_data );
+            }
+
+            return $result;
+        }
+
+        return false;
+    }
+
+    /**
+     * Determine if settings should be autoloaded.
+     *
+     * @since 1.0.0
+     *
+     * @param array $settings The settings array to check.
+     * @return bool True if settings should be autoloaded, false otherwise.
+     */
+    private function should_autoload( array $settings ): bool {
+        $size = strlen( wp_json_encode( $settings ) );
+        return $size <= self::MAX_AUTOLOAD_SIZE;
+    }
+}

--- a/nuclear-engagement/includes/class-settings-repository.php
+++ b/nuclear-engagement/includes/class-settings-repository.php
@@ -117,212 +117,24 @@ final class SettingsRepository {
 		* ===================================================================
 		*/
 
-	/**
-	 * Get all settings with defaults merged in.
-	 *
-	 * @since 1.0.0
-	 *
-	 * @return array The complete settings array with defaults merged in.
-	 */
-	public function all(): array {
-		$cached = $this->cache->get();
-		if ( null !== $cached ) {
-			return $cached;
-		}
+use SettingsGettersTrait;
+use SettingsPersistenceTrait;
+use SettingsCacheTrait;
+use SettingsAccessTrait;
+use PendingSettingsTrait;
 
-		// Not in cache, fetch from database.
-		$saved    = get_option( self::OPTION, array() );
-		$settings = wp_parse_args(
-			is_array( $saved ) ? $saved : array(),
-			$this->defaults
-		);
-
-		// Store in cache.
-		$this->cache->set( $settings );
-
-		return $settings;
-	}
-
-	/**
-	 * Get all settings from database (bypasses cache).
-	 *
-	 * @since 1.0.0
-	 *
-	 * @return array The complete settings array.
-	 */
-	public function get_all(): array {
-		return $this->all();
-	}
-
-	/**
-	 * Get a specific setting by key.
-	 *
-	 * @since 1.0.0
-	 *
-	 * @param string $key    The setting key to retrieve.
-	 * @param mixed  $fallback Optional. Fallback value if the setting doesn't exist.
-	 * @return mixed The setting value, or fallback if not found.
-	 */
-	public function get( string $key, $fallback = null ) {
-		$all   = $this->all();
-		$value = $all[ $key ] ?? $fallback;
-
-		// Allow filtering of individual settings.
-		if ( 1 === func_num_args() ) {
-			$value = apply_filters( "nuclen_setting_{$key}", $value, $key );
-		}
-
-		return $value;
-	}
-
-	use SettingsAccessTrait;
-	use PendingSettingsTrait;
+        /**
+         * Get the default values.
+         *
+         * @since 1.0.0
+         *
+         * @return array The default settings values.
+         */
+        public function get_defaults(): array {
+                return $this->defaults;
+        }
 
 
-		/*
-		===================================================================
-		* SAVE/PERSISTENCE
-		* ===================================================================
-		*/
-
-	/**
-	 * Save pending settings to database.
-	 *
-	 * @since 1.0.0
-	 *
-	 * @return bool True if settings were saved, false otherwise.
-	 */
-	public function save(): bool {
-		if ( empty( $this->pending ) ) {
-			return false;
-		}
-
-		$current   = $this->all();
-		$sanitized = SettingsSanitizer::sanitize_settings( $this->pending );
-		$merged    = wp_parse_args( $sanitized, $current );
-
-		// Clear pending settings.
-		$this->pending = array();
-
-		// Invalidate cache before save.
-		$this->invalidate_cache();
-
-		// Only update if settings have changed.
-		if ( $merged !== $current ) {
-			$autoload = $this->should_autoload( $merged );
-			$result   = update_option( self::OPTION, $merged, $autoload ? 'yes' : 'no' );
-
-			// Also update legacy option for backward compatibility.
-			if ( $result && false !== get_option( 'nuclear_engagement_setup' ) ) {
-				$legacy_data = array(
-					'api_key'             => $merged['api_key'] ?? '',
-					'connected'           => $merged['connected'] ?? false,
-					'wp_app_pass_created' => $merged['wp_app_pass_created'] ?? false,
-					'wp_app_pass_uuid'    => $merged['wp_app_pass_uuid'] ?? '',
-					'plugin_password'     => $merged['plugin_password'] ?? '',
-				);
-				update_option( 'nuclear_engagement_setup', $legacy_data );
-			}
-
-			return $result;
-		}
-
-		return false;
-	}
-
-
-		/*
-		===================================================================
-		* CACHE MANAGEMENT
-		* ===================================================================
-		*/
-
-	/**
-	 * Invalidate the settings cache.
-	 *
-	 * @since 1.0.0
-	 */
-	public function invalidate_cache(): void {
-		$this->cache->invalidate_cache();
-	}
-
-	/**
-	 * Handle option updates to invalidate cache.
-	 *
-	 * @since 1.0.0
-	 *
-	 * @param string $option    The option name being updated.
-	 * @param mixed  $old_value The old option value.
-	 * @param mixed  $value  The new option value.
-	 */
-	public function maybe_invalidate_cache( $option, $old_value, $value ): void {
-			unset( $old_value, $value );
-			$this->cache->maybe_invalidate_cache( $option );
-	}
-
-	/**
-	 * Handle option deletion to invalidate cache.
-	 *
-	 * @since 1.0.0
-	 *
-	 * @param string $option The option name being deleted.
-	 */
-	public function maybe_invalidate_cache_on_delete( $option ): void {
-		$this->cache->maybe_invalidate_cache( $option );
-	}
-
-		/*
-		===================================================================
-		* HELPERS
-		* ===================================================================
-		*/
-
-	/**
-	 * Check if a setting exists.
-	 *
-	 * @since 1.0.0
-	 *
-	 * @param string $key The setting key to check.
-	 * @return bool True if the setting exists, false otherwise.
-	 */
-	public function has( string $key ): bool {
-		$all = $this->all();
-		return array_key_exists( $key, $all );
-	}
-
-
-	/**
-	 * Determine if settings should be autoloaded.
-	 *
-	 * @since 1.0.0
-	 *
-	 * @param array $settings The settings array to check.
-	 * @return bool True if settings should be autoloaded, false otherwise.
-	 */
-	private function should_autoload( array $settings ): bool {
-			$size = strlen( wp_json_encode( $settings ) );
-			return $size <= self::MAX_AUTOLOAD_SIZE;
-	}
-
-	/**
-	 * Get the default values.
-	 *
-	 * @since 1.0.0
-	 *
-	 * @return array The default settings values.
-	 */
-	public function get_defaults(): array {
-		return $this->defaults;
-	}
-
-	/**
-	 * Clear all cached data (for testing).
-	 *
-	 * @since 1.0.0
-	 */
-	public function clear_cache(): void {
-		$this->cache->clear();
-	}
 
 	/**
 	 * Reset singleton instance (for testing).


### PR DESCRIPTION
## Summary
- break `SettingsRepository` responsibilities into small traits
- implement `SettingsGettersTrait`, `SettingsPersistenceTrait`, and `SettingsCacheTrait`
- update `SettingsRepository` to compose these traits

## Testing
- `phpcs` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685a3634f5508327a8e5a82b5f8cd33e

<!-- Korbit AI PR Description Start -->
## Description by Korbit AI

### What change is being made?
Refactor the `SettingsRepository` class by extracting its functionality into separate traits for cache management, getters, and persistence, and then incorporate these traits back into the class for modularization.

### Why are these changes being made?
This refactor improves code organization and maintainability by leveraging traits to separate concerns, allowing each aspect of the `SettingsRepository` class to be clearly defined and easily reusable. This modular approach not only enhances readability but also simplifies future extensions and testing efforts.

> Is this description stale? Ask me to generate a new description by commenting `/korbit-generate-pr-description`
<!-- Korbit AI PR Description End -->