### PR TITLE
Fix uninstall autoload

### DIFF
--- a/nuclear-engagement/uninstall.php
+++ b/nuclear-engagement/uninstall.php
@@ -32,7 +32,25 @@ if ( ! defined( 'ABSPATH' ) ) {
 
 // If uninstall not called from WordPress, then exit.
 if ( ! defined( 'WP_UNINSTALL_PLUGIN' ) ) {
-		exit;
+                exit;
+}
+
+// Load the plugin autoloader when available.
+$autoload = __DIR__ . '/vendor/autoload.php';
+if ( ! file_exists( $autoload ) ) {
+    $autoload = dirname( __DIR__ ) . '/vendor/autoload.php';
+}
+if ( file_exists( $autoload ) ) {
+    require_once $autoload;
+} else {
+    $utils    = __DIR__ . '/includes/class-utils.php';
+    $logging  = __DIR__ . '/includes/Services/LoggingService.php';
+    if ( file_exists( $utils ) ) {
+        require_once $utils;
+    }
+    if ( file_exists( $logging ) ) {
+        require_once $logging;
+    }
 }
 
 // Get plugin settings.


### PR DESCRIPTION
## Summary
- ensure uninstall loads autoloader and fallback files

## Testing
- `composer lint` *(fails: command not found)*
- `composer test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685abbcb39548327825597506b8fc9b0

<!-- Korbit AI PR Description Start -->
## Description by Korbit AI

### What change is being made?

Modify the uninstall.php script to conditionally load the plugin autoloader or specific utility classes if the autoloader is not available.

### Why are these changes being made?

These changes ensure that the necessary classes are loaded during uninstallation, improving robustness if the autoloader is missing, thereby preventing potential errors associated with class dependencies during the plugin removal process. This approach provides a fallback mechanism, ensuring the required resources are available for script execution.

> Is this description stale? Ask me to generate a new description by commenting `/korbit-generate-pr-description`
<!-- Korbit AI PR Description End -->