### PR TITLE
Implement debounced inventory cache

### DIFF
--- a/tests/InventoryCacheTest.php
+++ b/tests/InventoryCacheTest.php
@@ -1,0 +1,53 @@
+<?php
+use PHPUnit\Framework\TestCase;
+use NuclearEngagement\InventoryCache;
+
+// ----------------------------------------------
+// WordPress cache stubs
+// ----------------------------------------------
+
+$GLOBALS['wp_cache'] = [];
+$GLOBALS['flush_count'] = 0;
+
+if ( ! function_exists( 'wp_cache_get' ) ) {
+    function wp_cache_get( $key, $group = '', $force = false, &$found = null ) {
+        $found = isset( $GLOBALS['wp_cache'][ $group ][ $key ] );
+        return $GLOBALS['wp_cache'][ $group ][ $key ] ?? false;
+    }
+}
+if ( ! function_exists( 'wp_cache_set' ) ) {
+    function wp_cache_set( $key, $value, $group = '', $ttl = 0 ) {
+        $GLOBALS['wp_cache'][ $group ][ $key ] = $value;
+    }
+}
+if ( ! function_exists( 'wp_cache_delete' ) ) {
+    function wp_cache_delete( $key, $group = '' ) {
+        $GLOBALS['flush_count']++;
+        unset( $GLOBALS['wp_cache'][ $group ][ $key ] );
+    }
+}
+if ( ! function_exists( 'wp_cache_flush_group' ) ) {
+    function wp_cache_flush_group( $group ) {
+        unset( $GLOBALS['wp_cache'][ $group ] );
+    }
+}
+
+class InventoryCacheTest extends TestCase {
+    protected function setUp(): void {
+        global $wp_cache, $flush_count;
+        $wp_cache = [];
+        $flush_count = 0;
+    }
+
+    public function test_clear_is_debounced() {
+        InventoryCache::clear();
+        $this->assertSame( 1, $GLOBALS['flush_count'] );
+
+        InventoryCache::clear();
+        $this->assertSame( 1, $GLOBALS['flush_count'] );
+
+        usleep( ( InventoryCache::CLEAR_DEBOUNCE + 1 ) * 1000000 );
+        InventoryCache::clear();
+        $this->assertSame( 2, $GLOBALS['flush_count'] );
+    }
+}


### PR DESCRIPTION
## Summary
- debounce cache clearing in `InventoryCache` to avoid repeated flushes
- add unit test for debounce logic

## Testing
- `composer lint` *(fails: command not found)*
- `composer test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685a37884ad88327aa1339cd904ab9b1

<!-- Korbit AI PR Description Start -->
## Description by Korbit AI

### What change is being made?
Implement a debounced mechanism for the inventory cache clear operation to minimize redundant cache clear calls within a short timeframe.

### Why are these changes being made?
The changes optimize the cache clear operation by introducing a debounce feature that prevents multiple cache clears from occurring within two seconds. This helps improve performance by reducing unnecessary cache operations, especially in scenarios where posts are frequently updated. The accompanying tests ensure that the debouncing logic functions correctly.

> Is this description stale? Ask me to generate a new description by commenting `/korbit-generate-pr-description`
<!-- Korbit AI PR Description End -->