### PR TITLE
Add Summary module

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -77,6 +77,15 @@ handling with asset management and content filtering. To stay within the
 The loader now requires these files and spins up each class. This keeps
 responsibilities narrow and makes future maintenance easier.
 
+## Summary Module Decomposition
+
+The summary shortcode and meta box live in their own module under
+`modules/summary/`. `Nuclen_Summary_Shortcode` renders the
+`[nuclear_engagement_summary]` shortcode using a lightweight view helper.
+`Nuclen_Summary_Metabox` registers the Summary meta box and saves its data.
+`loader.php` includes these classes and instantiates them on
+`plugins_loaded`, mirroring how the TOC module loads its handlers.
+
 
 ## Settings Cache Extraction
 

--- a/nuclear-engagement/admin/Admin.php
+++ b/nuclear-engagement/admin/Admin.php
@@ -53,8 +53,6 @@ class Admin {
 		// Meta-boxes
 		add_action( 'add_meta_boxes', array( $this, 'nuclen_add_quiz_data_meta_box' ) );
 		add_action( 'save_post', array( $this, 'nuclen_save_quiz_data_meta' ) );
-		add_action( 'add_meta_boxes', array( $this, 'nuclen_add_summary_data_meta_box' ) );
-		add_action( 'save_post', array( $this, 'nuclen_save_summary_data_meta' ) );
 
 		// AJAX & assets
 		add_action( 'wp_ajax_nuclen_fetch_app_updates', array( $this, 'nuclen_fetch_app_updates' ) );

--- a/nuclear-engagement/admin/Traits/AdminMetaboxes.php
+++ b/nuclear-engagement/admin/Traits/AdminMetaboxes.php
@@ -23,5 +23,4 @@ if ( ! defined( 'ABSPATH' ) ) {
  */
 trait AdminMetaboxes {
     use AdminQuizMetabox;
-    use AdminSummaryMetabox;
 }

--- a/nuclear-engagement/includes/Plugin.php
+++ b/nuclear-engagement/includes/Plugin.php
@@ -80,8 +80,11 @@ class Plugin {
 		/* ► Ensure OptinData hooks are registered */
 		OptinData::init();
 
-		// TOC module
-		require_once plugin_dir_path( __FILE__ ) . '../modules/toc/loader.php';
+                // TOC module
+                require_once plugin_dir_path( __FILE__ ) . '../modules/toc/loader.php';
+
+                // Summary module
+                require_once plugin_dir_path( __FILE__ ) . '../modules/summary/loader.php';
 
 		$this->loader = new Loader();
 	}

--- a/nuclear-engagement/modules/summary/includes/class-nuclen-summary-metabox.php
+++ b/nuclear-engagement/modules/summary/includes/class-nuclen-summary-metabox.php
@@ -1,18 +1,33 @@
 <?php
 declare(strict_types=1);
 /**
- * File: admin/Traits/AdminSummaryMetabox.php
+ * Summary meta box handler.
  *
- * Handles Summary meta-box registration, rendering, and saving.
+ * Formerly the AdminSummaryMetabox trait, converted into a dedicated class
+ * under the Summary module.
  */
 
-namespace NuclearEngagement\Admin\Traits;
+namespace {
 
 if ( ! defined( 'ABSPATH' ) ) {
 	exit;
 }
 
-trait AdminSummaryMetabox {
+use NuclearEngagement\SettingsRepository;
+
+final class Nuclen_Summary_Metabox {
+
+        private SettingsRepository $settings;
+
+        public function __construct( SettingsRepository $settings ) {
+                $this->settings = $settings;
+                add_action( 'add_meta_boxes', array( $this, 'nuclen_add_summary_data_meta_box' ) );
+                add_action( 'save_post', array( $this, 'nuclen_save_summary_data_meta' ) );
+        }
+
+        private function nuclen_get_settings_repository(): SettingsRepository {
+                return $this->settings;
+        }
 
 	/*
 	-------------------------------------------------------------------------
@@ -133,9 +148,8 @@ trait AdminSummaryMetabox {
 		/* ---- Update post_modified if enabled ----------------------------- */
 		$settings_repo = $this->nuclen_get_settings_repository();
 		$settings      = $settings_repo->get( 'update_last_modified', 0 );
-		if ( ! empty( $settings ) && (int) $settings === 1 ) {
-			remove_action( 'save_post', array( $this, 'nuclen_save_quiz_data_meta' ), 10 );
-			remove_action( 'save_post', array( $this, 'nuclen_save_summary_data_meta' ), 10 );
+                if ( ! empty( $settings ) && (int) $settings === 1 ) {
+                        remove_action( 'save_post', array( $this, 'nuclen_save_summary_data_meta' ), 10 );
 
                         $time   = current_time( 'mysql' );
                         $result = wp_update_post(
@@ -152,8 +166,7 @@ trait AdminSummaryMetabox {
                                 \NuclearEngagement\Services\LoggingService::notify_admin( 'Failed to update modified time for post ' . $post_id . ': ' . $result->get_error_message() );
                         }
 
-			add_action( 'save_post', array( $this, 'nuclen_save_quiz_data_meta' ), 10, 1 );
-			add_action( 'save_post', array( $this, 'nuclen_save_summary_data_meta' ), 10, 1 );
+                        add_action( 'save_post', array( $this, 'nuclen_save_summary_data_meta' ), 10, 1 );
 		}
 
 		/* ---- Protected flag ---------------------------------------------- */

--- a/nuclear-engagement/modules/summary/includes/class-nuclen-summary-shortcode.php
+++ b/nuclear-engagement/modules/summary/includes/class-nuclen-summary-shortcode.php
@@ -1,6 +1,7 @@
 <?php
 declare(strict_types=1);
-namespace NuclearEngagement\Front;
+
+namespace {
 
 use NuclearEngagement\SettingsRepository;
 use NuclearEngagement\Front\FrontClass;
@@ -9,15 +10,15 @@ if ( ! defined( 'ABSPATH' ) ) {
 	exit;
 }
 
-class SummaryShortcode {
+final class Nuclen_Summary_Shortcode {
 	private SettingsRepository $settings;
-	private SummaryView $view;
+        private Nuclen_Summary_View $view;
 	private FrontClass $front;
 
 	public function __construct( SettingsRepository $settings, FrontClass $front ) {
 		$this->settings = $settings;
 		$this->front    = $front;
-		$this->view     = new SummaryView();
+                $this->view     = new Nuclen_Summary_View();
 	}
 
 	public function register(): void {

--- a/nuclear-engagement/modules/summary/includes/class-nuclen-summary-view.php
+++ b/nuclear-engagement/modules/summary/includes/class-nuclen-summary-view.php
@@ -1,12 +1,13 @@
 <?php
 declare(strict_types=1);
-namespace NuclearEngagement\Front;
+
+namespace {
 
 if ( ! defined( 'ABSPATH' ) ) {
 	exit;
 }
 
-class SummaryView {
+final class Nuclen_Summary_View {
 	public function container( array $summary_data, array $settings ): string {
 		$summary_content = wp_kses_post( $summary_data['summary'] );
 		return sprintf(

--- a/nuclear-engagement/modules/summary/loader.php
+++ b/nuclear-engagement/modules/summary/loader.php
@@ -1,0 +1,40 @@
+<?php
+/**
+ * File: modules/summary/loader.php
+ *
+ * Loads the Nuclen Summary sub-module.
+ *
+ * @package NuclearEngagement
+ */
+
+declare(strict_types=1);
+
+if ( ! defined( 'ABSPATH' ) ) {
+    exit;
+}
+
+/* ------------------------------------------------------------------
+ * Local constants (prefixed, module-scoped)
+ * ------------------------------------------------------------------ */
+define( 'NUCLEN_SUMMARY_DIR', __DIR__ . '/' );
+define( 'NUCLEN_SUMMARY_URL', plugin_dir_url( __FILE__ ) );
+
+/* ------------------------------------------------------------------
+ * Includes
+ * ------------------------------------------------------------------ */
+require_once NUCLEN_SUMMARY_DIR . 'includes/class-nuclen-summary-view.php';
+require_once NUCLEN_SUMMARY_DIR . 'includes/class-nuclen-summary-shortcode.php';
+require_once NUCLEN_SUMMARY_DIR . 'includes/class-nuclen-summary-metabox.php';
+
+/* ------------------------------------------------------------------
+ * Spin-up
+ * ------------------------------------------------------------------ */
+add_action(
+    'plugins_loaded',
+    static function () {
+        new Nuclen_Summary_Shortcode( \NuclearEngagement\SettingsRepository::get_instance(), new \NuclearEngagement\Front\FrontClass() );
+        if ( is_admin() ) {
+            new Nuclen_Summary_Metabox( \NuclearEngagement\SettingsRepository::get_instance() );
+        }
+    }
+);

--- a/tests/SummaryShortcodeViewTest.php
+++ b/tests/SummaryShortcodeViewTest.php
@@ -1,12 +1,10 @@
 <?php
 use PHPUnit\Framework\TestCase;
-use NuclearEngagement\Front\SummaryShortcode;
-use NuclearEngagement\Front\SummaryView;
+use Nuclen_Summary_Shortcode as SummaryShortcode;
+use Nuclen_Summary_View as SummaryView;
 use NuclearEngagement\SettingsRepository;
 
-namespace NuclearEngagement\Front {
-    function get_the_ID() { return $GLOBALS['current_post_id'] ?? 0; }
-}
+function get_the_ID() { return $GLOBALS['current_post_id'] ?? 0; }
 
 namespace {
     if (!function_exists('esc_html')) {


### PR DESCRIPTION
## Summary
- add Summary module directory and loader
- move Summary classes under modules and convert them to prefixed classes
- convert AdminSummaryMetabox trait into Nuclen_Summary_Metabox class
- load the new module from Plugin
- update tests and docs

## Testing
- `composer lint` *(fails: command not found)*
- `composer test` *(fails: command not found)*


------
https://chatgpt.com/codex/tasks/task_e_685b813e32208327b693d1ebb8374bb8