### PR TITLE
Replace error_log with LoggingService

### DIFF
--- a/nuclear-engagement/bootstrap.php
+++ b/nuclear-engagement/bootstrap.php
@@ -37,7 +37,7 @@ if ( ! file_exists( $autoload ) ) {
 if ( file_exists( $autoload ) ) {
         require_once $autoload;
 } else {
-        error_log( 'Nuclear Engagement: vendor autoload not found.' );
+        \NuclearEngagement\Services\LoggingService::log( 'Nuclear Engagement: vendor autoload not found.' );
 }
 
 // Register plugin autoloader for internal classes.
@@ -105,7 +105,7 @@ spl_autoload_register(
 if ( file_exists( NUCLEN_PLUGIN_DIR . 'includes/constants.php' ) ) {
     require_once NUCLEN_PLUGIN_DIR . 'includes/constants.php';
 } else {
-    error_log( 'Nuclear Engagement: constants.php missing.' );
+    \NuclearEngagement\Services\LoggingService::log( 'Nuclear Engagement: constants.php missing.' );
 }
 
 AssetVersions::init();
@@ -220,7 +220,7 @@ function nuclear_engagement_init() {
     try {
         InventoryCache::register_hooks();
     } catch ( \Throwable $e ) {
-        error_log( 'Nuclear Engagement: Cache registration failed - ' . $e->getMessage() );
+        \NuclearEngagement\Services\LoggingService::log( 'Nuclear Engagement: Cache registration failed - ' . $e->getMessage() );
         add_action(
             'admin_notices',
             static function () {

--- a/nuclear-engagement/includes/Blocks.php
+++ b/nuclear-engagement/includes/Blocks.php
@@ -13,15 +13,15 @@ if ( ! defined( 'ABSPATH' ) ) {
  */
 final class Blocks {
 	public static function register(): void {
-		if ( ! function_exists( 'register_block_type' ) ) {
-			error_log( 'Nuclear Engagement: block registration unavailable.' );
-			return;
-		}
+                if ( ! function_exists( 'register_block_type' ) ) {
+                        \NuclearEngagement\Services\LoggingService::log( 'Nuclear Engagement: block registration unavailable.' );
+                        return;
+                }
 
-		if ( ! wp_script_is( 'nuclen-admin', 'registered' ) ) {
-			error_log( 'Nuclear Engagement: nuclen-admin script missing.' );
-			return;
-		}
+                if ( ! wp_script_is( 'nuclen-admin', 'registered' ) ) {
+                        \NuclearEngagement\Services\LoggingService::log( 'Nuclear Engagement: nuclen-admin script missing.' );
+                        return;
+                }
 
 		register_block_type(
 			'nuclear-engagement/quiz',


### PR DESCRIPTION
## Summary
- log failures in plugin via `LoggingService::log`

## Testing
- `composer lint` *(fails: command not found)*
- `composer test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685a700c87108327bce2ef1eae0991c6


> [!NOTE]
> I'm currently writing a description for your pull request. I should be done shortly (<1 minute). Please don't edit the description field until I'm finished, or we may overwrite each other. If I find nothing to write about, I'll delete this message.
