### PR TITLE
Handle runtime exceptions in auto-generation

### DIFF
--- a/nuclear-engagement/includes/Services/AutoGenerationService.php
+++ b/nuclear-engagement/includes/Services/AutoGenerationService.php
@@ -210,7 +210,7 @@ class AutoGenerationService {
                             'generation_id' => $generation_id,
                         )
                     );
-                } catch ( ApiException $e ) {
+                } catch ( \Throwable $e ) {
                     \NuclearEngagement\Services\LoggingService::log( 'Failed to start generation: ' . $e->getMessage() );
                     \NuclearEngagement\Services\LoggingService::notify_admin( 'Auto-generation failed: ' . $e->getMessage() );
                     continue;

--- a/tests/AutoGenerationServiceTest.php
+++ b/tests/AutoGenerationServiceTest.php
@@ -62,6 +62,19 @@ class AutoGenerationServiceTest extends TestCase {
         $this->assertArrayNotHasKey('nuclen_autogen_queue', $wp_options);
     }
 
+    public function test_process_queue_handles_runtime_exception(): void {
+        global $wp_posts, $wp_events, $wp_options;
+        $wp_posts[1] = (object)[ 'ID' => 1, 'post_title' => 'T', 'post_content' => 'C' ];
+        $api = new DummyRemoteApiService();
+        $api->generateResponse = new \RuntimeException('missing key');
+        $service = $this->makeService($api);
+        $service->generate_single(1, 'quiz');
+        $service->process_queue();
+        $this->assertEmpty($wp_events);
+        $this->assertEmpty($wp_options['nuclen_active_generations'] ?? []);
+        $this->assertArrayNotHasKey('nuclen_autogen_queue', $wp_options);
+    }
+
     public function test_poll_generation_removes_entry_after_success(): void {
         global $wp_options;
         $id = 'gen123';


### PR DESCRIPTION
## Summary
- handle RuntimeException thrown by RemoteApiService when auto-generating content
- broaden catch block and notify the admin
- test runtime exception handling in AutoGenerationService

## Testing
- `composer lint` *(fails: command not found)*
- `composer test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685abcc294988327adb4f25d23b7c9b9

<!-- Korbit AI PR Description Start -->
## Description by Korbit AI

### What change is being made?
Update the `AutoGenerationService` to handle all runtime exceptions during auto-generation processes by catching `\Throwable` instead of specifically `ApiException` and add a test to verify this behavior.

### Why are these changes being made?
The previous implementation only handled `ApiException`, which could lead to unhandled exceptions if a different type of error occurred. By catching `\Throwable`, we ensure that all runtime errors are appropriately logged and notify the admin, preventing potential disruptions. A new test was added to confirm that the queue processing correctly handles runtime exceptions.

> Is this description stale? Ask me to generate a new description by commenting `/korbit-generate-pr-description`
<!-- Korbit AI PR Description End -->