### PR TITLE
Add fallback autoloader

### DIFF
--- a/nuclear-engagement/bootstrap.php
+++ b/nuclear-engagement/bootstrap.php
@@ -30,9 +30,23 @@ if ( ! file_exists( $autoload ) ) {
 	$autoload = dirname( __DIR__ ) . '/vendor/autoload.php';
 }
 if ( file_exists( $autoload ) ) {
-	require_once $autoload;
+        require_once $autoload;
 } else {
-	error_log( 'Nuclear Engagement: vendor autoload not found.' );
+        error_log( 'Nuclear Engagement: vendor autoload not found.' );
+        spl_autoload_register(
+                static function ( $class ) {
+                        $prefix = 'NuclearEngagement\\';
+                        if ( strpos( $class, $prefix ) !== 0 ) {
+                                return;
+                        }
+
+                        $relative = str_replace( '\\', '/', substr( $class, strlen( $prefix ) ) );
+                        $path     = NUCLEN_PLUGIN_DIR . $relative . '.php';
+                        if ( file_exists( $path ) ) {
+                                require_once $path;
+                        }
+                }
+        );
 }
 if ( file_exists( NUCLEN_PLUGIN_DIR . 'includes/constants.php' ) ) {
 	require_once NUCLEN_PLUGIN_DIR . 'includes/constants.php';


### PR DESCRIPTION
## Summary
- fallback to an internal PSR-4 autoloader when vendor dependencies are missing

## Testing
- `composer lint` *(fails: command not found)*
- `composer test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685a552921c083278df3fc9e8cce2f0c