### PR TITLE
Add hook usage examples

### DIFF
--- a/docs/hooks.md
+++ b/docs/hooks.md
@@ -28,3 +28,21 @@ into two groups: **actions** (events you can run code on) and
 | --- | --- | --- |
 | `nuclen_setting_*` | `mixed $value`, `string $key` | Called when retrieving a plugin setting from `SettingsRepository`. Replace `*` with the setting key. Return a new value to override the stored setting. |
 | `nuclen_toc_enable_heading_ids` | `bool $enabled` | Allows disabling the automatic ID injection used by the Table of Contents module. Return `false` to leave headings untouched. |
+
+## Usage Examples
+
+Register a callback for the `nuclen_start_generation` action:
+
+```php
+add_action( 'nuclen_start_generation', function ( $post_id, $workflow_type ) {
+    // Custom logic before generation starts.
+} );
+```
+
+Modify a setting via the `nuclen_setting_*` filter:
+
+```php
+add_filter( 'nuclen_setting_quiz_title', function ( $value, $key ) {
+    return 'My Custom Title';
+}, 10, 2 );
+```


### PR DESCRIPTION
## Summary
- document how to hook into `nuclen_start_generation`
- document how to filter settings via `nuclen_setting_*`

## Testing
- `composer lint` *(fails: command not found)*
- `composer test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685ac86108b483279c2afbda6ddb4c76

<!-- Korbit AI PR Description Start -->
## Description by Korbit AI

### What change is being made?

Add usage examples for hook registration and modification in the `docs/hooks.md`.

### Why are these changes being made?

These examples are being added to improve the documentation by providing concrete guidance on how to register callbacks and modify settings using hooks, which will help developers understand and implement these features more effectively. This change enhances clarity and usability, addressing potential confusion in the absence of examples.

> Is this description stale? Ask me to generate a new description by commenting `/korbit-generate-pr-description`
<!-- Korbit AI PR Description End -->