### PR TITLE
Add hook usage samples to docs

### DIFF
--- a/docs/hooks.md
+++ b/docs/hooks.md
@@ -28,3 +28,21 @@ into two groups: **actions** (events you can run code on) and
 | --- | --- | --- |
 | `nuclen_setting_*` | `mixed $value`, `string $key` | Called when retrieving a plugin setting from `SettingsRepository`. Replace `*` with the setting key. Return a new value to override the stored setting. |
 | `nuclen_toc_enable_heading_ids` | `bool $enabled` | Allows disabling the automatic ID injection used by the Table of Contents module. Return `false` to leave headings untouched. |
+
+## Usage Examples
+
+Register a callback when generation begins:
+
+```php
+add_action( 'nuclen_start_generation', function ( $post_id, $workflow_type ) {
+    error_log( "Starting $workflow_type for post $post_id" );
+} );
+```
+
+Override a saved setting when retrieved:
+
+```php
+add_filter( 'nuclen_setting_api_timeout', function ( $value ) {
+    return 30; // seconds
+} );
+```


### PR DESCRIPTION
## Summary
- document sample usage for `nuclen_start_generation` and `nuclen_setting_*` hooks

## Testing
- `composer lint` *(fails: command not found)*
- `composer test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685ac8322ef48327a6e3ce893272462a

<!-- Korbit AI PR Description Start -->
## Description by Korbit AI

### What change is being made?

Add usage examples to the hooks documentation.

### Why are these changes being made?

The examples provide developers with clear, practical illustrations of how to use hooks effectively, improving their understanding and enhancing the usability of the documentation. This approach addresses a common user request for more detailed examples.

> Is this description stale? Ask me to generate a new description by commenting `/korbit-generate-pr-description`
<!-- Korbit AI PR Description End -->