### PR TITLE
Implement posts query caching

### DIFF
--- a/nuclear-engagement/bootstrap.php
+++ b/nuclear-engagement/bootstrap.php
@@ -9,6 +9,7 @@ use NuclearEngagement\MetaRegistration;
 use NuclearEngagement\AssetVersions;
 use NuclearEngagement\Plugin;
 use NuclearEngagement\InventoryCache;
+use NuclearEngagement\Services\PostsQueryService;
 
 if ( ! defined( 'ABSPATH' ) ) {
     exit;
@@ -221,6 +222,7 @@ function nuclear_engagement_run_plugin() {
 function nuclear_engagement_init() {
     try {
         InventoryCache::register_hooks();
+        PostsQueryService::register_hooks();
     } catch ( \Throwable $e ) {
         \NuclearEngagement\Services\LoggingService::log( 'Nuclear Engagement: Cache registration failed - ' . $e->getMessage() );
         add_action(


### PR DESCRIPTION
## Summary
- add transient and object cache logic to `PostsQueryService`
- clear posts query cache when posts, meta or terms change
- register cache hooks during bootstrap

## Testing
- `composer lint` *(fails: command not found)*
- `composer test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685ac58e5ee483279c7348a28a2dea20