### PR TITLE
Add postmeta indexes on activation

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -17,6 +17,9 @@ Release notes for the Nuclear Engagement plugin.
 ## 1.1.1 – 2025-06-24
 - Fixed: Constant evaluation error in `GenerationService` on PHP 8.1.
 
+## 1.1.2 – 2025-07-01
+- Added: Database indexes on `wp_postmeta` for quiz and summary meta keys to improve query performance.
+
 ## 1.0.3 – 2025-06-11
 - Added: Uninstall data options.
 - Fixed: Auto content generation upon post publish.

--- a/nuclear-engagement/inc/Core/Activator.php
+++ b/nuclear-engagement/inc/Core/Activator.php
@@ -33,10 +33,43 @@ class Activator {
 			update_option( 'nuclear_engagement_setup', $default_settings );
 		}
 
-		// Ensure opt-in table exists on activation
-		OptinData::maybe_create_table();
+                // Ensure opt-in table exists on activation
+                OptinData::maybe_create_table();
 
-		// Generate asset version strings for cache busting
-		AssetVersions::update_versions();
-	}
+                // Create indexes on wp_postmeta for faster lookups
+                self::maybe_create_postmeta_indexes();
+
+                // Generate asset version strings for cache busting
+                AssetVersions::update_versions();
+        }
+
+        /**
+         * Create custom indexes on the postmeta table if they do not exist.
+         */
+        private static function maybe_create_postmeta_indexes(): void {
+                global $wpdb;
+
+                $table   = $wpdb->postmeta;
+                $indexes = array(
+                        'nuclen_quiz_data_idx'        => 'nuclen-quiz-data',
+                        'nuclen_summary_data_idx'     => 'nuclen-summary-data',
+                        'nuclen_quiz_protected_idx'   => 'nuclen_quiz_protected',
+                        'nuclen_summary_protected_idx' => 'nuclen_summary_protected',
+                );
+
+                foreach ( $indexes as $index => $meta_key ) {
+                        $exists = $wpdb->get_var(
+                                $wpdb->prepare(
+                                        "SHOW INDEX FROM {$table} WHERE Key_name = %s",
+                                        $index
+                                )
+                        );
+                        if ( $exists ) {
+                                continue;
+                        }
+
+                        $sql = "CREATE INDEX {$index} ON {$table} (post_id, meta_key(191))";
+                        $wpdb->query( $sql );
+                }
+        }
 }


### PR DESCRIPTION
## Summary
- add custom index creation during activation
- document new database upgrade step

## Testing
- `composer lint` *(fails: command not found)*
- `composer test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685c12e836188327b5825e024f5b7223

<!-- Korbit AI PR Description Start -->
## Description by Korbit AI


### What change is being made?

Add database indexes on the `wp_postmeta` table for specific quiz and summary meta keys during plugin activation to enhance query performance.

### Why are these changes being made?

These changes aim to optimize database queries related to quiz and summary metadata, thus improving the performance of the Nuclear Engagement plugin. Introducing custom indexes will decrease query execution time for these specific keys, thereby enhancing overall efficiency for operations dependent on them.


> Is this description stale? Ask me to generate a new description by commenting `/korbit-generate-pr-description`
<!-- Korbit AI PR Description End -->