### PR TITLE
Stream opt-in export in batches

### DIFF
--- a/nuclear-engagement/includes/OptinData.php
+++ b/nuclear-engagement/includes/OptinData.php
@@ -187,44 +187,56 @@ class OptinData {
 			wp_die( __( 'Invalid nonce.', 'nuclear-engagement' ), 400 );
 		}
 
-		global $wpdb;
-		$rows = $wpdb->get_results(
-			'SELECT submitted_at AS datetime,
-					url,
-					name,
-					email
-			   FROM ' . self::table_name() . '
-			   ORDER BY submitted_at DESC',
-			ARRAY_A
-		);
+               global $wpdb;
 
-		/* Output */
-		if ( ob_get_length() ) {
-			ob_end_clean();
-		}
-		nocache_headers();
-		header( 'Content-Type: text/csv; charset=utf-8' );
-		header( 'Content-Disposition: attachment; filename=nuclen_optins_' . gmdate( 'Y-m-d' ) . '.csv' );
+               if ( ob_get_length() ) {
+                       ob_end_clean();
+               }
+               nocache_headers();
+               header( 'Content-Type: text/csv; charset=utf-8' );
+               header( 'Content-Disposition: attachment; filename=nuclen_optins_' . gmdate( 'Y-m-d' ) . '.csv' );
 
-                $out = fopen( 'php://output', 'w' );
-                if ( false === $out ) {
-                        LoggingService::log( 'Failed to open output stream for CSV export' );
-                        wp_die( __( 'Unable to generate export.', 'nuclear-engagement' ), 500 );
-                }
+               $out = fopen( 'php://output', 'w' );
+               if ( false === $out ) {
+                       LoggingService::log( 'Failed to open output stream for CSV export' );
+                       wp_die( __( 'Unable to generate export.', 'nuclear-engagement' ), 500 );
+               }
 
-                if ( false === fputcsv( $out, array( 'datetime', 'url', 'name', 'email' ) ) ) { // headings
-                        LoggingService::log( 'Failed writing CSV header' );
-                }
-		foreach ( $rows as $r ) {
-				// Prevent formula injection when opened in spreadsheet apps.
-				$r['name']  = self::escape_csv_field( $r['name'] );
-				$r['email'] = self::escape_csv_field( $r['email'] );
-				$r['url']   = self::escape_csv_field( $r['url'] );
-                                if ( false === fputcsv( $out, $r ) ) {
-                                        LoggingService::log( 'Failed writing CSV row' );
-                                }
-		}
-		fclose( $out );
-		exit;
-	}
+               if ( false === fputcsv( $out, array( 'datetime', 'url', 'name', 'email' ) ) ) { // headings
+                       LoggingService::log( 'Failed writing CSV header' );
+               }
+
+               $limit  = 500;
+               $offset = 0;
+               do {
+                       $rows = $wpdb->get_results(
+                               $wpdb->prepare(
+                                       'SELECT submitted_at AS datetime,
+                                                       url,
+                                                       name,
+                                                       email
+                                          FROM ' . self::table_name() . '
+                                          ORDER BY submitted_at DESC
+                                          LIMIT %d OFFSET %d',
+                                       $limit,
+                                       $offset
+                               ),
+                               ARRAY_A
+                       );
+
+                       foreach ( $rows as $r ) {
+                               $r['name']  = self::escape_csv_field( $r['name'] );
+                               $r['email'] = self::escape_csv_field( $r['email'] );
+                               $r['url']   = self::escape_csv_field( $r['url'] );
+                               if ( false === fputcsv( $out, $r ) ) {
+                                       LoggingService::log( 'Failed writing CSV row' );
+                               }
+                       }
+
+                       $offset += $limit;
+               } while ( count( $rows ) === $limit );
+
+               fclose( $out );
+               exit;
+        }
 }


### PR DESCRIPTION
## Summary
- stream CSV export using a LIMIT/OFFSET loop

## Testing
- `composer lint` *(fails: command not found)*
- `composer test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685abc5808c48327bdfaeb097fa7ccca

<!-- Korbit AI PR Description Start -->
## Description by Korbit AI

### What change is being made?

Export opt-in data in CSV format in batches of 500 entries to optimize memory usage during the export process.

### Why are these changes being made?

Exporting large datasets in a single query can lead to high memory consumption and potential server issues. By exporting data in batches, the process becomes more efficient and less resource-intensive, reducing the risk of timeouts or memory-related errors during export.

> Is this description stale? Ask me to generate a new description by commenting `/korbit-generate-pr-description`
<!-- Korbit AI PR Description End -->