### PR TITLE
Fix invalid class constant expression

### DIFF
--- a/nuclear-engagement/includes/Services/GenerationService.php
+++ b/nuclear-engagement/includes/Services/GenerationService.php
@@ -24,8 +24,8 @@ if ( ! defined( 'ABSPATH' ) ) {
  * Service for handling content generation
  */
 class GenerationService {
-	/** Seconds to wait between polling events. */
-	public const POLL_DELAY = defined( 'NUCLEN_GENERATION_POLL_DELAY' ) ? NUCLEN_GENERATION_POLL_DELAY : 30;
+    /** Seconds to wait between polling events. */
+    public const POLL_DELAY = NUCLEN_GENERATION_POLL_DELAY;
 	/**
 	 * @var SettingsRepository
 	 */


### PR DESCRIPTION
## Summary
- fix constant expression error in `GenerationService`

## Testing
- `composer lint` *(fails: command not found)*
- `composer test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685a5d383b2c8327824e24e731db4df7

<!-- Korbit AI PR Description Start -->
## Description by Korbit AI

### What change is being made?

Correct the definition of the class constant `POLL_DELAY` in `GenerationService.php` by removing the conditional expression and directly assigning `NUCLEN_GENERATION_POLL_DELAY`.

### Why are these changes being made?

The conditional expression in the class constant definition was invalid, as constants must be initialized with a fixed value or another constant. Removing the condition simplifies the code and ensures the constant is always correctly initialized, assuming `NUCLEN_GENERATION_POLL_DELAY` is defined elsewhere in the codebase.

> Is this description stale? Ask me to generate a new description by commenting `/korbit-generate-pr-description`
<!-- Korbit AI PR Description End -->