### PR TITLE
Handle log rotation failures

### DIFF
--- a/nuclear-engagement/includes/Services/LoggingService.php
+++ b/nuclear-engagement/includes/Services/LoggingService.php
@@ -153,7 +153,12 @@ class LoggingService {
 
                 if ( file_exists( $log_file ) && filesize( $log_file ) > $max_size ) {
                         $timestamped = $log_folder . '/log-' . gmdate( 'Y-m-d-His' ) . '.txt';
-                        @rename( $log_file, $timestamped );
+                        $renamed     = rename( $log_file, $timestamped );
+                        if ( ! $renamed ) {
+                                foreach ( $messages as $msg ) {
+                                        self::fallback( $msg, 'Failed to rotate log file: ' . $timestamped );
+                                }
+                        }
                 }
 
                 $data = '';


### PR DESCRIPTION
## Summary
- log rotation captures `rename()` result
- use fallback when rotation fails
- test log rotation failure

## Testing
- `composer lint`
- `composer test`


------
https://chatgpt.com/codex/tasks/task_e_685a56d1cf5483278604f3de25b2543c