### PR TITLE
Fix TOC utilities import warning

### DIFF
--- a/nuclear-engagement/modules/toc/includes/class-nuclen-toc-headings.php
+++ b/nuclear-engagement/modules/toc/includes/class-nuclen-toc-headings.php
@@ -11,8 +11,6 @@ if ( ! defined( 'ABSPATH' ) ) {
 	exit;
 }
 
-use function nuclen_str_contains;
-
 /**
  * Adds unique IDs to headings within post content.
  */

--- a/nuclear-engagement/modules/toc/includes/class-nuclen-toc-utils.php
+++ b/nuclear-engagement/modules/toc/includes/class-nuclen-toc-utils.php
@@ -16,8 +16,6 @@ if ( ! defined( 'ABSPATH' ) ) {
 	exit;
 }
 
-use function nuclen_str_contains;
-
 /**
  * Utility helpers for TOC parsing and slug generation.
  */


### PR DESCRIPTION
## Summary
- remove `use function nuclen_str_contains` statements from TOC utilities

## Testing
- `composer lint` *(fails: command not found)*
- `composer test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685a57b0d7788327b48c6859a4dd2192