### PR TITLE
Fix strict types position

### DIFF
--- a/nuclear-engagement/nuclear-engagement.php
+++ b/nuclear-engagement/nuclear-engagement.php
@@ -17,6 +17,8 @@
  * @since      1.0.0
  */
 
+declare(strict_types=1);
+
 // Bail if accessed directly.
 if ( ! defined( 'ABSPATH' ) ) {
     exit;
@@ -43,7 +45,6 @@ if ( version_compare( PHP_VERSION, '7.4', '<' ) ) {
 }
 
 // PHP version is sufficient; continue loading typed code.
-declare(strict_types=1);
 
 define( 'NUCLEN_PLUGIN_FILE', __FILE__ );
 


### PR DESCRIPTION
## Summary
- ensure `declare(strict_types=1);` is the first statement of the plugin bootstrap

## Testing
- `composer lint` *(fails: command not found)*
- `composer test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685b892e3db4832796fc85b184ecbb56


> [!NOTE]
> I'm currently writing a description for your pull request. I should be done shortly (<1 minute). Please don't edit the description field until I'm finished, or we may overwrite each other. If I find nothing to write about, I'll delete this message.
