### PR TITLE
Handle failed scheduling

### DIFF
--- a/nuclear-engagement/includes/Services/AutoGenerationService.php
+++ b/nuclear-engagement/includes/Services/AutoGenerationService.php
@@ -144,6 +144,12 @@ class AutoGenerationService {
                 \NuclearEngagement\Services\LoggingService::log(
                     'Failed to schedule event ' . self::QUEUE_HOOK
                 );
+                \NuclearEngagement\Services\LoggingService::notify_admin(
+                    sprintf(
+                        __( 'Failed to schedule event %s', 'nuclear-engagement' ),
+                        self::QUEUE_HOOK
+                    )
+                );
             }
         }
     }
@@ -238,6 +244,12 @@ class AutoGenerationService {
                     \NuclearEngagement\Services\LoggingService::log(
                         'Failed to schedule event nuclen_poll_generation for generation ' . $generation_id
                     );
+                    \NuclearEngagement\Services\LoggingService::notify_admin(
+                        sprintf(
+                            __( 'Failed to schedule event nuclen_poll_generation for generation %s', 'nuclear-engagement' ),
+                            $generation_id
+                        )
+                    );
                 }
             }
 
@@ -258,6 +270,12 @@ class AutoGenerationService {
             if ( false === $scheduled ) {
                 \NuclearEngagement\Services\LoggingService::log(
                     'Failed to schedule event ' . self::QUEUE_HOOK
+                );
+                \NuclearEngagement\Services\LoggingService::notify_admin(
+                    sprintf(
+                        __( 'Failed to schedule event %s', 'nuclear-engagement' ),
+                        self::QUEUE_HOOK
+                    )
                 );
             }
         }

--- a/nuclear-engagement/includes/Services/GenerationPoller.php
+++ b/nuclear-engagement/includes/Services/GenerationPoller.php
@@ -119,6 +119,12 @@ class GenerationPoller {
                                 \NuclearEngagement\Services\LoggingService::log(
                                         'Failed to schedule event nuclen_poll_generation for generation ' . $generation_id
                                 );
+                                \NuclearEngagement\Services\LoggingService::notify_admin(
+                                        sprintf(
+                                                __( 'Failed to schedule event nuclen_poll_generation for generation %s', 'nuclear-engagement' ),
+                                                $generation_id
+                                        )
+                                );
                         }
                 } else {
 			\NuclearEngagement\Services\LoggingService::log(

--- a/tests/ScheduleFailureTest.php
+++ b/tests/ScheduleFailureTest.php
@@ -1,0 +1,87 @@
+<?php
+use PHPUnit\Framework\TestCase;
+use NuclearEngagement\Services\AutoGenerationService;
+use NuclearEngagement\Services\GenerationPoller;
+use NuclearEngagement\SettingsRepository;
+
+namespace NuclearEngagement\Services {
+    if (!class_exists('NuclearEngagement\\Services\\LoggingService')) {
+        class LoggingService {
+            public static array $logs = [];
+            public static array $notices = [];
+            public static function log(string $msg): void { self::$logs[] = $msg; }
+            public static function notify_admin(string $msg): void { self::$notices[] = $msg; }
+        }
+    }
+    function wp_schedule_single_event($timestamp, $hook, $args) {
+        return false;
+    }
+}
+
+namespace {
+    class DummyRemoteApiService {
+        public array $updates = [];
+        public $generateResponse = [];
+        public array $lastData = [];
+        public function send_posts_to_generate(array $data): array {
+            $this->lastData = $data;
+            return $this->generateResponse;
+        }
+        public function fetch_updates(string $id): array {
+            return $this->updates[$id] ?? [];
+        }
+    }
+
+    class DummyContentStorageService {
+        public array $stored = [];
+        public function storeResults(array $results, string $type): void {
+            $this->stored[] = [$results, $type];
+        }
+    }
+
+    class ScheduleFailureTest extends TestCase {
+        protected function setUp(): void {
+            global $wp_options, $wp_autoload, $wp_posts, $wp_meta, $wp_events;
+            $wp_options = $wp_autoload = $wp_posts = $wp_meta = $wp_events = [];
+            \NuclearEngagement\Services\LoggingService::$logs = [];
+            \NuclearEngagement\Services\LoggingService::$notices = [];
+            SettingsRepository::reset_for_tests();
+        }
+
+        private function makeService(?DummyRemoteApiService $api = null): AutoGenerationService {
+            $settings = SettingsRepository::get_instance();
+            $api      = $api ?: new DummyRemoteApiService();
+            $storage  = new DummyContentStorageService();
+            $poller   = new GenerationPoller($settings, $api, $storage);
+            $handler  = new \NuclearEngagement\Services\PublishGenerationHandler($settings);
+            return new AutoGenerationService($settings, $api, $storage, $poller, $handler);
+        }
+
+        public function test_queue_post_failure_notifies_admin(): void {
+            global $wp_posts, $wp_events;
+            $wp_posts[1] = (object)[ 'ID' => 1, 'post_title' => 'T', 'post_content' => 'C' ];
+            $service = $this->makeService();
+            $service->generate_single(1, 'quiz');
+            $this->assertEmpty($wp_events);
+            $this->assertNotEmpty(\NuclearEngagement\Services\LoggingService::$notices);
+        }
+
+        public function test_process_queue_failure_notifies_admin(): void {
+            global $wp_posts;
+            $wp_posts[2] = (object)[ 'ID' => 2, 'post_title' => 'B', 'post_content' => 'C2' ];
+            update_option('nuclen_autogen_queue', ['quiz' => [2]], 'no');
+            $service = $this->makeService();
+            $service->process_queue();
+            $this->assertNotEmpty(\NuclearEngagement\Services\LoggingService::$notices);
+        }
+
+        public function test_poller_failure_notifies_admin(): void {
+            $settings = SettingsRepository::get_instance();
+            $api      = new DummyRemoteApiService();
+            $storage  = new DummyContentStorageService();
+            $poller   = new GenerationPoller($settings, $api, $storage);
+            $poller->poll_generation('gid', 'quiz', [1], 1);
+            $this->assertNotEmpty(\NuclearEngagement\Services\LoggingService::$notices);
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- notify admins when scheduling cron events fails
- make scheduling failure messages translatable
- cover failure paths with integration tests

## Testing
- `composer lint` *(fails: command not found)*
- `composer test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685ac76296208327832d25d5c90e873b


> [!NOTE]
> I'm currently writing a description for your pull request. I should be done shortly (<1 minute). Please don't edit the description field until I'm finished, or we may overwrite each other. If I find nothing to write about, I'll delete this message.
