### PR TITLE
Update dev workflow for PHPStan

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -23,6 +23,7 @@
   },
   "scripts": {
     "lint": "phpcs",
-    "test": "phpunit"
+    "test": "phpunit",
+    "phpstan": "vendor/bin/phpstan analyse"
   }
 }

--- a/docs/DEV_WORKFLOW.md
+++ b/docs/DEV_WORKFLOW.md
@@ -58,11 +58,10 @@ After starting the environment, run PHPUnit from the repository root:
 composer test
 ```
 
-You can also run static analysis (optional):
+Run PHPStan for static analysis (required):
 
 ```bash
-composer require --dev phpstan/phpstan-deprecation
-vendor/bin/phpstan analyse
+composer phpstan
 ```
 
 ## Typical workflow


### PR DESCRIPTION
## Summary
- document PHPStan as mandatory in development workflow
- add a composer script for running PHPStan

## Testing
- `composer lint` *(fails: command not found)*
- `composer test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685bcb102bc48327a5ccc29148fbe2d5