### PR TITLE
Fix QuizShortcode constructor call

### DIFF
--- a/nuclear-engagement/front/traits/ShortcodesTrait.php
+++ b/nuclear-engagement/front/traits/ShortcodesTrait.php
@@ -17,6 +17,7 @@ namespace NuclearEngagement\Front;
 
 use NuclearEngagement\Front\QuizShortcode;
 use NuclearEngagement\Front\SummaryShortcode;
+use NuclearEngagement\Modules\Quiz\Quiz_Service;
 
 if ( ! defined( 'ABSPATH' ) ) {
 	exit;
@@ -27,12 +28,13 @@ trait ShortcodesTrait {
 	private ?SummaryShortcode $summary_shortcode = null;
 
 	private function get_quiz_shortcode(): QuizShortcode {
-		if ( $this->quiz_shortcode === null ) {
-			$this->quiz_shortcode = new QuizShortcode(
-				$this->nuclen_get_settings_repository(),
-				$this
-			);
-		}
+                if ( $this->quiz_shortcode === null ) {
+                        $this->quiz_shortcode = new QuizShortcode(
+                                $this->nuclen_get_settings_repository(),
+                                $this,
+                                new Quiz_Service()
+                        );
+                }
 		return $this->quiz_shortcode;
 	}
 


### PR DESCRIPTION
## Summary
- inject `Quiz_Service` when creating `QuizShortcode`

## Testing
- `composer lint` *(fails: command not found)*
- `composer test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685bb15bfeb083279a402e0720ee26e3


> [!NOTE]
> I'm currently writing a description for your pull request. I should be done shortly (<1 minute). Please don't edit the description field until I'm finished, or we may overwrite each other. If I find nothing to write about, I'll delete this message.
