### PR TITLE
Update polling constants usage

### DIFF
--- a/nuclear-engagement/admin/Traits/AdminAutoGenerate.php
+++ b/nuclear-engagement/admin/Traits/AdminAutoGenerate.php
@@ -91,8 +91,8 @@ trait AdminAutoGenerate {
 		Cron callback: poll SaaS /updates - now uses services
 	──────────────────────────────────────────────────────────*/
 	public function nuclen_cron_poll_generation( $generation_id, $workflow_type, $post_id, $attempt ) {
-		$max_attempts = \NuclearEngagement\Services\AutoGenerationService::MAX_ATTEMPTS;
-		$retry_delay  = \NuclearEngagement\Services\AutoGenerationService::RETRY_DELAY; // 1 minute between retries
+               $max_attempts = NUCLEN_MAX_POLL_ATTEMPTS;
+               $retry_delay  = NUCLEN_POLL_RETRY_DELAY; // 1 minute between retries
 
 		try {
 			// Check if auto-generation is enabled for this post type.

--- a/nuclear-engagement/inc/Services/AutoGenerationQueue.php
+++ b/nuclear-engagement/inc/Services/AutoGenerationQueue.php
@@ -19,8 +19,6 @@ class AutoGenerationQueue {
     /** Maximum number of posts to send in one batch. */
     private const BATCH_SIZE = 5;
 
-    /** Number of seconds before the first poll runs. */
-    private const INITIAL_POLL_DELAY = 15;
 
     private RemoteApiService $remote_api;
     private ContentStorageService $content_storage;
@@ -128,7 +126,7 @@ class AutoGenerationQueue {
                     continue;
                 }
 
-                $next_poll                    = time() + self::INITIAL_POLL_DELAY + mt_rand( 1, 5 );
+                $next_poll                    = time() + NUCLEN_INITIAL_POLL_DELAY + mt_rand( 1, 5 );
                 $generations[ $generation_id ] = array(
                     'started_at'    => current_time( 'mysql' ),
                     'post_ids'      => $batch,

--- a/nuclear-engagement/inc/Services/AutoGenerationService.php
+++ b/nuclear-engagement/inc/Services/AutoGenerationService.php
@@ -26,11 +26,6 @@ class AutoGenerationService {
         public const QUEUE_HOOK = 'nuclen_process_autogen_queue';
 
 
-        /** Maximum number of API polling attempts. */
-        public const MAX_ATTEMPTS = 10;
-
-        /** Delay in seconds between poll attempts. */
-        public const RETRY_DELAY = 60;
 
 	/**
 	 * @var SettingsRepository

--- a/nuclear-engagement/inc/Services/GenerationPoller.php
+++ b/nuclear-engagement/inc/Services/GenerationPoller.php
@@ -64,8 +64,8 @@ class GenerationPoller {
          * @param int   $attempt       Current attempt number
          */
         public function poll_generation( string $generation_id, string $workflow_type, array $post_ids, int $attempt ): void {
-		$max_attempts = AutoGenerationService::MAX_ATTEMPTS;
-		$retry_delay  = AutoGenerationService::RETRY_DELAY;
+                $max_attempts = NUCLEN_MAX_POLL_ATTEMPTS;
+                $retry_delay  = NUCLEN_POLL_RETRY_DELAY;
 
 		try {
 			$connected      = $this->settings_repository->get( 'connected', false );

--- a/tests/AutoGenerationServiceTest.php
+++ b/tests/AutoGenerationServiceTest.php
@@ -96,7 +96,7 @@ class AutoGenerationServiceTest extends TestCase {
         $wp_options['nuclen_active_generations'] = [ $id => ['foo'=>'bar'] ];
         $api = new DummyRemoteApiService();
         $service = $this->makeService($api);
-        $service->poll_generation($id, 'quiz', [1], AutoGenerationService::MAX_ATTEMPTS);
+        $service->poll_generation($id, 'quiz', [1], NUCLEN_MAX_POLL_ATTEMPTS);
         $this->assertArrayNotHasKey($id, $wp_options['nuclen_active_generations'] ?? []);
     }
 


### PR DESCRIPTION
## Summary
- use global poll constants throughout plugin
- drop unused local constants
- update tests for the new constants

## Testing
- `composer lint` *(fails: command not found)*
- `composer test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685bc5a17f58832787860c0a47ce2433

<!-- Korbit AI PR Description Start -->
## Description by Korbit AI

### What change is being made?

Update the usage of polling constants from class constants within `AutoGenerationService` to global constants for consistency across the codebase.

### Why are these changes being made?

The change enhances maintainability by consolidating constants like `MAX_ATTEMPTS` and `RETRY_DELAY` into global constants (`NUCLEN_MAX_POLL_ATTEMPTS`, `NUCLEN_POLL_RETRY_DELAY`). This approach simplifies updates and avoids discrepancies across different files and components, ensuring uniform polling behavior within the system.

> Is this description stale? Ask me to generate a new description by commenting `/korbit-generate-pr-description`
<!-- Korbit AI PR Description End -->