### PR TITLE
Handle custom CSS directory failure

### DIFF
--- a/nuclear-engagement/admin/trait-settings-custom-css.php
+++ b/nuclear-engagement/admin/trait-settings-custom-css.php
@@ -123,9 +123,13 @@ trait SettingsPageCustomCSSTrait {
 }
 CSS;
 
-		$css_info        = \NuclearEngagement\Utils::nuclen_get_custom_css_info();
-		$custom_dir      = $css_info['dir'];
-		$custom_css_path = $css_info['path'];
+                $css_info = \NuclearEngagement\Utils::nuclen_get_custom_css_info();
+                if ( empty( $css_info ) ) {
+                        \NuclearEngagement\Services\LoggingService::notify_admin( __( 'Could not create custom CSS directory.', 'nuclear-engagement' ) );
+                        return;
+                }
+                $custom_dir      = $css_info['dir'];
+                $custom_css_path = $css_info['path'];
 
 		if ( ! function_exists( 'WP_Filesystem' ) ) {
 			require_once ABSPATH . 'wp-admin/includes/file.php';

--- a/nuclear-engagement/front/traits/AssetsTrait.php
+++ b/nuclear-engagement/front/traits/AssetsTrait.php
@@ -32,18 +32,18 @@ trait AssetsTrait {
 	private function get_theme_assets( string $theme_choice ): array {
 		$default = 'bright';
 
-		if ( $theme_choice === 'custom' ) {
-			$css_info = \NuclearEngagement\Utils::nuclen_get_custom_css_info();
-			if ( empty( $css_info['url'] ) ) {
-				error_log( 'Invalid custom CSS info - falling back to bright theme' );
-				$theme_choice = $default;
-			} else {
-				return array(
-					'url'     => $css_info['url'],
-					'version' => get_option( 'nuclen_custom_css_version', AssetVersions::get( 'theme_bright_css' ) ),
-				);
-			}
-		}
+                if ( $theme_choice === 'custom' ) {
+                        $css_info = \NuclearEngagement\Utils::nuclen_get_custom_css_info();
+                        if ( empty( $css_info ) || empty( $css_info['url'] ) ) {
+                                \NuclearEngagement\Services\LoggingService::log( 'Invalid custom CSS info - falling back to bright theme' );
+                                $theme_choice = $default;
+                        } else {
+                                return array(
+                                        'url'     => $css_info['url'],
+                                        'version' => get_option( 'nuclen_custom_css_version', AssetVersions::get( 'theme_bright_css' ) ),
+                                );
+                        }
+                }
 
 		$themes      = ThemeRegistry::get_themes();
 		$theme       = isset( $themes[ $theme_choice ] ) ? $theme_choice : $default;

--- a/nuclear-engagement/includes/class-utils.php
+++ b/nuclear-engagement/includes/class-utils.php
@@ -50,7 +50,10 @@ class Utils {
         $custom_dir = $upload_dir['basedir'] . '/nuclear-engagement';
 
         if ( ! file_exists( $custom_dir ) ) {
-            wp_mkdir_p( $custom_dir );
+            if ( ! wp_mkdir_p( $custom_dir ) ) {
+                \NuclearEngagement\Services\LoggingService::log( 'Failed creating custom CSS directory: ' . $custom_dir );
+                return array();
+            }
         }
 
         $base_css_file_name = 'nuclen-theme-custom.css';

--- a/nuclear-engagement/uninstall.php
+++ b/nuclear-engagement/uninstall.php
@@ -74,11 +74,11 @@ if ( $delete_log ) {
 
 // Remove custom theme file if requested.
 if ( $delete_css ) {
-		$info = \NuclearEngagement\Utils::nuclen_get_custom_css_info();
-	if ( file_exists( $info['path'] ) ) {
-			wp_delete_file( $info['path'] );
-	}
-		delete_option( 'nuclen_custom_css_version' );
+                $info = \NuclearEngagement\Utils::nuclen_get_custom_css_info();
+        if ( ! empty( $info ) && file_exists( $info['path'] ) ) {
+                        wp_delete_file( $info['path'] );
+        }
+                delete_option( 'nuclen_custom_css_version' );
 }
 
 // Drop opt-in table only when the user opts to delete settings or generated

--- a/tests/UtilsTest.php
+++ b/tests/UtilsTest.php
@@ -10,10 +10,20 @@ namespace NuclearEngagement {
         ];
     }
     function wp_mkdir_p($dir) {
+        if (!empty($GLOBALS['ut_fail_mkdir'])) {
+            return false;
+        }
         return mkdir($dir, 0777, true);
     }
     function get_option($name, $default = '') {
         return $GLOBALS['ut_options'][$name] ?? $default;
+    }
+}
+
+namespace NuclearEngagement\Services {
+    class LoggingService {
+        public static array $logs = [];
+        public static function log(string $msg): void { self::$logs[] = $msg; }
     }
 }
 
@@ -62,6 +72,14 @@ namespace {
             $GLOBALS['ut_options']['nuclen_custom_css_version'] = 'abc123';
             $info = Utils::nuclen_get_custom_css_info();
             $this->assertStringContainsString('?v=abc123', $info['url']);
+        }
+
+        public function test_returns_empty_array_on_directory_failure(): void {
+            $GLOBALS['ut_fail_mkdir'] = true;
+            $info = Utils::nuclen_get_custom_css_info();
+            $this->assertSame([], $info);
+            $this->assertNotEmpty(\NuclearEngagement\Services\LoggingService::$logs);
+            unset($GLOBALS['ut_fail_mkdir']);
         }
     }
 }


### PR DESCRIPTION
## Summary
- handle wp_mkdir_p failure in `nuclen_get_custom_css_info`
- show an admin notice when CSS directory can't be created
- fall back when custom CSS info is empty in assets
- guard uninstall when CSS info is missing
- update unit tests for new behavior

## Testing
- `composer lint` *(fails: command not found)*
- `composer test` *(fails: command not found)*


------
https://chatgpt.com/codex/tasks/task_e_685a56da4e0c83278119979d655ec5d1