### PR TITLE
Fix summary module parse errors

### DIFF
--- a/nuclear-engagement/modules/summary/includes/class-nuclen-summary-metabox.php
+++ b/nuclear-engagement/modules/summary/includes/class-nuclen-summary-metabox.php
@@ -48,8 +48,10 @@ final class Nuclen_Summary_Metabox {
 				'normal',
 				'default'
 			);
-		}
-	}
+        }
+}
+
+}
 
 	/*
 	-------------------------------------------------------------------------
@@ -176,4 +178,6 @@ final class Nuclen_Summary_Metabox {
 			delete_post_meta( $post_id, 'nuclen_summary_protected' );
 		}
 	}
+}
+
 }

--- a/nuclear-engagement/modules/summary/includes/class-nuclen-summary-shortcode.php
+++ b/nuclear-engagement/modules/summary/includes/class-nuclen-summary-shortcode.php
@@ -49,10 +49,12 @@ final class Nuclen_Summary_Shortcode {
 		return ! empty( $summary_data ) && ! empty( trim( $summary_data['summary'] ?? '' ) );
 	}
 
-	private function getSummarySettings(): array {
-		return array(
-			'summary_title'    => $this->settings->get_string( 'summary_title', __( 'Key Facts', 'nuclear-engagement' ) ),
-			'show_attribution' => $this->settings->get_bool( 'show_attribution', false ),
-		);
-	}
+        private function getSummarySettings(): array {
+                return array(
+                        'summary_title'    => $this->settings->get_string( 'summary_title', __( 'Key Facts', 'nuclear-engagement' ) ),
+                        'show_attribution' => $this->settings->get_bool( 'show_attribution', false ),
+                );
+        }
+}
+
 }

--- a/nuclear-engagement/modules/summary/includes/class-nuclen-summary-view.php
+++ b/nuclear-engagement/modules/summary/includes/class-nuclen-summary-view.php
@@ -20,14 +20,16 @@ final class Nuclen_Summary_View {
 		);
 	}
 
-	public function attribution( bool $show ): string {
-		if ( ! $show ) {
-			return '';
-		}
-		return sprintf(
-			'<div class="nuclen-attribution">%s <a rel="nofollow" href="https://www.nuclearengagement.com" target="_blank">%s</a></div>',
-			esc_html__( 'Summary by', 'nuclear-engagement' ),
-			esc_html__( 'Nuclear Engagement', 'nuclear-engagement' )
-		);
-	}
+        public function attribution( bool $show ): string {
+                if ( ! $show ) {
+                        return '';
+                }
+                return sprintf(
+                        '<div class="nuclen-attribution">%s <a rel="nofollow" href="https://www.nuclearengagement.com" target="_blank">%s</a></div>',
+                        esc_html__( 'Summary by', 'nuclear-engagement' ),
+                        esc_html__( 'Nuclear Engagement', 'nuclear-engagement' )
+                );
+        }
+}
+
 }


### PR DESCRIPTION
## Summary
- close PHP namespace blocks in summary module

## Testing
- `composer lint` *(fails: command not found)*
- `composer test` *(fails: command not found)*


------
https://chatgpt.com/codex/tasks/task_e_685b84d369a083278d7c457356720b3c