### PR TITLE
Notify admin on API communication errors

### DIFF
--- a/nuclear-engagement/includes/Services/RemoteApiService.php
+++ b/nuclear-engagement/includes/Services/RemoteApiService.php
@@ -123,11 +123,12 @@ class RemoteApiService {
 			)
 		);
 
-		if ( is_wp_error( $response ) ) {
-			$error = 'API request failed: ' . $response->get_error_message();
-			\NuclearEngagement\Services\LoggingService::log( $error ); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
-			throw new ApiException( $error );
-		}
+                if ( is_wp_error( $response ) ) {
+                        $error = 'API request failed: ' . $response->get_error_message();
+                        \NuclearEngagement\Services\LoggingService::log( $error ); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
+                        \NuclearEngagement\Services\LoggingService::notify_admin( __( 'Failed to contact the Nuclear Engagement API.', 'nuclear-engagement' ) );
+                        throw new ApiException( $error );
+                }
 
 		$code = wp_remote_retrieve_response_code( $response );
 		$body = wp_remote_retrieve_body( $response );
@@ -201,11 +202,12 @@ class RemoteApiService {
 			)
 		);
 
-		if ( is_wp_error( $response ) ) {
-			$error = 'API request failed: ' . $response->get_error_message();
-					\NuclearEngagement\Services\LoggingService::log( $error ); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
-			throw new ApiException( $error );
-		}
+                if ( is_wp_error( $response ) ) {
+                        $error = 'API request failed: ' . $response->get_error_message();
+                                        \NuclearEngagement\Services\LoggingService::log( $error ); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
+                        \NuclearEngagement\Services\LoggingService::notify_admin( __( 'Failed to contact the Nuclear Engagement API.', 'nuclear-engagement' ) );
+                        throw new ApiException( $error );
+                }
 
 		$code = wp_remote_retrieve_response_code( $response );
 		$body = wp_remote_retrieve_body( $response );


### PR DESCRIPTION
## Summary
- alert admins when RemoteApiService encounters WP_Error
- add localizable notice message
- extend RemoteApiServiceTest for notification cases

## Testing
- `composer lint` *(fails: command not found)*
- `composer test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685ac75b37608327b3d09fdee96fae15