### PR TITLE
Fix outdated plugin folder references

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -18,19 +18,19 @@ Each folder stays under the 300 LOC guideline described in `nuclear-engagement/
 The file `nuclear-engagement/AGENTS.md` defines the high‑level folder layout for the plugin:
 
 plugin-root/
+├── admin/               # wp-admin functionality
+├── assets/              # compiled JS/CSS
+├── front/               # public-facing assets
 ├── inc/
-│   ├── Modules/
-│   │   ├── Quiz/          # 1 feature = 1 folder
-│   │   │   ├── class-quiz-service.php
-│   │   │   ├── quiz-admin.php
-│   │   │   └── assets/
-│   │   └── Summary/
-│   ├── Core/              # shared kernel (loader, i18n, settings API)
-│   └── Utils/             # truly generic helpers
-├── templates/             # view partials only—no logic
-├── assets/                # compiled JS/CSS
+│   └── Modules/
+│       └── Quiz/        # 1 feature = 1 folder
+│           ├── class-quiz-service.php
+│           ├── quiz-admin.php
+│           └── assets/
+├── includes/            # shared kernel (loader, i18n, settings API)
 ├── languages/
-└── tests/
+├── modules/             # optional features such as Summary and TOC
+└── vendor/
 
 Key guidelines from that document include:
 

--- a/nuclear-engagement/AGENTS.md
+++ b/nuclear-engagement/AGENTS.md
@@ -3,19 +3,19 @@ Slice by concern, not by type
 
 ```
 plugin-root/
-├── inc/
-│   ├── Modules/
-│   │   ├── Quiz/          # 1 feature = 1 folder
-│   │   │   ├── class-quiz-service.php
-│   │   │   ├── quiz-admin.php
-│   │   │   └── assets/
-│   │   └── Summary/
-│   ├── Core/              # shared kernel (loader, i18n, settings API)
-│   └── Utils/             # truly generic helpers
-├── templates/             # view partials only—no logic
+├── admin/
 ├── assets/                # compiled JS/CSS
+├── front/
+├── inc/
+│   └── Modules/
+│       └── Quiz/
+│           ├── class-quiz-service.php
+│           ├── quiz-admin.php
+│           └── assets/
+├── includes/
 ├── languages/
-└── tests/
+├── modules/               # optional features such as Summary and TOC
+└── vendor/
 ```
 Central bootloader (plugin.php) stays 50 LOC max
 Register autoloader → instantiate Core\\Plugin → add_action hooks—nothing else.


### PR DESCRIPTION
## Summary
- update plugin layout in architecture docs
- sync plugin tree reference in AGENTS guide

## Testing
- `composer lint` *(fails: command not found)*
- `composer test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685b84ba984c832782c37bba16dc719d