### PR TITLE
Implement custom password auth

### DIFF
--- a/nuclear-engagement/README.txt
+++ b/nuclear-engagement/README.txt
@@ -133,7 +133,7 @@ I'm also looking forward to get feature requests and suggestions. Help me make N
 2. Create a **free account** on the [Nuclear Engagement app](https://app.nuclearengagement.com/signup?ref=wp_listing&link=nuclear_engagement_app)
 3. On the NE app, create a **Gold Code** (API key used for authentication)
 4. On the plugin's **setup page**, enter the Gold Code (to connect your site to the NE app)
-5. A WordPress application password is generated automatically, completing setup (to allow the NE app to send data to your site)
+5. A plugin password is generated automatically, completing setup (used for secure communication with the NE app)
 6. Done! You are ready to generate engaging content.
 
 [youtube https://www.youtube.com/watch?v=NJBjsCSEj34]

--- a/nuclear-engagement/admin/trait-admin-menu.php
+++ b/nuclear-engagement/admin/trait-admin-menu.php
@@ -77,16 +77,16 @@ trait Admin_Menu {
 		$connected           = $settings_repo->get( 'connected', false );
 		$wp_app_pass_created = $settings_repo->get( 'wp_app_pass_created', false );
 
-		// Block access unless the API key **and** WP App Password are present.
-		if ( ! $connected || ! $wp_app_pass_created ) {
-			echo '<div class="notice notice-warning"><p>'
-				. esc_html__(
-					'Please finish the plugin setup (Step 1: API key and Step 2: WP App Password) before generating content. Go to the Setup page to complete the configuration.',
-					'nuclear-engagement'
-				)
-				. '</p></div>';
-			return;
-		}
+               // Block access unless the API key **and** plugin password are present.
+               if ( ! $connected || ! $wp_app_pass_created ) {
+                       echo '<div class="notice notice-warning"><p>'
+                               . esc_html__(
+                                       'Please finish the plugin setup (Step 1: API key and Step 2: plugin password) before generating content. Go to the Setup page to complete the configuration.',
+                                       'nuclear-engagement'
+                               )
+                               . '</p></div>';
+                       return;
+               }
 
 		include plugin_dir_path( __FILE__ ) . 'partials/nuclen-admin-generate.php';
 	}

--- a/nuclear-engagement/includes/ContainerRegistrar.php
+++ b/nuclear-engagement/includes/ContainerRegistrar.php
@@ -68,7 +68,13 @@ final class ContainerRegistrar {
 		$container->register( 'updates_controller', static fn( $c ) => new UpdatesController( $c->get( 'remote_api' ), $c->get( 'content_storage' ) ) );
 		$container->register( 'pointer_controller', static fn( $c ) => new PointerController( $c->get( 'pointer_service' ) ) );
 		$container->register( 'posts_count_controller', static fn( $c ) => new PostsCountController( $c->get( 'posts_query_service' ) ) );
-		$container->register( 'content_controller', static fn( $c ) => new ContentController( $c->get( 'content_storage' ) ) );
+                $container->register(
+                        'content_controller',
+                        static fn( $c ) => new ContentController(
+                                $c->get( 'content_storage' ),
+                                $c->get( 'settings' )
+                        )
+                );
 		$container->register( 'optin_export_controller', static fn() => new OptinExportController() );
 	}
 }

--- a/nuclear-engagement/includes/Services/RemoteApiService.php
+++ b/nuclear-engagement/includes/Services/RemoteApiService.php
@@ -257,11 +257,11 @@ class RemoteApiService {
 			}
 
 			if ( 'invalid_wp_app_pass' === $error_code ) {
-				return array(
-					'error'       => 'Invalid WP App Password. Please re-generate on the Setup page.',
-					'error_code'  => 'invalid_wp_app_pass',
-					'status_code' => $code,
-				);
+                               return array(
+                                       'error'       => 'Invalid plugin password. Please re-generate on the Setup page.',
+                                       'error_code'  => 'invalid_wp_app_pass',
+                                       'status_code' => $code,
+                               );
 			}
 		}
 
@@ -273,17 +273,17 @@ class RemoteApiService {
 			);
 		}
 
-		if ( false !== strpos( $body, 'invalid_wp_app_pass' ) ) {
-			return array(
-				'error'       => 'Invalid WP App Password. Please re-generate on the Setup page.',
-				'error_code'  => 'invalid_wp_app_pass',
-				'status_code' => $code,
-			);
-		}
+                if ( false !== strpos( $body, 'invalid_wp_app_pass' ) ) {
+                        return array(
+                                'error'       => 'Invalid plugin password. Please re-generate on the Setup page.',
+                                'error_code'  => 'invalid_wp_app_pass',
+                                'status_code' => $code,
+                        );
+                }
 
-		return array(
-			'error'       => 'Authentication error (API key or WP App Password may be invalid).',
-			'status_code' => $code,
-		);
+                return array(
+                        'error'       => 'Authentication error (API key or plugin password may be invalid).',
+                        'status_code' => $code,
+                );
 	}
 }


### PR DESCRIPTION
## Summary
- add SettingsRepository to REST ContentController
- accept custom `X-WP-App-Password` header for authentication
- fall back to admin nonce if present
- document the generated password in README
- refine password checks and messages

## Testing
- `composer lint` *(fails: command not found)*
- `composer test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685a5def8d9c83278be80e267ac999fe

<!-- Korbit AI PR Description Start -->
## Description by Korbit AI

### What change is being made?

Implement custom password authentication by replacing the use of the WordPress application password with a plugin-generated password for secure communication with the Nuclear Engagement app.

### Why are these changes being made?

These changes are made to enhance the security and alignment of authentication processes by using a plugin-specific password for communication with the Nuclear Engagement app instead of relying on WordPress's default application password. This change ensures that authentication is managed directly within the nuclear-engagement plugin's environment, allowing for better control and improved security practices.

> Is this description stale? Ask me to generate a new description by commenting `/korbit-generate-pr-description`
<!-- Korbit AI PR Description End -->