### PR TITLE
Handle wp_update_post errors in metaboxes

### DIFF
--- a/nuclear-engagement/admin/trait-admin-metabox-quiz.php
+++ b/nuclear-engagement/admin/trait-admin-metabox-quiz.php
@@ -184,14 +184,20 @@ trait Admin_Quiz_Metabox {
 			remove_action( 'save_post', array( $this, 'nuclen_save_quiz_data_meta' ), 10 );
 			remove_action( 'save_post', array( $this, 'nuclen_save_summary_data_meta' ), 10 );
 
-			$time = current_time( 'mysql' );
-			wp_update_post(
-				array(
-					'ID'                => $post_id,
-					'post_modified'     => $time,
-					'post_modified_gmt' => get_gmt_from_date( $time ),
-				)
-			);
+                        $time   = current_time( 'mysql' );
+                        $result = wp_update_post(
+                                array(
+                                        'ID'                => $post_id,
+                                        'post_modified'     => $time,
+                                        'post_modified_gmt' => get_gmt_from_date( $time ),
+                                ),
+                                true
+                        );
+
+                        if ( is_wp_error( $result ) ) {
+                                \NuclearEngagement\Services\LoggingService::log( 'Failed to update modified time for post ' . $post_id . ': ' . $result->get_error_message() );
+                                \NuclearEngagement\Services\LoggingService::notify_admin( 'Failed to update modified time for post ' . $post_id . ': ' . $result->get_error_message() );
+                        }
 
 			add_action( 'save_post', array( $this, 'nuclen_save_quiz_data_meta' ), 10, 1 );
 			add_action( 'save_post', array( $this, 'nuclen_save_summary_data_meta' ), 10, 1 );

--- a/nuclear-engagement/admin/trait-admin-metabox-summary.php
+++ b/nuclear-engagement/admin/trait-admin-metabox-summary.php
@@ -137,14 +137,20 @@ trait Admin_Summary_Metabox {
 			remove_action( 'save_post', array( $this, 'nuclen_save_quiz_data_meta' ), 10 );
 			remove_action( 'save_post', array( $this, 'nuclen_save_summary_data_meta' ), 10 );
 
-			$time = current_time( 'mysql' );
-			wp_update_post(
-				array(
-					'ID'                => $post_id,
-					'post_modified'     => $time,
-					'post_modified_gmt' => get_gmt_from_date( $time ),
-				)
-			);
+                        $time   = current_time( 'mysql' );
+                        $result = wp_update_post(
+                                array(
+                                        'ID'                => $post_id,
+                                        'post_modified'     => $time,
+                                        'post_modified_gmt' => get_gmt_from_date( $time ),
+                                ),
+                                true
+                        );
+
+                        if ( is_wp_error( $result ) ) {
+                                \NuclearEngagement\Services\LoggingService::log( 'Failed to update modified time for post ' . $post_id . ': ' . $result->get_error_message() );
+                                \NuclearEngagement\Services\LoggingService::notify_admin( 'Failed to update modified time for post ' . $post_id . ': ' . $result->get_error_message() );
+                        }
 
 			add_action( 'save_post', array( $this, 'nuclen_save_quiz_data_meta' ), 10, 1 );
 			add_action( 'save_post', array( $this, 'nuclen_save_summary_data_meta' ), 10, 1 );

--- a/tests/MetaboxUpdateErrorTest.php
+++ b/tests/MetaboxUpdateErrorTest.php
@@ -1,0 +1,75 @@
+<?php
+use PHPUnit\Framework\TestCase;
+
+namespace NuclearEngagement\Admin {
+    function wp_verify_nonce($nonce, $action) { return true; }
+    function current_user_can($cap, $id) { return true; }
+    function wp_unslash($val) { return $val; }
+    function sanitize_text_field($val) { return $val; }
+    function wp_kses_post($val) { return $val; }
+    function update_post_meta($id, $key, $value) {}
+    function delete_post_meta($id, $key) {}
+    function clean_post_cache($id) {}
+    function remove_action(...$args) {}
+    function add_action(...$args) {}
+    function get_gmt_from_date($time) { return $time; }
+    function wp_update_post(array $data, $error = false) { return $GLOBALS['mb_result']; }
+}
+
+namespace NuclearEngagement\Services {
+    class LoggingService {
+        public static array $logs = [];
+        public static array $notices = [];
+        public static function log(string $msg): void { self::$logs[] = $msg; }
+        public static function notify_admin(string $msg): void { self::$notices[] = $msg; }
+    }
+}
+
+namespace {
+    require_once dirname(__DIR__) . '/nuclear-engagement/admin/trait-admin-metabox-quiz.php';
+    require_once dirname(__DIR__) . '/nuclear-engagement/admin/trait-admin-metabox-summary.php';
+
+    class DummyRepo {
+        public function get($key, $default = 0) { return 1; }
+    }
+
+    class QuizBox {
+        use \NuclearEngagement\Admin\Admin_Quiz_Metabox;
+        public function nuclen_get_settings_repository() { return new DummyRepo(); }
+    }
+
+    class SummaryBox {
+        use \NuclearEngagement\Admin\Admin_Summary_Metabox;
+        public function nuclen_get_settings_repository() { return new DummyRepo(); }
+    }
+
+    class MetaboxUpdateErrorTest extends TestCase {
+        protected function setUp(): void {
+            $_POST = [
+                'nuclen_quiz_data_nonce' => 'n',
+                'nuclen_quiz_data' => [],
+                'nuclen_summary_data_nonce' => 'n',
+                'nuclen_summary_data' => [],
+            ];
+            $GLOBALS['mb_result'] = new \WP_Error();
+            \NuclearEngagement\Services\LoggingService::$logs = [];
+            \NuclearEngagement\Services\LoggingService::$notices = [];
+        }
+
+        public function test_quiz_update_error_logs_and_notifies(): void {
+            $box = new QuizBox();
+            $box->nuclen_save_quiz_data_meta(1);
+            $expected = ['Failed to update modified time for post 1: error'];
+            $this->assertSame($expected, \NuclearEngagement\Services\LoggingService::$logs);
+            $this->assertSame($expected, \NuclearEngagement\Services\LoggingService::$notices);
+        }
+
+        public function test_summary_update_error_logs_and_notifies(): void {
+            $box = new SummaryBox();
+            $box->nuclen_save_summary_data_meta(2);
+            $expected = ['Failed to update modified time for post 2: error'];
+            $this->assertSame($expected, \NuclearEngagement\Services\LoggingService::$logs);
+            $this->assertSame($expected, \NuclearEngagement\Services\LoggingService::$notices);
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- capture wp_update_post() return values
- log and show admin notice on WP_Error
- add regression tests for metabox error handling

## Testing
- `composer lint` *(fails: command not found)*
- `composer test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685a56d661208327a0b7ec145db641c5

<!-- Korbit AI PR Description Start -->
## Description by Korbit AI

### What change is being made?

Handle errors from `wp_update_post` in quiz and summary metaboxes by logging errors and notifying administrators, and add related PHPUnit tests.

### Why are these changes being made?

These changes enhance error-handling measures for post data updates, ensuring errors are captured, logged, and administrators are notified, thereby improving the robustness and reliability of the application. The addition of automated tests verifies that the logging and notification functionalities work as expected.

> Is this description stale? Ask me to generate a new description by commenting `/korbit-generate-pr-description`
<!-- Korbit AI PR Description End -->