### PR TITLE
Implement dynamic module loading

### DIFF
--- a/nuclear-engagement/inc/Core/ModuleLoader.php
+++ b/nuclear-engagement/inc/Core/ModuleLoader.php
@@ -1,0 +1,28 @@
+<?php
+declare(strict_types=1);
+namespace NuclearEngagement;
+
+if ( ! defined( 'ABSPATH' ) ) {
+    exit;
+}
+
+class ModuleLoader {
+    private string $base_dir;
+
+    public function __construct( string $base_dir = NUCLEN_PLUGIN_DIR ) {
+        $this->base_dir = rtrim( $base_dir, '/\\' ) . '/';
+    }
+
+    public function load_all(): void {
+        $pattern = $this->base_dir . 'inc/Modules/*/loader.php';
+        $files   = glob( $pattern );
+        if ( ! is_array( $files ) ) {
+            return;
+        }
+        foreach ( $files as $file ) {
+            if ( file_exists( $file ) ) {
+                require_once $file;
+            }
+        }
+    }
+}

--- a/nuclear-engagement/inc/Core/Plugin.php
+++ b/nuclear-engagement/inc/Core/Plugin.php
@@ -80,28 +80,9 @@ class Plugin {
 		/* ► Ensure OptinData hooks are registered */
 		OptinData::init();
 
-                // TOC module
-                $toc_loader = NUCLEN_PLUGIN_DIR . 'inc/Modules/TOC/loader.php';
-                if ( file_exists( $toc_loader ) ) {
-                        require_once $toc_loader;
-                } else {
-                        Services\LoggingService::notify_admin(
-                                'Nuclear Engagement TOC module missing.'
-                        );
-                }
-
-                // Summary module
-                $summary_loader = NUCLEN_PLUGIN_DIR . 'inc/Modules/Summary/loader.php';
-                if ( file_exists( $summary_loader ) ) {
-                        require_once $summary_loader;
-                } else {
-                        Services\LoggingService::notify_admin(
-                                'Nuclear Engagement Summary module missing.'
-                        );
-                }
-
-		$this->loader = new Loader();
-	}
+                ( new ModuleLoader() )->load_all();
+                $this->loader = new Loader();
+        }
 
 	/*
 	─────────────────────────────────────────────

--- a/tests/ModuleLoaderTest.php
+++ b/tests/ModuleLoaderTest.php
@@ -1,0 +1,50 @@
+<?php
+use PHPUnit\Framework\TestCase;
+use NuclearEngagement\ModuleLoader;
+
+class ModuleLoaderTest extends TestCase {
+    private static string $dir;
+
+    public static function setUpBeforeClass(): void {
+        self::$dir = sys_get_temp_dir() . '/mods_' . uniqid();
+        mkdir(self::$dir . '/inc/Modules/Alpha', 0777, true);
+        mkdir(self::$dir . '/inc/Modules/Beta', 0777, true);
+        file_put_contents(self::$dir . '/inc/Modules/Alpha/loader.php', "<?php\n\$GLOBALS['loaded'][] = 'alpha';\n");
+        file_put_contents(self::$dir . '/inc/Modules/Beta/loader.php', "<?php\n\$GLOBALS['loaded'][] = 'beta';\n");
+        require_once dirname(__DIR__) . '/nuclear-engagement/inc/Core/ModuleLoader.php';
+    }
+
+    protected function setUp(): void {
+        $GLOBALS['loaded'] = [];
+    }
+
+    public static function tearDownAfterClass(): void {
+        self::deleteDir(self::$dir);
+    }
+
+    private static function deleteDir(string $dir): void {
+        if (!is_dir($dir)) {
+            return;
+        }
+        $items = scandir($dir);
+        foreach ($items as $item) {
+            if ($item === '.' || $item === '..') {
+                continue;
+            }
+            $path = $dir . '/' . $item;
+            if (is_dir($path)) {
+                self::deleteDir($path);
+            } else {
+                @unlink($path);
+            }
+        }
+        @rmdir($dir);
+    }
+
+    public function test_load_all_loads_modules(): void {
+        $loader = new ModuleLoader(self::$dir . '/');
+        $loader->load_all();
+        sort($GLOBALS['loaded']);
+        $this->assertSame(['alpha', 'beta'], $GLOBALS['loaded']);
+    }
+}


### PR DESCRIPTION
## Summary
- add a `ModuleLoader` class to load all module loaders automatically
- update the plugin to use `ModuleLoader` instead of explicit `require_once` calls
- test that `ModuleLoader::load_all()` loads modules

## Testing
- `composer lint` *(fails: command not found)*
- `composer test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685bc58e240883279e9d11e34c30c58c


> [!NOTE]
> I'm currently writing a description for your pull request. I should be done shortly (<1 minute). Please don't edit the description field until I'm finished, or we may overwrite each other. If I find nothing to write about, I'll delete this message.
