### PR TITLE
Handle missing autoload file gracefully

### DIFF
--- a/nuclear-engagement/bootstrap.php
+++ b/nuclear-engagement/bootstrap.php
@@ -38,6 +38,8 @@ if ( file_exists( $autoload ) ) {
         require_once $autoload;
 } else {
         \NuclearEngagement\Services\LoggingService::log( 'Nuclear Engagement: vendor autoload not found.' );
+        \NuclearEngagement\Services\LoggingService::notify_admin( 'Nuclear Engagement dependencies missing. Please run composer install.' );
+        return;
 }
 
 // Register plugin autoloader for internal classes.


### PR DESCRIPTION
## Summary
- display an admin notice when the vendor autoload file is missing
- stop bootstrap after notifying the admin

## Testing
- `composer lint` *(fails: composer not found)*
- `composer test` *(fails: composer not found)*

------
https://chatgpt.com/codex/tasks/task_e_685abcd11c1483279d5d4f6506bb963e

<!-- Korbit AI PR Description Start -->
## Description by Korbit AI

### What change is being made?
Enhance error handling in `nuclear-engagement/bootstrap.php` by notifying admins when the vendor autoload file is missing and halting execution.

### Why are these changes being made?
Previously, when the autoload file was missing, only a log entry was created, which might go unnoticed. Introducing admin notifications ensures the responsible parties are alerted to run `composer install` to prevent functionality issues, improving system reliability and maintainability.

> Is this description stale? Ask me to generate a new description by commenting `/korbit-generate-pr-description`
<!-- Korbit AI PR Description End -->