### PR TITLE
Ensure plugin cron hooks cleared on deactivation

### DIFF
--- a/nuclear-engagement/includes/Deactivator.php
+++ b/nuclear-engagement/includes/Deactivator.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 namespace NuclearEngagement;
 
 use NuclearEngagement\SettingsRepository;
+use NuclearEngagement\Services\AutoGenerationService;
 
 if ( ! defined( 'ABSPATH' ) ) {
 	exit;
@@ -36,9 +37,17 @@ class Deactivator {
 	 * @since 0.3.1
 	 * @param SettingsRepository|null $settings Optional settings repository instance
 	 */
-	public static function nuclen_deactivate( ?SettingsRepository $settings = null ) {
-		// Clear any scheduled hooks or transients if needed
-		delete_transient( 'nuclen_plugin_activation_redirect' );
+        public static function nuclen_deactivate( ?SettingsRepository $settings = null ) {
+                // Clear scheduled cron hooks
+                wp_clear_scheduled_hook( AutoGenerationService::START_HOOK );
+                wp_clear_scheduled_hook( AutoGenerationService::QUEUE_HOOK );
+                wp_clear_scheduled_hook( 'nuclen_poll_generation' );
+
+                // Remove any pending generation records
+                delete_option( 'nuclen_active_generations' );
+
+                // Clear any scheduled hooks or transients if needed
+                delete_transient( 'nuclen_plugin_activation_redirect' );
 
 		// If settings instance is provided, perform any necessary cleanup
 		if ( $settings !== null ) {


### PR DESCRIPTION
## Summary
- deactivate scheduler hooks when disabling plugin
- drop `nuclen_active_generations` option on deactivation

## Testing
- `composer lint` *(fails: command not found)*
- `composer test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685a66fa92a883279fdf9f43722b7b83


> [!NOTE]
> I'm currently writing a description for your pull request. I should be done shortly (<1 minute). Please don't edit the description field until I'm finished, or we may overwrite each other. If I find nothing to write about, I'll delete this message.
