### PR TITLE
Refactor quiz code into module directory

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -6,6 +6,7 @@
       "NuclearEngagement\\Services\\": "includes/Services/",
       "NuclearEngagement\\Requests\\": "includes/Requests/",
       "NuclearEngagement\\Responses\\": "includes/Responses/",
+      "NuclearEngagement\\Modules\\": "nuclear-engagement/inc/Modules/",
       "NuclearEngagement\\": "nuclear-engagement/"
     }
   },

--- a/nuclear-engagement/admin/Traits/AdminQuizMetabox.php
+++ b/nuclear-engagement/admin/Traits/AdminQuizMetabox.php
@@ -1,213 +1,39 @@
 <?php
-declare(strict_types=1);
 /**
- * File: admin/Traits/AdminQuizMetabox.php
- *
- * Handles Quiz meta-box registration, rendering, and saving.
+ * Wrapper trait delegating quiz meta box logic to the new module.
  */
+
+declare(strict_types=1);
 
 namespace NuclearEngagement\Admin\Traits;
 
+use NuclearEngagement\Modules\Quiz\Quiz_Admin;
+use NuclearEngagement\Modules\Quiz\Quiz_Service;
+
 if ( ! defined( 'ABSPATH' ) ) {
-	exit;
+    exit;
 }
 
 trait AdminQuizMetabox {
+    private ?Quiz_Admin $quiz_admin = null;
 
-	/*
-	-------------------------------------------------------------------------
-	 *  Meta-box registration
-	 * ---------------------------------------------------------------------- */
+    private function get_quiz_admin(): Quiz_Admin {
+        if ( $this->quiz_admin === null ) {
+            $service       = new Quiz_Service();
+            $this->quiz_admin = new Quiz_Admin( $this->nuclen_get_settings_repository(), $service );
+        }
+        return $this->quiz_admin;
+    }
 
-	public function nuclen_add_quiz_data_meta_box() {
-		$settings_repo = $this->nuclen_get_settings_repository();
-		$post_types    = $settings_repo->get( 'generation_post_types', array( 'post' ) );
-		$post_types    = is_array( $post_types ) ? $post_types : array( 'post' );
+    public function nuclen_add_quiz_data_meta_box() {
+        $this->get_quiz_admin()->add_meta_box();
+    }
 
-		foreach ( $post_types as $post_type ) {
-			add_meta_box(
-				'nuclen-quiz-data-meta-box',
-				'Quiz',
-				array( $this, 'nuclen_render_quiz_data_meta_box' ),
-				$post_type,
-				'normal',
-				'default'
-			);
-		}
-	}
+    public function nuclen_render_quiz_data_meta_box( $post ) {
+        $this->get_quiz_admin()->render_meta_box( $post );
+    }
 
-	/*
-	-------------------------------------------------------------------------
-	 *  Quiz meta-box – render
-	 * ---------------------------------------------------------------------- */
-
-	public function nuclen_render_quiz_data_meta_box( $post ) {
-		$quiz_data = get_post_meta( $post->ID, 'nuclen-quiz-data', true );
-		if ( ! empty( $quiz_data ) ) {
-			$quiz_data = maybe_unserialize( $quiz_data );
-		} else {
-			$quiz_data = array(
-				'questions' => array(),
-				'date'      => '',
-			);
-		}
-
-		$questions = isset( $quiz_data['questions'] ) && is_array( $quiz_data['questions'] )
-			? $quiz_data['questions']
-			: array();
-		$date      = isset( $quiz_data['date'] ) ? $quiz_data['date'] : '';
-
-		/* Ensure ten question slots */
-		for ( $i = 0; $i < 10; $i++ ) {
-			if ( ! isset( $questions[ $i ] ) ) {
-				$questions[ $i ] = array(
-					'question'    => '',
-					'answers'     => array( '', '', '', '' ),
-					'explanation' => '',
-				);
-			}
-		}
-
-		$quiz_protected = get_post_meta( $post->ID, 'nuclen_quiz_protected', true );
-
-		wp_nonce_field( 'nuclen_quiz_data_nonce', 'nuclen_quiz_data_nonce' );
-
-		echo '<div><label>';
-		echo '<input type="checkbox" name="nuclen_quiz_protected" value="1"';
-		checked( $quiz_protected, 1 );
-		echo ' /> Protected? <span nuclen-tooltip="Tick this box and save post to prevent overwriting during bulk generation.">🛈</span>';
-		echo '</label></div>';
-
-		echo '<div>
-            <button type="button"
-                    id="nuclen-generate-quiz-single"
-                    class="button nuclen-generate-single"
-                    data-post-id="' . esc_attr( $post->ID ) . '"
-                    data-workflow="quiz">
-                Generate Quiz with AI
-            </button>
-            <span nuclen-tooltip="(re)Generate. Data will be stored automatically (no need to save post).">🛈</span>
-        </div>';
-
-		echo '<p><strong>Date</strong><br>';
-				echo '<input type="text" name="nuclen_quiz_data[date]" value="' . esc_attr( $date ) . '" readonly class="nuclen-meta-date-input" />';
-		echo '</p>';
-
-		/* Render the 10 question blocks */
-		for ( $q_index = 0; $q_index < 10; $q_index++ ) {
-			$q_data  = $questions[ $q_index ];
-			$q_text  = $q_data['question'] ?? '';
-			$answers = ( isset( $q_data['answers'] ) && is_array( $q_data['answers'] ) )
-				? $q_data['answers']
-				: array( '', '', '', '' );
-			$explan  = $q_data['explanation'] ?? '';
-
-			/* Ensure exactly 4 answers */
-			$answers = array_pad( $answers, 4, '' );
-
-			echo '<div class="nuclen-quiz-metabox-question">';
-			echo '<h4>Question ' . ( $q_index + 1 ) . '</h4>';
-
-						echo '<input type="text" name="nuclen_quiz_data[questions][' . $q_index . '][question]" value="' . esc_attr( $q_text ) . '" class="nuclen-width-full" />';
-
-			echo '<p><strong>Answers</strong></p>';
-			foreach ( $answers as $a_index => $answer ) {
-								$class = $a_index === 0 ? 'nuclen-answer-correct' : '';
-								echo '<p class="nuclen-answer-label ' . esc_attr( $class ) . '">Answer ' . ( $a_index + 1 ) . '<br>';
-								echo '<input type="text" name="nuclen_quiz_data[questions][' . $q_index . '][answers][' . $a_index . ']" value="' . esc_attr( $answer ) . '" class="nuclen-width-full" /></p>';
-			}
-
-			echo '<p><strong>Explanation</strong><br>';
-						echo '<textarea name="nuclen_quiz_data[questions][' . $q_index . '][explanation]" rows="3" class="nuclen-width-full">' . esc_textarea( $explan ) . '</textarea></p>';
-			echo '</div>';
-		}
-	}
-
-	/*
-	-------------------------------------------------------------------------
-	 *  Quiz meta-box – save
-	 * ---------------------------------------------------------------------- */
-
-	public function nuclen_save_quiz_data_meta( $post_id ) {
-
-		/* ---- Capability / nonce / autosave checks ------------------------ */
-		$nonce = $_POST['nuclen_quiz_data_nonce'] ?? '';
-		if ( ! wp_verify_nonce( $nonce, 'nuclen_quiz_data_nonce' ) ) {
-			return;
-		}
-		if ( defined( 'DOING_AUTOSAVE' ) && DOING_AUTOSAVE ) {
-			return;
-		}
-		if ( ! current_user_can( 'edit_post', $post_id ) ) {
-			return;
-		}
-
-		/* ---- Raw input ---------------------------------------------------- */
-		$raw_quiz_data = $_POST['nuclen_quiz_data'] ?? array();
-		$raw_quiz_data = is_array( $raw_quiz_data ) ? wp_unslash( $raw_quiz_data ) : array();
-
-		/* ---- Sanitise & format ------------------------------------------- */
-		$formatted = array(
-			'date'      => sanitize_text_field( $raw_quiz_data['date'] ?? gmdate( 'Y-m-d H:i:s' ) ),
-			'questions' => array(),
-		);
-
-		if ( isset( $raw_quiz_data['questions'] ) && is_array( $raw_quiz_data['questions'] ) ) {
-			foreach ( $raw_quiz_data['questions'] as $q_index => $q_raw ) {
-
-				$question = isset( $q_raw['question'] ) ? wp_kses_post( $q_raw['question'] ) : '';
-
-				$answers_raw = $q_raw['answers'] ?? array();
-				$answers_raw = is_array( $answers_raw ) ? $answers_raw : array();
-				$answers_raw = array_pad( $answers_raw, 4, '' );
-
-				$answers = array_map( 'wp_kses_post', $answers_raw );
-
-				$explan = isset( $q_raw['explanation'] ) ? wp_kses_post( $q_raw['explanation'] ) : '';
-
-				$formatted['questions'][ $q_index ] = array(
-					'question'    => $question,
-					'answers'     => $answers,
-					'explanation' => $explan,
-				);
-			}
-		}
-
-		/* ---- Save to DB --------------------------------------------------- */
-		update_post_meta( $post_id, 'nuclen-quiz-data', $formatted );
-		clean_post_cache( $post_id );
-
-		/* ---- Update post_modified if enabled ----------------------------- */
-		$settings_repo        = $this->nuclen_get_settings_repository();
-		$update_last_modified = $settings_repo->get( 'update_last_modified', 0 );
-		if ( ! empty( $update_last_modified ) && (int) $update_last_modified === 1 ) {
-			remove_action( 'save_post', array( $this, 'nuclen_save_quiz_data_meta' ), 10 );
-			remove_action( 'save_post', array( $this, 'nuclen_save_summary_data_meta' ), 10 );
-
-                        $time   = current_time( 'mysql' );
-                        $result = wp_update_post(
-                                array(
-                                        'ID'                => $post_id,
-                                        'post_modified'     => $time,
-                                        'post_modified_gmt' => get_gmt_from_date( $time ),
-                                ),
-                                true
-                        );
-
-                        if ( is_wp_error( $result ) ) {
-                                \NuclearEngagement\Services\LoggingService::log( 'Failed to update modified time for post ' . $post_id . ': ' . $result->get_error_message() );
-                                \NuclearEngagement\Services\LoggingService::notify_admin( 'Failed to update modified time for post ' . $post_id . ': ' . $result->get_error_message() );
-                        }
-
-			add_action( 'save_post', array( $this, 'nuclen_save_quiz_data_meta' ), 10, 1 );
-			add_action( 'save_post', array( $this, 'nuclen_save_summary_data_meta' ), 10, 1 );
-		}
-
-		/* ---- Protected flag ---------------------------------------------- */
-		if ( isset( $_POST['nuclen_quiz_protected'] ) && $_POST['nuclen_quiz_protected'] === '1' ) {
-			update_post_meta( $post_id, 'nuclen_quiz_protected', 1 );
-		} else {
-			delete_post_meta( $post_id, 'nuclen_quiz_protected' );
-		}
-	}
+    public function nuclen_save_quiz_data_meta( $post_id ) {
+        $this->get_quiz_admin()->save_meta( (int) $post_id );
+    }
 }

--- a/nuclear-engagement/bootstrap.php
+++ b/nuclear-engagement/bootstrap.php
@@ -68,6 +68,8 @@ spl_autoload_register(
 
         // Classes living under includes/.
         $paths[] = NUCLEN_PLUGIN_DIR . 'includes/' . $relative . '.php';
+        // Module classes under inc/.
+        $paths[] = NUCLEN_PLUGIN_DIR . 'inc/' . $relative . '.php';
 
         foreach ( $paths as $file ) {
             if ( file_exists( $file ) ) {

--- a/nuclear-engagement/front/QuizShortcode.php
+++ b/nuclear-engagement/front/QuizShortcode.php
@@ -1,70 +1,12 @@
 <?php
+/**
+ * Backwards compatibility wrapper for moved class.
+ */
+
 declare(strict_types=1);
+
 namespace NuclearEngagement\Front;
 
-use NuclearEngagement\SettingsRepository;
-use NuclearEngagement\Front\FrontClass;
+use NuclearEngagement\Modules\Quiz\Quiz_Shortcode as ModuleQuizShortcode;
 
-if ( ! defined( 'ABSPATH' ) ) {
-	exit;
-}
-
-class QuizShortcode {
-	private SettingsRepository $settings;
-	private QuizView $view;
-	private FrontClass $front;
-
-	public function __construct( SettingsRepository $settings, FrontClass $front ) {
-		$this->settings = $settings;
-		$this->front    = $front;
-		$this->view     = new QuizView();
-	}
-
-	public function register(): void {
-		add_shortcode( 'nuclear_engagement_quiz', array( $this, 'render' ) );
-	}
-
-	public function render(): string {
-		$this->front->nuclen_force_enqueue_assets();
-		$quiz_data = $this->getQuizData();
-		if ( ! $this->isValidQuizData( $quiz_data ) ) {
-			return '';
-		}
-
-		$settings = $this->getQuizSettings();
-		$html     = '<div class="nuclen-root">';
-		$html    .= $this->view->container( $settings );
-		$html    .= $this->view->attribution( $settings['show_attribution'] );
-		$html    .= '</div>';
-		return $html;
-	}
-
-	private function getQuizData() {
-		$post_id   = get_the_ID();
-		$quiz_meta = get_post_meta( $post_id, 'nuclen-quiz-data', true );
-		return maybe_unserialize( $quiz_meta );
-	}
-
-	private function isValidQuizData( $quiz_data ): bool {
-		if ( ! is_array( $quiz_data ) || empty( $quiz_data['questions'] ) ) {
-			return false;
-		}
-
-		$valid_questions = array_filter(
-			$quiz_data['questions'],
-			static function ( $q ) {
-				return isset( $q['question'] ) && trim( $q['question'] ) !== '';
-			}
-		);
-
-		return ! empty( $valid_questions );
-	}
-
-	private function getQuizSettings(): array {
-		return array(
-			'quiz_title'       => $this->settings->get_string( 'quiz_title', __( 'Test your knowledge', 'nuclear-engagement' ) ),
-			'html_before'      => $this->settings->get_string( 'custom_quiz_html_before', '' ),
-			'show_attribution' => $this->settings->get_bool( 'show_attribution', false ),
-		);
-	}
-}
+class QuizShortcode extends ModuleQuizShortcode {}

--- a/nuclear-engagement/inc/Modules/Quiz/class-quiz-service.php
+++ b/nuclear-engagement/inc/Modules/Quiz/class-quiz-service.php
@@ -1,0 +1,84 @@
+<?php
+declare(strict_types=1);
+/**
+ * Quiz data storage handler.
+ *
+ * @package NuclearEngagement\Modules\Quiz
+ */
+
+namespace NuclearEngagement\Modules\Quiz;
+
+use NuclearEngagement\Services\LoggingService;
+
+if ( ! defined( 'ABSPATH' ) ) {
+    exit;
+}
+
+final class Quiz_Service {
+    public const META_KEY      = 'nuclen-quiz-data';
+    public const PROTECTED_KEY = 'nuclen_quiz_protected';
+
+    /**
+     * Retrieve quiz meta for a post.
+     */
+    public function get_quiz_data( int $post_id ): array {
+        $quiz_data = get_post_meta( $post_id, self::META_KEY, true );
+        if ( ! empty( $quiz_data ) ) {
+            $quiz_data = maybe_unserialize( $quiz_data );
+        }
+        if ( ! is_array( $quiz_data ) ) {
+            $quiz_data = array(
+                'questions' => array(),
+                'date'      => '',
+            );
+        }
+        return $quiz_data;
+    }
+
+    /**
+     * Persist quiz data for a post.
+     */
+    public function save_quiz_data( int $post_id, array $raw ): void {
+        $formatted = array(
+            'date'      => sanitize_text_field( $raw['date'] ?? gmdate( 'Y-m-d H:i:s' ) ),
+            'questions' => array(),
+        );
+
+        if ( isset( $raw['questions'] ) && is_array( $raw['questions'] ) ) {
+            foreach ( $raw['questions'] as $q_index => $q_raw ) {
+                $question    = isset( $q_raw['question'] ) ? wp_kses_post( $q_raw['question'] ) : '';
+                $answers_raw = isset( $q_raw['answers'] ) && is_array( $q_raw['answers'] ) ? $q_raw['answers'] : array();
+                $answers_raw = array_pad( $answers_raw, 4, '' );
+                $answers     = array_map( 'wp_kses_post', $answers_raw );
+                $explan      = isset( $q_raw['explanation'] ) ? wp_kses_post( $q_raw['explanation'] ) : '';
+
+                $formatted['questions'][ $q_index ] = array(
+                    'question'    => $question,
+                    'answers'     => $answers,
+                    'explanation' => $explan,
+                );
+            }
+        }
+
+        update_post_meta( $post_id, self::META_KEY, $formatted );
+        clean_post_cache( $post_id );
+    }
+
+    /**
+     * Get protected flag for a post.
+     */
+    public function is_protected( int $post_id ): bool {
+        return (bool) get_post_meta( $post_id, self::PROTECTED_KEY, true );
+    }
+
+    /**
+     * Store protected flag for a post.
+     */
+    public function set_protected( int $post_id, bool $protected ): void {
+        if ( $protected ) {
+            update_post_meta( $post_id, self::PROTECTED_KEY, 1 );
+        } else {
+            delete_post_meta( $post_id, self::PROTECTED_KEY );
+        }
+    }
+}

--- a/nuclear-engagement/inc/Modules/Quiz/class-quiz-shortcode.php
+++ b/nuclear-engagement/inc/Modules/Quiz/class-quiz-shortcode.php
@@ -1,0 +1,73 @@
+<?php
+declare(strict_types=1);
+/**
+ * Quiz shortcode handler.
+ *
+ * @package NuclearEngagement\Modules\Quiz
+ */
+
+namespace NuclearEngagement\Modules\Quiz;
+
+use NuclearEngagement\SettingsRepository;
+use NuclearEngagement\Front\FrontClass;
+use NuclearEngagement\Front\QuizView;
+
+if ( ! defined( 'ABSPATH' ) ) {
+    exit;
+}
+
+class Quiz_Shortcode {
+    private SettingsRepository $settings;
+    private QuizView $view;
+    private FrontClass $front;
+    private Quiz_Service $service;
+
+    public function __construct( SettingsRepository $settings, FrontClass $front, Quiz_Service $service ) {
+        $this->settings = $settings;
+        $this->front    = $front;
+        $this->view     = new QuizView();
+        $this->service  = $service;
+    }
+
+    public function register(): void {
+        add_shortcode( 'nuclear_engagement_quiz', array( $this, 'render' ) );
+    }
+
+    public function render(): string {
+        $this->front->nuclen_force_enqueue_assets();
+        $quiz_data = $this->service->get_quiz_data( get_the_ID() );
+        if ( ! $this->isValidQuizData( $quiz_data ) ) {
+            return '';
+        }
+
+        $settings = $this->getQuizSettings();
+        $html     = '<div class="nuclen-root">';
+        $html    .= $this->view->container( $settings );
+        $html    .= $this->view->attribution( $settings['show_attribution'] );
+        $html    .= '</div>';
+        return $html;
+    }
+
+    private function isValidQuizData( $quiz_data ): bool {
+        if ( ! is_array( $quiz_data ) || empty( $quiz_data['questions'] ) ) {
+            return false;
+        }
+
+        $valid_questions = array_filter(
+            $quiz_data['questions'],
+            static function ( $q ) {
+                return isset( $q['question'] ) && trim( $q['question'] ) !== '';
+            }
+        );
+
+        return ! empty( $valid_questions );
+    }
+
+    private function getQuizSettings(): array {
+        return array(
+            'quiz_title'       => $this->settings->get_string( 'quiz_title', __( 'Test your knowledge', 'nuclear-engagement' ) ),
+            'html_before'      => $this->settings->get_string( 'custom_quiz_html_before', '' ),
+            'show_attribution' => $this->settings->get_bool( 'show_attribution', false ),
+        );
+    }
+}

--- a/nuclear-engagement/inc/Modules/Quiz/quiz-admin.php
+++ b/nuclear-engagement/inc/Modules/Quiz/quiz-admin.php
@@ -1,0 +1,168 @@
+<?php
+declare(strict_types=1);
+/**
+ * Quiz admin UI and meta box handling.
+ *
+ * @package NuclearEngagement\Modules\Quiz
+ */
+
+namespace NuclearEngagement\Modules\Quiz;
+
+use NuclearEngagement\SettingsRepository;
+use NuclearEngagement\Services\LoggingService;
+
+if ( ! defined( 'ABSPATH' ) ) {
+    exit;
+}
+
+final class Quiz_Admin {
+    private SettingsRepository $settings;
+    private Quiz_Service $service;
+
+    public function __construct( SettingsRepository $settings, Quiz_Service $service ) {
+        $this->settings = $settings;
+        $this->service  = $service;
+    }
+
+    /** Register meta box actions. */
+    public function register_hooks(): void {
+        add_action( 'add_meta_boxes', array( $this, 'add_meta_box' ) );
+        add_action( 'save_post', array( $this, 'save_meta' ) );
+    }
+
+    /** Add the Quiz meta box. */
+    public function add_meta_box(): void {
+        $post_types = $this->settings->get( 'generation_post_types', array( 'post' ) );
+        $post_types = is_array( $post_types ) ? $post_types : array( 'post' );
+
+        foreach ( $post_types as $post_type ) {
+            add_meta_box(
+                'nuclen-quiz-data-meta-box',
+                'Quiz',
+                array( $this, 'render_meta_box' ),
+                $post_type,
+                'normal',
+                'default'
+            );
+        }
+    }
+
+    /** Render the Quiz meta box. */
+    public function render_meta_box( $post ): void {
+        $quiz_data = $this->service->get_quiz_data( $post->ID );
+
+        $questions = isset( $quiz_data['questions'] ) && is_array( $quiz_data['questions'] )
+            ? $quiz_data['questions']
+            : array();
+        $date = $quiz_data['date'] ?? '';
+
+        for ( $i = 0; $i < 10; $i++ ) {
+            if ( ! isset( $questions[ $i ] ) ) {
+                $questions[ $i ] = array(
+                    'question'    => '',
+                    'answers'     => array( '', '', '', '' ),
+                    'explanation' => '',
+                );
+            }
+        }
+
+        $quiz_protected = $this->service->is_protected( $post->ID );
+
+        wp_nonce_field( 'nuclen_quiz_data_nonce', 'nuclen_quiz_data_nonce' );
+
+        echo '<div><label>';
+        echo '<input type="checkbox" name="nuclen_quiz_protected" value="1"';
+        checked( $quiz_protected, 1 );
+        echo ' /> Protected? <span nuclen-tooltip="Tick this box and save post to prevent overwriting during bulk generation.">🛈</span>';
+        echo '</label></div>';
+
+        echo '<div>
+            <button type="button"
+                    id="nuclen-generate-quiz-single"
+                    class="button nuclen-generate-single"
+                    data-post-id="' . esc_attr( $post->ID ) . '"
+                    data-workflow="quiz">
+                Generate Quiz with AI
+            </button>
+            <span nuclen-tooltip="(re)Generate. Data will be stored automatically (no need to save post).">🛈</span>
+        </div>';
+
+        echo '<p><strong>Date</strong><br>';
+        echo '<input type="text" name="nuclen_quiz_data[date]" value="' . esc_attr( $date ) . '" readonly class="nuclen-meta-date-input" />';
+        echo '</p>';
+
+        for ( $q_index = 0; $q_index < 10; $q_index++ ) {
+            $q_data  = $questions[ $q_index ];
+            $q_text  = $q_data['question'] ?? '';
+            $answers = isset( $q_data['answers'] ) && is_array( $q_data['answers'] )
+                ? $q_data['answers']
+                : array( '', '', '', '' );
+            $explan  = $q_data['explanation'] ?? '';
+
+            $answers = array_pad( $answers, 4, '' );
+
+            echo '<div class="nuclen-quiz-metabox-question">';
+            echo '<h4>Question ' . ( $q_index + 1 ) . '</h4>';
+
+            echo '<input type="text" name="nuclen_quiz_data[questions][' . $q_index . '][question]" value="' . esc_attr( $q_text ) . '" class="nuclen-width-full" />';
+
+            echo '<p><strong>Answers</strong></p>';
+            foreach ( $answers as $a_index => $answer ) {
+                $class = $a_index === 0 ? 'nuclen-answer-correct' : '';
+                echo '<p class="nuclen-answer-label ' . esc_attr( $class ) . '">Answer ' . ( $a_index + 1 ) . '<br>';
+                echo '<input type="text" name="nuclen_quiz_data[questions][' . $q_index . '][answers][' . $a_index . ']" value="' . esc_attr( $answer ) . '" class="nuclen-width-full" /></p>';
+            }
+
+            echo '<p><strong>Explanation</strong><br>';
+            echo '<textarea name="nuclen_quiz_data[questions][' . $q_index . '][explanation]" rows="3" class="nuclen-width-full">' . esc_textarea( $explan ) . '</textarea></p>';
+            echo '</div>';
+        }
+    }
+
+    /** Save quiz meta on post save. */
+    public function save_meta( int $post_id ): void {
+        $nonce = $_POST['nuclen_quiz_data_nonce'] ?? '';
+        if ( ! wp_verify_nonce( $nonce, 'nuclen_quiz_data_nonce' ) ) {
+            return;
+        }
+        if ( defined( 'DOING_AUTOSAVE' ) && DOING_AUTOSAVE ) {
+            return;
+        }
+        if ( ! current_user_can( 'edit_post', $post_id ) ) {
+            return;
+        }
+
+        $raw_quiz_data = $_POST['nuclen_quiz_data'] ?? array();
+        $raw_quiz_data = is_array( $raw_quiz_data ) ? wp_unslash( $raw_quiz_data ) : array();
+
+        $this->service->save_quiz_data( $post_id, $raw_quiz_data );
+
+        $update_last_modified = $this->settings->get( 'update_last_modified', 0 );
+        if ( ! empty( $update_last_modified ) && (int) $update_last_modified === 1 ) {
+            remove_action( 'save_post', array( $this, 'save_meta' ), 10 );
+
+            $time   = current_time( 'mysql' );
+            $result = wp_update_post(
+                array(
+                    'ID'                => $post_id,
+                    'post_modified'     => $time,
+                    'post_modified_gmt' => get_gmt_from_date( $time ),
+                ),
+                true
+            );
+
+            if ( is_wp_error( $result ) ) {
+                LoggingService::log( 'Failed to update modified time for post ' . $post_id . ': ' . $result->get_error_message() );
+                LoggingService::notify_admin( 'Failed to update modified time for post ' . $post_id . ': ' . $result->get_error_message() );
+            }
+
+            add_action( 'save_post', array( $this, 'save_meta' ), 10 );
+        }
+
+        if ( isset( $_POST['nuclen_quiz_protected'] ) && $_POST['nuclen_quiz_protected'] === '1' ) {
+            $this->service->set_protected( $post_id, true );
+        } else {
+            $this->service->set_protected( $post_id, false );
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- add new Quiz module under `inc/Modules`
- implement `Quiz_Service`, `Quiz_Admin` and `Quiz_Shortcode`
- delegate old metabox trait and shortcode class to the module
- extend autoloader to load files from `inc/`
- update composer autoload mapping

## Testing
- `vendor/bin/phpcs` *(fails: command not found)*
- `vendor/bin/phpunit` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685b802c5cc08327957a50eb41ef565b

<!-- Korbit AI PR Description Start -->
## Description by Korbit AI

### What change is being made?
Refactor quiz-related logic into a new module, organizing code into the `nuclear-engagement/inc/Modules/Quiz` directory and updating references and uses accordingly across the codebase.

### Why are these changes being made?
This refactoring enhances the modularity and maintainability of the code by encapsulating quiz functionalities in a dedicated module, which makes the codebase cleaner and separates concerns for easier future updates or feature enhancements. This approach also promotes reuse and clearer organization by leveraging standard module patterns within the application.

> Is this description stale? Ask me to generate a new description by commenting `/korbit-generate-pr-description`
<!-- Korbit AI PR Description End -->