### PR TITLE
Fix composer autoload warnings

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -6,13 +6,11 @@
       "NuclearEngagement\\Services\\": "nuclear-engagement/inc/Services/",
       "NuclearEngagement\\Requests\\": "nuclear-engagement/inc/Requests/",
       "NuclearEngagement\\Responses\\": "nuclear-engagement/inc/Responses/",
-      "NuclearEngagement\\Modules\\": "nuclear-engagement/inc/Modules/",
-      "NuclearEngagement\\": [
-        "nuclear-engagement/",
-        "nuclear-engagement/inc/Core/",
-        "nuclear-engagement/inc/Utils/"
-      ]
-    }
+      "NuclearEngagement\\Modules\\": "nuclear-engagement/inc/Modules/"
+    },
+    "classmap": [
+      "nuclear-engagement/"
+    ]
   },
   "config": {
         "allow-plugins": {


### PR DESCRIPTION
## Summary
- stop PSR-4 warnings by using a classmap for plugin code

## Testing
- `composer lint` *(fails: composer not found)*
- `composer test` *(fails: composer not found)*

------
https://chatgpt.com/codex/tasks/task_e_685b9a9342108327a40bbd1339a5960c