### PR TITLE
Log custom CSS write failures

### DIFF
--- a/nuclear-engagement/admin/trait-settings-custom-css.php
+++ b/nuclear-engagement/admin/trait-settings-custom-css.php
@@ -139,44 +139,54 @@ CSS;
 
 		/* create dir if needed, then write */
 		if ( is_object( $wp_filesystem ) ) {
-			if ( ! $wp_filesystem->exists( $custom_dir ) && ! wp_mkdir_p( $custom_dir ) ) {
-				echo '<div class="notice notice-error"><p>' .
-					esc_html__( 'Could not create custom CSS directory.', 'nuclear-engagement' ) .
-					'</p></div>';
-				return;
-			}
-			if ( ! $wp_filesystem->is_writable( $custom_dir ) ) {
-				echo '<div class="notice notice-error"><p>' .
-					esc_html__( 'Custom CSS directory not writable.', 'nuclear-engagement' ) .
-					'</p></div>';
-				return;
-			}
-			if ( $wp_filesystem->put_contents( $custom_css_path, $css ) !== false ) {
-				// Update the version hash when the file is successfully saved
-				$file_mtime = time();
-				$file_hash  = md5( $css );
-				$version    = $file_mtime . '-' . substr( $file_hash, 0, 8 );
-				update_option( 'nuclen_custom_css_version', $version );
-			}
+                       if ( ! $wp_filesystem->exists( $custom_dir ) && ! wp_mkdir_p( $custom_dir ) ) {
+                               echo '<div class="notice notice-error"><p>' .
+                                       esc_html__( 'Could not create custom CSS directory.', 'nuclear-engagement' ) .
+                                       '</p></div>';
+                               \NuclearEngagement\Services\LoggingService::log( 'Failed to create custom CSS directory: ' . $custom_dir );
+                               return;
+                       }
+                       if ( ! $wp_filesystem->is_writable( $custom_dir ) ) {
+                               echo '<div class="notice notice-error"><p>' .
+                                       esc_html__( 'Custom CSS directory not writable.', 'nuclear-engagement' ) .
+                                       '</p></div>';
+                               \NuclearEngagement\Services\LoggingService::log( 'Custom CSS directory not writable: ' . $custom_dir );
+                               return;
+                       }
+                       if ( $wp_filesystem->put_contents( $custom_css_path, $css ) !== false ) {
+                               // Update the version hash when the file is successfully saved
+                               $file_mtime = time();
+                               $file_hash  = md5( $css );
+                               $version    = $file_mtime . '-' . substr( $file_hash, 0, 8 );
+                               update_option( 'nuclen_custom_css_version', $version );
+                       } else {
+                               echo '<div class="notice notice-error"><p>' .
+                                       esc_html__( 'Could not write custom CSS file.', 'nuclear-engagement' ) .
+                                       '</p></div>';
+                               \NuclearEngagement\Services\LoggingService::log( 'Failed to write custom CSS file: ' . $custom_css_path );
+                       }
 		} else {
-			/* fallback */
-			if ( ! file_exists( $custom_dir ) && ! wp_mkdir_p( $custom_dir ) ) {
-				echo '<div class="notice notice-error"><p>' .
-					esc_html__( 'Could not create custom CSS directory.', 'nuclear-engagement' ) .
-					'</p></div>';
-				return;
-			}
-			if ( false !== @file_put_contents( $custom_css_path, $css, LOCK_EX ) ) {
-				// Update the version hash when the file is successfully saved (fallback)
-				$file_mtime = time();
-				$file_hash  = md5( $css );
-				$version    = $file_mtime . '-' . substr( $file_hash, 0, 8 );
-				update_option( 'nuclen_custom_css_version', $version );
-			} else {
-				echo '<div class="notice notice-error"><p>' .
-					esc_html__( 'Could not write custom CSS file.', 'nuclear-engagement' ) .
-					'</p></div>';
-			}
+                       /* fallback */
+                       if ( ! file_exists( $custom_dir ) && ! wp_mkdir_p( $custom_dir ) ) {
+                               echo '<div class="notice notice-error"><p>' .
+                                       esc_html__( 'Could not create custom CSS directory.', 'nuclear-engagement' ) .
+                                       '</p></div>';
+                               \NuclearEngagement\Services\LoggingService::log( 'Failed to create custom CSS directory: ' . $custom_dir );
+                               return;
+                       }
+                       $result = file_put_contents( $custom_css_path, $css, LOCK_EX );
+                       if ( false !== $result ) {
+                               // Update the version hash when the file is successfully saved (fallback)
+                               $file_mtime = time();
+                               $file_hash  = md5( $css );
+                               $version    = $file_mtime . '-' . substr( $file_hash, 0, 8 );
+                               update_option( 'nuclen_custom_css_version', $version );
+                       } else {
+                               echo '<div class="notice notice-error"><p>' .
+                                       esc_html__( 'Could not write custom CSS file.', 'nuclear-engagement' ) .
+                                       '</p></div>';
+                               \NuclearEngagement\Services\LoggingService::log( 'Failed to write custom CSS file: ' . $custom_css_path );
+                       }
 		}
 	}
 }


### PR DESCRIPTION
## Summary
- log when custom CSS directory creation or file writes fail
- remove silenced `file_put_contents` and log failures

## Testing
- `composer lint` *(fails: command not found)*
- `composer test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685a700e23548327bdf290a42891885c

<!-- Korbit AI PR Description Start -->
## Description by Korbit AI

### What change is being made?

Add logging functionality for failures related to creating directories and writing custom CSS files in the `nuclen_write_custom_css` method.

### Why are these changes being made?

These changes are being made to enhance debugging and traceability by capturing detailed logs for potential errors when creating directories or writing CSS files, allowing developers to better understand failure points and take corrective actions. This approach improves the maintainability and reliability of the codebase by using the `LoggingService`.

> Is this description stale? Ask me to generate a new description by commenting `/korbit-generate-pr-description`
<!-- Korbit AI PR Description End -->