### PR TITLE
Batch polling for auto generation

### DIFF
--- a/docs/hooks.md
+++ b/docs/hooks.md
@@ -10,7 +10,7 @@ into two groups: **actions** (events you can run code on) and
 | Hook | Parameters | Usage |
 | --- | --- | --- |
 | `nuclen_start_generation` | `int $post_id`, `string $workflow_type` | Fired by WP‑Cron to kick off generation of a quiz or summary for a post. You can hook in to log or modify the process before content is generated. |
-| `nuclen_poll_generation` | `string $generation_id`, `string $workflow_type`, `int $post_id`, `int $attempt` | Runs on a schedule to poll the Nuclear Engagement API for generation results. Useful for monitoring or altering the polling behaviour. |
+| `nuclen_poll_generation` | `string $generation_id`, `string $workflow_type`, `array $post_ids`, `int $attempt` | Runs on a schedule to poll the Nuclear Engagement API for generation results. Useful for monitoring or altering the polling behaviour. |
 | `wp_ajax_nuclen_trigger_generation` | `$_POST` data | AJAX endpoint to start manual generation from the admin. |
 | `wp_ajax_nuclen_fetch_app_updates` | `$_POST` data | Retrieves generation progress updates via AJAX. |
 | `wp_ajax_nuclen_get_posts_count` | `$_POST` data | Returns the number of posts that match the current bulk generate filters. |


### PR DESCRIPTION
## Summary
- batch queued posts before sending to API
- poll multiple posts per generation
- document updated poll generation hook
- adapt tests for batching

## Testing
- `composer lint` *(fails: command not found)*
- `composer test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685a378556948327873c7cc51534a64f

<!-- Korbit AI PR Description Start -->
## Description by Korbit AI

### What change is being made?

Implement batch polling for auto-generation by modifying the `nuclen_poll_generation` hook to handle multiple post IDs and introducing a queue system to process posts in batches.

### Why are these changes being made?

This change improves the efficiency of auto-generation by processing posts in batches instead of individually, reducing the number of API calls and potentially decreasing overall processing time. It addresses scalability issues by batching operations, which will allow the system to handle a higher volume of posts more efficiently.

> Is this description stale? Ask me to generate a new description by commenting `/korbit-generate-pr-description`
<!-- Korbit AI PR Description End -->