### PR TITLE
Fix trait namespace in SettingsRepository

### DIFF
--- a/nuclear-engagement/includes/SettingsRepository.php
+++ b/nuclear-engagement/includes/SettingsRepository.php
@@ -117,10 +117,10 @@ final class SettingsRepository {
 		* ===================================================================
 		*/
 
-use NuclearEngagement\Traits\SettingsGettersTrait;
-use NuclearEngagement\Traits\SettingsPersistenceTrait;
-use NuclearEngagement\Traits\SettingsCacheTrait;
-use NuclearEngagement\Traits\SettingsAccessTrait;
+use \NuclearEngagement\Traits\SettingsGettersTrait;
+use \NuclearEngagement\Traits\SettingsPersistenceTrait;
+use \NuclearEngagement\Traits\SettingsCacheTrait;
+use \NuclearEngagement\Traits\SettingsAccessTrait;
 use PendingSettingsTrait;
 
         /**


### PR DESCRIPTION
## Summary
- fix fully qualified trait names in `SettingsRepository`

## Testing
- `composer lint` *(fails: command not found)*
- `composer test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685b81c6ddf08327911b7dbb78c3d7d1

<!-- Korbit AI PR Description Start -->
## Description by Korbit AI

### What change is being made?

Correct the trait namespace usage by adding leading backslashes to trait import statements in the `SettingsRepository.php` file.

### Why are these changes being made?

The leading backslashes ensure that the traits are correctly recognized in global namespace context, aligning with best practices for namespacing in PHP and preventing potential issues when these traits are used in varying scopes.

> Is this description stale? Ask me to generate a new description by commenting `/korbit-generate-pr-description`
<!-- Korbit AI PR Description End -->