### PR TITLE
Update API allowed origin

### DIFF
--- a/src/admin/ts/utils/api.ts
+++ b/src/admin/ts/utils/api.ts
@@ -1,5 +1,5 @@
 export async function apiRequest(url: string, options: RequestInit): Promise<Response> {
-  const allowedOrigins = ['https://api.example.com'];
+  const allowedOrigins = ['https://app.nuclearengagement.com'];
   const urlObj = new URL(url, window.location.origin);
   if (!allowedOrigins.includes(urlObj.origin)) {
     throw new Error('Invalid URL origin');


### PR DESCRIPTION
## Summary
- use Nuclear Engagement domain in API utils

## Testing
- `composer lint` *(fails: composer not found)*
- `composer test` *(fails: composer not found)*
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_685a6f84af2c8327925830f39c624c66