### PR TITLE
Fix module loader paths

### DIFF
--- a/nuclear-engagement/inc/Core/Plugin.php
+++ b/nuclear-engagement/inc/Core/Plugin.php
@@ -81,10 +81,10 @@ class Plugin {
 		OptinData::init();
 
                 // TOC module
-                require_once plugin_dir_path( __FILE__ ) . '../inc/Modules/TOC/loader.php';
+                require_once NUCLEN_PLUGIN_DIR . 'inc/Modules/TOC/loader.php';
 
                 // Summary module
-                require_once plugin_dir_path( __FILE__ ) . '../inc/Modules/Summary/loader.php';
+                require_once NUCLEN_PLUGIN_DIR . 'inc/Modules/Summary/loader.php';
 
 		$this->loader = new Loader();
 	}


### PR DESCRIPTION
## Summary
- use NUCLEN_PLUGIN_DIR when loading module loader files

## Testing
- `composer lint` *(fails: command not found)*
- `composer test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685b8a93dbd483279d5639ba2b0ef040


> [!NOTE]
> I'm currently writing a description for your pull request. I should be done shortly (<1 minute). Please don't edit the description field until I'm finished, or we may overwrite each other. If I find nothing to write about, I'll delete this message.
