### PR TITLE
Fix missing class autoload

### DIFF
--- a/nuclear-engagement/bootstrap.php
+++ b/nuclear-engagement/bootstrap.php
@@ -43,6 +43,24 @@ if ( file_exists( $autoload ) ) {
         return;
 }
 
+// Register a minimal PSR-4 autoloader for plugin classes when Composer
+// autoload rules are incomplete.
+spl_autoload_register(
+    static function ( $class ) {
+        $prefix = 'NuclearEngagement\\';
+        if ( 0 !== strpos( $class, $prefix ) ) {
+            return;
+        }
+
+        $relative = str_replace( '\\', '/', substr( $class, strlen( $prefix ) ) );
+        $file     = NUCLEN_PLUGIN_DIR . $relative . '.php';
+
+        if ( file_exists( $file ) ) {
+            require_once $file;
+        }
+    }
+);
+
 // Fallback for class maps missing from autoload.
 if ( ! class_exists( \NuclearEngagement\AssetVersions::class ) ) {
     $asset_versions_path = NUCLEN_PLUGIN_DIR . 'includes/AssetVersions.php';


### PR DESCRIPTION
## Summary
- add PSR-4 fallback autoloader in plugin bootstrap

## Testing
- `composer lint` *(fails: command not found)*
- `composer test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685b69e736408327847b364480382159

<!-- Korbit AI PR Description Start -->
## Description by Korbit AI

### What change is being made?

Add a PSR-4 autoloader registration to bootstrap.php to ensure missing plugin classes are loaded when Composer autoload rules are incomplete.

### Why are these changes being made?

The change addresses the issue of plugin class loading failures due to incomplete Composer autoload rules by implementing a minimal PSR-4 autoloader. This ensures that plugin classes under the 'NuclearEngagement' namespace are properly included, thereby preventing potential runtime errors.

> Is this description stale? Ask me to generate a new description by commenting `/korbit-generate-pr-description`
<!-- Korbit AI PR Description End -->