### PR TITLE
Handle upload directory errors

### DIFF
--- a/nuclear-engagement/inc/Services/LoggingService.php
+++ b/nuclear-engagement/inc/Services/LoggingService.php
@@ -33,19 +33,33 @@ class LoggingService {
 	/**
 	 * Get directory, path and URL for the log file.
 	 */
-	public static function get_log_file_info(): array {
-		$upload_dir = wp_upload_dir();
+        public static function get_log_file_info(): array {
+                $upload_dir = wp_upload_dir();
 
-		$log_folder = $upload_dir['basedir'] . '/nuclear-engagement';
-		$log_file   = $log_folder . '/log.txt';
-		$log_url    = $upload_dir['baseurl'] . '/nuclear-engagement/log.txt';
+                if ( ! empty( $upload_dir['error'] ) ) {
+                        $timestamp = gmdate( 'Y-m-d H:i:s' );
+                        $message   = 'Upload directory error: ' . $upload_dir['error'];
+                        error_log( "[Nuclear Engagement] [$timestamp] {$message}" );
+                        self::add_admin_notice( 'Uploads directory unavailable. Using plugin directory for logs.' );
 
-		return array(
-			'dir'  => $log_folder,
-			'path' => $log_file,
-			'url'  => $log_url,
-		);
-	}
+                        $fallback  = rtrim( NUCLEN_PLUGIN_DIR, '/' ) . '/logs';
+                        return array(
+                                'dir'  => $fallback,
+                                'path' => $fallback . '/log.txt',
+                                'url'  => '',
+                        );
+                }
+
+                $log_folder = $upload_dir['basedir'] . '/nuclear-engagement';
+                $log_file   = $log_folder . '/log.txt';
+                $log_url    = $upload_dir['baseurl'] . '/nuclear-engagement/log.txt';
+
+                return array(
+                        'dir'  => $log_folder,
+                        'path' => $log_file,
+                        'url'  => $log_url,
+                );
+        }
 
 	/**
 	 * Store an admin notice and ensure the hook is registered.

--- a/nuclear-engagement/inc/Utils/Utils.php
+++ b/nuclear-engagement/inc/Utils/Utils.php
@@ -47,6 +47,13 @@ class Utils {
      */
     public static function nuclen_get_custom_css_info(): array {
         $upload_dir = wp_upload_dir();
+
+        if ( ! empty( $upload_dir['error'] ) ) {
+            \NuclearEngagement\Services\LoggingService::log( 'Upload directory error: ' . $upload_dir['error'] );
+            \NuclearEngagement\Services\LoggingService::notify_admin( 'Uploads directory unavailable for custom CSS.' );
+            return array();
+        }
+
         $custom_dir = $upload_dir['basedir'] . '/nuclear-engagement';
 
         if ( ! file_exists( $custom_dir ) ) {

--- a/tests/LoggingServiceTest.php
+++ b/tests/LoggingServiceTest.php
@@ -134,5 +134,19 @@ namespace {
             $this->assertNotEmpty($GLOBALS['ls_errors']);
             $this->assertStringContainsString('Failed to rotate log file', $GLOBALS['ls_errors'][0]);
         }
+
+        public function test_wp_upload_dir_error_uses_plugin_path(): void {
+            $GLOBALS['test_upload_error'] = 'fail';
+            if (!defined('NUCLEN_PLUGIN_DIR')) {
+                define('NUCLEN_PLUGIN_DIR', sys_get_temp_dir() . '/plugin/');
+            }
+
+            $info = LoggingService::get_log_file_info();
+
+            $this->assertSame(rtrim(NUCLEN_PLUGIN_DIR, '/') . '/logs', $info['dir']);
+            $this->assertSame('admin_notices', $GLOBALS['ls_actions'][0][0]);
+
+            unset($GLOBALS['test_upload_error']);
+        }
     }
 }

--- a/tests/UtilsTest.php
+++ b/tests/UtilsTest.php
@@ -11,7 +11,9 @@ namespace NuclearEngagement {
 namespace NuclearEngagement\Services {
     class LoggingService {
         public static array $logs = [];
+        public static array $notices = [];
         public static function log(string $msg): void { self::$logs[] = $msg; }
+        public static function notify_admin(string $msg): void { self::$notices[] = $msg; }
     }
 }
 
@@ -68,6 +70,15 @@ namespace {
             $this->assertSame([], $info);
             $this->assertNotEmpty(\NuclearEngagement\Services\LoggingService::$logs);
             unset($GLOBALS['test_wp_mkdir_p_failure']);
+        }
+
+        public function test_wp_upload_dir_error_returns_empty(): void {
+            $GLOBALS['test_upload_error'] = 'fail';
+            $info = Utils::nuclen_get_custom_css_info();
+            $this->assertSame([], $info);
+            $this->assertNotEmpty(\NuclearEngagement\Services\LoggingService::$logs);
+            $this->assertNotEmpty(\NuclearEngagement\Services\LoggingService::$notices);
+            unset($GLOBALS['test_upload_error']);
         }
     }
 }

--- a/tests/wp-stubs.php
+++ b/tests/wp-stubs.php
@@ -1,6 +1,9 @@
 <?php
 if (!function_exists('wp_upload_dir')) {
     function wp_upload_dir() {
+        if (isset($GLOBALS['test_upload_error'])) {
+            return ['error' => $GLOBALS['test_upload_error']];
+        }
         return [
             'basedir' => $GLOBALS['test_upload_basedir'] ?? sys_get_temp_dir(),
             'baseurl'  => $GLOBALS['test_upload_baseurl'] ?? 'http://example.com/uploads',


### PR DESCRIPTION
## Summary
- log and notify when uploads folder is unavailable
- handle upload directory errors for custom CSS
- add tests for fallback paths and notices

## Testing
- `composer lint` *(fails: composer not found)*
- `composer test` *(fails: composer not found)*

------
https://chatgpt.com/codex/tasks/task_e_685c14cea87c8327bc610021ebfe1665