### PR TITLE
Implement cache invalidation for TOC

### DIFF
--- a/nuclear-engagement/modules/toc/includes/class-nuclen-toc-utils.php
+++ b/nuclear-engagement/modules/toc/includes/class-nuclen-toc-utils.php
@@ -192,6 +192,37 @@ final class Nuclen_TOC_Utils {
                 return self::$last_parse_ms;
         }
 
+       /**
+        * Clear cached headings for a post.
+        *
+        * @param int $post_id Post ID to clear cache for.
+        */
+       public static function clear_cache_for_post( int $post_id ): void {
+               $post = get_post( $post_id );
+               if ( ! $post ) {
+                       return;
+               }
+
+               $levels = range( 2, 6 );
+               if ( class_exists( '\\NuclearEngagement\\Container' ) ) {
+                       try {
+                               $settings = \NuclearEngagement\Container::getInstance()->get( 'settings' );
+                               $levels   = $settings->get_array( 'toc_heading_levels', $levels );
+                       } catch ( \Throwable $e ) {
+                               // Use default levels if settings unavailable.
+                       }
+               }
+
+               $levels = array_unique( array_map( 'intval', $levels ) );
+               sort( $levels );
+
+               $key       = md5( $post->post_content ) . '_' . implode( '', $levels );
+               $transient = 'nuclen_toc_' . $key;
+
+               wp_cache_delete( $key, self::CACHE_GROUP );
+               delete_transient( $transient );
+       }
+
 		/**
 		 * Tiny wrapper so callers can import just one name.
 		 *

--- a/nuclear-engagement/modules/toc/loader.php
+++ b/nuclear-engagement/modules/toc/loader.php
@@ -34,6 +34,10 @@ require_once NUCLEN_TOC_DIR . 'includes/class-nuclen-toc-headings.php';
 require_once NUCLEN_TOC_DIR . 'includes/class-nuclen-toc-render.php';
 require_once NUCLEN_TOC_DIR . 'includes/class-nuclen-toc-admin.php';
 
+// Clear caches when posts are saved or deleted.
+add_action( 'save_post', array( 'Nuclen_TOC_Utils', 'clear_cache_for_post' ) );
+add_action( 'delete_post', array( 'Nuclen_TOC_Utils', 'clear_cache_for_post' ) );
+
 /*
  * ------------------------------------------------------------------
  * Spin-up

--- a/tests/TocModuleTest.php
+++ b/tests/TocModuleTest.php
@@ -227,4 +227,26 @@ class TocModuleTest extends TestCase {
         $this->assertStringContainsString('<a href="#sub">Sub</a>', $out);
         $this->assertStringContainsString('class="nuclen-toc', $out);
     }
+
+    public function test_cache_is_cleared_for_post() {
+        global $wp_posts, $wp_cache, $transients;
+
+        $wp_posts[1] = (object) [
+            'ID'           => 1,
+            'post_content' => '<h2>One</h2>',
+        ];
+
+        $this->registerSettings();
+
+        Nuclen_TOC_Utils::extract( $wp_posts[1]->post_content, [2, 3] );
+        $key = md5( $wp_posts[1]->post_content ) . '_23';
+
+        $this->assertArrayHasKey( $key, $wp_cache['nuclen_toc'] );
+        $this->assertArrayHasKey( 'nuclen_toc_' . $key, $transients );
+
+        Nuclen_TOC_Utils::clear_cache_for_post( 1 );
+
+        $this->assertArrayNotHasKey( $key, $wp_cache['nuclen_toc'] );
+        $this->assertArrayNotHasKey( 'nuclen_toc_' . $key, $transients );
+    }
 }


### PR DESCRIPTION
## Summary
- clear TOC caches for a post when content changes
- hook cache clearing into save/delete post events
- add unit tests covering cache invalidation

## Testing
- `composer lint` *(fails: command not found)*
- `composer test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685b7c22251c8327959b7a28eb9bf8c3