### PR TITLE
Add tests for quiz shortcode and storage service

### DIFF
--- a/tests/ContentStorageServiceTest.php
+++ b/tests/ContentStorageServiceTest.php
@@ -1,0 +1,47 @@
+<?php
+use PHPUnit\Framework\TestCase;
+use NuclearEngagement\Services\ContentStorageService;
+use NuclearEngagement\SettingsRepository;
+
+namespace NuclearEngagement\Services {
+    function update_post_meta($postId, $key, $val) {
+        $GLOBALS['wp_meta'][$postId][$key] = $val;
+        return true;
+    }
+}
+
+namespace {
+    class ContentStorageServiceTest extends TestCase {
+        protected function setUp(): void {
+            global $wp_meta, $wp_options, $wp_autoload;
+            $wp_meta = $wp_options = $wp_autoload = [];
+            SettingsRepository::reset_for_tests();
+        }
+
+        public function test_store_quiz_data_saves_formatted_meta(): void {
+            $settings = SettingsRepository::get_instance();
+            $service = new ContentStorageService($settings);
+            $data = [
+                'questions' => [
+                    ['question' => 'Q1', 'answers' => ['A'], 'explanation' => 'E'],
+                ],
+                'date' => '2025-05-01',
+            ];
+            $service->storeQuizData(1, $data);
+            $expected = [
+                'questions' => [
+                    ['question' => 'Q1', 'answers' => ['A'], 'explanation' => 'E'],
+                ],
+                'date' => '2025-05-01',
+            ];
+            $this->assertSame($expected, $GLOBALS['wp_meta'][1]['nuclen-quiz-data']);
+        }
+
+        public function test_store_quiz_data_throws_on_invalid_questions(): void {
+            $settings = SettingsRepository::get_instance();
+            $service = new ContentStorageService($settings);
+            $this->expectException(InvalidArgumentException::class);
+            $service->storeQuizData(2, []);
+        }
+    }
+}

--- a/tests/QuizShortcodeTest.php
+++ b/tests/QuizShortcodeTest.php
@@ -1,0 +1,51 @@
+<?php
+use PHPUnit\Framework\TestCase;
+use NuclearEngagement\Front\QuizShortcode;
+use NuclearEngagement\SettingsRepository;
+use NuclearEngagement\Front\FrontClass;
+use NuclearEngagement\Container;
+
+if (!function_exists('get_the_ID')) {
+    function get_the_ID() { return 1; }
+}
+
+class DummyFront extends FrontClass {
+    public function __construct(SettingsRepository $settings) {
+        parent::__construct('ne', '1.0', $settings, Container::getInstance());
+    }
+    public function nuclen_force_enqueue_assets(): void {}
+}
+
+class QuizShortcodeTest extends TestCase {
+    protected function setUp(): void {
+        global $wp_meta, $wp_options, $wp_autoload;
+        $wp_meta = $wp_options = $wp_autoload = [];
+        SettingsRepository::reset_for_tests();
+    }
+
+    private function makeShortcode(): QuizShortcode {
+        $settings = SettingsRepository::get_instance();
+        $front    = new DummyFront($settings);
+        return new QuizShortcode($settings, $front);
+    }
+
+    public function test_render_returns_html_with_valid_meta(): void {
+        global $wp_meta;
+        $wp_meta[1]['nuclen-quiz-data'] = [
+            'questions' => [
+                ['question' => 'Q1?', 'answers' => ['A', 'B'], 'explanation' => 'E'],
+            ],
+        ];
+        $shortcode = $this->makeShortcode();
+        $out = $shortcode->render();
+        $this->assertStringContainsString('nuclen-root', $out);
+        $this->assertStringContainsString('nuclen-quiz-container', $out);
+    }
+
+    public function test_render_returns_empty_string_with_invalid_meta(): void {
+        global $wp_meta;
+        $wp_meta[1]['nuclen-quiz-data'] = ['questions' => []];
+        $shortcode = $this->makeShortcode();
+        $this->assertSame('', $shortcode->render());
+    }
+}


### PR DESCRIPTION
## Summary
- add unit tests for QuizShortcode rendering behavior
- add integration tests for ContentStorageService::storeQuizData

## Testing
- `composer lint` *(fails: command not found)*
- `composer test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685b7c564e348327b7f4fb0552635957