### PR TITLE
Update workflow docs for PHPStan

### DIFF
--- a/docs/DEV_WORKFLOW.md
+++ b/docs/DEV_WORKFLOW.md
@@ -52,17 +52,11 @@ Use these commands as needed while the environment is running:
 
 ## Running tests
 
-After starting the environment, run PHPUnit from the repository root:
+After starting the environment, run PHPUnit and PHPStan from the repository root:
 
 ```bash
 composer test --working-dir=nuclear-engagement
-```
-
-You can also run static analysis (optional):
-
-```bash
-composer require --dev phpstan/phpstan-deprecation --working-dir=nuclear-engagement
-vendor/bin/phpstan analyse
+composer phpstan --working-dir=nuclear-engagement
 ```
 
 ## Typical workflow

--- a/nuclear-engagement/composer.json
+++ b/nuclear-engagement/composer.json
@@ -19,10 +19,12 @@
     },
   "require-dev": {
     "wp-coding-standards/wpcs": "3.0",
-    "phpunit/phpunit": "^9.6"
+    "phpunit/phpunit": "^9.6",
+    "phpstan/phpstan-deprecation": "^1.0"
   },
   "scripts": {
     "lint": "phpcs",
+    "phpstan": "vendor/bin/phpstan analyse",
     "test": "phpunit"
   }
 }


### PR DESCRIPTION
## Summary
- update developer workflow docs to require running PHPStan
- add PHPStan composer script

## Testing
- `composer lint --working-dir=nuclear-engagement` *(fails: command not found)*
- `composer test --working-dir=nuclear-engagement` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685bcc150cf48327ae843b655e5a584e


> [!NOTE]
> I'm currently writing a description for your pull request. I should be done shortly (<1 minute). Please don't edit the description field until I'm finished, or we may overwrite each other. If I find nothing to write about, I'll delete this message.
