### PR TITLE
Handle invalid JSON in ContentController

### DIFF
--- a/nuclear-engagement/front/Controller/Rest/ContentController.php
+++ b/nuclear-engagement/front/Controller/Rest/ContentController.php
@@ -65,14 +65,23 @@ class ContentController {
 
                         $data = $request->get_json_params();
 
-			\NuclearEngagement\Services\LoggingService::log(
-				'Received content via REST: ' . json_encode(
-					array(
-						'workflow'      => $data['workflow'] ?? 'unknown',
-						'results_count' => is_array( $data['results'] ?? null ) ? count( $data['results'] ) : 0,
-					)
-				)
-			);
+                        if ( ! is_array( $data ) ) {
+                                \NuclearEngagement\Services\LoggingService::log( 'Invalid JSON received in REST request' );
+                                return new \WP_Error(
+                                        'ne_invalid_json',
+                                        __( 'Invalid JSON', 'nuclear-engagement' ),
+                                        array( 'status' => 400 )
+                                );
+                        }
+
+                        \NuclearEngagement\Services\LoggingService::log(
+                                'Received content via REST: ' . json_encode(
+                                        array(
+                                                'workflow'      => $data['workflow'] ?? 'unknown',
+                                                'results_count' => is_array( $data['results'] ?? null ) ? count( $data['results'] ) : 0,
+                                        )
+                                )
+                        );
 
 			$contentRequest = ContentRequest::fromJson( $data );
 

--- a/tests/ContentControllerTest.php
+++ b/tests/ContentControllerTest.php
@@ -1,0 +1,43 @@
+<?php
+use PHPUnit\Framework\TestCase;
+use NuclearEngagement\Front\Controller\Rest\ContentController;
+use NuclearEngagement\SettingsRepository;
+use NuclearEngagement\Services\ContentStorageService;
+
+namespace NuclearEngagement\Services {
+    class LoggingService {
+        public static array $logs = [];
+        public static function log(string $msg): void {
+            self::$logs[] = $msg;
+        }
+    }
+}
+
+namespace {
+    class DummyRequest {
+        public function get_json_params() {
+            return null;
+        }
+    }
+
+    class ContentControllerTest extends TestCase {
+        protected function setUp(): void {
+            global $wp_options, $wp_autoload, $wp_posts, $wp_meta;
+            $wp_options = $wp_autoload = $wp_posts = $wp_meta = [];
+            SettingsRepository::reset_for_tests();
+            \NuclearEngagement\Services\LoggingService::$logs = [];
+        }
+
+        public function test_handle_invalid_json_returns_error(): void {
+            $settings = SettingsRepository::get_instance();
+            $storage = new ContentStorageService($settings);
+            $controller = new ContentController($storage, $settings);
+            $req = new DummyRequest();
+
+            $res = $controller->handle($req);
+
+            $this->assertInstanceOf(WP_Error::class, $res);
+            $this->assertNotEmpty(\NuclearEngagement\Services\LoggingService::$logs);
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- guard ContentController against invalid JSON
- add tests ensuring invalid JSON returns a 400 error

## Testing
- `composer lint` *(fails: command not found)*
- `composer test` *(fails: command not found)*


------
https://chatgpt.com/codex/tasks/task_e_685a66b9b0908327966248a0c4f05fca


> [!NOTE]
> I'm currently writing a description for your pull request. I should be done shortly (<1 minute). Please don't edit the description field until I'm finished, or we may overwrite each other. If I find nothing to write about, I'll delete this message.
