### PR TITLE
Fix early translation loading warning

### DIFF
--- a/nuclear-engagement/bootstrap.php
+++ b/nuclear-engagement/bootstrap.php
@@ -16,11 +16,15 @@ if ( ! defined( 'ABSPATH' ) ) {
 define( 'NUCLEN_PLUGIN_DIR', plugin_dir_path( NUCLEN_PLUGIN_FILE ) );
 
 if ( ! defined( 'NUCLEN_PLUGIN_VERSION' ) ) {
-	if ( ! function_exists( 'get_plugin_data' ) ) {
-		require_once ABSPATH . 'wp-admin/includes/plugin.php';
-	}
-	$data = get_plugin_data( NUCLEN_PLUGIN_FILE );
-	define( 'NUCLEN_PLUGIN_VERSION', $data['Version'] );
+        if ( ! function_exists( 'get_file_data' ) ) {
+                require_once ABSPATH . 'wp-includes/functions.php';
+        }
+        $data = get_file_data(
+                NUCLEN_PLUGIN_FILE,
+                array( 'Version' => 'Version' ),
+                'plugin'
+        );
+        define( 'NUCLEN_PLUGIN_VERSION', $data['Version'] );
 }
 
 define( 'NUCLEN_ASSET_VERSION', '250624-1' );


### PR DESCRIPTION
## Summary
- use `get_file_data` instead of `get_plugin_data` to avoid loading translations before `init`

## Testing
- `composer lint` *(fails: command not found)*
- `composer test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685a551d1ce083279a9317edb4e5ac69


> [!NOTE]
> I'm currently writing a description for your pull request. I should be done shortly (<1 minute). Please don't edit the description field until I'm finished, or we may overwrite each other. If I find nothing to write about, I'll delete this message.
