### PR TITLE
Centralize WordPress stubs

### DIFF
--- a/tests/ContentControllerTest.php
+++ b/tests/ContentControllerTest.php
@@ -20,9 +20,6 @@ namespace {
     if (!function_exists('sanitize_text_field')) {
         function sanitize_text_field($t) { return $t; }
     }
-    if (!function_exists('wp_verify_nonce')) {
-        function wp_verify_nonce($nonce, $action) { return $nonce === 'valid'; }
-    }
     if (!function_exists('current_user_can')) {
         function current_user_can($cap) { return true; }
     }

--- a/tests/LoggingServiceTest.php
+++ b/tests/LoggingServiceTest.php
@@ -3,15 +3,6 @@ use PHPUnit\Framework\TestCase;
 use NuclearEngagement\Services\LoggingService;
 
 namespace NuclearEngagement\Services {
-    function wp_upload_dir() {
-        return [
-            'basedir' => $GLOBALS['ls_base'],
-            'baseurl'  => 'http://example.com/uploads',
-        ];
-    }
-    function wp_mkdir_p($dir) {
-        return mkdir($dir, 0777, true);
-    }
     function add_action(...$args) {
         $GLOBALS['ls_actions'][] = $args;
     }
@@ -51,8 +42,8 @@ namespace {
             $GLOBALS['ls_errors'] = [];
             $GLOBALS['ls_puts'] = [];
             $GLOBALS['ls_shutdown'] = [];
-            $GLOBALS['ls_base'] = sys_get_temp_dir() . '/ls_' . uniqid();
-            mkdir($GLOBALS['ls_base']);
+            $GLOBALS['test_upload_basedir'] = sys_get_temp_dir() . '/ls_' . uniqid();
+            mkdir($GLOBALS['test_upload_basedir']);
             $GLOBALS['ls_filter_buffer'] = false;
             $GLOBALS['ls_rename_fail'] = false;
         }
@@ -64,7 +55,7 @@ namespace {
             }
             unset($GLOBALS['ls_filter_buffer']);
             unset($GLOBALS['ls_rename_fail']);
-            $base = $GLOBALS['ls_base'];
+            $base = $GLOBALS['test_upload_basedir'];
             foreach (glob("$base/*") as $file) {
                 @unlink($file);
             }
@@ -72,7 +63,7 @@ namespace {
         }
 
         public function test_unwritable_directory_triggers_fallback(): void {
-            chmod($GLOBALS['ls_base'], 0555);
+            chmod($GLOBALS['test_upload_basedir'], 0555);
             LoggingService::log('test message');
             $this->assertSame(['test message'], $GLOBALS['ls_errors']);
             $this->assertSame('admin_notices', $GLOBALS['ls_actions'][0][0]);

--- a/tests/MetaboxUpdateErrorTest.php
+++ b/tests/MetaboxUpdateErrorTest.php
@@ -2,7 +2,6 @@
 use PHPUnit\Framework\TestCase;
 
 namespace NuclearEngagement\Admin {
-    function wp_verify_nonce($nonce, $action) { return true; }
     function current_user_can($cap, $id) { return true; }
     function wp_unslash($val) { return $val; }
     function sanitize_text_field($val) { return $val; }
@@ -54,6 +53,11 @@ namespace {
             $GLOBALS['mb_result'] = new \WP_Error();
             \NuclearEngagement\Services\LoggingService::$logs = [];
             \NuclearEngagement\Services\LoggingService::$notices = [];
+            $GLOBALS['test_verify_nonce'] = true;
+        }
+
+        protected function tearDown(): void {
+            unset($GLOBALS['test_verify_nonce']);
         }
 
         public function test_quiz_update_error_logs_and_notifies(): void {

--- a/tests/SetupServiceTest.php
+++ b/tests/SetupServiceTest.php
@@ -8,15 +8,6 @@ namespace NuclearEngagement\Services {
         public static array $logs = [];
         public static function log(string $msg): void { self::$logs[] = $msg; }
     }
-    function wp_remote_post(string $url, array $args = []) {
-        return $GLOBALS['ss_response'];
-    }
-    function wp_remote_retrieve_response_code($res) {
-        return is_array($res) ? ($res['code'] ?? 0) : 0;
-    }
-    function wp_remote_retrieve_body($res) {
-        return is_array($res) ? ($res['body'] ?? '') : '';
-    }
     function wp_json_encode($data) { return json_encode($data); }
 }
 
@@ -29,26 +20,26 @@ namespace {
 
     class SetupServiceTest extends TestCase {
         protected function setUp(): void {
-            $GLOBALS['ss_response'] = null;
+            $GLOBALS['test_http_response'] = null;
             LoggingService::$logs = [];
         }
 
         public function test_validate_api_key_success(): void {
-            $GLOBALS['ss_response'] = ['code' => 200];
+            $GLOBALS['test_http_response'] = ['code' => 200];
             $svc = new SetupService();
             $this->assertTrue($svc->validate_api_key('key'));
             $this->assertEmpty(LoggingService::$logs);
         }
 
         public function test_validate_api_key_failure_logs_error(): void {
-            $GLOBALS['ss_response'] = new \WP_Error();
+            $GLOBALS['test_http_response'] = new \WP_Error();
             $svc = new SetupService();
             $this->assertFalse($svc->validate_api_key('key'));
             $this->assertSame(['API-key validation error: error'], LoggingService::$logs);
         }
 
         public function test_send_app_password_success(): void {
-            $GLOBALS['ss_response'] = ['code' => 200];
+            $GLOBALS['test_http_response'] = ['code' => 200];
             $svc = new SetupService();
             $data = ['appApiKey' => 'key', 'user' => 'u'];
             $this->assertTrue($svc->send_app_password($data));
@@ -56,7 +47,7 @@ namespace {
         }
 
         public function test_send_app_password_failure_logs_error(): void {
-            $GLOBALS['ss_response'] = new \WP_Error();
+            $GLOBALS['test_http_response'] = new \WP_Error();
             $svc = new SetupService();
             $data = ['appApiKey' => 'key', 'user' => 'u'];
             $this->assertFalse($svc->send_app_password($data));
@@ -64,7 +55,7 @@ namespace {
         }
 
         public function test_send_app_password_http_error_logs_error(): void {
-            $GLOBALS['ss_response'] = ['code' => 400, 'body' => 'bad'];
+            $GLOBALS['test_http_response'] = ['code' => 400, 'body' => 'bad'];
             $svc = new SetupService();
             $data = ['appApiKey' => 'key', 'user' => 'u'];
             $this->assertFalse($svc->send_app_password($data));

--- a/tests/UtilsTest.php
+++ b/tests/UtilsTest.php
@@ -3,18 +3,6 @@ use PHPUnit\Framework\TestCase;
 use NuclearEngagement\Utils;
 
 namespace NuclearEngagement {
-    function wp_upload_dir() {
-        return [
-            'basedir' => $GLOBALS['ut_base'],
-            'baseurl'  => 'http://example.com/uploads',
-        ];
-    }
-    function wp_mkdir_p($dir) {
-        if (!empty($GLOBALS['ut_fail_mkdir'])) {
-            return false;
-        }
-        return mkdir($dir, 0777, true);
-    }
     function get_option($name, $default = '') {
         return $GLOBALS['ut_options'][$name] ?? $default;
     }
@@ -30,16 +18,16 @@ namespace NuclearEngagement\Services {
 namespace {
     class UtilsTest extends TestCase {
         protected function setUp(): void {
-            $GLOBALS['ut_base'] = sys_get_temp_dir() . '/ut_' . uniqid();
+            $GLOBALS['test_upload_basedir'] = sys_get_temp_dir() . '/ut_' . uniqid();
             $GLOBALS['ut_options'] = [];
-            if (file_exists($GLOBALS['ut_base'])) {
+            if (file_exists($GLOBALS['test_upload_basedir'])) {
                 // clean leftover
-                @unlink($GLOBALS['ut_base']);
+                @unlink($GLOBALS['test_upload_basedir']);
             }
         }
 
         protected function tearDown(): void {
-            $base = $GLOBALS['ut_base'];
+            $base = $GLOBALS['test_upload_basedir'];
             if (is_dir($base)) {
                 array_map('unlink', glob("$base/*"));
                 rmdir($base);
@@ -53,7 +41,7 @@ namespace {
         }
 
         public function test_version_generated_when_option_empty(): void {
-            $dir = $GLOBALS['ut_base'] . '/nuclear-engagement';
+            $dir = $GLOBALS['test_upload_basedir'] . '/nuclear-engagement';
             mkdir($dir, 0777, true);
             $file = $dir . '/nuclen-theme-custom.css';
             file_put_contents($file, 'body{}');
@@ -65,7 +53,7 @@ namespace {
         }
 
         public function test_version_from_option_used_when_set(): void {
-            $dir = $GLOBALS['ut_base'] . '/nuclear-engagement';
+            $dir = $GLOBALS['test_upload_basedir'] . '/nuclear-engagement';
             mkdir($dir, 0777, true);
             $file = $dir . '/nuclen-theme-custom.css';
             file_put_contents($file, 'body{}');
@@ -75,11 +63,11 @@ namespace {
         }
 
         public function test_returns_empty_array_on_directory_failure(): void {
-            $GLOBALS['ut_fail_mkdir'] = true;
+            $GLOBALS['test_wp_mkdir_p_failure'] = true;
             $info = Utils::nuclen_get_custom_css_info();
             $this->assertSame([], $info);
             $this->assertNotEmpty(\NuclearEngagement\Services\LoggingService::$logs);
-            unset($GLOBALS['ut_fail_mkdir']);
+            unset($GLOBALS['test_wp_mkdir_p_failure']);
         }
     }
 }

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -6,6 +6,8 @@ if ( ! defined( 'ABSPATH' ) ) {
 // Track calls to dbDelta in unit tests
 global $dbDelta_called;
 $dbDelta_called = false;
+// Load shared WordPress function stubs
+require_once __DIR__ . '/wp-stubs.php';
 // Minimal stubs for WordPress functions used in included files
 if (!function_exists('add_action')) {
     function add_action(...$args) {}

--- a/tests/wp-stubs.php
+++ b/tests/wp-stubs.php
@@ -1,0 +1,41 @@
+<?php
+if (!function_exists('wp_upload_dir')) {
+    function wp_upload_dir() {
+        return [
+            'basedir' => $GLOBALS['test_upload_basedir'] ?? sys_get_temp_dir(),
+            'baseurl'  => $GLOBALS['test_upload_baseurl'] ?? 'http://example.com/uploads',
+        ];
+    }
+}
+if (!function_exists('wp_mkdir_p')) {
+    function wp_mkdir_p($dir) {
+        if (!empty($GLOBALS['test_wp_mkdir_p_failure'])) {
+            return false;
+        }
+        return mkdir($dir, 0777, true);
+    }
+}
+if (!function_exists('wp_verify_nonce')) {
+    function wp_verify_nonce($nonce, $action) {
+        if (array_key_exists('test_verify_nonce', $GLOBALS)) {
+            return (bool) $GLOBALS['test_verify_nonce'];
+        }
+        return $nonce === 'valid';
+    }
+}
+if (!function_exists('wp_remote_post')) {
+    function wp_remote_post(string $url, array $args = []) {
+        return $GLOBALS['test_http_response'] ?? null;
+    }
+}
+if (!function_exists('wp_remote_retrieve_response_code')) {
+    function wp_remote_retrieve_response_code($res) {
+        return is_array($res) ? ($res['code'] ?? 0) : 0;
+    }
+}
+if (!function_exists('wp_remote_retrieve_body')) {
+    function wp_remote_retrieve_body($res) {
+        return is_array($res) ? ($res['body'] ?? '') : '';
+    }
+}
+


### PR DESCRIPTION
## Summary
- add shared wp-stubs.php with WordPress function shims
- load shared stubs from bootstrap
- remove duplicate function definitions from tests
- use common globals in affected tests

## Testing
- `composer lint` *(fails: composer not found)*
- `composer test` *(fails: composer not found)*

------
https://chatgpt.com/codex/tasks/task_e_685b9292b86483278f0ad0a72165ab9e

<!-- Korbit AI PR Description Start -->
## Description by Korbit AI

### What change is being made?
Centralize WordPress function stubs into a new `wp-stubs.php` file from multiple test files and update references accordingly.

### Why are these changes being made?
The changes reduce code duplication and improve maintainability by consolidating WordPress function mocks that were scattered across different test files into a single location. This centralization ensures consistency, making it easier to manage and update the stubs, especially focusing on functions like `wp_upload_dir`, `wp_mkdir_p`, `wp_verify_nonce`, and HTTP request-related functions.

> Is this description stale? Ask me to generate a new description by commenting `/korbit-generate-pr-description`
<!-- Korbit AI PR Description End -->