### PR TITLE
Fix missing trait loader

### DIFF
--- a/nuclear-engagement/front/FrontClass.php
+++ b/nuclear-engagement/front/FrontClass.php
@@ -18,8 +18,12 @@ declare(strict_types=1);
 namespace NuclearEngagement\Front;
 
 if ( ! defined( 'ABSPATH' ) ) {
-	exit;
+        exit;
 }
+
+require_once __DIR__ . '/traits/AssetsTrait.php';
+require_once __DIR__ . '/traits/RestTrait.php';
+require_once __DIR__ . '/traits/ShortcodesTrait.php';
 
 use NuclearEngagement\Utils;
 use NuclearEngagement\SettingsRepository;


### PR DESCRIPTION
## Summary
- ensure FrontClass explicitly loads asset-related traits

## Testing
- `composer lint` *(fails: command not found)*
- `composer test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685a6454aefc83278a631cb1088971c0


> [!NOTE]
> I'm currently writing a description for your pull request. I should be done shortly (<1 minute). Please don't edit the description field until I'm finished, or we may overwrite each other. If I find nothing to write about, I'll delete this message.
