### PR TITLE
Add Container tests

### DIFF
--- a/tests/ContainerTest.php
+++ b/tests/ContainerTest.php
@@ -1,0 +1,42 @@
+<?php
+use PHPUnit\Framework\TestCase;
+use NuclearEngagement\Container;
+
+class ContainerTest extends TestCase {
+    protected function setUp(): void {
+        Container::getInstance()->reset();
+    }
+
+    public function test_singleton_returns_same_instance(): void {
+        $a = Container::getInstance();
+        $b = Container::getInstance();
+        $this->assertSame($a, $b);
+    }
+
+    public function test_register_and_get_service(): void {
+        $container = Container::getInstance();
+        $obj = new stdClass();
+        $container->register('foo', static function () use ($obj) {
+            return $obj;
+        });
+        $this->assertTrue($container->has('foo'));
+        $this->assertSame($obj, $container->get('foo'));
+    }
+
+    public function test_get_throws_for_unknown_service(): void {
+        $this->expectException(\RuntimeException::class);
+        Container::getInstance()->get('missing');
+    }
+
+    public function test_reset_clears_registered_services(): void {
+        $c = Container::getInstance();
+        $c->register('foo', static function () {
+            return new stdClass();
+        });
+        $c->get('foo');
+        $c->reset();
+        $this->assertFalse($c->has('foo'));
+        $this->expectException(\RuntimeException::class);
+        $c->get('foo');
+    }
+}


### PR DESCRIPTION
## Summary
- add a new PHPUnit test suite for the dependency injection container

## Testing
- `composer lint` *(fails: command not found)*
- `composer test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685a556ae8a88327bb0f0a30a81c1211


> [!NOTE]
> I'm currently writing a description for your pull request. I should be done shortly (<1 minute). Please don't edit the description field until I'm finished, or we may overwrite each other. If I find nothing to write about, I'll delete this message.
