### PR TITLE
Remove local summary constants

### DIFF
--- a/nuclear-engagement/admin/trait-admin-metabox-summary.php
+++ b/nuclear-engagement/admin/trait-admin-metabox-summary.php
@@ -50,9 +50,9 @@ trait Admin_Summary_Metabox {
 				'summary'         => '',
 				'date'            => '',
 				'format'          => 'paragraph',
-				'length'          => \NuclearEngagement\Services\AutoGenerationService::SUMMARY_LENGTH,
-				'number_of_items' => \NuclearEngagement\Services\AutoGenerationService::SUMMARY_ITEMS,
-			);
+                                'length'          => NUCLEN_SUMMARY_LENGTH_DEFAULT,
+                                'number_of_items' => NUCLEN_SUMMARY_ITEMS_DEFAULT,
+                        );
 		}
 
 		$summary = $summary_data['summary'] ?? '';

--- a/nuclear-engagement/includes/Services/AutoGenerationService.php
+++ b/nuclear-engagement/includes/Services/AutoGenerationService.php
@@ -41,11 +41,6 @@ class AutoGenerationService {
         /** Delay in seconds between poll attempts. */
         public const RETRY_DELAY = 60;
 
-        /** Default length used when summarizing posts. */
-        public const SUMMARY_LENGTH = 30;
-
-        /** Default number of items in auto summaries. */
-        public const SUMMARY_ITEMS = 3;
 	/**
 	 * @var SettingsRepository
 	 */
@@ -196,8 +191,8 @@ class AutoGenerationService {
                 $workflow = array(
                     'type'                    => $workflow_type,
                     'summary_format'          => 'paragraph',
-                    'summary_length'          => self::SUMMARY_LENGTH,
-                    'summary_number_of_items' => self::SUMMARY_ITEMS,
+                    'summary_length'          => NUCLEN_SUMMARY_LENGTH_DEFAULT,
+                    'summary_number_of_items' => NUCLEN_SUMMARY_ITEMS_DEFAULT,
                 );
 
                 $generation_id = 'gen_' . uniqid( 'auto_', true );


### PR DESCRIPTION
## Summary
- drop `SUMMARY_LENGTH` and `SUMMARY_ITEMS` constants
- use global constants from `includes/constants.php`

## Testing
- `composer lint` *(fails: command not found)*
- `composer test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685a6f63c7f88327a9c85c4a1ca8e56d

<!-- Korbit AI PR Description Start -->
## Description by Korbit AI

### What change is being made?

Replace the use of local summary constants in `AutoGenerationService` with global default constants `NUCLEN_SUMMARY_LENGTH_DEFAULT` and `NUCLEN_SUMMARY_ITEMS_DEFAULT`.

### Why are these changes being made?

The change standardizes the configuration of summary length and item count across the codebase by using global constants, reducing redundancy, and improving maintainability. It ensures consistent behavior throughout the application by consolidating these settings in a centralized location.

> Is this description stale? Ask me to generate a new description by commenting `/korbit-generate-pr-description`
<!-- Korbit AI PR Description End -->