### PR TITLE
Fix module paths in plugin loader

### DIFF
--- a/nuclear-engagement/inc/Core/Plugin.php
+++ b/nuclear-engagement/inc/Core/Plugin.php
@@ -81,10 +81,10 @@ class Plugin {
 		OptinData::init();
 
                 // TOC module
-                require_once plugin_dir_path( __FILE__ ) . '../inc/Modules/TOC/loader.php';
+                require_once plugin_dir_path( __FILE__ ) . '../Modules/TOC/loader.php';
 
                 // Summary module
-                require_once plugin_dir_path( __FILE__ ) . '../inc/Modules/Summary/loader.php';
+                require_once plugin_dir_path( __FILE__ ) . '../Modules/Summary/loader.php';
 
 		$this->loader = new Loader();
 	}


### PR DESCRIPTION
## Summary
- correct paths for TOC and Summary modules

## Testing
- `composer lint` *(fails: command not found)*
- `composer test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685b8b1c24608327b36ec4a370e6bae3