### PR TITLE
Handle upload directory failures

### DIFF
--- a/nuclear-engagement/inc/Services/LoggingService.php
+++ b/nuclear-engagement/inc/Services/LoggingService.php
@@ -33,19 +33,30 @@ class LoggingService {
 	/**
 	 * Get directory, path and URL for the log file.
 	 */
-	public static function get_log_file_info(): array {
-		$upload_dir = wp_upload_dir();
+        public static function get_log_file_info(): array {
+                $upload_dir = wp_upload_dir();
 
-		$log_folder = $upload_dir['basedir'] . '/nuclear-engagement';
-		$log_file   = $log_folder . '/log.txt';
-		$log_url    = $upload_dir['baseurl'] . '/nuclear-engagement/log.txt';
+                if ( ! empty( $upload_dir['error'] ) ) {
+                        error_log( '[Nuclear Engagement] ' . $upload_dir['error'] );
+                        self::add_admin_notice( 'Uploads directory unavailable. Using plugin directory for logs.' );
+                        $fallback_dir = rtrim( NUCLEN_PLUGIN_DIR, '/' ) . '/logs';
+                        return array(
+                                'dir'  => $fallback_dir,
+                                'path' => $fallback_dir . '/log.txt',
+                                'url'  => '',
+                        );
+                }
 
-		return array(
-			'dir'  => $log_folder,
-			'path' => $log_file,
-			'url'  => $log_url,
-		);
-	}
+                $log_folder = $upload_dir['basedir'] . '/nuclear-engagement';
+                $log_file   = $log_folder . '/log.txt';
+                $log_url    = $upload_dir['baseurl'] . '/nuclear-engagement/log.txt';
+
+                return array(
+                        'dir'  => $log_folder,
+                        'path' => $log_file,
+                        'url'  => $log_url,
+                );
+        }
 
 	/**
 	 * Store an admin notice and ensure the hook is registered.

--- a/nuclear-engagement/inc/Utils/Utils.php
+++ b/nuclear-engagement/inc/Utils/Utils.php
@@ -47,6 +47,12 @@ class Utils {
      */
     public static function nuclen_get_custom_css_info(): array {
         $upload_dir = wp_upload_dir();
+        if ( ! empty( $upload_dir['error'] ) ) {
+            \NuclearEngagement\Services\LoggingService::log( 'wp_upload_dir error: ' . $upload_dir['error'] );
+            \NuclearEngagement\Services\LoggingService::notify_admin( 'Uploads directory unavailable.' );
+            return array();
+        }
+
         $custom_dir = $upload_dir['basedir'] . '/nuclear-engagement';
 
         if ( ! file_exists( $custom_dir ) ) {

--- a/tests/UtilsTest.php
+++ b/tests/UtilsTest.php
@@ -69,5 +69,13 @@ namespace {
             $this->assertNotEmpty(\NuclearEngagement\Services\LoggingService::$logs);
             unset($GLOBALS['test_wp_mkdir_p_failure']);
         }
+
+        public function test_returns_empty_array_on_upload_dir_error(): void {
+            $GLOBALS['test_upload_error'] = 'fail';
+            $info = Utils::nuclen_get_custom_css_info();
+            $this->assertSame([], $info);
+            $this->assertNotEmpty(\NuclearEngagement\Services\LoggingService::$logs);
+            unset($GLOBALS['test_upload_error']);
+        }
     }
 }

--- a/tests/wp-stubs.php
+++ b/tests/wp-stubs.php
@@ -4,6 +4,7 @@ if (!function_exists('wp_upload_dir')) {
         return [
             'basedir' => $GLOBALS['test_upload_basedir'] ?? sys_get_temp_dir(),
             'baseurl'  => $GLOBALS['test_upload_baseurl'] ?? 'http://example.com/uploads',
+            'error'    => $GLOBALS['test_upload_error'] ?? '',
         ];
     }
 }


### PR DESCRIPTION
## Summary
- handle `wp_upload_dir` errors for log file paths
- surface upload directory issues when obtaining custom CSS info
- cover new error scenarios in unit tests

## Testing
- `composer lint` *(fails: command not found)*
- `composer test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685c163619fc8327b616289e676c025f


> [!NOTE]
> I'm currently writing a description for your pull request. I should be done shortly (<1 minute). Please don't edit the description field until I'm finished, or we may overwrite each other. If I find nothing to write about, I'll delete this message.
