### PR TITLE
Add auth tests for ContentController

### DIFF
--- a/tests/ContentControllerTest.php
+++ b/tests/ContentControllerTest.php
@@ -14,9 +14,53 @@ namespace NuclearEngagement\Services {
 }
 
 namespace {
+    if (!function_exists('__')) {
+        function __($t, $d = null) { return $t; }
+    }
+    if (!function_exists('sanitize_text_field')) {
+        function sanitize_text_field($t) { return $t; }
+    }
+    if (!function_exists('wp_verify_nonce')) {
+        function wp_verify_nonce($nonce, $action) { return $nonce === 'valid'; }
+    }
+    if (!function_exists('current_user_can')) {
+        function current_user_can($cap) { return true; }
+    }
+    if (!class_exists('WP_REST_Response')) {
+        class WP_REST_Response {
+            public $data;
+            public $status;
+            public function __construct($data = null, $status = 200) {
+                $this->data = $data;
+                $this->status = $status;
+            }
+        }
+    }
+
     class DummyRequest {
+        private $json;
+        private $headers;
+        public function __construct($json = null, array $headers = []) {
+            $this->json = $json;
+            $this->headers = $headers;
+        }
         public function get_json_params() {
-            return null;
+            return $this->json;
+        }
+        public function get_header($name) {
+            return $this->headers[$name] ?? '';
+        }
+    }
+
+    class DummyStorage {
+        public array $stored = [];
+        public function storeResults(array $results, string $workflowType): void {
+            global $wp_meta;
+            $metaKey = $workflowType === 'quiz' ? 'nuclen-quiz-data' : 'nuclen-summary-data';
+            foreach ($results as $id => $data) {
+                $wp_meta[$id][$metaKey] = $data;
+            }
+            $this->stored[] = [$results, $workflowType];
         }
     }
 
@@ -28,16 +72,81 @@ namespace {
             \NuclearEngagement\Services\LoggingService::$logs = [];
         }
 
-        public function test_handle_invalid_json_returns_error(): void {
-            $settings = SettingsRepository::get_instance();
-            $storage = new ContentStorageService($settings);
-            $controller = new ContentController($storage, $settings);
-            $req = new DummyRequest();
+    public function test_handle_invalid_json_returns_error(): void {
+        $settings = SettingsRepository::get_instance();
+        $storage = new ContentStorageService($settings);
+        $controller = new ContentController($storage, $settings);
+        $req = new DummyRequest();
 
             $res = $controller->handle($req);
 
-            $this->assertInstanceOf(WP_Error::class, $res);
-            $this->assertNotEmpty(\NuclearEngagement\Services\LoggingService::$logs);
-        }
+        $this->assertInstanceOf(WP_Error::class, $res);
+        $this->assertNotEmpty(\NuclearEngagement\Services\LoggingService::$logs);
+    }
+
+    public function test_valid_password_returns_rest_response(): void {
+        global $wp_posts;
+        $wp_posts[1] = (object)['ID' => 1];
+
+        $settings = SettingsRepository::get_instance();
+        $settings->set_string('plugin_password', 'secret')->save();
+
+        $storage = new DummyStorage();
+        $controller = new ContentController($storage, $settings);
+
+        $data = [
+            'workflow' => 'summary',
+            'results'  => [1 => ['summary' => 'ok', 'date' => '2025-01-01']],
+        ];
+        $req = new DummyRequest($data, ['X-WP-App-Password' => 'secret']);
+
+        $this->assertTrue($controller->permissions($req));
+
+        $res = $controller->handle($req);
+
+        $this->assertInstanceOf(WP_REST_Response::class, $res);
+        $this->assertSame(200, $res->status);
+        $this->assertNotEmpty($storage->stored);
+    }
+
+    public function test_valid_nonce_returns_rest_response(): void {
+        global $wp_posts;
+        $wp_posts[2] = (object)['ID' => 2];
+
+        $settings = SettingsRepository::get_instance();
+        $storage  = new DummyStorage();
+        $controller = new ContentController($storage, $settings);
+
+        $data = [
+            'workflow' => 'quiz',
+            'results'  => [2 => ['questions' => [], 'date' => '2025-01-02']],
+        ];
+        $req = new DummyRequest($data, ['X-WP-Nonce' => 'valid']);
+
+        $this->assertTrue($controller->permissions($req));
+        $res = $controller->handle($req);
+
+        $this->assertInstanceOf(WP_REST_Response::class, $res);
+        $this->assertSame(200, $res->status);
+        $this->assertNotEmpty($storage->stored);
+    }
+
+    public function test_invalid_credentials_return_error(): void {
+        $settings = SettingsRepository::get_instance();
+        $settings->set_string('plugin_password', 'secret')->save();
+
+        $storage  = new DummyStorage();
+        $controller = new ContentController($storage, $settings);
+        $data = ['workflow' => 'quiz', 'results' => [3 => ['questions' => []]]];
+        $req = new DummyRequest($data, ['X-WP-App-Password' => 'wrong']);
+
+        $allowed = $controller->permissions($req);
+        $res = $allowed ? $controller->handle($req)
+                        : new WP_Error('rest_forbidden', 'forbidden', ['status' => 401]);
+
+        $this->assertFalse($allowed);
+        $this->assertInstanceOf(WP_Error::class, $res);
+        $this->assertSame(401, $res->data['status']);
+    }
     }
 }

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -106,7 +106,15 @@ if (!function_exists('is_wp_error')) {
 }
 if (!class_exists('WP_Error')) {
     class WP_Error {
-        public function get_error_message() { return 'error'; }
+        public $data;
+        public $code;
+        public $message;
+        public function __construct($code = '', $message = '', $data = null) {
+            $this->code = $code;
+            $this->message = $message;
+            $this->data = $data;
+        }
+        public function get_error_message() { return $this->message ?: 'error'; }
     }
 }
 


### PR DESCRIPTION
## Summary
- extend test bootstrap to store WP_Error data
- stub REST and WP helper functions in ContentControllerTest
- add tests covering plugin password and nonce authentication

## Testing
- `composer lint` *(fails: command not found)*
- `composer test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685a6f5112f48327995afc13927c5ef0


> [!NOTE]
> I'm currently writing a description for your pull request. I should be done shortly (<1 minute). Please don't edit the description field until I'm finished, or we may overwrite each other. If I find nothing to write about, I'll delete this message.
