### PR TITLE
Optimize GenerationService post queries

### DIFF
--- a/nuclear-engagement/includes/Services/GenerationService.php
+++ b/nuclear-engagement/includes/Services/GenerationService.php
@@ -192,11 +192,16 @@ class GenerationService {
 
         foreach ( array_chunk( $postIds, 50 ) as $chunk ) {
             $args = array(
-                'post__in'    => $chunk,
-                'numberposts' => -1,
-                'post_type'   => $postType,
-                'post_status' => $postStatus,
-                'orderby'     => 'post__in',
+                'post__in'               => $chunk,
+                'numberposts'            => -1,
+                'post_type'              => $postType,
+                'post_status'            => $postStatus,
+                'orderby'                => 'post__in',
+                // Disable caching for performance when bulk generating.
+                'update_post_meta_cache' => false,
+                'update_post_term_cache' => false,
+                'cache_results'          => false,
+                'no_found_rows'          => true,
             );
 
             $posts = get_posts( $args );


### PR DESCRIPTION
## Summary
- reduce caching overhead when querying posts for generation

## Testing
- `composer lint` *(fails: command not found)*
- `composer test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685a6fca7fd883279e632f36988b1513

<!-- Korbit AI PR Description Start -->
## Description by Korbit AI

### What change is being made?

Optimize the `getPostsData` method in the `GenerationService` by disabling caching and row count calculations for post queries.

### Why are these changes being made?

These changes target performance improvements for bulk post generation by reducing unnecessary caching and computation overhead, thus optimizing query executions for the service. This approach is beneficial when the primary goal is rapid data retrieval without the need for cached metadata, which is not going to be reused immediately.

> Is this description stale? Ask me to generate a new description by commenting `/korbit-generate-pr-description`
<!-- Korbit AI PR Description End -->