### PR TITLE
Add wp-env port override note

### DIFF
--- a/docs/DEV_WORKFLOW.md
+++ b/docs/DEV_WORKFLOW.md
@@ -25,6 +25,13 @@ This guide shows how to run and debug the plugin locally using `wp-env` and Dock
 
 3. Access WordPress at `http://localhost:8888` and log in with the default credentials provided by `wp-env`.
 
+   If port `8888` is already in use, create a `.wp-env.override.json` file and specify a new port, for example:
+
+   ```json
+   { "port": 8889 }
+   ```
+   Restart the environment and visit `http://localhost:8889` instead.
+
 ## Fast-loop debugging
 
 Use these commands as needed while the environment is running:


### PR DESCRIPTION
## Summary
- document how to override the default wp-env port

## Testing
- `composer lint` *(fails: composer not installed)*
- `composer test` *(fails: composer not installed)*

------
https://chatgpt.com/codex/tasks/task_e_685bb84b4ef88327887e9d83c300e456

<!-- Korbit AI PR Description Start -->
## Description by Korbit AI

### What change is being made?

Add guidance in the development workflow documentation on how to override the default `wp-env` port if it's already in use.

### Why are these changes being made?

Developers may encounter issues if port `8888` is occupied, causing conflicts that prevent accessing the local WordPress environment. This change provides a simple workaround by instructing users to modify the `.wp-env.override.json` file to avoid port conflicts.

> Is this description stale? Ask me to generate a new description by commenting `/korbit-generate-pr-description`
<!-- Korbit AI PR Description End -->