### PR TITLE
Add fallback autoloader

### DIFF
--- a/nuclear-engagement/bootstrap.php
+++ b/nuclear-engagement/bootstrap.php
@@ -30,9 +30,23 @@ if ( ! file_exists( $autoload ) ) {
 	$autoload = dirname( __DIR__ ) . '/vendor/autoload.php';
 }
 if ( file_exists( $autoload ) ) {
-	require_once $autoload;
+        require_once $autoload;
 } else {
-	error_log( 'Nuclear Engagement: vendor autoload not found.' );
+        error_log( 'Nuclear Engagement: vendor autoload not found.' );
+        spl_autoload_register(
+                static function ( $class ) {
+                        $prefix = 'NuclearEngagement\\';
+                        if ( strpos( $class, $prefix ) !== 0 ) {
+                                return;
+                        }
+
+                        $relative = str_replace( '\\', '/', substr( $class, strlen( $prefix ) ) );
+                        $path     = NUCLEN_PLUGIN_DIR . $relative . '.php';
+                        if ( file_exists( $path ) ) {
+                                require_once $path;
+                        }
+                }
+        );
 }
 if ( file_exists( NUCLEN_PLUGIN_DIR . 'includes/constants.php' ) ) {
 	require_once NUCLEN_PLUGIN_DIR . 'includes/constants.php';


### PR DESCRIPTION
## Summary
- fallback to an internal PSR-4 autoloader when vendor dependencies are missing

## Testing
- `composer lint` *(fails: command not found)*
- `composer test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685a552921c083278df3fc9e8cce2f0c

<!-- Korbit AI PR Description Start -->
## Description by Korbit AI

### What change is being made?

Add a fallback autoloader to ensure classes are autoloaded even if the vendor autoload.php is not found.

### Why are these changes being made?

This change addresses the issue where the vendor autoload.php might be missing, which previously resulted in a logged error but no further action. By adding a fallback autoloader, it ensures that classes prefixed with "NuclearEngagement" can still be loaded from the project's directory, improving resilience and maintainability of the application.

> Is this description stale? Ask me to generate a new description by commenting `/korbit-generate-pr-description`
<!-- Korbit AI PR Description End -->