### PR TITLE
Handle missing post in TOC shortcode

### DIFF
--- a/nuclear-engagement/inc/Modules/TOC/includes/class-nuclen-toc-render.php
+++ b/nuclear-engagement/inc/Modules/TOC/includes/class-nuclen-toc-render.php
@@ -164,11 +164,11 @@ final class Nuclen_TOC_Render {
 	 * @param array $atts Shortcode attributes.
 	 * @return string Generated HTML markup.
 	 */
-	public function nuclen_toc_shortcode( array $atts ): string {
-		global $post;
-		if ( empty( $post ) ) {
-			return '';
-		}
+        public function nuclen_toc_shortcode( array $atts ): string {
+                $post = get_post( get_the_ID() );
+                if ( null === $post ) {
+                        return '';
+                }
 
 		$settings = \NuclearEngagement\Container::getInstance()->get( 'settings' );
 		$atts     = $this->prepare_shortcode_attributes( $atts, $settings );


### PR DESCRIPTION
## Summary
- retrieve current post using `get_post( get_the_ID() )`
- update tests to use `$wp_posts` and `$current_post_id`
- add test for when no post is available

## Testing
- `composer lint` *(fails: composer not found)*
- `composer test` *(fails: composer not found)*

------
https://chatgpt.com/codex/tasks/task_e_685bc596835883278dcb7133ae761b75