### PR TITLE
Handle wp_schedule_single_event failures

### DIFF
--- a/nuclear-engagement/admin/trait-admin-autogenerate.php
+++ b/nuclear-engagement/admin/trait-admin-autogenerate.php
@@ -132,13 +132,18 @@ trait Admin_AutoGenerate {
 		}
 
 		// Schedule next poll if not at max attempts
-		if ( $attempt < $max_attempts ) {
-			wp_schedule_single_event(
-				time() + $retry_delay,
-				'nuclen_poll_generation',
-				array( $generation_id, $workflow_type, $post_id, $attempt + 1 )
-			);
-		} else {
+                if ( $attempt < $max_attempts ) {
+                        $scheduled = wp_schedule_single_event(
+                                time() + $retry_delay,
+                                'nuclen_poll_generation',
+                                array( $generation_id, $workflow_type, $post_id, $attempt + 1 )
+                        );
+                        if ( false === $scheduled ) {
+                                \NuclearEngagement\Services\LoggingService::log(
+                                        'Failed to schedule event nuclen_poll_generation for generation ' . $generation_id
+                                );
+                        }
+                } else {
 			\NuclearEngagement\Services\LoggingService::log(
 				"Polling aborted after {$max_attempts} attempts for post {$post_id} ({$workflow_type})"
 			);

--- a/nuclear-engagement/includes/Services/AutoGenerationService.php
+++ b/nuclear-engagement/includes/Services/AutoGenerationService.php
@@ -144,7 +144,12 @@ class AutoGenerationService {
             update_option( self::QUEUE_OPTION, $queue, 'no' );
         }
         if ( ! wp_next_scheduled( self::QUEUE_HOOK ) ) {
-            wp_schedule_single_event( time(), self::QUEUE_HOOK, array() );
+            $scheduled = wp_schedule_single_event( time(), self::QUEUE_HOOK, array() );
+            if ( false === $scheduled ) {
+                \NuclearEngagement\Services\LoggingService::log(
+                    'Failed to schedule event ' . self::QUEUE_HOOK
+                );
+            }
         }
     }
 
@@ -226,7 +231,12 @@ class AutoGenerationService {
                 );
 
                 update_option( 'nuclen_active_generations', $generations, 'no' );
-                wp_schedule_single_event( $next_poll, 'nuclen_poll_generation', array( $generation_id, $workflow_type, $batch, 1 ) );
+                $scheduled = wp_schedule_single_event( $next_poll, 'nuclen_poll_generation', array( $generation_id, $workflow_type, $batch, 1 ) );
+                if ( false === $scheduled ) {
+                    \NuclearEngagement\Services\LoggingService::log(
+                        'Failed to schedule event nuclen_poll_generation for generation ' . $generation_id
+                    );
+                }
             }
 
             $queue[ $workflow_type ] = $ids;
@@ -242,7 +252,12 @@ class AutoGenerationService {
             delete_option( self::QUEUE_OPTION );
         } else {
             update_option( self::QUEUE_OPTION, $queue, 'no' );
-            wp_schedule_single_event( time() + 1, self::QUEUE_HOOK, array() );
+            $scheduled = wp_schedule_single_event( time() + 1, self::QUEUE_HOOK, array() );
+            if ( false === $scheduled ) {
+                \NuclearEngagement\Services\LoggingService::log(
+                    'Failed to schedule event ' . self::QUEUE_HOOK
+                );
+            }
         }
     }
 

--- a/nuclear-engagement/includes/Services/GenerationPoller.php
+++ b/nuclear-engagement/includes/Services/GenerationPoller.php
@@ -110,12 +110,17 @@ class GenerationPoller {
 
                 if ( $attempt < $max_attempts ) {
                         $event_args = array( $generation_id, $workflow_type, $post_ids, $attempt + 1 );
-			wp_schedule_single_event(
-				time() + $retry_delay,
-				'nuclen_poll_generation',
-				$event_args
-			);
-		} else {
+                        $scheduled  = wp_schedule_single_event(
+                                time() + $retry_delay,
+                                'nuclen_poll_generation',
+                                $event_args
+                        );
+                        if ( false === $scheduled ) {
+                                \NuclearEngagement\Services\LoggingService::log(
+                                        'Failed to schedule event nuclen_poll_generation for generation ' . $generation_id
+                                );
+                        }
+                } else {
 			\NuclearEngagement\Services\LoggingService::log(
                                 "Polling aborted after {$max_attempts} attempts for generation {$generation_id}"
 			);

--- a/nuclear-engagement/includes/Services/GenerationService.php
+++ b/nuclear-engagement/includes/Services/GenerationService.php
@@ -164,14 +164,19 @@ class GenerationService {
 			}
 
 			// If no immediate results, schedule polling
-			if ( empty( $response->results ) ) {
-                                wp_schedule_single_event(
+                        if ( empty( $response->results ) ) {
+                                $scheduled = wp_schedule_single_event(
                                         time() + $this->pollDelay,
                                         'nuclen_poll_generation',
                                         array( $response->generationId, $workflowType, $postId, 1 )
                                 );
-				\NuclearEngagement\Services\LoggingService::log( "Scheduled polling for post {$postId}, generation {$response->generationId}" );
-			}
+                                if ( false === $scheduled ) {
+                                        \NuclearEngagement\Services\LoggingService::log(
+                                                'Failed to schedule event nuclen_poll_generation for generation ' . $response->generationId
+                                        );
+                                }
+                                \NuclearEngagement\Services\LoggingService::log( "Scheduled polling for post {$postId}, generation {$response->generationId}" );
+                        }
 		} catch ( \Exception $e ) {
 			\NuclearEngagement\Services\LoggingService::log( "Error generating {$workflowType} for post {$postId}: " . $e->getMessage() );
 			throw $e;

--- a/nuclear-engagement/includes/Services/PublishGenerationHandler.php
+++ b/nuclear-engagement/includes/Services/PublishGenerationHandler.php
@@ -76,9 +76,14 @@ class PublishGenerationHandler {
 			$protected = get_post_meta( $post->ID, 'nuclen_quiz_protected', true );
 			if ( ! $protected ) {
 				$args = array( $post->ID, 'quiz' );
-				if ( ! wp_next_scheduled( AutoGenerationService::START_HOOK, $args ) ) {
-					wp_schedule_single_event( time(), AutoGenerationService::START_HOOK, $args );
-				}
+                                if ( ! wp_next_scheduled( AutoGenerationService::START_HOOK, $args ) ) {
+                                        $scheduled = wp_schedule_single_event( time(), AutoGenerationService::START_HOOK, $args );
+                                        if ( false === $scheduled ) {
+                                                \NuclearEngagement\Services\LoggingService::log(
+                                                        'Failed to schedule event ' . AutoGenerationService::START_HOOK
+                                                );
+                                        }
+                                }
 			}
 		}
 
@@ -86,9 +91,14 @@ class PublishGenerationHandler {
 			$protected = get_post_meta( $post->ID, 'nuclen_summary_protected', true );
 			if ( ! $protected ) {
 				$args = array( $post->ID, 'summary' );
-				if ( ! wp_next_scheduled( AutoGenerationService::START_HOOK, $args ) ) {
-					wp_schedule_single_event( time(), AutoGenerationService::START_HOOK, $args );
-				}
+                                if ( ! wp_next_scheduled( AutoGenerationService::START_HOOK, $args ) ) {
+                                        $scheduled = wp_schedule_single_event( time(), AutoGenerationService::START_HOOK, $args );
+                                        if ( false === $scheduled ) {
+                                                \NuclearEngagement\Services\LoggingService::log(
+                                                        'Failed to schedule event ' . AutoGenerationService::START_HOOK
+                                                );
+                                        }
+                                }
 			}
 		}
 	}


### PR DESCRIPTION
## Summary
- log failures when cron events fail to schedule

## Testing
- `composer lint` *(fails: command not found)*
- `composer test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685a700fc5508327a198733dc8766823

<!-- Korbit AI PR Description Start -->
## Description by Korbit AI

### What change is being made?

Implement logging to capture and report failures related to `wp_schedule_single_event` function calls across various components to enhance the system's error tracking capabilities.

### Why are these changes being made?

Certain scheduling events can fail silently in the WordPress environment, leading to missed crucial operations without visibility into the failure. By logging these failures, we provide a mechanism for proactive troubleshooting and ensure that failures in scheduling can be investigated and resolved, thus maintaining the reliability and integrity of the automated tasks.

> Is this description stale? Ask me to generate a new description by commenting `/korbit-generate-pr-description`
<!-- Korbit AI PR Description End -->