### PR TITLE
Add caching to dashboard queries

### DIFF
--- a/nuclear-engagement/inc/Core/InventoryCache.php
+++ b/nuclear-engagement/inc/Core/InventoryCache.php
@@ -118,5 +118,7 @@ final class InventoryCache {
                if ( function_exists( 'wp_cache_flush_group' ) ) {
                        wp_cache_flush_group( self::CACHE_GROUP );
                }
-        }
+
+               \NuclearEngagement\Services\DashboardDataService::clear_cache();
+       }
 }


### PR DESCRIPTION
## Summary
- introduce short-lived object cache in `DashboardDataService`
- purge dashboard caches when `InventoryCache::clear()` runs
- test that dashboard queries use cached results when available

## Testing
- `composer install` *(fails: command not found)*
- `composer lint` *(fails: command not found)*
- `composer test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685c1302a7b483279d4df4ffefc11a5f

<!-- Korbit AI PR Description Start -->
## Description by Korbit AI

### What change is being made?

Add caching mechanisms to dashboard queries in the `DashboardDataService` to improve query performance and reduce database load.

### Why are these changes being made?

The changes optimize performance by storing the results of dashboard queries in cache, which prevents redundant database operations and improves response time. By implementing a cache versioning system and leveraging both object cache and transients, the solution maintains data freshness while significantly decreasing database query frequency. This approach is ideal given the performance demands on frequently accessed but seldom changed data, and operates within the existing WordPress infrastructure.

> Is this description stale? Ask me to generate a new description by commenting `/korbit-generate-pr-description`
<!-- Korbit AI PR Description End -->