### PR TITLE
Fix fatal error when vendor autoload missing

### DIFF
--- a/nuclear-engagement/bootstrap.php
+++ b/nuclear-engagement/bootstrap.php
@@ -38,6 +38,12 @@ if ( ! file_exists( $autoload ) ) {
 if ( file_exists( $autoload ) ) {
         require_once $autoload;
 } else {
+        // Manually load the logging class so we can output an error.
+        $logging = __DIR__ . '/inc/Services/LoggingService.php';
+        if ( file_exists( $logging ) ) {
+                require_once $logging;
+        }
+
         \NuclearEngagement\Services\LoggingService::log( 'Nuclear Engagement: vendor autoload not found.' );
         \NuclearEngagement\Services\LoggingService::notify_admin( 'Nuclear Engagement dependencies missing. Please run composer install.' );
         return;


### PR DESCRIPTION
## Summary
- load `LoggingService` manually in `bootstrap.php` if Composer autoload isn't found

## Testing
- `composer lint` *(fails: command not found)*
- `composer test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685b8dd0ec508327aa63f5d9fcceeee0

<!-- Korbit AI PR Description Start -->
## Description by Korbit AI

### What change is being made?

Add a manual inclusion of the LoggingService when the vendor autoload is missing to handle errors gracefully.

### Why are these changes being made?

The change ensures that meaningful error messages can be logged and administrators are notified in scenarios where the vendor autoload file is missing, preventing a fatal error and providing clear instructions to resolve the issue by running `composer install`. This approach ensures smoother error handling and improved user experience without relying on autoload.

> Is this description stale? Ask me to generate a new description by commenting `/korbit-generate-pr-description`
<!-- Korbit AI PR Description End -->