### PR TITLE
Add PHP version check for older environments

### DIFF
--- a/nuclear-engagement/nuclear-engagement.php
+++ b/nuclear-engagement/nuclear-engagement.php
@@ -17,15 +17,34 @@
  * @since      1.0.0
  */
 
-declare(strict_types=1);
-
-// If this file is called directly, abort.
+// Bail if accessed directly.
 if ( ! defined( 'ABSPATH' ) ) {
-	exit;
+    exit;
 }
 
-// Define plugin constants.
+// Minimum PHP version requirement.
+if ( version_compare( PHP_VERSION, '7.4', '<' ) ) {
+    /**
+     * Display admin notice when PHP version is too low.
+     *
+     * This wrapper uses only PHP 5.6 compatible syntax so it can run on
+     * older installations without causing a fatal error.
+     */
+    function nuclear_engagement_php_notice() {
+        echo '<div class="error"><p>' .
+            esc_html__(
+                'Nuclear Engagement requires PHP 7.4 or higher.',
+                'nuclear-engagement'
+            ) .
+            '</p></div>';
+    }
+    add_action( 'admin_notices', 'nuclear_engagement_php_notice' );
+    return;
+}
+
+// PHP version is sufficient; continue loading typed code.
+declare(strict_types=1);
+
 define( 'NUCLEN_PLUGIN_FILE', __FILE__ );
 
-// Include the main plugin class.
 require_once __DIR__ . '/bootstrap.php';


### PR DESCRIPTION
## Summary
- guard against older PHP versions in plugin entrypoint

## Testing
- `composer lint` *(fails: command not found)*
- `composer test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685b859a5748832787468a093a425fed