### PR TITLE
Refactor metabox markup into templates

### DIFF
--- a/nuclear-engagement/inc/Modules/Quiz/quiz-admin.php
+++ b/nuclear-engagement/inc/Modules/Quiz/quiz-admin.php
@@ -68,55 +68,7 @@ final class Quiz_Admin {
 
         $quiz_protected = $this->service->is_protected( $post->ID );
 
-        wp_nonce_field( 'nuclen_quiz_data_nonce', 'nuclen_quiz_data_nonce' );
-
-        echo '<div><label>';
-        echo '<input type="checkbox" name="nuclen_quiz_protected" value="1"';
-        checked( $quiz_protected, 1 );
-        echo ' /> Protected? <span nuclen-tooltip="Tick this box and save post to prevent overwriting during bulk generation.">🛈</span>';
-        echo '</label></div>';
-
-        echo '<div>
-            <button type="button"
-                    id="nuclen-generate-quiz-single"
-                    class="button nuclen-generate-single"
-                    data-post-id="' . esc_attr( $post->ID ) . '"
-                    data-workflow="quiz">
-                Generate Quiz with AI
-            </button>
-            <span nuclen-tooltip="(re)Generate. Data will be stored automatically (no need to save post).">🛈</span>
-        </div>';
-
-        echo '<p><strong>Date</strong><br>';
-        echo '<input type="text" name="nuclen_quiz_data[date]" value="' . esc_attr( $date ) . '" readonly class="nuclen-meta-date-input" />';
-        echo '</p>';
-
-        for ( $q_index = 0; $q_index < 10; $q_index++ ) {
-            $q_data  = $questions[ $q_index ];
-            $q_text  = $q_data['question'] ?? '';
-            $answers = isset( $q_data['answers'] ) && is_array( $q_data['answers'] )
-                ? $q_data['answers']
-                : array( '', '', '', '' );
-            $explan  = $q_data['explanation'] ?? '';
-
-            $answers = array_pad( $answers, 4, '' );
-
-            echo '<div class="nuclen-quiz-metabox-question">';
-            echo '<h4>Question ' . ( $q_index + 1 ) . '</h4>';
-
-            echo '<input type="text" name="nuclen_quiz_data[questions][' . $q_index . '][question]" value="' . esc_attr( $q_text ) . '" class="nuclen-width-full" />';
-
-            echo '<p><strong>Answers</strong></p>';
-            foreach ( $answers as $a_index => $answer ) {
-                $class = $a_index === 0 ? 'nuclen-answer-correct' : '';
-                echo '<p class="nuclen-answer-label ' . esc_attr( $class ) . '">Answer ' . ( $a_index + 1 ) . '<br>';
-                echo '<input type="text" name="nuclen_quiz_data[questions][' . $q_index . '][answers][' . $a_index . ']" value="' . esc_attr( $answer ) . '" class="nuclen-width-full" /></p>';
-            }
-
-            echo '<p><strong>Explanation</strong><br>';
-            echo '<textarea name="nuclen_quiz_data[questions][' . $q_index . '][explanation]" rows="3" class="nuclen-width-full">' . esc_textarea( $explan ) . '</textarea></p>';
-            echo '</div>';
-        }
+        require NUCLEN_PLUGIN_DIR . 'templates/admin/quiz-metabox.php';
     }
 
     /** Save quiz meta on post save. */

--- a/nuclear-engagement/inc/Modules/Summary/includes/class-nuclen-summary-metabox.php
+++ b/nuclear-engagement/inc/Modules/Summary/includes/class-nuclen-summary-metabox.php
@@ -75,42 +75,8 @@ final class Nuclen_Summary_Metabox {
 
 		$summary_protected = get_post_meta( $post->ID, 'nuclen_summary_protected', true );
 
-		wp_nonce_field( 'nuclen_summary_data_nonce', 'nuclen_summary_data_nonce' );
-
-		echo '<div><label>';
-		echo '<input type="checkbox" name="nuclen_summary_protected" value="1"';
-		checked( $summary_protected, 1 );
-		echo ' /> Protected? <span nuclen-tooltip="Tick this box and save post to prevent overwriting during bulk generation.">🛈</span>';
-		echo '</label></div>';
-
-		echo '<div>
-            <button type="button"
-                    id="nuclen-generate-summary-single"
-                    class="button nuclen-generate-single"
-                    data-post-id="' . esc_attr( $post->ID ) . '"
-                    data-workflow="summary">
-                Generate Summary with AI
-            </button>
-            <span nuclen-tooltip="(re)Generate. Data will be stored automatically (no need to save post).">🛈</span>
-        </div>';
-
-		echo '<p><strong>Date</strong><br>';
-				echo '<input type="text" name="nuclen_summary_data[date]" value="' . esc_attr( $date ) . '" readonly class="nuclen-meta-date-input" />';
-		echo '</p>';
-
-		echo '<p><strong>Summary</strong><br>';
-		wp_editor(
-			$summary,
-			'nuclen_summary_data_summary',
-			array(
-				'textarea_name' => 'nuclen_summary_data[summary]',
-				'textarea_rows' => 5,
-				'media_buttons' => false,
-				'teeny'         => true,
-			)
-		);
-		echo '</p>';
-	}
+                require NUCLEN_PLUGIN_DIR . 'templates/admin/summary-metabox.php';
+        }
 
 	/*
 	-------------------------------------------------------------------------

--- a/nuclear-engagement/templates/admin/quiz-metabox.php
+++ b/nuclear-engagement/templates/admin/quiz-metabox.php
@@ -1,0 +1,49 @@
+<?php
+if ( ! defined( 'ABSPATH' ) ) {
+    exit;
+}
+
+wp_nonce_field( 'nuclen_quiz_data_nonce', 'nuclen_quiz_data_nonce' );
+?>
+<div><label>
+    <input type="checkbox" name="nuclen_quiz_protected" value="1" <?php checked( $quiz_protected, 1 ); ?> />
+    Protected? <span nuclen-tooltip="Tick this box and save post to prevent overwriting during bulk generation.">🛈</span>
+</label></div>
+<div>
+    <button type="button"
+            id="nuclen-generate-quiz-single"
+            class="button nuclen-generate-single"
+            data-post-id="<?php echo esc_attr( $post->ID ); ?>"
+            data-workflow="quiz">
+        Generate Quiz with AI
+    </button>
+    <span nuclen-tooltip="(re)Generate. Data will be stored automatically (no need to save post).">🛈</span>
+</div>
+<p><strong>Date</strong><br>
+    <input type="text" name="nuclen_quiz_data[date]" value="<?php echo esc_attr( $date ); ?>" readonly class="nuclen-meta-date-input" />
+</p>
+<?php for ( $q_index = 0; $q_index < 10; $q_index++ ) :
+    $q_data  = $questions[ $q_index ];
+    $q_text  = $q_data['question'] ?? '';
+    $answers = isset( $q_data['answers'] ) && is_array( $q_data['answers'] )
+        ? $q_data['answers']
+        : array( '', '', '', '' );
+    $explan  = $q_data['explanation'] ?? '';
+    $answers = array_pad( $answers, 4, '' );
+    ?>
+    <div class="nuclen-quiz-metabox-question">
+        <h4><?php echo esc_html( 'Question ' . ( $q_index + 1 ) ); ?></h4>
+        <input type="text" name="nuclen_quiz_data[questions][<?php echo esc_attr( $q_index ); ?>][question]" value="<?php echo esc_attr( $q_text ); ?>" class="nuclen-width-full" />
+        <p><strong>Answers</strong></p>
+        <?php foreach ( $answers as $a_index => $answer ) :
+            $class = $a_index === 0 ? 'nuclen-answer-correct' : '';
+            ?>
+            <p class="nuclen-answer-label <?php echo esc_attr( $class ); ?>">Answer <?php echo esc_html( $a_index + 1 ); ?><br>
+                <input type="text" name="nuclen_quiz_data[questions][<?php echo esc_attr( $q_index ); ?>][answers][<?php echo esc_attr( $a_index ); ?>]" value="<?php echo esc_attr( $answer ); ?>" class="nuclen-width-full" />
+            </p>
+        <?php endforeach; ?>
+        <p><strong>Explanation</strong><br>
+            <textarea name="nuclen_quiz_data[questions][<?php echo esc_attr( $q_index ); ?>][explanation]" rows="3" class="nuclen-width-full"><?php echo esc_textarea( $explan ); ?></textarea>
+        </p>
+    </div>
+<?php endfor; ?>

--- a/nuclear-engagement/templates/admin/summary-metabox.php
+++ b/nuclear-engagement/templates/admin/summary-metabox.php
@@ -1,0 +1,38 @@
+<?php
+if ( ! defined( 'ABSPATH' ) ) {
+    exit;
+}
+
+wp_nonce_field( 'nuclen_summary_data_nonce', 'nuclen_summary_data_nonce' );
+?>
+<div><label>
+    <input type="checkbox" name="nuclen_summary_protected" value="1" <?php checked( $summary_protected, 1 ); ?> />
+    Protected? <span nuclen-tooltip="Tick this box and save post to prevent overwriting during bulk generation.">🛈</span>
+</label></div>
+<div>
+    <button type="button"
+            id="nuclen-generate-summary-single"
+            class="button nuclen-generate-single"
+            data-post-id="<?php echo esc_attr( $post->ID ); ?>"
+            data-workflow="summary">
+        Generate Summary with AI
+    </button>
+    <span nuclen-tooltip="(re)Generate. Data will be stored automatically (no need to save post).">🛈</span>
+</div>
+<p><strong>Date</strong><br>
+    <input type="text" name="nuclen_summary_data[date]" value="<?php echo esc_attr( $date ); ?>" readonly class="nuclen-meta-date-input" />
+</p>
+<p><strong>Summary</strong><br>
+<?php
+wp_editor(
+    $summary,
+    'nuclen_summary_data_summary',
+    array(
+        'textarea_name' => 'nuclen_summary_data[summary]',
+        'textarea_rows' => 5,
+        'media_buttons' => false,
+        'teeny'         => true,
+    )
+);
+?>
+</p>


### PR DESCRIPTION
## Summary
- add new admin templates for quiz and summary metaboxes
- load these templates from `Quiz_Admin` and `Nuclen_Summary_Metabox`

## Testing
- `composer lint` *(fails: command not found)*
- `composer test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685bc59b40fc83278fd55e1cee0e5a04

<!-- Korbit AI PR Description Start -->
## Description by Korbit AI

### What change is being made?

Refactor metabox markup for quizzes and summaries into separate template files.

### Why are these changes being made?

To improve code maintainability and readability by separating the HTML structure from the PHP logic, which allows for easier updates and modifications to the UI components without affecting the underlying logic. This approach also enhances reusability and consistency across similar components.

> Is this description stale? Ask me to generate a new description by commenting `/korbit-generate-pr-description`
<!-- Korbit AI PR Description End -->