### PR TITLE
Add dev workflow docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,3 +65,4 @@ npm run dev
 - [Translation Guide](docs/TRANSLATION.md)
 - [Hooks Reference](docs/hooks.md)
 - [CI Guidelines](docs/CI_GUIDELINES.md)
+- [Development Workflow](docs/DEV_WORKFLOW.md)

--- a/docs/DEV_WORKFLOW.md
+++ b/docs/DEV_WORKFLOW.md
@@ -1,0 +1,63 @@
+# Development Workflow
+
+This guide shows how to run and debug the plugin locally using `wp-env` and Docker.
+
+## Quick start
+
+1. Install dependencies:
+   ```bash
+   composer install
+   npm install
+   ```
+
+2. Start WordPress with the plugin:
+   ```bash
+   npx wp-env start --xdebug
+   ```
+   The environment mounts your working directory so changes take effect immediately.
+
+3. Access WordPress at `http://localhost:8888` and log in with the default credentials provided by `wp-env`.
+
+## Fast-loop debugging
+
+Use these commands as needed while the environment is running:
+
+- **View PHP errors live**
+  ```bash
+  npx wp-env run cli tail -f /var/www/html/wp-content/debug.log
+  ```
+- **Trigger plugin hooks from the command line**
+  ```bash
+  npx wp-env run cli wp eval 'do_action("your_hook");'
+  ```
+- **Inspect queries and REST calls**
+  ```bash
+  npx wp-env run cli wp plugin install query-monitor --activate
+  ```
+  Then reload the page and use the admin bar to view debugging information.
+
+## Running tests
+
+After starting the environment, run PHPUnit from the repository root:
+
+```bash
+composer test
+```
+
+You can also run static analysis (optional):
+
+```bash
+composer require --dev phpstan/phpstan-deprecation
+vendor/bin/phpstan analyse
+```
+
+## Typical workflow
+
+```bash
+wp-env destroy && wp-env start --xdebug
+# set breakpoints in your IDE mapped to /var/www/html
+# visit the admin page that triggers plugin code
+# tail debug.log in another terminal
+```
+
+This loop lets you step through the plugin, inspect variables, and iterate quickly.


### PR DESCRIPTION
## Summary
- add documentation for local development workflow
- link to the new doc from README

## Testing
- `composer lint` *(fails: composer not found)*
- `composer test` *(fails: composer not found)*

------
https://chatgpt.com/codex/tasks/task_e_685a6e035c488327b74f20c6a547db0b

<!-- Korbit AI PR Description Start -->
## Description by Korbit AI

### What change is being made?

Add new documentation for the development workflow to the repository, and link it from the README.md file.

### Why are these changes being made?

This documentation provides clear instructions and tools for developers on how to set up, run, and debug the plugin using `wp-env` and Docker, ensuring that they can efficiently test and iterate on code changes. This addition aims to streamline the development process and improve the onboarding experience for new contributors by providing a structured guide.

> Is this description stale? Ask me to generate a new description by commenting `/korbit-generate-pr-description`
<!-- Korbit AI PR Description End -->