### PR TITLE
Fix constant initialization

### DIFF
--- a/nuclear-engagement/includes/Services/AutoGenerationService.php
+++ b/nuclear-engagement/includes/Services/AutoGenerationService.php
@@ -32,20 +32,20 @@ class AutoGenerationService {
         /** Option name storing the queued post IDs. */
         private const QUEUE_OPTION = 'nuclen_autogen_queue';
 
-	/** Number of seconds before the first poll runs. */
-	public const INITIAL_POLL_DELAY = NUCLEN_INITIAL_POLL_DELAY;
+        /** Number of seconds before the first poll runs. */
+        public const INITIAL_POLL_DELAY = 15;
 
-	/** Maximum number of API polling attempts. */
-	public const MAX_ATTEMPTS = NUCLEN_MAX_POLL_ATTEMPTS;
+        /** Maximum number of API polling attempts. */
+        public const MAX_ATTEMPTS = 10;
 
-	/** Delay in seconds between poll attempts. */
-	public const RETRY_DELAY = NUCLEN_POLL_RETRY_DELAY;
+        /** Delay in seconds between poll attempts. */
+        public const RETRY_DELAY = 60;
 
-	/** Default length used when summarizing posts. */
-	public const SUMMARY_LENGTH = NUCLEN_SUMMARY_LENGTH_DEFAULT;
+        /** Default length used when summarizing posts. */
+        public const SUMMARY_LENGTH = 30;
 
-	/** Default number of items in auto summaries. */
-	public const SUMMARY_ITEMS = NUCLEN_SUMMARY_ITEMS_DEFAULT;
+        /** Default number of items in auto summaries. */
+        public const SUMMARY_ITEMS = 3;
 	/**
 	 * @var SettingsRepository
 	 */


### PR DESCRIPTION
## Summary
- avoid compile errors by reading `NUCLEN_GENERATION_POLL_DELAY` at runtime
- inline default configuration values for autogeneration service

## Testing
- `composer lint` *(fails: command not found)*
- `composer test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685a6561e16c8327938e158234900e78

<!-- Korbit AI PR Description Start -->
## Description by Korbit AI

### What change is being made?

Replace dynamic constant references with explicit values for configuration parameters in `AutoGenerationService.php`, and adjust poll delay handling using a `private int` in `GenerationService.php` with conditional logic.

### Why are these changes being made?

To eliminate reliance on potentially undefined constants and ensure configuration parameters have meaningful default values, improving code robustness and readability. This approach avoids runtime errors due to undefined constants and allows easy management of default values.

> Is this description stale? Ask me to generate a new description by commenting `/korbit-generate-pr-description`
<!-- Korbit AI PR Description End -->