### PR TITLE
Consolidate duplicate release info in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ npm run dev
 
 ## Release
 
-Create a production archive with:
+Create a production archive with runtime dependencies only:
 
 ```bash
 composer install --no-dev --optimize-autoloader
@@ -79,17 +79,4 @@ This builds the plugin and packages it. See [CI Guidelines](docs/CI_GUIDELINES.m
 - [Hooks Reference](docs/hooks.md)
 - [CI Guidelines](docs/CI_GUIDELINES.md)
 - [Development Workflow](docs/DEV_WORKFLOW.md)
-
-## Release
-
-Create a production archive with runtime dependencies only:
-
-```bash
-composer install --no-dev --optimize-autoloader
-npm ci
-npm run build
-./scripts/build-release.sh
-```
-
-See [CI Guidelines](docs/CI_GUIDELINES.md) for full details.
 


### PR DESCRIPTION
## Summary
- keep only one *Release* section
- clarify how to create the production archive

## Testing
- `composer lint` *(fails: command not found)*
- `composer test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685bb83580d88327bb9ec5cf627d5143

<!-- Korbit AI PR Description Start -->
## Description by Korbit AI

### What change is being made?

Consolidate duplicate release information in the README file by removing redundant instructions and retaining a single, clear section.

### Why are these changes being made?

The README previously had two sections with identical instructions for creating a production archive, leading to unnecessary duplication and potential confusion. Consolidating this information ensures clarity and maintainability, and simplifies the documentation for developers.

> Is this description stale? Ask me to generate a new description by commenting `/korbit-generate-pr-description`
<!-- Korbit AI PR Description End -->