### PR TITLE
Fix posts query duplicates

### DIFF
--- a/nuclear-engagement/includes/Services/PostsQueryService.php
+++ b/nuclear-engagement/includes/Services/PostsQueryService.php
@@ -129,8 +129,8 @@ class PostsQueryService {
                        $sql .= ' WHERE ' . implode( ' AND ', $wheres );
                }
 
-               $post_ids = $wpdb->get_col( "SELECT p.ID $sql" );
-               $count    = (int) $wpdb->get_var( "SELECT COUNT(*) $sql" );
+               $post_ids = $wpdb->get_col( "SELECT DISTINCT p.ID $sql" );
+               $count    = (int) $wpdb->get_var( "SELECT COUNT(DISTINCT p.ID) $sql" );
 
                if ( $wpdb->last_error ) {
                        LoggingService::log( 'Posts query error: ' . $wpdb->last_error );


### PR DESCRIPTION
## Summary
- ensure `PostsQueryService::getPostsCount()` selects distinct IDs and counts them correctly

## Testing
- `composer lint` *(fails: command not found)*
- `composer test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685a6fd394a88327bbc0a0c7e0c84042

<!-- Korbit AI PR Description Start -->
## Description by Korbit AI

### What change is being made?
Modify the query in `PostsQueryService.php` to select distinct post IDs to prevent duplicate entries in the results.

### Why are these changes being made?
This change addresses the issue of duplicate posts being returned by ensuring that only unique post IDs are selected, which corrects the inaccurate post count and prevents redundant data processing. Distinct selection offers an efficient resolution without altering the query structure significantly.

> Is this description stale? Ask me to generate a new description by commenting `/korbit-generate-pr-description`
<!-- Korbit AI PR Description End -->