### PR TITLE
Fix class loading for AssetVersions and Utils

### DIFF
--- a/nuclear-engagement/bootstrap.php
+++ b/nuclear-engagement/bootstrap.php
@@ -43,6 +43,14 @@ if ( file_exists( $autoload ) ) {
         return;
 }
 
+// Fallback for class maps missing from autoload.
+if ( ! class_exists( \NuclearEngagement\AssetVersions::class ) ) {
+    $asset_versions_path = NUCLEN_PLUGIN_DIR . 'includes/AssetVersions.php';
+    if ( file_exists( $asset_versions_path ) ) {
+        require_once $asset_versions_path;
+    }
+}
+
 
 if ( file_exists( NUCLEN_PLUGIN_DIR . 'includes/constants.php' ) ) {
     require_once NUCLEN_PLUGIN_DIR . 'includes/constants.php';

--- a/nuclear-engagement/uninstall.php
+++ b/nuclear-engagement/uninstall.php
@@ -43,7 +43,7 @@ if ( ! file_exists( $autoload ) ) {
 if ( file_exists( $autoload ) ) {
     require_once $autoload;
 } else {
-    $utils    = __DIR__ . '/includes/class-utils.php';
+    $utils    = __DIR__ . '/includes/Utils.php';
     $logging  = __DIR__ . '/includes/Services/LoggingService.php';
     if ( file_exists( $utils ) ) {
         require_once $utils;


### PR DESCRIPTION
## Summary
- correct path to Utils fallback in uninstall.php
- load AssetVersions manually if composer classmap is missing

## Testing
- `composer lint` *(fails: command not found)*
- `composer test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685b686cbbf48327bdf6ca67be502b7d