### PR TITLE
Add buffered logging option

### DIFF
--- a/nuclear-engagement/includes/constants.php
+++ b/nuclear-engagement/includes/constants.php
@@ -16,6 +16,9 @@ if ( ! defined( 'ABSPATH' ) ) {
 /** Maximum log file size in bytes. */
 define( 'NUCLEN_LOG_FILE_MAX_SIZE', MB_IN_BYTES );
 
+/** Enable buffered logging. */
+define( 'NUCLEN_BUFFER_LOGS', true );
+
 /** Timeout for API requests in seconds. */
 define( 'NUCLEN_API_TIMEOUT', 30 );
 


### PR DESCRIPTION
## Summary
- add `NUCLEN_BUFFER_LOGS` constant and filter to enable buffering
- buffer log messages and flush on shutdown
- write log messages in batches
- test buffered behaviour

## Testing
- `composer lint` *(fails: command not found)*
- `composer test` *(fails: command not found)*
- `phpunit` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685a378714ec832793b3ed2ccff66499