### PR TITLE
Fix autoloader for service classes

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -3,6 +3,9 @@
   },
   "autoload": {
     "psr-4": {
+      "NuclearEngagement\\Services\\": "nuclear-engagement/includes/Services/",
+      "NuclearEngagement\\Requests\\": "nuclear-engagement/includes/Requests/",
+      "NuclearEngagement\\Responses\\": "nuclear-engagement/includes/Responses/",
       "NuclearEngagement\\": "nuclear-engagement/"
     }
   },

--- a/nuclear-engagement/bootstrap.php
+++ b/nuclear-engagement/bootstrap.php
@@ -58,8 +58,13 @@ spl_autoload_register(
                                 $path  = NUCLEN_PLUGIN_DIR . 'includes/' . $snake;
                         }
                 } else {
-                        $dir  = strtolower( array_shift( $parts ) );
-                        $path = NUCLEN_PLUGIN_DIR . $dir . '/' . implode( '/', $parts ) . '.php';
+                        $dir = strtolower( array_shift( $parts ) );
+
+                        if ( in_array( $dir, array( 'services', 'requests', 'responses' ), true ) ) {
+                                $path = NUCLEN_PLUGIN_DIR . 'includes/' . ucfirst( $dir ) . '/' . implode( '/', $parts ) . '.php';
+                        } else {
+                                $path = NUCLEN_PLUGIN_DIR . $dir . '/' . implode( '/', $parts ) . '.php';
+                        }
                 }
 
                 if ( file_exists( $path ) ) {


### PR DESCRIPTION
## Summary
- adjust autoloader paths for Services, Requests, and Responses
- add explicit PSR-4 mappings for those folders

## Testing
- `composer dump-autoload` *(fails: composer not found)*
- `composer lint` *(fails: composer not found)*
- `composer test` *(fails: composer not found)*

------
https://chatgpt.com/codex/tasks/task_e_685a57995714832795591609ff269ade