### PR TITLE
Improve quiz data validation

### DIFF
--- a/tests/ContentStorageServiceTest.php
+++ b/tests/ContentStorageServiceTest.php
@@ -1,0 +1,78 @@
+<?php
+use PHPUnit\Framework\TestCase;
+use NuclearEngagement\Services\ContentStorageService;
+use NuclearEngagement\SettingsRepository;
+
+namespace NuclearEngagement\Services {
+    function update_post_meta($postId, $key, $value) {
+        $GLOBALS['wp_meta'][$postId][$key] = $value;
+        return true;
+    }
+    if (!function_exists('sanitize_text_field')) {
+        function sanitize_text_field($text) { return trim($text); }
+    }
+}
+
+namespace {
+    class ContentStorageServiceTest extends TestCase {
+        protected function setUp(): void {
+            global $wp_options, $wp_autoload, $wp_meta;
+            $wp_options = $wp_autoload = $wp_meta = [];
+            NuclearEngagement\SettingsRepository::reset_for_tests();
+        }
+
+        public function test_store_quiz_data_filters_and_limits_answers(): void {
+            $settings = NuclearEngagement\SettingsRepository::get_instance();
+            $settings->set_int('answers_per_question', 2)->save();
+            $service = new NuclearEngagement\Services\ContentStorageService($settings);
+            $data = [
+                'questions' => [
+                    [
+                        'question' => 'Q1',
+                        'answers' => ['A1','A2','A3',''],
+                        'explanation' => 'E1',
+                    ],
+                    [
+                        'question' => '',
+                        'answers' => ['A'],
+                    ],
+                    [
+                        'question' => 'Q2',
+                        'answers' => ['A1'],
+                    ],
+                ],
+                'date' => '2025-01-01',
+            ];
+            $service->storeQuizData(1, $data);
+            $expected = [
+                'questions' => [
+                    [
+                        'question' => 'Q1',
+                        'answers' => ['A1','A2'],
+                        'explanation' => 'E1',
+                    ],
+                    [
+                        'question' => 'Q2',
+                        'answers' => ['A1'],
+                        'explanation' => '',
+                    ],
+                ],
+                'date' => '2025-01-01',
+            ];
+            $this->assertSame($expected, $GLOBALS['wp_meta'][1]['nuclen-quiz-data']);
+        }
+
+        public function test_store_quiz_data_throws_when_no_valid_question(): void {
+            $settings = NuclearEngagement\SettingsRepository::get_instance();
+            $service = new NuclearEngagement\Services\ContentStorageService($settings);
+            $data = [
+                'questions' => [
+                    [ 'question' => '', 'answers' => [''] ],
+                    [ 'question' => ' ', 'answers' => [] ],
+                ],
+            ];
+            $this->expectException(\InvalidArgumentException::class);
+            $service->storeQuizData(1, $data);
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- validate and sanitize quiz questions in `storeQuizData`
- trim answers to the configured limit
- add unit tests for quiz data handling

## Testing
- `composer lint` *(fails: composer not found)*
- `composer test` *(fails: composer not found)*

------
https://chatgpt.com/codex/tasks/task_e_685b7c593b6083278fe311f2893bd2c7

<!-- Korbit AI PR Description Start -->
## Description by Korbit AI

### What change is being made?

Enhance the `storeQuizData` method to include improved validation and sanitization of quiz data, and introduce corresponding unit tests.

### Why are these changes being made?

The update ensures that each quiz entry meets a standard of quality by validating and sanitizing questions and answers, thereby preventing invalid or incomplete data entries. It also introduces limits on the number of answers per question according to application settings, enhancing data integrity and allowing for more robust error handling. The new unit tests verify the correctness and robustness of these enhancements.

> Is this description stale? Ask me to generate a new description by commenting `/korbit-generate-pr-description`
<!-- Korbit AI PR Description End -->