### PR TITLE
Add log_exception helper

### DIFF
--- a/nuclear-engagement/admin/Traits/AdminAutoGenerate.php
+++ b/nuclear-engagement/admin/Traits/AdminAutoGenerate.php
@@ -81,10 +81,10 @@ trait AdminAutoGenerate {
 			$container = $this->get_container();
 			$service   = $container->get( 'generation_service' );
 			$service->generateSingle( $post_id, $workflow_type );
-		} catch ( \Exception $e ) {
-			\NuclearEngagement\Services\LoggingService::log( 'Auto-generation error: ' . $e->getMessage() );
-		}
-	}
+               } catch ( \Exception $e ) {
+                       \NuclearEngagement\Services\LoggingService::log_exception( $e );
+               }
+       }
 
 	/*
 	──────────────────────────────────────────────────────────
@@ -125,11 +125,9 @@ trait AdminAutoGenerate {
 					"Still processing post {$post_id} ({$workflow_type}), attempt {$attempt}/{$max_attempts}"
 				);
 			}
-		} catch ( \Exception $e ) {
-			\NuclearEngagement\Services\LoggingService::log(
-				"Polling error for post {$post_id} ({$workflow_type}): " . $e->getMessage()
-			);
-		}
+               } catch ( \Exception $e ) {
+                       \NuclearEngagement\Services\LoggingService::log_exception( $e );
+               }
 
 		// Schedule next poll if not at max attempts
                 if ( $attempt < $max_attempts ) {

--- a/nuclear-engagement/front/Controller/Rest/ContentController.php
+++ b/nuclear-engagement/front/Controller/Rest/ContentController.php
@@ -108,14 +108,14 @@ class ContentController {
 				200
 			);
 
-		} catch ( \InvalidArgumentException $e ) {
-			\NuclearEngagement\Services\LoggingService::log( 'REST validation error: ' . $e->getMessage() );
-			return new \WP_Error( 'ne_invalid', $e->getMessage(), array( 'status' => 400 ) );
-		} catch ( \Exception $e ) {
-			\NuclearEngagement\Services\LoggingService::log( 'REST error: ' . $e->getMessage() );
-			return new \WP_Error( 'ne_error', __( 'An error occurred', 'nuclear-engagement' ), array( 'status' => 500 ) );
-		}
-	}
+               } catch ( \InvalidArgumentException $e ) {
+                       \NuclearEngagement\Services\LoggingService::log_exception( $e );
+                       return new \WP_Error( 'ne_invalid', $e->getMessage(), array( 'status' => 400 ) );
+               } catch ( \Exception $e ) {
+                       \NuclearEngagement\Services\LoggingService::log_exception( $e );
+                       return new \WP_Error( 'ne_error', __( 'An error occurred', 'nuclear-engagement' ), array( 'status' => 500 ) );
+               }
+       }
 
 	/**
 	 * Check permissions

--- a/nuclear-engagement/front/traits/RestTrait.php
+++ b/nuclear-engagement/front/traits/RestTrait.php
@@ -39,20 +39,20 @@ trait RestTrait {
 						$storage   = $container->get( 'content_storage' );
 			$storage->storeQuizData( $post_id, $quiz_data );
 			return true;
-		} catch ( \Exception $e ) {
-			\NuclearEngagement\Services\LoggingService::log( "Failed storing quiz-data for {$post_id}: " . $e->getMessage() );
-			return false;
-		}
-	}
+               } catch ( \Exception $e ) {
+                       \NuclearEngagement\Services\LoggingService::log_exception( $e );
+                       return false;
+               }
+       }
 
 	public function nuclen_send_posts_to_app_backend( $data_to_send ) {
 		try {
 						$container = $this->get_container();
 						$api       = $container->get( 'remote_api' );
 						return $api->send_posts_to_generate( $data_to_send );
-		} catch ( \RuntimeException $e ) {
-			\NuclearEngagement\Services\LoggingService::log( 'Error sending data: ' . $e->getMessage() );
-			return false;
-		}
-	}
+               } catch ( \RuntimeException $e ) {
+                       \NuclearEngagement\Services\LoggingService::log_exception( $e );
+                       return false;
+               }
+       }
 }

--- a/nuclear-engagement/inc/Services/LoggingService.php
+++ b/nuclear-engagement/inc/Services/LoggingService.php
@@ -67,11 +67,25 @@ class LoggingService {
 	/**
 	 * Debug level logging, only when WP_DEBUG is true.
 	 */
-	public static function debug( string $message ): void {
-		if ( defined( 'WP_DEBUG' ) && WP_DEBUG ) {
-			self::log( '[DEBUG] ' . $message );
-		}
-	}
+        public static function debug( string $message ): void {
+                if ( defined( 'WP_DEBUG' ) && WP_DEBUG ) {
+                        self::log( '[DEBUG] ' . $message );
+                }
+        }
+
+       /**
+        * Log an exception including file and line. When WP_DEBUG is true
+        * append a short stack trace.
+        */
+       public static function log_exception( \Throwable $e ): void {
+               $msg = $e->getMessage() . ' in ' . $e->getFile() . ':' . $e->getLine();
+               if ( defined( 'WP_DEBUG' ) && WP_DEBUG ) {
+                       $trace_lines = explode( "\n", $e->getTraceAsString() );
+                       $trace       = implode( ' | ', array_slice( $trace_lines, 0, 3 ) );
+                       $msg        .= ' Stack trace: ' . $trace;
+               }
+               self::log( $msg );
+       }
 
 	/**
 	 * Output stored admin notices.

--- a/tests/LoggingServiceTest.php
+++ b/tests/LoggingServiceTest.php
@@ -134,5 +134,28 @@ namespace {
             $this->assertNotEmpty($GLOBALS['ls_errors']);
             $this->assertStringContainsString('Failed to rotate log file', $GLOBALS['ls_errors'][0]);
         }
+
+        public function test_log_exception_without_debug(): void {
+            $e = new \Exception('oops');
+            LoggingService::log_exception($e);
+            $info = LoggingService::get_log_file_info();
+            $this->assertFileExists($info['path']);
+            $contents = file_get_contents($info['path']);
+            $this->assertStringContainsString('oops in', $contents);
+            $this->assertStringNotContainsString('Stack trace:', $contents);
+        }
+
+        public function test_log_exception_with_debug(): void {
+            if (!defined('WP_DEBUG')) {
+                define('WP_DEBUG', true);
+            }
+            $e = new \Exception('boom');
+            LoggingService::log_exception($e);
+            $info = LoggingService::get_log_file_info();
+            $this->assertFileExists($info['path']);
+            $contents = file_get_contents($info['path']);
+            $this->assertStringContainsString('boom in', $contents);
+            $this->assertStringContainsString('Stack trace:', $contents);
+        }
     }
 }


### PR DESCRIPTION
## Summary
- add `LoggingService::log_exception()` for rich exception logging
- use `log_exception()` across REST and admin handlers
- test logging with and without debug

## Testing
- `composer lint` *(fails: command not found)*
- `composer test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685c14cca3648327a6a4543c7d42bcab

<!-- Korbit AI PR Description Start -->
## Description by Korbit AI

### What change is being made?

Add a `log_exception` helper function to the `LoggingService` for consistent exception logging, and update catch blocks to utilize this new method.

### Why are these changes being made?

The previous implementation log error messages inconsistently and often excluded valuable exception details like file name and line number. By creating a dedicated `log_exception` method, exceptions are logged more uniformly and comprehensively, aiding in debugging, especially when `WP_DEBUG` is true. This change refines our logging strategy and ensures important exception information is preserved and traceable across the codebase.

> Is this description stale? Ask me to generate a new description by commenting `/korbit-generate-pr-description`
<!-- Korbit AI PR Description End -->