### PR TITLE
Fix send_app_password docblock

### DIFF
--- a/nuclear-engagement/includes/Services/SetupService.php
+++ b/nuclear-engagement/includes/Services/SetupService.php
@@ -14,7 +14,6 @@ declare( strict_types = 1 );
 namespace NuclearEngagement\Services;
 
 use NuclearEngagement\Utils;
-use WP_Error;
 
 // If this file is called directly, abort.
 if ( ! defined( 'ABSPATH' ) ) {
@@ -106,9 +105,7 @@ class SetupService {
 	 * @since 1.0.0
 	 *
 	 * @param array $data Credential payload containing appApiKey and other credentials.
-	 * @return bool Whether the request succeeded.
-	 *
-	 * @throws WP_Error If there's an error with the request.
+         * @return bool True on success, false on failure.
 	 */
 	public function send_app_password( array $data ): bool {
 		if ( empty( $data['appApiKey'] ) ) {


### PR DESCRIPTION
## Summary
- remove unused `WP_Error` import
- clarify `send_app_password` docblock to note boolean return and no exceptions

## Testing
- `composer lint` *(fails: command not found)*
- `composer test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685abcc4fa748327b9d0e35985e2a7dd


> [!NOTE]
> I'm currently writing a description for your pull request. I should be done shortly (<1 minute). Please don't edit the description field until I'm finished, or we may overwrite each other. If I find nothing to write about, I'll delete this message.
