### PR TITLE
Improve error handling across plugin

### DIFF
--- a/nuclear-engagement/includes/OptinData.php
+++ b/nuclear-engagement/includes/OptinData.php
@@ -206,14 +206,23 @@ class OptinData {
 		header( 'Content-Type: text/csv; charset=utf-8' );
 		header( 'Content-Disposition: attachment; filename=nuclen_optins_' . gmdate( 'Y-m-d' ) . '.csv' );
 
-		$out = fopen( 'php://output', 'w' );
-		fputcsv( $out, array( 'datetime', 'url', 'name', 'email' ) );   // headings
+                $out = fopen( 'php://output', 'w' );
+                if ( false === $out ) {
+                        LoggingService::log( 'Failed to open output stream for CSV export' );
+                        wp_die( __( 'Unable to generate export.', 'nuclear-engagement' ), 500 );
+                }
+
+                if ( false === fputcsv( $out, array( 'datetime', 'url', 'name', 'email' ) ) ) { // headings
+                        LoggingService::log( 'Failed writing CSV header' );
+                }
 		foreach ( $rows as $r ) {
 				// Prevent formula injection when opened in spreadsheet apps.
 				$r['name']  = self::escape_csv_field( $r['name'] );
 				$r['email'] = self::escape_csv_field( $r['email'] );
 				$r['url']   = self::escape_csv_field( $r['url'] );
-				fputcsv( $out, $r );
+                                if ( false === fputcsv( $out, $r ) ) {
+                                        LoggingService::log( 'Failed writing CSV row' );
+                                }
 		}
 		fclose( $out );
 		exit;

--- a/nuclear-engagement/includes/Services/PostsQueryService.php
+++ b/nuclear-engagement/includes/Services/PostsQueryService.php
@@ -11,6 +11,7 @@ declare(strict_types=1);
 namespace NuclearEngagement\Services;
 
 use NuclearEngagement\Requests\PostsCountRequest;
+use NuclearEngagement\Services\LoggingService;
 
 if ( ! defined( 'ABSPATH' ) ) {
 	exit;
@@ -130,6 +131,10 @@ class PostsQueryService {
 
                $post_ids = $wpdb->get_col( "SELECT p.ID $sql" );
                $count    = (int) $wpdb->get_var( "SELECT COUNT(*) $sql" );
+
+               if ( $wpdb->last_error ) {
+                       LoggingService::log( 'Posts query error: ' . $wpdb->last_error );
+               }
 
                return array(
                        'count'    => $count,

--- a/nuclear-engagement/includes/Services/SetupService.php
+++ b/nuclear-engagement/includes/Services/SetupService.php
@@ -127,12 +127,20 @@ class SetupService {
 			)
 		);
 
-		if ( is_wp_error( $response ) ) {
-			\NuclearEngagement\Services\LoggingService::log( 'Error sending creds: ' . $response->get_error_message() );
-			return false;
-		}
+                if ( is_wp_error( $response ) ) {
+                        \NuclearEngagement\Services\LoggingService::log( 'Error sending creds: ' . $response->get_error_message() );
+                        return false;
+                }
 
-		\NuclearEngagement\Services\LoggingService::debug( 'Send creds response: ' . wp_remote_retrieve_body( $response ) );
-		return wp_remote_retrieve_response_code( $response ) === 200;
-	}
+                $code = wp_remote_retrieve_response_code( $response );
+                $body = wp_remote_retrieve_body( $response );
+                \NuclearEngagement\Services\LoggingService::debug( 'Send creds response: ' . $body );
+
+                if ( 200 !== $code ) {
+                        \NuclearEngagement\Services\LoggingService::log( 'Unexpected creds response code: ' . $code . ', body: ' . $body );
+                        return false;
+                }
+
+                return true;
+        }
 }

--- a/tests/SetupServiceTest.php
+++ b/tests/SetupServiceTest.php
@@ -14,6 +14,9 @@ namespace NuclearEngagement\Services {
     function wp_remote_retrieve_response_code($res) {
         return is_array($res) ? ($res['code'] ?? 0) : 0;
     }
+    function wp_remote_retrieve_body($res) {
+        return is_array($res) ? ($res['body'] ?? '') : '';
+    }
     function wp_json_encode($data) { return json_encode($data); }
 }
 
@@ -58,6 +61,16 @@ namespace {
             $data = ['appApiKey' => 'key', 'user' => 'u'];
             $this->assertFalse($svc->send_app_password($data));
             $this->assertSame(['Error sending creds: error'], LoggingService::$logs);
+        }
+
+        public function test_send_app_password_http_error_logs_error(): void {
+            $GLOBALS['ss_response'] = ['code' => 400, 'body' => 'bad'];
+            $svc = new SetupService();
+            $data = ['appApiKey' => 'key', 'user' => 'u'];
+            $this->assertFalse($svc->send_app_password($data));
+            $this->assertSame([
+                'Unexpected creds response code: 400, body: bad'
+            ], LoggingService::$logs);
         }
     }
 }


### PR DESCRIPTION
## Summary
- log failures in the quiz opt‑in helpers
- validate CSV stream operations when exporting
- log DB errors from `PostsQueryService`
- detect non‑200 codes when sending credentials
- cover new behaviour in `SetupServiceTest`

## Testing
- `npm run build` *(fails: vite not found)*
- `composer lint` *(fails: command not found)*
- `composer test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685a5e108ea88327b546a1667d7bf491