### PR TITLE
Fix: replace tabs with spaces in plugin PHP files

### DIFF
--- a/nuclear-engagement/admin/Admin.php
+++ b/nuclear-engagement/admin/Admin.php
@@ -11,7 +11,7 @@ declare(strict_types=1);
 namespace NuclearEngagement\Admin;
 
 if ( ! defined( 'ABSPATH' ) ) {
-	exit;
+    exit;
 }
 
 use NuclearEngagement\Utils;
@@ -29,71 +29,71 @@ class Admin {
     use AdminMenu;
     use AdminAssets;
 
-	private $plugin_name;
-	private $version;
-	private $utils;
-	private $settings_repository;
-	/** @var Container */
-	private $container;
+    private $plugin_name;
+    private $version;
+    private $utils;
+    private $settings_repository;
+    /** @var Container */
+    private $container;
 
-	/**
-	 * Constructor
-	 *
-	 * @param string             $plugin_name
-	 * @param string             $version
-	 * @param SettingsRepository $settings_repository
-	 */
-	public function __construct( $plugin_name, $version, SettingsRepository $settings_repository, Container $container ) {
-		$this->plugin_name         = $plugin_name;
-		$this->version             = $version;
-		$this->utils               = new Utils();
-		$this->settings_repository = $settings_repository;
-		$this->container           = $container;
+    /**
+     * Constructor
+     *
+     * @param string             $plugin_name
+     * @param string             $version
+     * @param SettingsRepository $settings_repository
+     */
+    public function __construct( $plugin_name, $version, SettingsRepository $settings_repository, Container $container ) {
+        $this->plugin_name         = $plugin_name;
+        $this->version             = $version;
+        $this->utils               = new Utils();
+        $this->settings_repository = $settings_repository;
+        $this->container           = $container;
 
-		// Meta-boxes
-		add_action( 'add_meta_boxes', array( $this, 'nuclen_add_quiz_data_meta_box' ) );
-		add_action( 'save_post', array( $this, 'nuclen_save_quiz_data_meta' ) );
+        // Meta-boxes
+        add_action( 'add_meta_boxes', array( $this, 'nuclen_add_quiz_data_meta_box' ) );
+        add_action( 'save_post', array( $this, 'nuclen_save_quiz_data_meta' ) );
 
-		// AJAX & assets
-		add_action( 'wp_ajax_nuclen_fetch_app_updates', array( $this, 'nuclen_fetch_app_updates' ) );
-		add_action( 'admin_enqueue_scripts', array( $this, 'wp_enqueue_scripts' ) );
-		add_action( 'admin_enqueue_scripts', array( $this, 'wp_enqueue_styles' ) );
-		add_action( 'admin_enqueue_scripts', array( $this, 'nuclen_enqueue_dashboard_styles' ) );
+        // AJAX & assets
+        add_action( 'wp_ajax_nuclen_fetch_app_updates', array( $this, 'nuclen_fetch_app_updates' ) );
+        add_action( 'admin_enqueue_scripts', array( $this, 'wp_enqueue_scripts' ) );
+        add_action( 'admin_enqueue_scripts', array( $this, 'wp_enqueue_styles' ) );
+        add_action( 'admin_enqueue_scripts', array( $this, 'nuclen_enqueue_dashboard_styles' ) );
 
-		// Admin menu
-		add_action( 'admin_menu', array( $this, 'nuclen_add_admin_menu' ) );
+        // Admin menu
+        add_action( 'admin_menu', array( $this, 'nuclen_add_admin_menu' ) );
 
-		// Auto-generation on publish is now handled by AutoGenerationService
-		// The service is registered in the Plugin class and handles its own hooks
-	}
+        // Auto-generation on publish is now handled by AutoGenerationService
+        // The service is registered in the Plugin class and handles its own hooks
+    }
 
-	/* --------------------------------‑ getters ---------------------------- */
+    /* --------------------------------‑ getters ---------------------------- */
 
-	public function nuclen_get_plugin_name() {
-		return $this->plugin_name;
-	}
-	public function nuclen_get_version() {
-		return $this->version;
-	}
-	public function nuclen_get_utils() {
-		return $this->utils;
-	}
+    public function nuclen_get_plugin_name() {
+        return $this->plugin_name;
+    }
+    public function nuclen_get_version() {
+        return $this->version;
+    }
+    public function nuclen_get_utils() {
+        return $this->utils;
+    }
 
-	/**
-	 * Get the settings repository instance.
-	 *
-	 * @return SettingsRepository
-	 */
-	public function nuclen_get_settings_repository() {
-		return $this->settings_repository;
-	}
+    /**
+     * Get the settings repository instance.
+     *
+     * @return SettingsRepository
+     */
+    public function nuclen_get_settings_repository() {
+        return $this->settings_repository;
+    }
 
-	/**
-	 * Get the container instance.
-	 *
-	 * @return \NuclearEngagement\Container
-	 */
-	protected function get_container() {
-		return $this->container;
-	}
+    /**
+     * Get the container instance.
+     *
+     * @return \NuclearEngagement\Container
+     */
+    protected function get_container() {
+        return $this->container;
+    }
 }

--- a/nuclear-engagement/admin/Controller/Ajax/BaseController.php
+++ b/nuclear-engagement/admin/Controller/Ajax/BaseController.php
@@ -11,55 +11,55 @@ declare(strict_types=1);
 namespace NuclearEngagement\Admin\Controller\Ajax;
 
 if ( ! defined( 'ABSPATH' ) ) {
-	exit;
+    exit;
 }
 
 /**
  * Provides common security helpers for AJAX controllers.
  */
 abstract class BaseController {
-	/**
-	 * Send a standardized JSON error response.
-	 *
-	 * @param string $message Error message.
-	 * @param int    $code    HTTP status code.
-	 */
-	protected function sendError( string $message, int $code = 500 ): void {
-		status_header( $code );
-		wp_send_json_error(
-			array(
-				'message' => $message,
-			),
-			$code
-		);
-	}
+    /**
+     * Send a standardized JSON error response.
+     *
+     * @param string $message Error message.
+     * @param int    $code    HTTP status code.
+     */
+    protected function sendError( string $message, int $code = 500 ): void {
+        status_header( $code );
+        wp_send_json_error(
+            array(
+                'message' => $message,
+            ),
+            $code
+        );
+    }
 
-	/**
-	 * Verify nonce and permissions.
-	 *
-	 * @param string $nonceAction Nonce action.
-	 * @param string $nonceField  Nonce field name.
-	 * @param string $capability  Capability to check.
-	 * @return bool Whether the request is valid.
-	 */
-	protected function verifyRequest(
-		string $nonceAction,
-		string $nonceField = 'security',
-		string $capability = 'manage_options'
-	): bool {
-		if ( ! check_ajax_referer( $nonceAction, $nonceField, false ) ) {
-			$this->sendError(
-				__( 'Security check failed', 'nuclear-engagement' ),
-				403
-			);
-			return false;
-		}
+    /**
+     * Verify nonce and permissions.
+     *
+     * @param string $nonceAction Nonce action.
+     * @param string $nonceField  Nonce field name.
+     * @param string $capability  Capability to check.
+     * @return bool Whether the request is valid.
+     */
+    protected function verifyRequest(
+        string $nonceAction,
+        string $nonceField = 'security',
+        string $capability = 'manage_options'
+    ): bool {
+        if ( ! check_ajax_referer( $nonceAction, $nonceField, false ) ) {
+            $this->sendError(
+                __( 'Security check failed', 'nuclear-engagement' ),
+                403
+            );
+            return false;
+        }
 
-		if ( ! current_user_can( $capability ) ) {
-			$this->sendError( __( 'Not allowed', 'nuclear-engagement' ), 403 );
-			return false;
-		}
+        if ( ! current_user_can( $capability ) ) {
+            $this->sendError( __( 'Not allowed', 'nuclear-engagement' ), 403 );
+            return false;
+        }
 
-		return true;
-	}
+        return true;
+    }
 }

--- a/nuclear-engagement/admin/Controller/Ajax/GenerateController.php
+++ b/nuclear-engagement/admin/Controller/Ajax/GenerateController.php
@@ -14,68 +14,68 @@ use NuclearEngagement\Requests\GenerateRequest;
 use NuclearEngagement\Services\GenerationService;
 
 if ( ! defined( 'ABSPATH' ) ) {
-	exit;
+    exit;
 }
 
 /**
  * Controller for content generation
  */
 class GenerateController extends BaseController {
-	/**
-	 * @var GenerationService
-	 */
-	private GenerationService $service;
+    /**
+     * @var GenerationService
+     */
+    private GenerationService $service;
 
-	/**
-	 * Constructor
-	 *
-	 * @param GenerationService $service
-	 */
-	public function __construct( GenerationService $service ) {
-		$this->service = $service;
-	}
+    /**
+     * Constructor
+     *
+     * @param GenerationService $service
+     */
+    public function __construct( GenerationService $service ) {
+        $this->service = $service;
+    }
 
-	/**
-	 * Handle generation request
-	 */
-	public function handle(): void {
-		try {
+    /**
+     * Handle generation request
+     */
+    public function handle(): void {
+        try {
 
-			if ( ! $this->verifyRequest( 'nuclen_admin_ajax_nonce' ) ) {
-				return;
-			}
+            if ( ! $this->verifyRequest( 'nuclen_admin_ajax_nonce' ) ) {
+                return;
+            }
 
-			if ( empty( $_POST['payload'] ) ) {
-				$this->sendError(
-					__( 'Missing payload in request', 'nuclear-engagement' ),
-					400
-				);
-				return;
-			}
+            if ( empty( $_POST['payload'] ) ) {
+                $this->sendError(
+                    __( 'Missing payload in request', 'nuclear-engagement' ),
+                    400
+                );
+                return;
+            }
 
-			// Parse request
-			$request = GenerateRequest::fromPost( $_POST );
+            // Parse request
+            $request = GenerateRequest::fromPost( $_POST );
 
-			// Process generation
-			$response = $this->service->generateContent( $request );
+            // Process generation
+            $response = $this->service->generateContent( $request );
 
-			// Return response
-			wp_send_json_success( $response->toArray() );
+            // Return response
+            wp_send_json_success( $response->toArray() );
 
-		} catch ( \InvalidArgumentException $e ) {
-			\NuclearEngagement\Services\LoggingService::log(
-				'Nuclear Engagement validation error: ' . $e->getMessage()
-			);
-			$this->sendError( $e->getMessage(), 400 );
-		} catch ( \Exception $e ) {
-			\NuclearEngagement\Services\LoggingService::log(
-				'Nuclear Engagement generation error: ' . $e->getMessage() . ' in ' . $e->getFile() . ':' . $e->getLine()
-			);
-			\NuclearEngagement\Services\LoggingService::log( 'Stack trace: ' . $e->getTraceAsString() );
-			$this->sendError(
-				__( 'An unexpected error occurred. Please check your error logs.', 'nuclear-engagement' ),
-				500
-			);
-		}
-	}
+        } catch ( \InvalidArgumentException $e ) {
+            \NuclearEngagement\Services\LoggingService::log(
+                'Nuclear Engagement validation error: ' . $e->getMessage()
+            );
+            $this->sendError( $e->getMessage(), 400 );
+        } catch ( \Exception $e ) {
+            \NuclearEngagement\Services\LoggingService::log(
+                'Nuclear Engagement generation error: ' . $e->getMessage() . ' in ' . $e->getFile() . ':' . $e->getLine()
+            );
+            \NuclearEngagement\Services\LoggingService::log( 'Stack trace: ' . $e->getTraceAsString() );
+            $this->sendError(
+                __( 'An unexpected error occurred. Please check your error logs.', 'nuclear-engagement' ),
+                500
+            );
+        }
+    }
 }

--- a/nuclear-engagement/admin/Controller/Ajax/PointerController.php
+++ b/nuclear-engagement/admin/Controller/Ajax/PointerController.php
@@ -13,47 +13,47 @@ namespace NuclearEngagement\Admin\Controller\Ajax;
 use NuclearEngagement\Services\PointerService;
 
 if ( ! defined( 'ABSPATH' ) ) {
-	exit;
+    exit;
 }
 
 /**
  * Controller for admin pointers
  */
 class PointerController extends BaseController {
-	/**
-	 * @var PointerService
-	 */
-	private PointerService $service;
+    /**
+     * @var PointerService
+     */
+    private PointerService $service;
 
-	/**
-	 * Constructor
-	 *
-	 * @param PointerService $service
-	 */
-	public function __construct( PointerService $service ) {
-		$this->service = $service;
-	}
+    /**
+     * Constructor
+     *
+     * @param PointerService $service
+     */
+    public function __construct( PointerService $service ) {
+        $this->service = $service;
+    }
 
-	/**
-	 * Dismiss a pointer
-	 */
-	public function dismiss(): void {
-		try {
-			if ( ! $this->verifyRequest( 'nuclen_dismiss_pointer_nonce', 'nonce' ) ) {
-				return;
-			}
+    /**
+     * Dismiss a pointer
+     */
+    public function dismiss(): void {
+        try {
+            if ( ! $this->verifyRequest( 'nuclen_dismiss_pointer_nonce', 'nonce' ) ) {
+                return;
+            }
 
-			$pointerId = isset( $_POST['pointer'] ) ? sanitize_text_field( wp_unslash( $_POST['pointer'] ) ) : '';
-			$userId    = get_current_user_id();
+            $pointerId = isset( $_POST['pointer'] ) ? sanitize_text_field( wp_unslash( $_POST['pointer'] ) ) : '';
+            $userId    = get_current_user_id();
 
-			$this->service->dismissPointer( $pointerId, $userId );
+            $this->service->dismissPointer( $pointerId, $userId );
 
-			wp_send_json_success( array( 'message' => __( 'Pointer dismissed.', 'nuclear-engagement' ) ) );
+            wp_send_json_success( array( 'message' => __( 'Pointer dismissed.', 'nuclear-engagement' ) ) );
 
-		} catch ( \InvalidArgumentException $e ) {
-			$this->sendError( $e->getMessage() );
-		} catch ( \Exception $e ) {
-			$this->sendError( __( 'An error occurred', 'nuclear-engagement' ) );
-		}
-	}
+        } catch ( \InvalidArgumentException $e ) {
+            $this->sendError( $e->getMessage() );
+        } catch ( \Exception $e ) {
+            $this->sendError( __( 'An error occurred', 'nuclear-engagement' ) );
+        }
+    }
 }

--- a/nuclear-engagement/admin/Controller/Ajax/PostsCountController.php
+++ b/nuclear-engagement/admin/Controller/Ajax/PostsCountController.php
@@ -14,46 +14,46 @@ use NuclearEngagement\Requests\PostsCountRequest;
 use NuclearEngagement\Services\PostsQueryService;
 
 if ( ! defined( 'ABSPATH' ) ) {
-	exit;
+    exit;
 }
 
 /**
  * Controller for getting posts count
  */
 class PostsCountController extends BaseController {
-	/**
-	 * @var PostsQueryService
-	 */
-	private PostsQueryService $service;
+    /**
+     * @var PostsQueryService
+     */
+    private PostsQueryService $service;
 
-	/**
-	 * Constructor
-	 *
-	 * @param PostsQueryService $service
-	 */
-	public function __construct( PostsQueryService $service ) {
-		$this->service = $service;
-	}
+    /**
+     * Constructor
+     *
+     * @param PostsQueryService $service
+     */
+    public function __construct( PostsQueryService $service ) {
+        $this->service = $service;
+    }
 
-	/**
-	 * Handle posts count request
-	 */
-	public function handle(): void {
-		try {
-			if ( ! $this->verifyRequest( 'nuclen_admin_ajax_nonce' ) ) {
-				return;
-			}
+    /**
+     * Handle posts count request
+     */
+    public function handle(): void {
+        try {
+            if ( ! $this->verifyRequest( 'nuclen_admin_ajax_nonce' ) ) {
+                return;
+            }
 
-			// Parse request
-			$request = PostsCountRequest::fromPost( $_POST );
+            // Parse request
+            $request = PostsCountRequest::fromPost( $_POST );
 
-			// Get posts
-			$result = $this->service->getPostsCount( $request );
+            // Get posts
+            $result = $this->service->getPostsCount( $request );
 
-			wp_send_json_success( $result );
+            wp_send_json_success( $result );
 
-		} catch ( \Exception $e ) {
-			$this->sendError( $e->getMessage() );
-		}
-	}
+        } catch ( \Exception $e ) {
+            $this->sendError( $e->getMessage() );
+        }
+    }
 }

--- a/nuclear-engagement/admin/Controller/Ajax/UpdatesController.php
+++ b/nuclear-engagement/admin/Controller/Ajax/UpdatesController.php
@@ -18,7 +18,7 @@ use NuclearEngagement\Services\ApiException;
 use NuclearEngagement\Utils;
 
 if ( ! defined( 'ABSPATH' ) ) {
-	exit;
+    exit;
 }
 
 /**
@@ -26,88 +26,88 @@ if ( ! defined( 'ABSPATH' ) ) {
  */
 class UpdatesController extends BaseController {
 
-	/**
-	 * @var RemoteApiService
-	 */
-	private RemoteApiService $api;
+    /**
+     * @var RemoteApiService
+     */
+    private RemoteApiService $api;
 
-	/**
-	 * @var ContentStorageService
-	 */
-	private ContentStorageService $storage;
+    /**
+     * @var ContentStorageService
+     */
+    private ContentStorageService $storage;
 
-	/**
-	 * @var Utils
-	 */
-	private Utils $utils;
+    /**
+     * @var Utils
+     */
+    private Utils $utils;
 
-	/**
-	 * Constructor.
-	 *
-	 * @param RemoteApiService      $api
-	 * @param ContentStorageService $storage
-	 */
-	public function __construct( RemoteApiService $api, ContentStorageService $storage ) {
-		$this->api     = $api;
-		$this->storage = $storage;
-		$this->utils   = new Utils();
-	}
+    /**
+     * Constructor.
+     *
+     * @param RemoteApiService      $api
+     * @param ContentStorageService $storage
+     */
+    public function __construct( RemoteApiService $api, ContentStorageService $storage ) {
+        $this->api     = $api;
+        $this->storage = $storage;
+        $this->utils   = new Utils();
+    }
 
-	/**
-	 * Handle updates request.
-	 */
-	public function handle(): void {
-		try {
-			if ( ! $this->verifyRequest( 'nuclen_admin_ajax_nonce' ) ) {
-				return;
-			}
+    /**
+     * Handle updates request.
+     */
+    public function handle(): void {
+        try {
+            if ( ! $this->verifyRequest( 'nuclen_admin_ajax_nonce' ) ) {
+                return;
+            }
 
-				$request = UpdatesRequest::fromPost( $_POST );
+                $request = UpdatesRequest::fromPost( $_POST );
 
-				// Credits-check ping uses a dummy generation_id.
-			if ( empty( $request->generationId ) ) {
-				$request->generationId = 'gen_' . uniqid( 'auto_', true );
-			}
+                // Credits-check ping uses a dummy generation_id.
+            if ( empty( $request->generationId ) ) {
+                $request->generationId = 'gen_' . uniqid( 'auto_', true );
+            }
 
-								$data = $this->api->fetch_updates( $request->generationId );
-				\NuclearEngagement\Services\LoggingService::log( 'Updates response: ' . wp_json_encode( $data ) );
+                                $data = $this->api->fetch_updates( $request->generationId );
+                \NuclearEngagement\Services\LoggingService::log( 'Updates response: ' . wp_json_encode( $data ) );
 
-				$response          = new UpdatesResponse();
-				$response->success = true;
+                $response          = new UpdatesResponse();
+                $response->success = true;
 
-			if ( isset( $data['processed'] ) ) {
-				$response->processed = (int) $data['processed'];
-			}
-			if ( isset( $data['total'] ) ) {
-				$response->total = (int) $data['total'];
-			}
-			if ( isset( $data['remaining_credits'] ) ) {
-				$response->remainingCredits = (int) $data['remaining_credits'];
-			}
-			if ( isset( $data['message'] ) ) {
-				$response->message = $data['message'];
-			}
+            if ( isset( $data['processed'] ) ) {
+                $response->processed = (int) $data['processed'];
+            }
+            if ( isset( $data['total'] ) ) {
+                $response->total = (int) $data['total'];
+            }
+            if ( isset( $data['remaining_credits'] ) ) {
+                $response->remainingCredits = (int) $data['remaining_credits'];
+            }
+            if ( isset( $data['message'] ) ) {
+                $response->message = $data['message'];
+            }
 
-				/* ── Persist & return results ───────────────────────────── */
-			if ( ! empty( $data['results'] ) && is_array( $data['results'] ) ) {
-				$first        = reset( $data['results'] );
-				$workflowType = isset( $first['questions'] ) ? 'quiz' : 'summary';
+                /* ── Persist & return results ───────────────────────────── */
+            if ( ! empty( $data['results'] ) && is_array( $data['results'] ) ) {
+                $first        = reset( $data['results'] );
+                $workflowType = isset( $first['questions'] ) ? 'quiz' : 'summary';
 
-				$this->storage->storeResults( $data['results'], $workflowType );
+                $this->storage->storeResults( $data['results'], $workflowType );
 
-				$response->results  = $data['results'];
-				$response->workflow = $workflowType; // NEW → lets JS forward it to /receive-content
-			}
+                $response->results  = $data['results'];
+                $response->workflow = $workflowType; // NEW → lets JS forward it to /receive-content
+            }
 
-				wp_send_json_success( $response->toArray() );
+                wp_send_json_success( $response->toArray() );
 
-		} catch ( ApiException $e ) {
-			\NuclearEngagement\Services\LoggingService::log( 'Error fetching updates: ' . $e->getMessage() );
-			$message = __( 'Failed to fetch updates. Please try again later.', 'nuclear-engagement' );
-			$this->sendError( $message, $e->getCode() ?: 500 );
-		} catch ( \Throwable $e ) {
-			\NuclearEngagement\Services\LoggingService::log( 'Error fetching updates: ' . $e->getMessage() );
-			$this->sendError( __( 'An unexpected error occurred.', 'nuclear-engagement' ) );
-		}
-	}
+        } catch ( ApiException $e ) {
+            \NuclearEngagement\Services\LoggingService::log( 'Error fetching updates: ' . $e->getMessage() );
+            $message = __( 'Failed to fetch updates. Please try again later.', 'nuclear-engagement' );
+            $this->sendError( $message, $e->getCode() ?: 500 );
+        } catch ( \Throwable $e ) {
+            \NuclearEngagement\Services\LoggingService::log( 'Error fetching updates: ' . $e->getMessage() );
+            $this->sendError( __( 'An unexpected error occurred.', 'nuclear-engagement' ) );
+        }
+    }
 }

--- a/nuclear-engagement/admin/Controller/OptinExportController.php
+++ b/nuclear-engagement/admin/Controller/OptinExportController.php
@@ -13,17 +13,17 @@ namespace NuclearEngagement\Admin\Controller;
 use NuclearEngagement\OptinData;
 
 if ( ! defined( 'ABSPATH' ) ) {
-	exit;
+    exit;
 }
 
 /**
  * Controller to stream the opt-in CSV file.
  */
 class OptinExportController {
-	/**
-	 * Execute export.
-	 */
-	public function handle(): void {
-		OptinData::handle_export();
-	}
+    /**
+     * Execute export.
+     */
+    public function handle(): void {
+        OptinData::handle_export();
+    }
 }

--- a/nuclear-engagement/admin/Dashboard.php
+++ b/nuclear-engagement/admin/Dashboard.php
@@ -11,7 +11,7 @@ declare(strict_types=1);
  */
 
 if ( ! defined( 'ABSPATH' ) ) {
-	exit;
+    exit;
 }
 
 use NuclearEngagement\Utils;
@@ -31,15 +31,15 @@ $allowed_post_types = is_array( $allowed_post_types ) ? $allowed_post_types : ar
 /* Attempt to use cached inventory unless refresh requested */
 $inventory_cache = \NuclearEngagement\InventoryCache::get();
 if (
-	isset( $_GET['nuclen_refresh_inventory'] ) &&
-	isset( $_GET['nuclen_refresh_inventory_nonce'] ) &&
-	wp_verify_nonce( sanitize_text_field( wp_unslash( $_GET['nuclen_refresh_inventory_nonce'] ) ), 'nuclen_refresh_inventory' ) &&
-	current_user_can( 'manage_options' )
+    isset( $_GET['nuclen_refresh_inventory'] ) &&
+    isset( $_GET['nuclen_refresh_inventory_nonce'] ) &&
+    wp_verify_nonce( sanitize_text_field( wp_unslash( $_GET['nuclen_refresh_inventory_nonce'] ) ), 'nuclen_refresh_inventory' ) &&
+    current_user_can( 'manage_options' )
 ) {
-	\NuclearEngagement\InventoryCache::clear();
-	$inventory_cache = null;
-	wp_safe_redirect( remove_query_arg( array( 'nuclen_refresh_inventory', 'nuclen_refresh_inventory_nonce' ) ) );
-	exit;
+    \NuclearEngagement\InventoryCache::clear();
+    $inventory_cache = null;
+    wp_safe_redirect( remove_query_arg( array( 'nuclen_refresh_inventory', 'nuclen_refresh_inventory_nonce' ) ) );
+    exit;
 }
 
 /*
@@ -55,31 +55,31 @@ $post_statuses = array( 'publish', 'pending', 'draft', 'future' );
 
 if ( null === $inventory_cache ) {
 
-	/* — By Post Status — */
+    /* — By Post Status — */
         $status_rows    = $data_service->get_dual_counts( 'p.post_status', $allowed_post_types, $post_statuses );
-	$status_objects = get_post_stati( array(), 'objects' );
-	$by_status_quiz = $by_status_summary = array();
+    $status_objects = get_post_stati( array(), 'objects' );
+    $by_status_quiz = $by_status_summary = array();
 
-	foreach ( $status_rows as $r ) {
-		$label                                  = $status_objects[ $r['g'] ]->label ?? ucfirst( $r['g'] );
-		$by_status_quiz[ $label ]['with']       = (int) $r['quiz_with'];
-		$by_status_quiz[ $label ]['without']    = (int) $r['quiz_without'];
-		$by_status_summary[ $label ]['with']    = (int) $r['summary_with'];
-		$by_status_summary[ $label ]['without'] = (int) $r['summary_without'];
-	}
+    foreach ( $status_rows as $r ) {
+        $label                                  = $status_objects[ $r['g'] ]->label ?? ucfirst( $r['g'] );
+        $by_status_quiz[ $label ]['with']       = (int) $r['quiz_with'];
+        $by_status_quiz[ $label ]['without']    = (int) $r['quiz_without'];
+        $by_status_summary[ $label ]['with']    = (int) $r['summary_with'];
+        $by_status_summary[ $label ]['without'] = (int) $r['summary_without'];
+    }
 
-	/* — By Post Type — */
+    /* — By Post Type — */
         $ptype_rows = $data_service->get_dual_counts( 'p.post_type', $allowed_post_types, $post_statuses );
 
-	$by_post_type_quiz = $by_post_type_summary = array();
-	foreach ( $ptype_rows as $r ) {
-		$pt_obj                                    = get_post_type_object( $r['g'] );
-		$label                                     = $pt_obj->labels->name ?? ucfirst( $r['g'] );
-		$by_post_type_quiz[ $label ]['with']       = (int) $r['quiz_with'];
-		$by_post_type_quiz[ $label ]['without']    = (int) $r['quiz_without'];
-		$by_post_type_summary[ $label ]['with']    = (int) $r['summary_with'];
-		$by_post_type_summary[ $label ]['without'] = (int) $r['summary_without'];
-	}
+    $by_post_type_quiz = $by_post_type_summary = array();
+    foreach ( $ptype_rows as $r ) {
+        $pt_obj                                    = get_post_type_object( $r['g'] );
+        $label                                     = $pt_obj->labels->name ?? ucfirst( $r['g'] );
+        $by_post_type_quiz[ $label ]['with']       = (int) $r['quiz_with'];
+        $by_post_type_quiz[ $label ]['without']    = (int) $r['quiz_without'];
+        $by_post_type_summary[ $label ]['with']    = (int) $r['summary_with'];
+        $by_post_type_summary[ $label ]['without'] = (int) $r['summary_without'];
+    }
 
         /* — By Author — */
         $author_rows = $data_service->get_dual_counts( 'p.post_author', $allowed_post_types, $post_statuses );
@@ -113,24 +113,24 @@ if ( null === $inventory_cache ) {
                 $by_author_summary[ $name ]['without'] = (int) $r['summary_without'];
         }
 
-	/* — By Category — (only for post-types that use the “category” taxonomy) */
-	$with_cat_pt      = array_filter(
-		$allowed_post_types,
-		fn( $pt ) => in_array( 'category', get_object_taxonomies( $pt ), true )
-	);
-	$by_category_quiz = $by_category_summary = array();
+    /* — By Category — (only for post-types that use the “category” taxonomy) */
+    $with_cat_pt      = array_filter(
+        $allowed_post_types,
+        fn( $pt ) => in_array( 'category', get_object_taxonomies( $pt ), true )
+    );
+    $by_category_quiz = $by_category_summary = array();
 
-	if ( $with_cat_pt ) {
+    if ( $with_cat_pt ) {
 
-		// Sanitize inputs and build placeholders for prepare()
-		$sanitized_pt = array_map( 'sanitize_key', $with_cat_pt );
-		$sanitized_st = array_map( 'sanitize_key', $post_statuses );
+        // Sanitize inputs and build placeholders for prepare()
+        $sanitized_pt = array_map( 'sanitize_key', $with_cat_pt );
+        $sanitized_st = array_map( 'sanitize_key', $post_statuses );
 
-		$placeholders_pt = implode( ',', array_fill( 0, count( $sanitized_pt ), '%s' ) );
-		$placeholders_st = implode( ',', array_fill( 0, count( $sanitized_st ), '%s' ) );
+        $placeholders_pt = implode( ',', array_fill( 0, count( $sanitized_pt ), '%s' ) );
+        $placeholders_st = implode( ',', array_fill( 0, count( $sanitized_st ), '%s' ) );
 
-		$sql_cat      = $wpdb->prepare(
-			"SELECT t.term_id,
+        $sql_cat      = $wpdb->prepare(
+            "SELECT t.term_id,
                        t.name AS cat_name,
                        SUM(CASE WHEN pm_q.meta_id IS NULL THEN 0 ELSE 1 END) AS quiz_with,
                        SUM(CASE WHEN pm_q.meta_id IS NULL THEN 1 ELSE 0 END) AS quiz_without,
@@ -145,59 +145,59 @@ if ( null === $inventory_cache ) {
                 WHERE p.post_type  IN ($placeholders_pt)
                   AND p.post_status IN ($placeholders_st)
                 GROUP BY t.term_id",
-			array_merge( $sanitized_pt, $sanitized_st )
-		);
-			$cat_rows = $wpdb->get_results( $sql_cat, ARRAY_A );
+            array_merge( $sanitized_pt, $sanitized_st )
+        );
+            $cat_rows = $wpdb->get_results( $sql_cat, ARRAY_A );
 
-		foreach ( $cat_rows as $r ) {
-			$by_category_quiz[ $r['cat_name'] ]['with']       = (int) $r['quiz_with'];
-			$by_category_quiz[ $r['cat_name'] ]['without']    = (int) $r['quiz_without'];
-			$by_category_summary[ $r['cat_name'] ]['with']    = (int) $r['summary_with'];
-			$by_category_summary[ $r['cat_name'] ]['without'] = (int) $r['summary_without'];
-		}
-	}
+        foreach ( $cat_rows as $r ) {
+            $by_category_quiz[ $r['cat_name'] ]['with']       = (int) $r['quiz_with'];
+            $by_category_quiz[ $r['cat_name'] ]['without']    = (int) $r['quiz_without'];
+            $by_category_summary[ $r['cat_name'] ]['with']    = (int) $r['summary_with'];
+            $by_category_summary[ $r['cat_name'] ]['without'] = (int) $r['summary_without'];
+        }
+    }
 
-	/*
-	──────────────────────────────────────────────────────────────
-	* 4. Drop any rows where total = 0
-	* ──────────────────────────────────────────────────────────── */
-	$drop_zeros = static function ( array $arr ) {
-		return array_filter(
-			$arr,
-			static fn ( $c ) => ( ( $c['with'] ?? 0 ) + ( $c['without'] ?? 0 ) ) > 0
-		);
-	};
+    /*
+    ──────────────────────────────────────────────────────────────
+    * 4. Drop any rows where total = 0
+    * ──────────────────────────────────────────────────────────── */
+    $drop_zeros = static function ( array $arr ) {
+        return array_filter(
+            $arr,
+            static fn ( $c ) => ( ( $c['with'] ?? 0 ) + ( $c['without'] ?? 0 ) ) > 0
+        );
+    };
 
-	$by_status_quiz       = $drop_zeros( $by_status_quiz );
-	$by_status_summary    = $drop_zeros( $by_status_summary );
-	$by_post_type_quiz    = $drop_zeros( $by_post_type_quiz );
-	$by_post_type_summary = $drop_zeros( $by_post_type_summary );
-	$by_author_quiz       = $drop_zeros( $by_author_quiz );
-	$by_author_summary    = $drop_zeros( $by_author_summary );
-	$by_category_quiz     = $drop_zeros( $by_category_quiz );
-	$by_category_summary  = $drop_zeros( $by_category_summary );
+    $by_status_quiz       = $drop_zeros( $by_status_quiz );
+    $by_status_summary    = $drop_zeros( $by_status_summary );
+    $by_post_type_quiz    = $drop_zeros( $by_post_type_quiz );
+    $by_post_type_summary = $drop_zeros( $by_post_type_summary );
+    $by_author_quiz       = $drop_zeros( $by_author_quiz );
+    $by_author_summary    = $drop_zeros( $by_author_summary );
+    $by_category_quiz     = $drop_zeros( $by_category_quiz );
+    $by_category_summary  = $drop_zeros( $by_category_summary );
 
-	\NuclearEngagement\InventoryCache::set(
-		array(
-			'by_status_quiz'       => $by_status_quiz,
-			'by_status_summary'    => $by_status_summary,
-			'by_post_type_quiz'    => $by_post_type_quiz,
-			'by_post_type_summary' => $by_post_type_summary,
-			'by_author_quiz'       => $by_author_quiz,
-			'by_author_summary'    => $by_author_summary,
-			'by_category_quiz'     => $by_category_quiz,
-			'by_category_summary'  => $by_category_summary,
-		)
-	);
+    \NuclearEngagement\InventoryCache::set(
+        array(
+            'by_status_quiz'       => $by_status_quiz,
+            'by_status_summary'    => $by_status_summary,
+            'by_post_type_quiz'    => $by_post_type_quiz,
+            'by_post_type_summary' => $by_post_type_summary,
+            'by_author_quiz'       => $by_author_quiz,
+            'by_author_summary'    => $by_author_summary,
+            'by_category_quiz'     => $by_category_quiz,
+            'by_category_summary'  => $by_category_summary,
+        )
+    );
 } else {
-	$by_status_quiz       = $inventory_cache['by_status_quiz'] ?? array();
-	$by_status_summary    = $inventory_cache['by_status_summary'] ?? array();
-	$by_post_type_quiz    = $inventory_cache['by_post_type_quiz'] ?? array();
-	$by_post_type_summary = $inventory_cache['by_post_type_summary'] ?? array();
-	$by_author_quiz       = $inventory_cache['by_author_quiz'] ?? array();
-	$by_author_summary    = $inventory_cache['by_author_summary'] ?? array();
-	$by_category_quiz     = $inventory_cache['by_category_quiz'] ?? array();
-	$by_category_summary  = $inventory_cache['by_category_summary'] ?? array();
+    $by_status_quiz       = $inventory_cache['by_status_quiz'] ?? array();
+    $by_status_summary    = $inventory_cache['by_status_summary'] ?? array();
+    $by_post_type_quiz    = $inventory_cache['by_post_type_quiz'] ?? array();
+    $by_post_type_summary = $inventory_cache['by_post_type_summary'] ?? array();
+    $by_author_quiz       = $inventory_cache['by_author_quiz'] ?? array();
+    $by_author_summary    = $inventory_cache['by_author_summary'] ?? array();
+    $by_category_quiz     = $inventory_cache['by_category_quiz'] ?? array();
+    $by_category_summary  = $inventory_cache['by_category_summary'] ?? array();
 }
 
 /*

--- a/nuclear-engagement/admin/Onboarding.php
+++ b/nuclear-engagement/admin/Onboarding.php
@@ -17,118 +17,118 @@ use NuclearEngagement\Admin\OnboardingPointers;
 use NuclearEngagement\AssetVersions;
 
 if ( ! defined( 'ABSPATH' ) ) {
-	exit;
+    exit;
 }
 
 class Onboarding {
 
-	/*
-	-------------------------------------------------------------------------
-	 *  Public API – called from Plugin::__construct()
-	 * ---------------------------------------------------------------------- */
+    /*
+    -------------------------------------------------------------------------
+     *  Public API – called from Plugin::__construct()
+     * ---------------------------------------------------------------------- */
 
-	/** Hook up everything we need (enqueue + AJAX) */
-	public function nuclen_register_hooks() {
-		add_action( 'admin_enqueue_scripts', array( $this, 'enqueue_nuclen_onboarding_pointers' ) );
-		add_action( 'wp_ajax_nuclen_dismiss_pointer', array( $this, 'nuclen_ajax_dismiss_pointer' ) );
-	}
+    /** Hook up everything we need (enqueue + AJAX) */
+    public function nuclen_register_hooks() {
+        add_action( 'admin_enqueue_scripts', array( $this, 'enqueue_nuclen_onboarding_pointers' ) );
+        add_action( 'wp_ajax_nuclen_dismiss_pointer', array( $this, 'nuclen_ajax_dismiss_pointer' ) );
+    }
 
-	/*
-	-------------------------------------------------------------------------
-	 *  Enqueue pointer assets on specific admin pages
-	 * ---------------------------------------------------------------------- */
+    /*
+    -------------------------------------------------------------------------
+     *  Enqueue pointer assets on specific admin pages
+     * ---------------------------------------------------------------------- */
 
-	/**
-	 * Conditionally enqueue the pointer JS bundle and inject its JSON payload.
-	 *
-	 * @param string $hook_suffix Current admin page hook.
-	 */
-	public function enqueue_nuclen_onboarding_pointers( $hook_suffix ) {
+    /**
+     * Conditionally enqueue the pointer JS bundle and inject its JSON payload.
+     *
+     * @param string $hook_suffix Current admin page hook.
+     */
+    public function enqueue_nuclen_onboarding_pointers( $hook_suffix ) {
 
-		/* ───── 1. Which admin pages can show pointers? ───── */
-		$target_pages = array(
-			'toplevel_page_nuclear-engagement',
-			'nuclear-engagement_page_nuclear-engagement-generate',
-			'nuclear-engagement_page_nuclear-engagement-settings',
-			'nuclear-engagement_page_nuclear-engagement-setup',
-			'post.php',
-			// 'post-new.php',
-		);
+        /* ───── 1. Which admin pages can show pointers? ───── */
+        $target_pages = array(
+            'toplevel_page_nuclear-engagement',
+            'nuclear-engagement_page_nuclear-engagement-generate',
+            'nuclear-engagement_page_nuclear-engagement-settings',
+            'nuclear-engagement_page_nuclear-engagement-setup',
+            'post.php',
+            // 'post-new.php',
+        );
 
-		if ( ! in_array( $hook_suffix, $target_pages, true ) ) {
-			return; // nothing to do on this screen
-		}
+        if ( ! in_array( $hook_suffix, $target_pages, true ) ) {
+            return; // nothing to do on this screen
+        }
 
-				/* ───── 2. Pointer definitions ───── */
-				$pointers_by_page = OnboardingPointers::get_pointers();
+                /* ───── 2. Pointer definitions ───── */
+                $pointers_by_page = OnboardingPointers::get_pointers();
 
-		$pointers_for_this_page = $pointers_by_page[ $hook_suffix ] ?? array();
-		if ( empty( $pointers_for_this_page ) ) {
-			return;
-		}
+        $pointers_for_this_page = $pointers_by_page[ $hook_suffix ] ?? array();
+        if ( empty( $pointers_for_this_page ) ) {
+            return;
+        }
 
-		/* ───── 3. Remove already-dismissed pointers ───── */
-		$current_user_id = get_current_user_id();
-		$undismissed     = array();
+        /* ───── 3. Remove already-dismissed pointers ───── */
+        $current_user_id = get_current_user_id();
+        $undismissed     = array();
 
-		foreach ( $pointers_for_this_page as $ptr ) {
-			$dismissed = get_user_meta( $current_user_id, 'nuclen_pointer_dismissed_' . $ptr['id'], true );
-			if ( ! $dismissed ) {
-				$undismissed[] = $ptr;
-			}
-		}
+        foreach ( $pointers_for_this_page as $ptr ) {
+            $dismissed = get_user_meta( $current_user_id, 'nuclen_pointer_dismissed_' . $ptr['id'], true );
+            if ( ! $dismissed ) {
+                $undismissed[] = $ptr;
+            }
+        }
 
-		if ( empty( $undismissed ) ) {
-			return; // nothing new to show
-		}
+        if ( empty( $undismissed ) ) {
+            return; // nothing new to show
+        }
 
-		/* ───── 4. Enqueue pointer assets ───── */
-				wp_enqueue_style( 'wp-pointer' );
+        /* ───── 4. Enqueue pointer assets ───── */
+                wp_enqueue_style( 'wp-pointer' );
 
-				wp_enqueue_script(
-					'nuclen-onboarding',
-					plugin_dir_url( __DIR__ ) . 'admin/js/onboarding-pointers.js',
-					array( 'wp-util' ),
-					AssetVersions::get( 'onboarding_js' ),
-					true
-				);
+                wp_enqueue_script(
+                    'nuclen-onboarding',
+                    plugin_dir_url( __DIR__ ) . 'admin/js/onboarding-pointers.js',
+                    array( 'wp-util' ),
+                    AssetVersions::get( 'onboarding_js' ),
+                    true
+                );
 
-		/* ───── 5. Inject payload via wp_add_inline_script() ───── */
-		$payload = array(
-			'pointers' => array_values( $undismissed ),
-			'ajaxurl'  => admin_url( 'admin-ajax.php' ),
-			'nonce'    => wp_create_nonce( 'nuclen_dismiss_pointer_nonce' ),
-		);
+        /* ───── 5. Inject payload via wp_add_inline_script() ───── */
+        $payload = array(
+            'pointers' => array_values( $undismissed ),
+            'ajaxurl'  => admin_url( 'admin-ajax.php' ),
+            'nonce'    => wp_create_nonce( 'nuclen_dismiss_pointer_nonce' ),
+        );
 
-		wp_add_inline_script(
-			'nuclen-onboarding',
-			'window.nePointerData = ' . wp_json_encode(
-				$payload,
-				JSON_HEX_TAG | JSON_HEX_APOS | JSON_HEX_QUOT | JSON_HEX_AMP
-			) . ';',
-			'before'
-		);
-	}
+        wp_add_inline_script(
+            'nuclen-onboarding',
+            'window.nePointerData = ' . wp_json_encode(
+                $payload,
+                JSON_HEX_TAG | JSON_HEX_APOS | JSON_HEX_QUOT | JSON_HEX_AMP
+            ) . ';',
+            'before'
+        );
+    }
 
-	/*
-	-------------------------------------------------------------------------
-	 *  AJAX: persist pointer dismissal
-	 * ---------------------------------------------------------------------- */
+    /*
+    -------------------------------------------------------------------------
+     *  AJAX: persist pointer dismissal
+     * ---------------------------------------------------------------------- */
 
-	public function nuclen_ajax_dismiss_pointer() {
-		if ( ! current_user_can( 'manage_options' ) ) {
-			wp_send_json_error( array( 'message' => esc_html__( 'No permission', 'nuclear-engagement' ) ) );
-		}
+    public function nuclen_ajax_dismiss_pointer() {
+        if ( ! current_user_can( 'manage_options' ) ) {
+            wp_send_json_error( array( 'message' => esc_html__( 'No permission', 'nuclear-engagement' ) ) );
+        }
 
-		check_ajax_referer( 'nuclen_dismiss_pointer_nonce', 'nonce' );
+        check_ajax_referer( 'nuclen_dismiss_pointer_nonce', 'nonce' );
 
-		$pointer_id = isset( $_POST['pointer'] ) ? sanitize_text_field( wp_unslash( $_POST['pointer'] ) ) : '';
-		if ( '' === $pointer_id ) {
-			wp_send_json_error( array( 'message' => esc_html__( 'No pointer ID.', 'nuclear-engagement' ) ) );
-		}
+        $pointer_id = isset( $_POST['pointer'] ) ? sanitize_text_field( wp_unslash( $_POST['pointer'] ) ) : '';
+        if ( '' === $pointer_id ) {
+            wp_send_json_error( array( 'message' => esc_html__( 'No pointer ID.', 'nuclear-engagement' ) ) );
+        }
 
-		update_user_meta( get_current_user_id(), 'nuclen_pointer_dismissed_' . $pointer_id, true );
+        update_user_meta( get_current_user_id(), 'nuclen_pointer_dismissed_' . $pointer_id, true );
 
-		wp_send_json_success( array( 'message' => esc_html__( 'Pointer dismissed.', 'nuclear-engagement' ) ) );
-	}
+        wp_send_json_success( array( 'message' => esc_html__( 'Pointer dismissed.', 'nuclear-engagement' ) ) );
+    }
 }

--- a/nuclear-engagement/admin/OnboardingPointers.php
+++ b/nuclear-engagement/admin/OnboardingPointers.php
@@ -11,177 +11,177 @@ declare(strict_types=1);
 namespace NuclearEngagement\Admin;
 
 if ( ! defined( 'ABSPATH' ) ) {
-	exit;
+    exit;
 }
 
 final class OnboardingPointers {
-	/**
-	 * Get pointer definitions grouped by admin page.
-	 *
-	 * @return array<string,array<int,array<string,mixed>>>
-	 */
-	public static function get_pointers(): array {
-		return array(
-			'toplevel_page_nuclear-engagement' => array(
-				array(
-					'id'       => 'nuclen_dashboard_step1',
-					'target'   => '#overview-tab',
-					'title'    => esc_html__( 'Post Inventory, at a Glance', 'nuclear-engagement' ),
-					'content'  => esc_html__( 'Keep track of which posts lack quizzes or summaries. Looks like many may need an upgrade!', 'nuclear-engagement' ),
-					'position' => array(
-						'edge'  => 'top',
-						'align' => 'center',
-					),
-				),
-				array(
-					'id'       => 'nuclen_dashboard_step2',
-					'target'   => '#post-type-tab',
-					'title'    => esc_html__( 'Custom Post Types', 'nuclear-engagement' ),
-					'content'  => esc_html__( 'Not only posts, but also pages and other custom types are supported.', 'nuclear-engagement' ),
-					'position' => array(
-						'edge'  => 'top',
-						'align' => 'center',
-					),
-				),
-				array(
-					'id'       => 'nuclen_dashboard_step3',
-					'target'   => 'li.toplevel_page_nuclear-engagement ul.wp-submenu a[href="admin.php?page=nuclear-engagement-generate"]',
-					'title'    => esc_html__( 'Generate Engaging Content', 'nuclear-engagement' ),
-					'content'  => esc_html__( 'Open the Generate page to create or update your content at scale.', 'nuclear-engagement' ),
-					'position' => array(
-						'edge'  => 'left',
-						'align' => 'center',
-					),
-				),
-			),
-			'nuclear-engagement_page_nuclear-engagement-generate' => array(
-				array(
-					'id'       => 'nuclen_generate_step1',
-					'target'   => '#nuclen_generate_workflow',
-					'title'    => esc_html__( 'Bulk Upgrade', 'nuclear-engagement' ),
-					'content'  => esc_html__( 'Generate content for all selected posts in one go.', 'nuclear-engagement' ),
-					'position' => array(
-						'edge'  => 'top',
-						'align' => 'center',
-					),
-				),
-				array(
-					'id'       => 'nuclen_generate_step2',
-					'target'   => '#nuclen-filters-form .form-table',
-					'title'    => esc_html__( 'Refine Your Selection', 'nuclear-engagement' ),
-					'content'  => esc_html__( 'You can filter down to specific authors, categories, or post types.', 'nuclear-engagement' ),
-					'position' => array(
-						'edge'  => 'top',
-						'align' => 'center',
-					),
-				),
-				array(
-					'id'       => 'nuclen_generate_step3',
-					'target'   => 'li.toplevel_page_nuclear-engagement ul.wp-submenu a[href="admin.php?page=nuclear-engagement-settings"]',
-					'title'    => esc_html__( 'Customize Behavior', 'nuclear-engagement' ),
-					'content'  => esc_html__( 'You can finuclen-tune how and where new content is displayed under Settings.', 'nuclear-engagement' ),
-					'position' => array(
-						'edge'  => 'left',
-						'align' => 'center',
-					),
-				),
-			),
-			'nuclear-engagement_page_nuclear-engagement-settings' => array(
-				array(
-					'id'       => 'nuclen_settings_step1',
-					'target'   => '#placement-tab',
-					'title'    => esc_html__( 'Display Sections as You Prefer', 'nuclear-engagement' ),
-					'content'  => esc_html__( 'Use shortcodes or automatically insert quiz/summary before/after post content.', 'nuclear-engagement' ),
-					'position' => array(
-						'edge'  => 'top',
-						'align' => 'center',
-					),
-				),
-				array(
-					'id'       => 'nuclen_settings_step2',
-					'target'   => '#optin-tab',
-					'title'    => esc_html__( 'Generate Leads', 'nuclear-engagement' ),
-					'content'  => esc_html__( 'Enable an email opt-in form at the end of the quiz, hooking into your marketing tools.', 'nuclear-engagement' ),
-					'position' => array(
-						'edge'  => 'top',
-						'align' => 'center',
-					),
-				),
-				array(
-					'id'       => 'nuclen_settings_step3',
-					'target'   => 'li.toplevel_page_nuclear-engagement ul.wp-submenu a[href="admin.php?page=nuclear-engagement-setup"]',
-					'title'    => esc_html__( 'Easy Setup', 'nuclear-engagement' ),
-					'content'  => esc_html__( 'Authorize your site to generate content with NE in two steps.', 'nuclear-engagement' ),
-					'position' => array(
-						'edge'  => 'left',
-						'align' => 'center',
-					),
-				),
-			),
-			'nuclear-engagement_page_nuclear-engagement-setup' => array(
-				array(
-					'id'       => 'nuclen_setup_step1',
-					'target'   => '#nuclen-setup-step-1',
-					'title'    => esc_html__( 'Enter Your Gold Code', 'nuclear-engagement' ),
-					'content'  => esc_html__( 'Paste your API key to connect your site with the NE service.', 'nuclear-engagement' ),
-					'position' => array(
-						'edge'  => 'top',
-						'align' => 'center',
-					),
-				),
-				array(
-					'id'       => 'nuclen_setup_step2',
-					'target'   => '#nuclen-setup-step-2',
-					'title'    => esc_html__( 'One More Click', 'nuclear-engagement' ),
-					'content'  => esc_html__( 'Allow NE to push generated content directly into your site.', 'nuclear-engagement' ),
-					'position' => array(
-						'edge'  => 'top',
-						'align' => 'center',
-					),
-				),
-				array(
-					'id'       => 'nuclen_setup_step3',
-					'target'   => 'li.toplevel_page_nuclear-engagement ul.wp-submenu li.wp-first-item',
-					'title'    => esc_html__( 'Check Your Dashboard', 'nuclear-engagement' ),
-					'content'  => esc_html__( 'See which posts need a quiz or summary the most.', 'nuclear-engagement' ),
-					'position' => array(
-						'edge'  => 'left',
-						'align' => 'center',
-					),
-				),
-			),
-			'post.php'                         => array(
-				array(
-					'id'       => 'nuclen_postedit_step1',
-					'target'   => '#nuclen-quiz-data-meta-box',
-					'title'    => esc_html__( 'Generate from Editor', 'nuclear-engagement' ),
-					'content'  => esc_html__( 'Create or edit quiz content for this single post.', 'nuclear-engagement' ),
-					'position' => array(
-						'edge'  => 'top',
-						'align' => 'center',
-					),
-				),
-				array(
-					'id'       => 'nuclen_postedit_step2',
-					'target'   => '#nuclen-generate-quiz-single',
-					'title'    => esc_html__( 'One‑Click Generation', 'nuclear-engagement' ),
-					'content'  => esc_html__( 'Immediately fetch new quiz data for this post.', 'nuclear-engagement' ),
-					'position' => array(
-						'edge'  => 'right',
-						'align' => 'center',
-					),
-				),
-				array(
-					'id'       => 'nuclen_postedit_step3',
-					'target'   => '#show-settings-link',
-					'title'    => esc_html__( 'Hide Metaboxes', 'nuclear-engagement' ),
-					'content'  => esc_html__( 'You can hide plugin sections here if your editor is cluttered.', 'nuclear-engagement' ),
-					'position' => array(
-						'edge'  => 'bottom',
-						'align' => 'center',
-					),
-				),
-			),
-		);
-	}
+    /**
+     * Get pointer definitions grouped by admin page.
+     *
+     * @return array<string,array<int,array<string,mixed>>>
+     */
+    public static function get_pointers(): array {
+        return array(
+            'toplevel_page_nuclear-engagement' => array(
+                array(
+                    'id'       => 'nuclen_dashboard_step1',
+                    'target'   => '#overview-tab',
+                    'title'    => esc_html__( 'Post Inventory, at a Glance', 'nuclear-engagement' ),
+                    'content'  => esc_html__( 'Keep track of which posts lack quizzes or summaries. Looks like many may need an upgrade!', 'nuclear-engagement' ),
+                    'position' => array(
+                        'edge'  => 'top',
+                        'align' => 'center',
+                    ),
+                ),
+                array(
+                    'id'       => 'nuclen_dashboard_step2',
+                    'target'   => '#post-type-tab',
+                    'title'    => esc_html__( 'Custom Post Types', 'nuclear-engagement' ),
+                    'content'  => esc_html__( 'Not only posts, but also pages and other custom types are supported.', 'nuclear-engagement' ),
+                    'position' => array(
+                        'edge'  => 'top',
+                        'align' => 'center',
+                    ),
+                ),
+                array(
+                    'id'       => 'nuclen_dashboard_step3',
+                    'target'   => 'li.toplevel_page_nuclear-engagement ul.wp-submenu a[href="admin.php?page=nuclear-engagement-generate"]',
+                    'title'    => esc_html__( 'Generate Engaging Content', 'nuclear-engagement' ),
+                    'content'  => esc_html__( 'Open the Generate page to create or update your content at scale.', 'nuclear-engagement' ),
+                    'position' => array(
+                        'edge'  => 'left',
+                        'align' => 'center',
+                    ),
+                ),
+            ),
+            'nuclear-engagement_page_nuclear-engagement-generate' => array(
+                array(
+                    'id'       => 'nuclen_generate_step1',
+                    'target'   => '#nuclen_generate_workflow',
+                    'title'    => esc_html__( 'Bulk Upgrade', 'nuclear-engagement' ),
+                    'content'  => esc_html__( 'Generate content for all selected posts in one go.', 'nuclear-engagement' ),
+                    'position' => array(
+                        'edge'  => 'top',
+                        'align' => 'center',
+                    ),
+                ),
+                array(
+                    'id'       => 'nuclen_generate_step2',
+                    'target'   => '#nuclen-filters-form .form-table',
+                    'title'    => esc_html__( 'Refine Your Selection', 'nuclear-engagement' ),
+                    'content'  => esc_html__( 'You can filter down to specific authors, categories, or post types.', 'nuclear-engagement' ),
+                    'position' => array(
+                        'edge'  => 'top',
+                        'align' => 'center',
+                    ),
+                ),
+                array(
+                    'id'       => 'nuclen_generate_step3',
+                    'target'   => 'li.toplevel_page_nuclear-engagement ul.wp-submenu a[href="admin.php?page=nuclear-engagement-settings"]',
+                    'title'    => esc_html__( 'Customize Behavior', 'nuclear-engagement' ),
+                    'content'  => esc_html__( 'You can finuclen-tune how and where new content is displayed under Settings.', 'nuclear-engagement' ),
+                    'position' => array(
+                        'edge'  => 'left',
+                        'align' => 'center',
+                    ),
+                ),
+            ),
+            'nuclear-engagement_page_nuclear-engagement-settings' => array(
+                array(
+                    'id'       => 'nuclen_settings_step1',
+                    'target'   => '#placement-tab',
+                    'title'    => esc_html__( 'Display Sections as You Prefer', 'nuclear-engagement' ),
+                    'content'  => esc_html__( 'Use shortcodes or automatically insert quiz/summary before/after post content.', 'nuclear-engagement' ),
+                    'position' => array(
+                        'edge'  => 'top',
+                        'align' => 'center',
+                    ),
+                ),
+                array(
+                    'id'       => 'nuclen_settings_step2',
+                    'target'   => '#optin-tab',
+                    'title'    => esc_html__( 'Generate Leads', 'nuclear-engagement' ),
+                    'content'  => esc_html__( 'Enable an email opt-in form at the end of the quiz, hooking into your marketing tools.', 'nuclear-engagement' ),
+                    'position' => array(
+                        'edge'  => 'top',
+                        'align' => 'center',
+                    ),
+                ),
+                array(
+                    'id'       => 'nuclen_settings_step3',
+                    'target'   => 'li.toplevel_page_nuclear-engagement ul.wp-submenu a[href="admin.php?page=nuclear-engagement-setup"]',
+                    'title'    => esc_html__( 'Easy Setup', 'nuclear-engagement' ),
+                    'content'  => esc_html__( 'Authorize your site to generate content with NE in two steps.', 'nuclear-engagement' ),
+                    'position' => array(
+                        'edge'  => 'left',
+                        'align' => 'center',
+                    ),
+                ),
+            ),
+            'nuclear-engagement_page_nuclear-engagement-setup' => array(
+                array(
+                    'id'       => 'nuclen_setup_step1',
+                    'target'   => '#nuclen-setup-step-1',
+                    'title'    => esc_html__( 'Enter Your Gold Code', 'nuclear-engagement' ),
+                    'content'  => esc_html__( 'Paste your API key to connect your site with the NE service.', 'nuclear-engagement' ),
+                    'position' => array(
+                        'edge'  => 'top',
+                        'align' => 'center',
+                    ),
+                ),
+                array(
+                    'id'       => 'nuclen_setup_step2',
+                    'target'   => '#nuclen-setup-step-2',
+                    'title'    => esc_html__( 'One More Click', 'nuclear-engagement' ),
+                    'content'  => esc_html__( 'Allow NE to push generated content directly into your site.', 'nuclear-engagement' ),
+                    'position' => array(
+                        'edge'  => 'top',
+                        'align' => 'center',
+                    ),
+                ),
+                array(
+                    'id'       => 'nuclen_setup_step3',
+                    'target'   => 'li.toplevel_page_nuclear-engagement ul.wp-submenu li.wp-first-item',
+                    'title'    => esc_html__( 'Check Your Dashboard', 'nuclear-engagement' ),
+                    'content'  => esc_html__( 'See which posts need a quiz or summary the most.', 'nuclear-engagement' ),
+                    'position' => array(
+                        'edge'  => 'left',
+                        'align' => 'center',
+                    ),
+                ),
+            ),
+            'post.php'                         => array(
+                array(
+                    'id'       => 'nuclen_postedit_step1',
+                    'target'   => '#nuclen-quiz-data-meta-box',
+                    'title'    => esc_html__( 'Generate from Editor', 'nuclear-engagement' ),
+                    'content'  => esc_html__( 'Create or edit quiz content for this single post.', 'nuclear-engagement' ),
+                    'position' => array(
+                        'edge'  => 'top',
+                        'align' => 'center',
+                    ),
+                ),
+                array(
+                    'id'       => 'nuclen_postedit_step2',
+                    'target'   => '#nuclen-generate-quiz-single',
+                    'title'    => esc_html__( 'One‑Click Generation', 'nuclear-engagement' ),
+                    'content'  => esc_html__( 'Immediately fetch new quiz data for this post.', 'nuclear-engagement' ),
+                    'position' => array(
+                        'edge'  => 'right',
+                        'align' => 'center',
+                    ),
+                ),
+                array(
+                    'id'       => 'nuclen_postedit_step3',
+                    'target'   => '#show-settings-link',
+                    'title'    => esc_html__( 'Hide Metaboxes', 'nuclear-engagement' ),
+                    'content'  => esc_html__( 'You can hide plugin sections here if your editor is cluttered.', 'nuclear-engagement' ),
+                    'position' => array(
+                        'edge'  => 'bottom',
+                        'align' => 'center',
+                    ),
+                ),
+            ),
+        );
+    }
 }

--- a/nuclear-engagement/admin/Settings.php
+++ b/nuclear-engagement/admin/Settings.php
@@ -11,33 +11,33 @@ declare(strict_types=1);
 namespace NuclearEngagement\Admin;
 
 if ( ! defined( 'ABSPATH' ) ) {
-		exit;
+        exit;
 }
 
 class Settings {
-	use SettingsColorPickerTrait;
-	use SettingsSanitizeTrait;
-	use SettingsPageTrait;
+    use SettingsColorPickerTrait;
+    use SettingsSanitizeTrait;
+    use SettingsPageTrait;
 
-	/**
-	 * @var SettingsRepository
-	 */
-	private $settings_repository;
+    /**
+     * @var SettingsRepository
+     */
+    private $settings_repository;
 
-	/**
-	 * Constructor – hooks assets only; the heavy lifting lives in the traits.
-	 */
-	public function __construct() {
-			$this->settings_repository = \NuclearEngagement\Container::getInstance()->get( 'settings' );
-			add_action( 'admin_enqueue_scripts', array( $this, 'nuclen_enqueue_color_picker' ) );
-	}
+    /**
+     * Constructor – hooks assets only; the heavy lifting lives in the traits.
+     */
+    public function __construct() {
+            $this->settings_repository = \NuclearEngagement\Container::getInstance()->get( 'settings' );
+            add_action( 'admin_enqueue_scripts', array( $this, 'nuclen_enqueue_color_picker' ) );
+    }
 
-	/**
-	 * Get the settings repository instance.
-	 *
-	 * @return SettingsRepository
-	 */
-	public function nuclen_get_settings_repository() {
-			return $this->settings_repository;
-	}
+    /**
+     * Get the settings repository instance.
+     *
+     * @return SettingsRepository
+     */
+    public function nuclen_get_settings_repository() {
+            return $this->settings_repository;
+    }
 }

--- a/nuclear-engagement/admin/SettingsColorPickerTrait.php
+++ b/nuclear-engagement/admin/SettingsColorPickerTrait.php
@@ -12,16 +12,16 @@ namespace NuclearEngagement\Admin;
 
 trait SettingsColorPickerTrait {
 
-		/**
-		 * Previously enqueued the jQuery-based WP color picker.
-		 *
-		 * The settings page now uses native <input type="color"> elements,
-		 * so no additional scripts are required. This method remains to
-		 * preserve the public API but performs no actions.
-		 *
-		 * @param string $hook_suffix Current admin screen.
-		 */
-	public function nuclen_enqueue_color_picker( $hook_suffix ) {
-			// No-op: color inputs rely on native browser widgets.
-	}
+        /**
+         * Previously enqueued the jQuery-based WP color picker.
+         *
+         * The settings page now uses native <input type="color"> elements,
+         * so no additional scripts are required. This method remains to
+         * preserve the public API but performs no actions.
+         *
+         * @param string $hook_suffix Current admin screen.
+         */
+    public function nuclen_enqueue_color_picker( $hook_suffix ) {
+            // No-op: color inputs rely on native browser widgets.
+    }
 }

--- a/nuclear-engagement/admin/SettingsPageTrait.php
+++ b/nuclear-engagement/admin/SettingsPageTrait.php
@@ -12,7 +12,7 @@ declare(strict_types=1);
 namespace NuclearEngagement\Admin;
 
 if ( ! defined( 'ABSPATH' ) ) {
-	exit;
+    exit;
 }
 
 use NuclearEngagement\Admin\Traits\SettingsPageLoadTrait;
@@ -26,26 +26,26 @@ use NuclearEngagement\Admin\Traits\SettingsPageCustomCSSTrait;
  */
 trait SettingsPageTrait {
 
-	use SettingsPageLoadTrait;
-	use SettingsPageSaveTrait;
-	use SettingsPageCustomCSSTrait;
+    use SettingsPageLoadTrait;
+    use SettingsPageSaveTrait;
+    use SettingsPageCustomCSSTrait;
 
-	/**
-	 * Render the plugin Settings page and handle form submission.
-	 */
-	public function nuclen_display_settings_page(): void {
+    /**
+     * Render the plugin Settings page and handle form submission.
+     */
+    public function nuclen_display_settings_page(): void {
 
-		/* 1) LOAD CURRENT SETTINGS --------------------------------- */
-		list( $settings, $defaults ) = $this->nuclen_get_current_settings();
+        /* 1) LOAD CURRENT SETTINGS --------------------------------- */
+        list( $settings, $defaults ) = $this->nuclen_get_current_settings();
 
-		/* 2) HANDLE SAVE (if submitted) ---------------------------- */
-		$new_settings = array();
-		$saved        = $this->nuclen_handle_save_settings( $settings, $defaults, $new_settings );
+        /* 2) HANDLE SAVE (if submitted) ---------------------------- */
+        $new_settings = array();
+        $saved        = $this->nuclen_handle_save_settings( $settings, $defaults, $new_settings );
 
-		/* 3) WRITE CUSTOM CSS (only right after a save) ------------ */
-		if ( $saved && isset( $new_settings['theme'] ) && $new_settings['theme'] === 'custom' ) {
-			$this->nuclen_write_custom_css( $new_settings );
-		}
+        /* 3) WRITE CUSTOM CSS (only right after a save) ------------ */
+        if ( $saved && isset( $new_settings['theme'] ) && $new_settings['theme'] === 'custom' ) {
+            $this->nuclen_write_custom_css( $new_settings );
+        }
 
                /* 4) RENDER THE ADMIN FORM -------------------------------- */
                include NUCLEN_PLUGIN_DIR . 'templates/admin/nuclen-admin-settings.php';

--- a/nuclear-engagement/admin/SettingsSanitizeTrait.php
+++ b/nuclear-engagement/admin/SettingsSanitizeTrait.php
@@ -14,19 +14,19 @@ use NuclearEngagement\Admin\Traits\SettingsSanitizeOptinTrait;
 
 trait SettingsSanitizeTrait {
 
-	use SettingsSanitizeCoreTrait;
-	use SettingsSanitizeOptinTrait;
+    use SettingsSanitizeCoreTrait;
+    use SettingsSanitizeOptinTrait;
 
-	/**
-	 * Merge the two sanitisation branches.
-	 *
-	 * @param array $input Raw settings array from the form.
-	 * @return array       Fully-clean settings.
-	 */
-	public function nuclen_sanitize_settings( $input ) {
-		return array_merge(
-			$this->nuclen_sanitize_core( $input ),
-			$this->nuclen_sanitize_optin( $input )
-		);
-	}
+    /**
+     * Merge the two sanitisation branches.
+     *
+     * @param array $input Raw settings array from the form.
+     * @return array       Fully-clean settings.
+     */
+    public function nuclen_sanitize_settings( $input ) {
+        return array_merge(
+            $this->nuclen_sanitize_core( $input ),
+            $this->nuclen_sanitize_optin( $input )
+        );
+    }
 }

--- a/nuclear-engagement/admin/Setup.php
+++ b/nuclear-engagement/admin/Setup.php
@@ -17,91 +17,91 @@ use NuclearEngagement\SettingsRepository;
 use NuclearEngagement\Services\SetupService;
 
 if ( ! defined( 'ABSPATH' ) ) {
-	exit;
+    exit;
 }
 
 
 class Setup {
 
-		use SetupHandlersTrait;
+        use SetupHandlersTrait;
 
-		/** @var \NuclearEngagement\Utils */
-		private $utils;
+        /** @var \NuclearEngagement\Utils */
+        private $utils;
 
-		/** @var SetupService */
-		private $setup_service;
+        /** @var SetupService */
+        private $setup_service;
 
-	public function __construct() {
-			$this->utils         = new \NuclearEngagement\Utils();
-			$this->setup_service = new SetupService();
-	}
+    public function __construct() {
+            $this->utils         = new \NuclearEngagement\Utils();
+            $this->setup_service = new SetupService();
+    }
 
-	public function nuclen_get_utils() {
-			return $this->utils;
-	}
+    public function nuclen_get_utils() {
+            return $this->utils;
+    }
 
-	public function nuclen_get_setup_service(): SetupService {
-			return $this->setup_service;
-	}
+    public function nuclen_get_setup_service(): SetupService {
+            return $this->setup_service;
+    }
 
-	/** Add the Setup submenu page. */
-	public function nuclen_add_setup_page() {
-		add_submenu_page(
-			'nuclear-engagement',
-			esc_html__( 'Nuclear Engagement – Setup', 'nuclear-engagement' ),
-			esc_html__( 'Setup', 'nuclear-engagement' ),
-			'manage_options',
-			'nuclear-engagement-setup',
-			array( $this, 'nuclen_render_setup_page' )
-		);
-	}
+    /** Add the Setup submenu page. */
+    public function nuclen_add_setup_page() {
+        add_submenu_page(
+            'nuclear-engagement',
+            esc_html__( 'Nuclear Engagement – Setup', 'nuclear-engagement' ),
+            esc_html__( 'Setup', 'nuclear-engagement' ),
+            'manage_options',
+            'nuclear-engagement-setup',
+            array( $this, 'nuclen_render_setup_page' )
+        );
+    }
 
-	/** Render the Setup screen. */
-	public function nuclen_render_setup_page() {
+    /** Render the Setup screen. */
+    public function nuclen_render_setup_page() {
 
-		/* ───── Notices ───── */
-		$nuclen_error   = isset( $_GET['nuclen_error'] )
-			? sanitize_text_field( wp_unslash( $_GET['nuclen_error'] ) )
-			: '';
-		$nuclen_success = isset( $_GET['nuclen_success'] )
-			? sanitize_text_field( wp_unslash( $_GET['nuclen_success'] ) )
-			: '';
-		$nonce          = isset( $_GET['_wpnonce'] ) ? sanitize_key( $_GET['_wpnonce'] ) : '';
+        /* ───── Notices ───── */
+        $nuclen_error   = isset( $_GET['nuclen_error'] )
+            ? sanitize_text_field( wp_unslash( $_GET['nuclen_error'] ) )
+            : '';
+        $nuclen_success = isset( $_GET['nuclen_success'] )
+            ? sanitize_text_field( wp_unslash( $_GET['nuclen_success'] ) )
+            : '';
+        $nonce          = isset( $_GET['_wpnonce'] ) ? sanitize_key( $_GET['_wpnonce'] ) : '';
 
-		if ( $nuclen_error && wp_verify_nonce( $nonce, 'nuclear-engagement-setup' ) ) {
-			echo '<div class="notice notice-error is-dismissible"><p>' . esc_html( $nuclen_error ) . '</p></div>';
-		}
-		if ( $nuclen_success && wp_verify_nonce( $nonce, 'nuclear-engagement-setup' ) ) {
-			echo '<div class="notice notice-success is-dismissible"><p>' . esc_html( $nuclen_success ) . '</p></div>';
-		}
+        if ( $nuclen_error && wp_verify_nonce( $nonce, 'nuclear-engagement-setup' ) ) {
+            echo '<div class="notice notice-error is-dismissible"><p>' . esc_html( $nuclen_error ) . '</p></div>';
+        }
+        if ( $nuclen_success && wp_verify_nonce( $nonce, 'nuclear-engagement-setup' ) ) {
+            echo '<div class="notice notice-success is-dismissible"><p>' . esc_html( $nuclen_success ) . '</p></div>';
+        }
 
-				/* ───── Retrieve settings ───── */
-				$settings = \NuclearEngagement\Container::getInstance()->get( 'settings' );
-		$app_setup        = array(
-			'api_key'             => $settings->get_string( 'api_key', '' ),
-			'connected'           => $settings->get_bool( 'connected', false ),
-			'wp_app_pass_created' => $settings->get_bool( 'wp_app_pass_created', false ),
-			'wp_app_pass_uuid'    => $settings->get_string( 'wp_app_pass_uuid', '' ),
-			'plugin_password'     => $settings->get_string( 'plugin_password', '' ),
-		);
+                /* ───── Retrieve settings ───── */
+                $settings = \NuclearEngagement\Container::getInstance()->get( 'settings' );
+        $app_setup        = array(
+            'api_key'             => $settings->get_string( 'api_key', '' ),
+            'connected'           => $settings->get_bool( 'connected', false ),
+            'wp_app_pass_created' => $settings->get_bool( 'wp_app_pass_created', false ),
+            'wp_app_pass_uuid'    => $settings->get_string( 'wp_app_pass_uuid', '' ),
+            'plugin_password'     => $settings->get_string( 'plugin_password', '' ),
+        );
 
-		$fully_setup = ( $app_setup['connected'] && $app_setup['wp_app_pass_created'] );
+        $fully_setup = ( $app_setup['connected'] && $app_setup['wp_app_pass_created'] );
 
                /* ───── View-partials directory ───── */
                $views_dir = NUCLEN_PLUGIN_DIR . 'templates/admin/setup/';
 
-		/* ───── Branding header ───── */
-		$this->utils->display_nuclen_page_header();
+        /* ───── Branding header ───── */
+        $this->utils->display_nuclen_page_header();
 
-		/* ───── Main container & partials ───── */
-		echo '<div class="wrap nuclen-container">';
+        /* ───── Main container & partials ───── */
+        echo '<div class="wrap nuclen-container">';
 
-		require $views_dir . 'header.php';
-		require $views_dir . 'step1.php';
-		require $views_dir . 'step2.php';
-		require $views_dir . 'credits.php';
-		require $views_dir . 'support.php';
+        require $views_dir . 'header.php';
+        require $views_dir . 'step1.php';
+        require $views_dir . 'step2.php';
+        require $views_dir . 'credits.php';
+        require $views_dir . 'support.php';
 
-		echo '</div><!-- /.wrap -->';
-	}
+        echo '</div><!-- /.wrap -->';
+    }
 }

--- a/nuclear-engagement/admin/SetupHandlersTrait.php
+++ b/nuclear-engagement/admin/SetupHandlersTrait.php
@@ -18,205 +18,205 @@ use NuclearEngagement\SettingsRepository;
 use NuclearEngagement\Services\SetupService;
 
 if ( ! defined( 'ABSPATH' ) ) {
-	exit;
+    exit;
 }
 
 trait SetupHandlersTrait {
 
-	/*
-	--------------------------------------------------------------
-	#  STEP 1 – Store the Gold Code
-	--------------------------------------------------------------*/
-	public function nuclen_handle_connect_app(): void {
+    /*
+    --------------------------------------------------------------
+    #  STEP 1 – Store the Gold Code
+    --------------------------------------------------------------*/
+    public function nuclen_handle_connect_app(): void {
 
-		if ( ! isset( $_POST['nuclen_connect_app_nonce'], $_POST['nuclen_api_key'] ) ||
-			! wp_verify_nonce( sanitize_text_field( wp_unslash( $_POST['nuclen_connect_app_nonce'] ) ), 'nuclen_connect_app_action' )
-		) {
-			$this->nuclen_redirect_with_error( 'Invalid nonce.' );
-		}
-		if ( ! current_user_can( 'manage_options' ) ) {
-			$this->nuclen_redirect_with_error( 'Insufficient permissions.' );
-		}
+        if ( ! isset( $_POST['nuclen_connect_app_nonce'], $_POST['nuclen_api_key'] ) ||
+            ! wp_verify_nonce( sanitize_text_field( wp_unslash( $_POST['nuclen_connect_app_nonce'] ) ), 'nuclen_connect_app_action' )
+        ) {
+            $this->nuclen_redirect_with_error( 'Invalid nonce.' );
+        }
+        if ( ! current_user_can( 'manage_options' ) ) {
+            $this->nuclen_redirect_with_error( 'Insufficient permissions.' );
+        }
 
-		$api_key = sanitize_text_field( wp_unslash( $_POST['nuclen_api_key'] ) );
-		if ( '' === $api_key ) {
-			$this->nuclen_redirect_with_error( 'Missing Gold Code.' );
-		}
+        $api_key = sanitize_text_field( wp_unslash( $_POST['nuclen_api_key'] ) );
+        if ( '' === $api_key ) {
+            $this->nuclen_redirect_with_error( 'Missing Gold Code.' );
+        }
 
-				// Validate API key with SaaS
-				$setup_service = $this->nuclen_get_setup_service();
-		if ( ! $setup_service->validate_api_key( $api_key ) ) {
-				$this->nuclen_redirect_with_error( 'Invalid or unknown Gold Code.' );
-		}
+                // Validate API key with SaaS
+                $setup_service = $this->nuclen_get_setup_service();
+        if ( ! $setup_service->validate_api_key( $api_key ) ) {
+                $this->nuclen_redirect_with_error( 'Invalid or unknown Gold Code.' );
+        }
 
-		// Store key & mark as connected
-				$settings = \NuclearEngagement\Container::getInstance()->get( 'settings' );
-		$settings->set( 'api_key', $api_key )
-				->set( 'connected', true )
-				->save();
+        // Store key & mark as connected
+                $settings = \NuclearEngagement\Container::getInstance()->get( 'settings' );
+        $settings->set( 'api_key', $api_key )
+                ->set( 'connected', true )
+                ->save();
 
-		// Auto‑create the plugin App Password (Step 2)
-				$settings = \NuclearEngagement\Container::getInstance()->get( 'settings' );
-		if ( ! $settings->get_bool( 'wp_app_pass_created', false ) ) {
-			$this->nuclen_handle_generate_app_password( true );
-			return; // that method redirects on success/fail
-		}
+        // Auto‑create the plugin App Password (Step 2)
+                $settings = \NuclearEngagement\Container::getInstance()->get( 'settings' );
+        if ( ! $settings->get_bool( 'wp_app_pass_created', false ) ) {
+            $this->nuclen_handle_generate_app_password( true );
+            return; // that method redirects on success/fail
+        }
 
-		$this->nuclen_redirect_with_success( 'Gold Code saved.' );
-	}
+        $this->nuclen_redirect_with_success( 'Gold Code saved.' );
+    }
 
-	/*
-	--------------------------------------------------------------
-	#  STEP 2 – Generate & store plugin App Password
-	--------------------------------------------------------------*/
-	public function nuclen_handle_generate_app_password( $bypass_nonce = false ): void {
+    /*
+    --------------------------------------------------------------
+    #  STEP 2 – Generate & store plugin App Password
+    --------------------------------------------------------------*/
+    public function nuclen_handle_generate_app_password( $bypass_nonce = false ): void {
 
-		if ( ! $bypass_nonce ) {
-			if ( ! isset( $_POST['nuclen_generate_app_password_nonce'] ) ||
-				! wp_verify_nonce( sanitize_text_field( wp_unslash( $_POST['nuclen_generate_app_password_nonce'] ) ), 'nuclen_generate_app_password_action' )
-			) {
-				$this->nuclen_redirect_with_error( 'Invalid nonce.' );
-			}
-		}
-		if ( ! current_user_can( 'manage_options' ) ) {
-			$this->nuclen_redirect_with_error( 'Insufficient permissions.' );
-		}
+        if ( ! $bypass_nonce ) {
+            if ( ! isset( $_POST['nuclen_generate_app_password_nonce'] ) ||
+                ! wp_verify_nonce( sanitize_text_field( wp_unslash( $_POST['nuclen_generate_app_password_nonce'] ) ), 'nuclen_generate_app_password_action' )
+            ) {
+                $this->nuclen_redirect_with_error( 'Invalid nonce.' );
+            }
+        }
+        if ( ! current_user_can( 'manage_options' ) ) {
+            $this->nuclen_redirect_with_error( 'Insufficient permissions.' );
+        }
 
-				$settings = \NuclearEngagement\Container::getInstance()->get( 'settings' );
-		if ( ! $settings->get_bool( 'connected', false ) || empty( $settings->get( 'api_key' ) ) ) {
-			$this->nuclen_redirect_with_error( 'Please complete Step 1 first.' );
-		}
+                $settings = \NuclearEngagement\Container::getInstance()->get( 'settings' );
+        if ( ! $settings->get_bool( 'connected', false ) || empty( $settings->get( 'api_key' ) ) ) {
+            $this->nuclen_redirect_with_error( 'Please complete Step 1 first.' );
+        }
 
-		// Get the current app setup data
-		$app_setup = get_option( 'nuclear_engagement_setup', array() );
+        // Get the current app setup data
+        $app_setup = get_option( 'nuclear_engagement_setup', array() );
 
-		// ──────────────────────────────────────────────────────────
-		// Generate a new random password & UUID
-		// ──────────────────────────────────────────────────────────
-		$new_password = wp_generate_password( 32, false, false );
-		$uuid         = wp_generate_uuid4();
-		$current_user = wp_get_current_user();
+        // ──────────────────────────────────────────────────────────
+        // Generate a new random password & UUID
+        // ──────────────────────────────────────────────────────────
+        $new_password = wp_generate_password( 32, false, false );
+        $uuid         = wp_generate_uuid4();
+        $current_user = wp_get_current_user();
 
-		// Get API key from settings
-		$api_key = $settings->get( 'api_key' );
-		if ( empty( $api_key ) ) {
-			$this->nuclen_redirect_with_error( 'API key is missing. Please complete Step 1 first.' );
-		}
+        // Get API key from settings
+        $api_key = $settings->get( 'api_key' );
+        if ( empty( $api_key ) ) {
+            $this->nuclen_redirect_with_error( 'API key is missing. Please complete Step 1 first.' );
+        }
 
-				// Send credentials to SaaS (keep payload identical to old format)
-				$setup_service = $this->nuclen_get_setup_service();
-				$ok            = $setup_service->send_app_password(
-					array(
-						'appApiKey'     => $api_key,
-						'siteUrl'       => get_site_url(),
-						'wpUserLogin'   => $current_user->user_login,
-						'wpAppPassword' => $new_password, // same key, new value
-						'wpAppPassUuid' => $uuid,
-					)
-				);
-		if ( ! $ok ) {
-			$this->nuclen_redirect_with_error( 'Failed to send App Password to the SaaS.' );
-		}
+                // Send credentials to SaaS (keep payload identical to old format)
+                $setup_service = $this->nuclen_get_setup_service();
+                $ok            = $setup_service->send_app_password(
+                    array(
+                        'appApiKey'     => $api_key,
+                        'siteUrl'       => get_site_url(),
+                        'wpUserLogin'   => $current_user->user_login,
+                        'wpAppPassword' => $new_password, // same key, new value
+                        'wpAppPassUuid' => $uuid,
+                    )
+                );
+        if ( ! $ok ) {
+            $this->nuclen_redirect_with_error( 'Failed to send App Password to the SaaS.' );
+        }
 
-		// Update SettingsRepository first
-				$settings = \NuclearEngagement\Container::getInstance()->get( 'settings' );
-		$settings->set( 'wp_app_pass_created', true )
-				->set( 'wp_app_pass_uuid', $uuid )
-				->set( 'plugin_password', $new_password )
-				->set( 'connected', true ) // Ensure connected is also set
-				->save();
+        // Update SettingsRepository first
+                $settings = \NuclearEngagement\Container::getInstance()->get( 'settings' );
+        $settings->set( 'wp_app_pass_created', true )
+                ->set( 'wp_app_pass_uuid', $uuid )
+                ->set( 'plugin_password', $new_password )
+                ->set( 'connected', true ) // Ensure connected is also set
+                ->save();
 
-		// Then update the legacy options for backward compatibility
-		$app_setup['wp_app_pass_created'] = true;
-		$app_setup['wp_app_pass_uuid']    = $uuid;
-		$app_setup['plugin_password']     = $new_password;
-		$app_setup['connected']           = true; // Ensure connected is also set in legacy option
-		update_option( 'nuclear_engagement_setup', $app_setup );
+        // Then update the legacy options for backward compatibility
+        $app_setup['wp_app_pass_created'] = true;
+        $app_setup['wp_app_pass_uuid']    = $uuid;
+        $app_setup['plugin_password']     = $new_password;
+        $app_setup['connected']           = true; // Ensure connected is also set in legacy option
+        update_option( 'nuclear_engagement_setup', $app_setup );
 
-		// Clear any caches that might be holding old values
-		wp_cache_delete( 'nuclear_engagement_setup', 'options' );
+        // Clear any caches that might be holding old values
+        wp_cache_delete( 'nuclear_engagement_setup', 'options' );
 
-		$this->nuclen_redirect_with_success( 'Setup completed – you are ready to go!' );
-	}
+        $this->nuclen_redirect_with_success( 'Setup completed – you are ready to go!' );
+    }
 
-	/*
-	--------------------------------------------------------------
-	#  Reset handlers
-	--------------------------------------------------------------*/
-	public function nuclen_handle_reset_api_key(): void {
+    /*
+    --------------------------------------------------------------
+    #  Reset handlers
+    --------------------------------------------------------------*/
+    public function nuclen_handle_reset_api_key(): void {
 
-		if ( ! isset( $_POST['nuclen_reset_api_key_nonce'] ) ||
-			! wp_verify_nonce( sanitize_text_field( wp_unslash( $_POST['nuclen_reset_api_key_nonce'] ) ), 'nuclen_reset_api_key_action' )
-		) {
-			$this->nuclen_redirect_with_error( 'Invalid nonce.' );
-		}
-		if ( ! current_user_can( 'manage_options' ) ) {
-			$this->nuclen_redirect_with_error( 'Insufficient permissions.' );
-		}
+        if ( ! isset( $_POST['nuclen_reset_api_key_nonce'] ) ||
+            ! wp_verify_nonce( sanitize_text_field( wp_unslash( $_POST['nuclen_reset_api_key_nonce'] ) ), 'nuclen_reset_api_key_action' )
+        ) {
+            $this->nuclen_redirect_with_error( 'Invalid nonce.' );
+        }
+        if ( ! current_user_can( 'manage_options' ) ) {
+            $this->nuclen_redirect_with_error( 'Insufficient permissions.' );
+        }
 
-				$settings = \NuclearEngagement\Container::getInstance()->get( 'settings' );
-		$settings->set( 'api_key', '' )
-				->set( 'connected', false )
-				->set( 'wp_app_pass_created', false )
-				->set( 'wp_app_pass_uuid', '' )
-				->set( 'plugin_password', '' )
-				->save();
+                $settings = \NuclearEngagement\Container::getInstance()->get( 'settings' );
+        $settings->set( 'api_key', '' )
+                ->set( 'connected', false )
+                ->set( 'wp_app_pass_created', false )
+                ->set( 'wp_app_pass_uuid', '' )
+                ->set( 'plugin_password', '' )
+                ->save();
 
-		$this->nuclen_redirect_with_success( 'Gold Code reset. Site disconnected.' );
-	}
+        $this->nuclen_redirect_with_success( 'Gold Code reset. Site disconnected.' );
+    }
 
-	public function nuclen_handle_reset_wp_app_connection(): void {
+    public function nuclen_handle_reset_wp_app_connection(): void {
 
-		if ( ! isset( $_POST['nuclen_reset_wp_app_nonce'] ) ||
-			! wp_verify_nonce( sanitize_text_field( wp_unslash( $_POST['nuclen_reset_wp_app_nonce'] ) ), 'nuclen_reset_wp_app_action' )
-		) {
-			$this->nuclen_redirect_with_error( 'Invalid nonce.' );
-		}
-		if ( ! current_user_can( 'manage_options' ) ) {
-			$this->nuclen_redirect_with_error( 'Insufficient permissions.' );
-		}
+        if ( ! isset( $_POST['nuclen_reset_wp_app_nonce'] ) ||
+            ! wp_verify_nonce( sanitize_text_field( wp_unslash( $_POST['nuclen_reset_wp_app_nonce'] ) ), 'nuclen_reset_wp_app_action' )
+        ) {
+            $this->nuclen_redirect_with_error( 'Invalid nonce.' );
+        }
+        if ( ! current_user_can( 'manage_options' ) ) {
+            $this->nuclen_redirect_with_error( 'Insufficient permissions.' );
+        }
 
-				$app_setup                        = get_option( 'nuclear_engagement_setup', array() );
-				$app_setup['wp_app_pass_created'] = false;
-				$app_setup['wp_app_pass_uuid']    = '';
-				$app_setup['plugin_password']     = '';
-				update_option( 'nuclear_engagement_setup', $app_setup );
+                $app_setup                        = get_option( 'nuclear_engagement_setup', array() );
+                $app_setup['wp_app_pass_created'] = false;
+                $app_setup['wp_app_pass_uuid']    = '';
+                $app_setup['plugin_password']     = '';
+                update_option( 'nuclear_engagement_setup', $app_setup );
 
-				$settings = \NuclearEngagement\Container::getInstance()->get( 'settings' );
-				$settings->set( 'wp_app_pass_created', false )
-						->set( 'wp_app_pass_uuid', '' )
-						->set( 'plugin_password', '' )
-						->save();
+                $settings = \NuclearEngagement\Container::getInstance()->get( 'settings' );
+                $settings->set( 'wp_app_pass_created', false )
+                        ->set( 'wp_app_pass_uuid', '' )
+                        ->set( 'plugin_password', '' )
+                        ->save();
 
-				$this->nuclen_redirect_with_success( 'App Password revoked.' );
-	}
+                $this->nuclen_redirect_with_success( 'App Password revoked.' );
+    }
 
 
-	private function nuclen_redirect_with_error( $msg ): void {
-		wp_redirect(
-			add_query_arg(
-				array(
-					'page'         => 'nuclear-engagement-setup',
-					'nuclen_error' => urlencode( $msg ),
-					'_wpnonce'     => wp_create_nonce( 'nuclear-engagement-setup' ),
-				),
-				admin_url( 'admin.php' )
-			)
-		);
-		exit;
-	}
+    private function nuclen_redirect_with_error( $msg ): void {
+        wp_redirect(
+            add_query_arg(
+                array(
+                    'page'         => 'nuclear-engagement-setup',
+                    'nuclen_error' => urlencode( $msg ),
+                    '_wpnonce'     => wp_create_nonce( 'nuclear-engagement-setup' ),
+                ),
+                admin_url( 'admin.php' )
+            )
+        );
+        exit;
+    }
 
-	private function nuclen_redirect_with_success( $msg ): void {
-		wp_redirect(
-			add_query_arg(
-				array(
-					'page'           => 'nuclear-engagement-setup',
-					'nuclen_success' => urlencode( $msg ),
-					'_wpnonce'       => wp_create_nonce( 'nuclear-engagement-setup' ),
-				),
-				admin_url( 'admin.php' )
-			)
-		);
-		exit;
-	}
+    private function nuclen_redirect_with_success( $msg ): void {
+        wp_redirect(
+            add_query_arg(
+                array(
+                    'page'           => 'nuclear-engagement-setup',
+                    'nuclen_success' => urlencode( $msg ),
+                    '_wpnonce'       => wp_create_nonce( 'nuclear-engagement-setup' ),
+                ),
+                admin_url( 'admin.php' )
+            )
+        );
+        exit;
+    }
 }

--- a/nuclear-engagement/admin/Traits/AdminAjax.php
+++ b/nuclear-engagement/admin/Traits/AdminAjax.php
@@ -11,35 +11,35 @@ declare(strict_types=1);
 namespace NuclearEngagement\Admin\Traits;
 
 if ( ! defined( 'ABSPATH' ) ) {
-	exit;
+    exit;
 }
 
 trait AdminAjax {
 
-	/**
-	 * Fetch updates from the remote app - delegates to controller
-	 */
-	public function nuclen_fetch_app_updates() {
-		$container  = $this->get_container();
-		$controller = $container->get( 'updates_controller' );
-		$controller->handle();
-	}
+    /**
+     * Fetch updates from the remote app - delegates to controller
+     */
+    public function nuclen_fetch_app_updates() {
+        $container  = $this->get_container();
+        $controller = $container->get( 'updates_controller' );
+        $controller->handle();
+    }
 
-	/**
-	 * AJAX to get a list of posts for bulk generation - delegates to controller
-	 */
-	public function nuclen_get_posts_count() {
-		$container  = $this->get_container();
-		$controller = $container->get( 'posts_count_controller' );
-		$controller->handle();
-	}
+    /**
+     * AJAX to get a list of posts for bulk generation - delegates to controller
+     */
+    public function nuclen_get_posts_count() {
+        $container  = $this->get_container();
+        $controller = $container->get( 'posts_count_controller' );
+        $controller->handle();
+    }
 
-	/**
-	 * AJAX to start generation - delegates to controller
-	 */
-	public function nuclen_handle_trigger_generation() {
-		$container  = $this->get_container();
-		$controller = $container->get( 'generate_controller' );
-		$controller->handle();
-	}
+    /**
+     * AJAX to start generation - delegates to controller
+     */
+    public function nuclen_handle_trigger_generation() {
+        $container  = $this->get_container();
+        $controller = $container->get( 'generate_controller' );
+        $controller->handle();
+    }
 }

--- a/nuclear-engagement/admin/Traits/AdminAssets.php
+++ b/nuclear-engagement/admin/Traits/AdminAssets.php
@@ -11,111 +11,111 @@ namespace NuclearEngagement\Admin\Traits;
 use NuclearEngagement\AssetVersions;
 
 if ( ! defined( 'ABSPATH' ) ) {
-	exit;
+    exit;
 }
 
 
 trait AdminAssets {
 
-	/**
-	 * Enqueue base admin CSS for all plugin admin screens.
-	 */
-	public function wp_enqueue_styles() {
-		wp_enqueue_style(
-			$this->nuclen_get_plugin_name(),
-			plugin_dir_url( __FILE__ ) . 'css/nuclen-admin.css',
-			array(),
-			AssetVersions::get( 'admin_css' ),
-			'all'
-		);
-	}
+    /**
+     * Enqueue base admin CSS for all plugin admin screens.
+     */
+    public function wp_enqueue_styles() {
+        wp_enqueue_style(
+            $this->nuclen_get_plugin_name(),
+            plugin_dir_url( __FILE__ ) . 'css/nuclen-admin.css',
+            array(),
+            AssetVersions::get( 'admin_css' ),
+            'all'
+        );
+    }
 
-	/**
-	 * Enqueue "nuclen-admin.js" for our NE admin pages & post editor.
-	 *
-	 * @param string $hook Current admin page hook suffix
-	 */
-	public function wp_enqueue_scripts( $hook ) {
-		// The pages we want our plugin JS to load on:
-		$allowed_hooks = array(
-			'post.php',
-			'post-new.php',
-			'toplevel_page_nuclear-engagement',
-			'nuclear-engagement_page_nuclear-engagement-generate',
-			'nuclear-engagement_page_nuclear-engagement-settings',
-			'nuclear-engagement_page_nuclear-engagement-setup',
-		);
+    /**
+     * Enqueue "nuclen-admin.js" for our NE admin pages & post editor.
+     *
+     * @param string $hook Current admin page hook suffix
+     */
+    public function wp_enqueue_scripts( $hook ) {
+        // The pages we want our plugin JS to load on:
+        $allowed_hooks = array(
+            'post.php',
+            'post-new.php',
+            'toplevel_page_nuclear-engagement',
+            'nuclear-engagement_page_nuclear-engagement-generate',
+            'nuclear-engagement_page_nuclear-engagement-settings',
+            'nuclear-engagement_page_nuclear-engagement-setup',
+        );
 
-		// Only enqueue on our plugin pages & post editor
-		if ( ! in_array( $hook, $allowed_hooks, true ) ) {
-			return;
-		}
+        // Only enqueue on our plugin pages & post editor
+        if ( ! in_array( $hook, $allowed_hooks, true ) ) {
+            return;
+        }
 
-				// Enqueue the admin bundle. Onboarding handles pointer styles
-				// separately, so no wp-pointer or jQuery dependencies here.
-				wp_enqueue_script(
-					'nuclen-admin',
-					plugin_dir_url( __DIR__ ) . 'admin/js/nuclen-admin.js',
-					array(),
-					AssetVersions::get( 'admin_js' ),
-					true
-				);
+                // Enqueue the admin bundle. Onboarding handles pointer styles
+                // separately, so no wp-pointer or jQuery dependencies here.
+                wp_enqueue_script(
+                    'nuclen-admin',
+                    plugin_dir_url( __DIR__ ) . 'admin/js/nuclen-admin.js',
+                    array(),
+                    AssetVersions::get( 'admin_js' ),
+                    true
+                );
 
-		// Provide two objects:
-		// 1) "security" => wp_create_nonce('nuclen_admin_ajax_nonce') for your admin-ajax calls
-		// 2) "rest_nonce" => wp_create_nonce('wp_rest') for your custom REST route
-		// 3) "rest_receive_content" => REST endpoint URL
-		wp_localize_script(
-			'nuclen-admin',
-			'nuclenAdminVars',
-			array(
-				'ajax_url'             => admin_url( 'admin-ajax.php' ),
-				'security'             => wp_create_nonce( 'nuclen_admin_ajax_nonce' ),
-				'rest_nonce'           => wp_create_nonce( 'wp_rest' ), // For X-WP-Nonce header
-				'rest_receive_content' => rest_url( 'nuclear-engagement/v1/receive-content' ),
-			)
-		);
+        // Provide two objects:
+        // 1) "security" => wp_create_nonce('nuclen_admin_ajax_nonce') for your admin-ajax calls
+        // 2) "rest_nonce" => wp_create_nonce('wp_rest') for your custom REST route
+        // 3) "rest_receive_content" => REST endpoint URL
+        wp_localize_script(
+            'nuclen-admin',
+            'nuclenAdminVars',
+            array(
+                'ajax_url'             => admin_url( 'admin-ajax.php' ),
+                'security'             => wp_create_nonce( 'nuclen_admin_ajax_nonce' ),
+                'rest_nonce'           => wp_create_nonce( 'wp_rest' ), // For X-WP-Nonce header
+                'rest_receive_content' => rest_url( 'nuclear-engagement/v1/receive-content' ),
+            )
+        );
 
-		// This ensures nuclenAjax is available on both the Generate page & single-post editor
-		$this->nuclen_enqueue_generate_page_scripts( $hook );
-	}
+        // This ensures nuclenAjax is available on both the Generate page & single-post editor
+        $this->nuclen_enqueue_generate_page_scripts( $hook );
+    }
 
-	/**
-	 * Optionally enqueue scripts just for the Generate page, if needed.
-	 * We also extend this to post.php/post-new.php so that single-post generation
-	 * does not fail due to missing nuclenAjax config.
-	 */
-	public function nuclen_enqueue_generate_page_scripts( $hook ) {
-		if (
-			$hook === 'nuclear-engagement_page_nuclear-engagement-generate'
-			|| $hook === 'post.php'
-			|| $hook === 'post-new.php'
-		) {
-			wp_localize_script(
-				'nuclen-admin',
-				'nuclenAjax',
-				array(
-					'ajax_url'     => admin_url( 'admin-ajax.php' ),
-					'fetch_action' => 'nuclen_fetch_app_updates',
-					// same exact nonce to match check_ajax_referer('nuclen_admin_ajax_nonce','security') for admin-ajax
-					'nonce'        => wp_create_nonce( 'nuclen_admin_ajax_nonce' ),
-				)
-			);
-		}
-	}
+    /**
+     * Optionally enqueue scripts just for the Generate page, if needed.
+     * We also extend this to post.php/post-new.php so that single-post generation
+     * does not fail due to missing nuclenAjax config.
+     */
+    public function nuclen_enqueue_generate_page_scripts( $hook ) {
+        if (
+            $hook === 'nuclear-engagement_page_nuclear-engagement-generate'
+            || $hook === 'post.php'
+            || $hook === 'post-new.php'
+        ) {
+            wp_localize_script(
+                'nuclen-admin',
+                'nuclenAjax',
+                array(
+                    'ajax_url'     => admin_url( 'admin-ajax.php' ),
+                    'fetch_action' => 'nuclen_fetch_app_updates',
+                    // same exact nonce to match check_ajax_referer('nuclen_admin_ajax_nonce','security') for admin-ajax
+                    'nonce'        => wp_create_nonce( 'nuclen_admin_ajax_nonce' ),
+                )
+            );
+        }
+    }
 
-	/**
-	 * Enqueue CSS only on the Dashboard page, if you want.
-	 */
-	public function nuclen_enqueue_dashboard_styles( $hook ) {
-		if ( $hook === 'toplevel_page_nuclear-engagement' ) {
-			wp_enqueue_style(
-				$this->nuclen_get_plugin_name() . '-dashboard',
-				plugin_dir_url( __FILE__ ) . 'css/nuclen-admin-dashboard.css?v=' . NUCLEN_ASSET_VERSION,
-				array(),
-				$this->nuclen_get_version(),
-				'all'
-			);
-		}
-	}
+    /**
+     * Enqueue CSS only on the Dashboard page, if you want.
+     */
+    public function nuclen_enqueue_dashboard_styles( $hook ) {
+        if ( $hook === 'toplevel_page_nuclear-engagement' ) {
+            wp_enqueue_style(
+                $this->nuclen_get_plugin_name() . '-dashboard',
+                plugin_dir_url( __FILE__ ) . 'css/nuclen-admin-dashboard.css?v=' . NUCLEN_ASSET_VERSION,
+                array(),
+                $this->nuclen_get_version(),
+                'all'
+            );
+        }
+    }
 }

--- a/nuclear-engagement/admin/Traits/AdminAutoGenerate.php
+++ b/nuclear-engagement/admin/Traits/AdminAutoGenerate.php
@@ -12,124 +12,124 @@ declare(strict_types=1);
 namespace NuclearEngagement\Admin\Traits;
 
 if ( ! defined( 'ABSPATH' ) ) {
-	exit;
+    exit;
 }
 
 trait AdminAutoGenerate {
 
-	/*
-	──────────────────────────────────────────────────────────
-		Register the WP-Cron action (called from Admin::__construct())
-	──────────────────────────────────────────────────────────*/
-	public function nuclen_register_autogen_cron_hook() {
-		add_action(
-			'nuclen_poll_generation',
-			array( $this, 'nuclen_cron_poll_generation' ),
-			10,
-			4 // generation_id, workflow_type, post_id, attempt
-		);
-	}
+    /*
+    ──────────────────────────────────────────────────────────
+        Register the WP-Cron action (called from Admin::__construct())
+    ──────────────────────────────────────────────────────────*/
+    public function nuclen_register_autogen_cron_hook() {
+        add_action(
+            'nuclen_poll_generation',
+            array( $this, 'nuclen_cron_poll_generation' ),
+            10,
+            4 // generation_id, workflow_type, post_id, attempt
+        );
+    }
 
-	/*
-	──────────────────────────────────────────────────────────
-		Hook: post transitions to "publish"
-	──────────────────────────────────────────────────────────*/
-	public function nuclen_auto_generate_on_publish( $new_status, $old_status, $post ) {
-		// Only when we enter publish
-		if ( $old_status === 'publish' || $new_status !== 'publish' ) {
-			return;
-		}
+    /*
+    ──────────────────────────────────────────────────────────
+        Hook: post transitions to "publish"
+    ──────────────────────────────────────────────────────────*/
+    public function nuclen_auto_generate_on_publish( $new_status, $old_status, $post ) {
+        // Only when we enter publish
+        if ( $old_status === 'publish' || $new_status !== 'publish' ) {
+            return;
+        }
 
-		// Get settings from repository
-		$settings_repo      = $this->nuclen_get_settings_repository();
-		$allowed_post_types = $settings_repo->get( 'generation_post_types', array( 'post' ) );
-		if ( ! in_array( $post->post_type, (array) $allowed_post_types, true ) ) {
-			return;
-		}
+        // Get settings from repository
+        $settings_repo      = $this->nuclen_get_settings_repository();
+        $allowed_post_types = $settings_repo->get( 'generation_post_types', array( 'post' ) );
+        if ( ! in_array( $post->post_type, (array) $allowed_post_types, true ) ) {
+            return;
+        }
 
-		$gen_quiz    = (bool) $settings_repo->get( 'auto_generate_quiz_on_publish', false );
-		$gen_summary = (bool) $settings_repo->get( 'auto_generate_summary_on_publish', false );
-		if ( ! $gen_quiz && ! $gen_summary ) {
-			return;
-		}
+        $gen_quiz    = (bool) $settings_repo->get( 'auto_generate_quiz_on_publish', false );
+        $gen_summary = (bool) $settings_repo->get( 'auto_generate_summary_on_publish', false );
+        if ( ! $gen_quiz && ! $gen_summary ) {
+            return;
+        }
 
-		// Auto-generate quiz
-		if ( $gen_quiz ) {
-			// Skip if quiz is protected
-			$protected = get_post_meta( $post->ID, 'nuclen_quiz_protected', true );
-			if ( ! $protected ) {
-				$this->nuclen_generate_single( $post->ID, 'quiz' );
-			}
-		}
+        // Auto-generate quiz
+        if ( $gen_quiz ) {
+            // Skip if quiz is protected
+            $protected = get_post_meta( $post->ID, 'nuclen_quiz_protected', true );
+            if ( ! $protected ) {
+                $this->nuclen_generate_single( $post->ID, 'quiz' );
+            }
+        }
 
-		// Auto-generate summary
-		if ( $gen_summary ) {
-			// Skip if summary is protected
-			$protected = get_post_meta( $post->ID, 'nuclen_summary_protected', true );
-			if ( ! $protected ) {
-				$this->nuclen_generate_single( $post->ID, 'summary' );
-			}
-		}
-	}
+        // Auto-generate summary
+        if ( $gen_summary ) {
+            // Skip if summary is protected
+            $protected = get_post_meta( $post->ID, 'nuclen_summary_protected', true );
+            if ( ! $protected ) {
+                $this->nuclen_generate_single( $post->ID, 'summary' );
+            }
+        }
+    }
 
-	/*
-	──────────────────────────────────────────────────────────
-		Send post to SaaS & schedule polling - now uses service
-	──────────────────────────────────────────────────────────*/
-	private function nuclen_generate_single( $post_id, $workflow_type ) {
-		try {
-			$container = $this->get_container();
-			$service   = $container->get( 'generation_service' );
-			$service->generateSingle( $post_id, $workflow_type );
+    /*
+    ──────────────────────────────────────────────────────────
+        Send post to SaaS & schedule polling - now uses service
+    ──────────────────────────────────────────────────────────*/
+    private function nuclen_generate_single( $post_id, $workflow_type ) {
+        try {
+            $container = $this->get_container();
+            $service   = $container->get( 'generation_service' );
+            $service->generateSingle( $post_id, $workflow_type );
                } catch ( \Exception $e ) {
                        \NuclearEngagement\Services\LoggingService::log_exception( $e );
                }
        }
 
-	/*
-	──────────────────────────────────────────────────────────
-		Cron callback: poll SaaS /updates - now uses services
-	──────────────────────────────────────────────────────────*/
-	public function nuclen_cron_poll_generation( $generation_id, $workflow_type, $post_id, $attempt ) {
+    /*
+    ──────────────────────────────────────────────────────────
+        Cron callback: poll SaaS /updates - now uses services
+    ──────────────────────────────────────────────────────────*/
+    public function nuclen_cron_poll_generation( $generation_id, $workflow_type, $post_id, $attempt ) {
                $max_attempts = NUCLEN_MAX_POLL_ATTEMPTS;
                $retry_delay  = NUCLEN_POLL_RETRY_DELAY * $attempt; // Increase delay per attempt
 
-		try {
-			// Check if auto-generation is enabled for this post type.
-			$settings_repo       = $this->nuclen_get_settings_repository();
-			$connected           = $settings_repo->get( 'connected', false );
-			$wp_app_pass_created = $settings_repo->get( 'wp_app_pass_created', false );
-			if ( ! $connected || ! $wp_app_pass_created ) {
-				return;
-			}
+        try {
+            // Check if auto-generation is enabled for this post type.
+            $settings_repo       = $this->nuclen_get_settings_repository();
+            $connected           = $settings_repo->get( 'connected', false );
+            $wp_app_pass_created = $settings_repo->get( 'wp_app_pass_created', false );
+            if ( ! $connected || ! $wp_app_pass_created ) {
+                return;
+            }
 
-			$container = $this->get_container();
-			$api       = $container->get( 'remote_api' );
-			$storage   = $container->get( 'content_storage' );
+            $container = $this->get_container();
+            $api       = $container->get( 'remote_api' );
+            $storage   = $container->get( 'content_storage' );
 
-						$data = $api->fetch_updates( $generation_id );
+                        $data = $api->fetch_updates( $generation_id );
 
-			// Check if we have results
-			if ( ! empty( $data['results'] ) && is_array( $data['results'] ) ) {
-				$storage->storeResults( $data['results'], $workflow_type );
-				\NuclearEngagement\Services\LoggingService::log(
-					"Poll success for post {$post_id} ({$workflow_type}), generation {$generation_id}"
-				);
-				return;
-			}
+            // Check if we have results
+            if ( ! empty( $data['results'] ) && is_array( $data['results'] ) ) {
+                $storage->storeResults( $data['results'], $workflow_type );
+                \NuclearEngagement\Services\LoggingService::log(
+                    "Poll success for post {$post_id} ({$workflow_type}), generation {$generation_id}"
+                );
+                return;
+            }
 
-			// Check if still processing
-			if ( isset( $data['success'] ) && $data['success'] === true ) {
-				// Still processing, continue polling
-				\NuclearEngagement\Services\LoggingService::log(
-					"Still processing post {$post_id} ({$workflow_type}), attempt {$attempt}/{$max_attempts}"
-				);
-			}
+            // Check if still processing
+            if ( isset( $data['success'] ) && $data['success'] === true ) {
+                // Still processing, continue polling
+                \NuclearEngagement\Services\LoggingService::log(
+                    "Still processing post {$post_id} ({$workflow_type}), attempt {$attempt}/{$max_attempts}"
+                );
+            }
                } catch ( \Exception $e ) {
                        \NuclearEngagement\Services\LoggingService::log_exception( $e );
                }
 
-		// Schedule next poll if not at max attempts
+        // Schedule next poll if not at max attempts
                 if ( $attempt < $max_attempts ) {
                         $scheduled = wp_schedule_single_event(
                                 time() + $retry_delay,
@@ -142,9 +142,9 @@ trait AdminAutoGenerate {
                                 );
                         }
                 } else {
-			\NuclearEngagement\Services\LoggingService::log(
-				"Polling aborted after {$max_attempts} attempts for post {$post_id} ({$workflow_type})"
-			);
-		}
-	}
+            \NuclearEngagement\Services\LoggingService::log(
+                "Polling aborted after {$max_attempts} attempts for post {$post_id} ({$workflow_type})"
+            );
+        }
+    }
 }

--- a/nuclear-engagement/admin/Traits/AdminMenu.php
+++ b/nuclear-engagement/admin/Traits/AdminMenu.php
@@ -12,70 +12,70 @@ declare(strict_types=1);
 namespace NuclearEngagement\Admin\Traits;
 
 if ( ! defined( 'ABSPATH' ) ) {
-	exit;
+    exit;
 }
 
 use NuclearEngagement\Admin\Settings;
 
 trait AdminMenu {
 
-	/**
-	 * Register top‑level menu and sub‑pages.
-	 */
-	public function nuclen_add_admin_menu() {
-		add_menu_page(
-			esc_html__( 'Nuclear Engagement', 'nuclear-engagement' ),
-			esc_html__( 'Nuclear Engagement', 'nuclear-engagement' ),
-			'manage_options',
-			'nuclear-engagement',
-			array( $this, 'nuclen_display_dashboard' ),
-			'dashicons-airplane',
-			NUCLEN_ADMIN_MENU_POSITION
-		);
+    /**
+     * Register top‑level menu and sub‑pages.
+     */
+    public function nuclen_add_admin_menu() {
+        add_menu_page(
+            esc_html__( 'Nuclear Engagement', 'nuclear-engagement' ),
+            esc_html__( 'Nuclear Engagement', 'nuclear-engagement' ),
+            'manage_options',
+            'nuclear-engagement',
+            array( $this, 'nuclen_display_dashboard' ),
+            'dashicons-airplane',
+            NUCLEN_ADMIN_MENU_POSITION
+        );
 
-		add_submenu_page(
-			'nuclear-engagement',
-			esc_html__( 'Nuclear Engagement – Dashboard', 'nuclear-engagement' ),
-			esc_html__( 'Dashboard', 'nuclear-engagement' ),
-			'manage_options',
-			'nuclear-engagement',
-			array( $this, 'nuclen_display_dashboard' )
-		);
+        add_submenu_page(
+            'nuclear-engagement',
+            esc_html__( 'Nuclear Engagement – Dashboard', 'nuclear-engagement' ),
+            esc_html__( 'Dashboard', 'nuclear-engagement' ),
+            'manage_options',
+            'nuclear-engagement',
+            array( $this, 'nuclen_display_dashboard' )
+        );
 
-		add_submenu_page(
-			'nuclear-engagement',
-			esc_html__( 'Nuclear Engagement – Generate Content', 'nuclear-engagement' ),
-			esc_html__( 'Generate', 'nuclear-engagement' ),
-			'manage_options',
-			'nuclear-engagement-generate',
-			array( $this, 'nuclen_display_generate_page' )
-		);
+        add_submenu_page(
+            'nuclear-engagement',
+            esc_html__( 'Nuclear Engagement – Generate Content', 'nuclear-engagement' ),
+            esc_html__( 'Generate', 'nuclear-engagement' ),
+            'manage_options',
+            'nuclear-engagement-generate',
+            array( $this, 'nuclen_display_generate_page' )
+        );
 
-		$settings = new Settings();
-		add_submenu_page(
-			'nuclear-engagement',
-			esc_html__( 'Nuclear Engagement – Settings', 'nuclear-engagement' ),
-			esc_html__( 'Settings', 'nuclear-engagement' ),
-			'manage_options',
-			'nuclear-engagement-settings',
-			array( $settings, 'nuclen_display_settings_page' )
-		);
-	}
+        $settings = new Settings();
+        add_submenu_page(
+            'nuclear-engagement',
+            esc_html__( 'Nuclear Engagement – Settings', 'nuclear-engagement' ),
+            esc_html__( 'Settings', 'nuclear-engagement' ),
+            'manage_options',
+            'nuclear-engagement-settings',
+            array( $settings, 'nuclen_display_settings_page' )
+        );
+    }
 
-	/** Dashboard page callback */
-	public function nuclen_display_dashboard() {
-		include plugin_dir_path( __FILE__ ) . 'Dashboard.php';
-	}
+    /** Dashboard page callback */
+    public function nuclen_display_dashboard() {
+        include plugin_dir_path( __FILE__ ) . 'Dashboard.php';
+    }
 
-	/**
-	 * “Generate” page callback.
-	 *
-	 * Shows only an admin notice until **both** setup steps are done.
-	 */
-	public function nuclen_display_generate_page() {
-		$settings_repo       = $this->nuclen_get_settings_repository();
-		$connected           = $settings_repo->get( 'connected', false );
-		$wp_app_pass_created = $settings_repo->get( 'wp_app_pass_created', false );
+    /**
+     * “Generate” page callback.
+     *
+     * Shows only an admin notice until **both** setup steps are done.
+     */
+    public function nuclen_display_generate_page() {
+        $settings_repo       = $this->nuclen_get_settings_repository();
+        $connected           = $settings_repo->get( 'connected', false );
+        $wp_app_pass_created = $settings_repo->get( 'wp_app_pass_created', false );
 
                // Block access unless the API key **and** plugin password are present.
                if ( ! $connected || ! $wp_app_pass_created ) {
@@ -91,34 +91,34 @@ trait AdminMenu {
                include NUCLEN_PLUGIN_DIR . 'templates/admin/nuclen-admin-generate.php';
         }
 
-	/**
-	 * Helper: build a small “with / without” stats table.
-	 *
-	 * @param array $data Stats array.
-	 * @return string HTML table.
-	 */
-	private function nuclen_render_dashboard_stats_table( $data ) {
-		if ( empty( $data ) ) {
-			return '<p>' . esc_html__( 'No items found.', 'nuclear-engagement' ) . '</p>';
-		}
+    /**
+     * Helper: build a small “with / without” stats table.
+     *
+     * @param array $data Stats array.
+     * @return string HTML table.
+     */
+    private function nuclen_render_dashboard_stats_table( $data ) {
+        if ( empty( $data ) ) {
+            return '<p>' . esc_html__( 'No items found.', 'nuclear-engagement' ) . '</p>';
+        }
 
-		$html  = '<table class="nuclen-stats-table">';
-		$html .= '<tr><th></th><th>' . esc_html__( 'With', 'nuclear-engagement' ) . '</th><th>' . esc_html__( 'Without', 'nuclear-engagement' ) . '</th></tr>';
+        $html  = '<table class="nuclen-stats-table">';
+        $html .= '<tr><th></th><th>' . esc_html__( 'With', 'nuclear-engagement' ) . '</th><th>' . esc_html__( 'Without', 'nuclear-engagement' ) . '</th></tr>';
 
-		foreach ( $data as $name => $counts ) {
-			$with    = isset( $counts['with'] ) ? (int) $counts['with'] : 0;
-			$without = isset( $counts['without'] ) ? (int) $counts['without'] : 0;
-			$total   = $with + $without;
-			if ( $total > 0 ) {
-				$html                 .= '<tr>';
-				$html                 .= '<td>' . esc_html( $name ) . '</td>';
-								$html .= '<td>' . esc_html( $with ) . '</td>';
-								$html .= '<td>' . esc_html( $without ) . '</td>';
-				$html                 .= '</tr>';
-			}
-		}
+        foreach ( $data as $name => $counts ) {
+            $with    = isset( $counts['with'] ) ? (int) $counts['with'] : 0;
+            $without = isset( $counts['without'] ) ? (int) $counts['without'] : 0;
+            $total   = $with + $without;
+            if ( $total > 0 ) {
+                $html                 .= '<tr>';
+                $html                 .= '<td>' . esc_html( $name ) . '</td>';
+                                $html .= '<td>' . esc_html( $with ) . '</td>';
+                                $html .= '<td>' . esc_html( $without ) . '</td>';
+                $html                 .= '</tr>';
+            }
+        }
 
-		$html .= '</table>';
-		return $html;
-	}
+        $html .= '</table>';
+        return $html;
+    }
 }

--- a/nuclear-engagement/admin/Traits/AdminMetaboxes.php
+++ b/nuclear-engagement/admin/Traits/AdminMetaboxes.php
@@ -11,7 +11,7 @@ declare(strict_types=1);
 namespace NuclearEngagement\Admin\Traits;
 
 if ( ! defined( 'ABSPATH' ) ) {
-	exit;
+    exit;
 }
 
 

--- a/nuclear-engagement/admin/Traits/SettingsPageCustomCSSTrait.php
+++ b/nuclear-engagement/admin/Traits/SettingsPageCustomCSSTrait.php
@@ -11,22 +11,22 @@ declare(strict_types=1);
 namespace NuclearEngagement\Admin\Traits;
 
 if ( ! defined( 'ABSPATH' ) ) {
-	exit;
+    exit;
 }
 
 trait SettingsPageCustomCSSTrait {
 
-	/**
-	 * Write (or overwrite) the custom-theme CSS file.
-	 *
-	 * @param array $s Sanitised settings array.
-	 */
-	protected function nuclen_write_custom_css( array $s ): void {
+    /**
+     * Write (or overwrite) the custom-theme CSS file.
+     *
+     * @param array $s Sanitised settings array.
+     */
+    protected function nuclen_write_custom_css( array $s ): void {
 
-		/* ── Fill any missing values so we never output empty CSS vars ── */
-		$s = wp_parse_args( $s, \NuclearEngagement\Defaults::nuclen_get_default_settings() );
+        /* ── Fill any missing values so we never output empty CSS vars ── */
+        $s = wp_parse_args( $s, \NuclearEngagement\Defaults::nuclen_get_default_settings() );
 
-		$css = <<<CSS
+        $css = <<<CSS
 :root{
     /* ───── Quiz container ───── */
     --nuclen-fg-color: {$s['font_color']};
@@ -131,14 +131,14 @@ CSS;
                 $custom_dir      = $css_info['dir'];
                 $custom_css_path = $css_info['path'];
 
-		if ( ! function_exists( 'WP_Filesystem' ) ) {
-			require_once ABSPATH . 'wp-admin/includes/file.php';
-		}
-		WP_Filesystem();
-		global $wp_filesystem;
+        if ( ! function_exists( 'WP_Filesystem' ) ) {
+            require_once ABSPATH . 'wp-admin/includes/file.php';
+        }
+        WP_Filesystem();
+        global $wp_filesystem;
 
-		/* create dir if needed, then write */
-		if ( is_object( $wp_filesystem ) ) {
+        /* create dir if needed, then write */
+        if ( is_object( $wp_filesystem ) ) {
                        if ( ! $wp_filesystem->exists( $custom_dir ) && ! wp_mkdir_p( $custom_dir ) ) {
                                echo '<div class="notice notice-error"><p>' .
                                        esc_html__( 'Could not create custom CSS directory.', 'nuclear-engagement' ) .
@@ -165,7 +165,7 @@ CSS;
                                        '</p></div>';
                                \NuclearEngagement\Services\LoggingService::log( 'Failed to write custom CSS file: ' . $custom_css_path );
                        }
-		} else {
+        } else {
                        /* fallback */
                        if ( ! file_exists( $custom_dir ) && ! wp_mkdir_p( $custom_dir ) ) {
                                echo '<div class="notice notice-error"><p>' .
@@ -187,6 +187,6 @@ CSS;
                                        '</p></div>';
                                \NuclearEngagement\Services\LoggingService::log( 'Failed to write custom CSS file: ' . $custom_css_path );
                        }
-		}
-	}
+        }
+    }
 }

--- a/nuclear-engagement/admin/Traits/SettingsPageLoadTrait.php
+++ b/nuclear-engagement/admin/Traits/SettingsPageLoadTrait.php
@@ -11,29 +11,29 @@ declare(strict_types=1);
 namespace NuclearEngagement\Admin\Traits;
 
 if ( ! defined( 'ABSPATH' ) ) {
-	exit;
+    exit;
 }
 
 trait SettingsPageLoadTrait {
 
-	/**
-	 * Retrieve and sanitize the current settings, merging with defaults.
-	 *
-	 * @return array [ $settings , $defaults ]
-	 */
-	protected function nuclen_get_current_settings(): array {
-		$settings_repo = $this->nuclen_get_settings_repository();
-		$defaults      = \NuclearEngagement\Defaults::nuclen_get_default_settings();
+    /**
+     * Retrieve and sanitize the current settings, merging with defaults.
+     *
+     * @return array [ $settings , $defaults ]
+     */
+    protected function nuclen_get_current_settings(): array {
+        $settings_repo = $this->nuclen_get_settings_repository();
+        $defaults      = \NuclearEngagement\Defaults::nuclen_get_default_settings();
 
-		// Get all settings from the repository
-		$settings = array();
-		foreach ( $defaults as $key => $default_value ) {
-			$settings[ $key ] = $settings_repo->get( $key, $default_value );
-		}
+        // Get all settings from the repository
+        $settings = array();
+        foreach ( $defaults as $key => $default_value ) {
+            $settings[ $key ] = $settings_repo->get( $key, $default_value );
+        }
 
-		// Sanitize the settings
-		$settings = $this->nuclen_sanitize_settings( $settings );
+        // Sanitize the settings
+        $settings = $this->nuclen_sanitize_settings( $settings );
 
-		return array( $settings, $defaults );
-	}
+        return array( $settings, $defaults );
+    }
 }

--- a/nuclear-engagement/admin/Traits/SettingsPageSaveTrait.php
+++ b/nuclear-engagement/admin/Traits/SettingsPageSaveTrait.php
@@ -11,234 +11,234 @@ declare(strict_types=1);
 namespace NuclearEngagement\Admin\Traits;
 
 if ( ! defined( 'ABSPATH' ) ) {
-	exit;
+    exit;
 }
 
 trait SettingsPageSaveTrait {
 
-	/**
-	 * Process and save submitted settings.
-	 *
-	 * @param array $settings      Current settings (passed by reference).
-	 * @param array $defaults      Default settings.
-	 * @param array &$new_settings Output: new sanitized settings.
-	 * @return bool                True if a save occurred.
-	 */
-	protected function nuclen_handle_save_settings( array &$settings, array $defaults, array &$new_settings ): bool {
+    /**
+     * Process and save submitted settings.
+     *
+     * @param array $settings      Current settings (passed by reference).
+     * @param array $defaults      Default settings.
+     * @param array &$new_settings Output: new sanitized settings.
+     * @return bool                True if a save occurred.
+     */
+    protected function nuclen_handle_save_settings( array &$settings, array $defaults, array &$new_settings ): bool {
 
-		/* ───────── Bail if not a form submission ───────── */
-		if (
-			! isset( $_POST['nuclen_save_settings'] ) ||
-			! check_admin_referer( 'nuclen_settings_nonce', 'nuclen_settings_nonce_field', false )
-		) {
-			return false;
-		}
+        /* ───────── Bail if not a form submission ───────── */
+        if (
+            ! isset( $_POST['nuclen_save_settings'] ) ||
+            ! check_admin_referer( 'nuclen_settings_nonce', 'nuclen_settings_nonce_field', false )
+        ) {
+            return false;
+        }
 
-		/* ───────── 1) COLLECT RAW INPUTS ───────── */
-		$raw = array();
+        /* ───────── 1) COLLECT RAW INPUTS ───────── */
+        $raw = array();
 
-		// theme preset
-		$raw['theme'] = isset( $_POST['nuclen_theme'] )
-			? sanitize_text_field( wp_unslash( $_POST['nuclen_theme'] ) )
-			: '';
+        // theme preset
+        $raw['theme'] = isset( $_POST['nuclen_theme'] )
+            ? sanitize_text_field( wp_unslash( $_POST['nuclen_theme'] ) )
+            : '';
 
-		// map <form field> → <settings key>
-		$field_map = array(
-			/* —— Quiz style —— */
-			'nuclen_font_size'                        => 'font_size',
-			'nuclen_font_color'                       => 'font_color',
-			'nuclen_bg_color'                         => 'bg_color',
-			'nuclen_quiz_border_color'                => 'quiz_border_color',
-			'nuclen_quiz_border_style'                => 'quiz_border_style',
-			'nuclen_quiz_border_width'                => 'quiz_border_width',
-			'nuclen_quiz_border_radius'               => 'quiz_border_radius',
-			'nuclen_quiz_shadow_color'                => 'quiz_shadow_color',
-			'nuclen_quiz_shadow_blur'                 => 'quiz_shadow_blur',
+        // map <form field> → <settings key>
+        $field_map = array(
+            /* —— Quiz style —— */
+            'nuclen_font_size'                        => 'font_size',
+            'nuclen_font_color'                       => 'font_color',
+            'nuclen_bg_color'                         => 'bg_color',
+            'nuclen_quiz_border_color'                => 'quiz_border_color',
+            'nuclen_quiz_border_style'                => 'quiz_border_style',
+            'nuclen_quiz_border_width'                => 'quiz_border_width',
+            'nuclen_quiz_border_radius'               => 'quiz_border_radius',
+            'nuclen_quiz_shadow_color'                => 'quiz_shadow_color',
+            'nuclen_quiz_shadow_blur'                 => 'quiz_shadow_blur',
 
-			'nuclen_quiz_answer_button_bg_color'      => 'quiz_answer_button_bg_color',
-			'nuclen_quiz_answer_button_border_color'  => 'quiz_answer_button_border_color',
-			'nuclen_quiz_answer_button_border_width'  => 'quiz_answer_button_border_width',
-			'nuclen_quiz_answer_button_border_radius' => 'quiz_answer_button_border_radius',
+            'nuclen_quiz_answer_button_bg_color'      => 'quiz_answer_button_bg_color',
+            'nuclen_quiz_answer_button_border_color'  => 'quiz_answer_button_border_color',
+            'nuclen_quiz_answer_button_border_width'  => 'quiz_answer_button_border_width',
+            'nuclen_quiz_answer_button_border_radius' => 'quiz_answer_button_border_radius',
 
-			'nuclen_quiz_progress_bar_fg_color'       => 'quiz_progress_bar_fg_color',
-			'nuclen_quiz_progress_bar_bg_color'       => 'quiz_progress_bar_bg_color',
-			'nuclen_quiz_progress_bar_height'         => 'quiz_progress_bar_height',
+            'nuclen_quiz_progress_bar_fg_color'       => 'quiz_progress_bar_fg_color',
+            'nuclen_quiz_progress_bar_bg_color'       => 'quiz_progress_bar_bg_color',
+            'nuclen_quiz_progress_bar_height'         => 'quiz_progress_bar_height',
 
-			/* —— Summary style —— */
-			'nuclen_summary_font_size'                => 'summary_font_size',
-			'nuclen_summary_font_color'               => 'summary_font_color',
-			'nuclen_summary_bg_color'                 => 'summary_bg_color',
-			'nuclen_summary_border_color'             => 'summary_border_color',
-			'nuclen_summary_border_style'             => 'summary_border_style',
-			'nuclen_summary_border_width'             => 'summary_border_width',
-			'nuclen_summary_border_radius'            => 'summary_border_radius',
-			'nuclen_summary_shadow_color'             => 'summary_shadow_color',
-			'nuclen_summary_shadow_blur'              => 'summary_shadow_blur',
+            /* —— Summary style —— */
+            'nuclen_summary_font_size'                => 'summary_font_size',
+            'nuclen_summary_font_color'               => 'summary_font_color',
+            'nuclen_summary_bg_color'                 => 'summary_bg_color',
+            'nuclen_summary_border_color'             => 'summary_border_color',
+            'nuclen_summary_border_style'             => 'summary_border_style',
+            'nuclen_summary_border_width'             => 'summary_border_width',
+            'nuclen_summary_border_radius'            => 'summary_border_radius',
+            'nuclen_summary_shadow_color'             => 'summary_shadow_color',
+            'nuclen_summary_shadow_blur'              => 'summary_shadow_blur',
 
-			/* —— TOC style —— */
-			'nuclen_toc_font_size'                    => 'toc_font_size',
-			'nuclen_toc_font_color'                   => 'toc_font_color',
-			'nuclen_toc_bg_color'                     => 'toc_bg_color',
-			'nuclen_toc_border_color'                 => 'toc_border_color',
-			'nuclen_toc_border_style'                 => 'toc_border_style',
-			'nuclen_toc_heading_levels'               => 'toc_heading_levels',
-			'nuclen_toc_show_toggle'                  => 'toc_show_toggle',
-			'nuclen_toc_show_content'                 => 'toc_show_content',
-			'nuclen_toc_border_width'                 => 'toc_border_width',
-			'nuclen_toc_border_radius'                => 'toc_border_radius',
-			'nuclen_toc_shadow_color'                 => 'toc_shadow_color',
-			'nuclen_toc_shadow_blur'                  => 'toc_shadow_blur',
-			'nuclen_toc_link_color'                   => 'toc_link_color',
-			'nuclen_toc_title'                        => 'toc_title',
+            /* —— TOC style —— */
+            'nuclen_toc_font_size'                    => 'toc_font_size',
+            'nuclen_toc_font_color'                   => 'toc_font_color',
+            'nuclen_toc_bg_color'                     => 'toc_bg_color',
+            'nuclen_toc_border_color'                 => 'toc_border_color',
+            'nuclen_toc_border_style'                 => 'toc_border_style',
+            'nuclen_toc_heading_levels'               => 'toc_heading_levels',
+            'nuclen_toc_show_toggle'                  => 'toc_show_toggle',
+            'nuclen_toc_show_content'                 => 'toc_show_content',
+            'nuclen_toc_border_width'                 => 'toc_border_width',
+            'nuclen_toc_border_radius'                => 'toc_border_radius',
+            'nuclen_toc_shadow_color'                 => 'toc_shadow_color',
+            'nuclen_toc_shadow_blur'                  => 'toc_shadow_blur',
+            'nuclen_toc_link_color'                   => 'toc_link_color',
+            'nuclen_toc_title'                        => 'toc_title',
 
-			/* —— NEW – sticky TOC options & z-index —— */
-			'toc_zindex'                              => 'toc_z_index',
-			'toc_sticky_offset_x'                     => 'toc_sticky_offset_x',
-			'toc_sticky_offset_y'                     => 'toc_sticky_offset_y',
-			'toc_sticky_max_width'                    => 'toc_sticky_max_width',
+            /* —— NEW – sticky TOC options & z-index —— */
+            'toc_zindex'                              => 'toc_z_index',
+            'toc_sticky_offset_x'                     => 'toc_sticky_offset_x',
+            'toc_sticky_offset_y'                     => 'toc_sticky_offset_y',
+            'toc_sticky_max_width'                    => 'toc_sticky_max_width',
 
-			/* —— Legacy generic —— */
-			'nuclen_border_color'                     => 'border_color',
-			'nuclen_border_style'                     => 'border_style',
-			'nuclen_border_width'                     => 'border_width',
+            /* —— Legacy generic —— */
+            'nuclen_border_color'                     => 'border_color',
+            'nuclen_border_style'                     => 'border_style',
+            'nuclen_border_width'                     => 'border_width',
 
-			/* —— Quiz structure —— */
-			'nuclen_questions_per_quiz'               => 'questions_per_quiz',
-			'nuclen_answers_per_question'             => 'answers_per_question',
+            /* —— Quiz structure —— */
+            'nuclen_questions_per_quiz'               => 'questions_per_quiz',
+            'nuclen_answers_per_question'             => 'answers_per_question',
 
-			/* —— Placement —— */
-			'nuclen_display_summary'                  => 'display_summary',
-			'nuclen_display_quiz'                     => 'display_quiz',
-			'nuclen_display_toc'                      => 'display_toc',
-			'toc_sticky'                              => 'toc_sticky',
-		);
+            /* —— Placement —— */
+            'nuclen_display_summary'                  => 'display_summary',
+            'nuclen_display_quiz'                     => 'display_quiz',
+            'nuclen_display_toc'                      => 'display_toc',
+            'toc_sticky'                              => 'toc_sticky',
+        );
 
-		foreach ( $field_map as $post_key => $opt_key ) {
-			if ( isset( $_POST[ $post_key ] ) ) {
-				$raw[ $opt_key ] = sanitize_text_field( wp_unslash( $_POST[ $post_key ] ) );
-			}
-		}
+        foreach ( $field_map as $post_key => $opt_key ) {
+            if ( isset( $_POST[ $post_key ] ) ) {
+                $raw[ $opt_key ] = sanitize_text_field( wp_unslash( $_POST[ $post_key ] ) );
+            }
+        }
 
-		/* —— TOC Heading Levels —— */
-		$raw['toc_heading_levels'] = isset( $_POST['nuclear_engagement_settings']['toc_heading_levels'] )
-			? array_map( 'intval', (array) $_POST['nuclear_engagement_settings']['toc_heading_levels'] )
-			: range( 2, 6 );
+        /* —— TOC Heading Levels —— */
+        $raw['toc_heading_levels'] = isset( $_POST['nuclear_engagement_settings']['toc_heading_levels'] )
+            ? array_map( 'intval', (array) $_POST['nuclear_engagement_settings']['toc_heading_levels'] )
+            : range( 2, 6 );
 
-		/* —— Custom HTML & titles —— */
-		$raw['custom_quiz_html_before']  = isset( $_POST['custom_quiz_html_before'] )
-			? wp_kses_post( wp_unslash( $_POST['custom_quiz_html_before'] ) )
-			: '';
-		$raw['custom_quiz_html_after']   = isset( $_POST['custom_quiz_html_after'] )
-			? wp_kses_post( wp_unslash( $_POST['custom_quiz_html_after'] ) )
-			: '';
-		$raw['quiz_title']               = isset( $_POST['quiz_title'] ) ? sanitize_text_field( wp_unslash( $_POST['quiz_title'] ) ) : '';
-		$raw['summary_title']            = isset( $_POST['summary_title'] ) ? sanitize_text_field( wp_unslash( $_POST['summary_title'] ) ) : '';
-		$raw['quiz_label_retake_test']   = isset( $_POST['quiz_label_retake_test'] )
-			? sanitize_text_field( wp_unslash( $_POST['quiz_label_retake_test'] ) )
-			: '';
-		$raw['quiz_label_your_score']    = isset( $_POST['quiz_label_your_score'] )
-			? sanitize_text_field( wp_unslash( $_POST['quiz_label_your_score'] ) )
-			: '';
-		$raw['quiz_label_perfect']       = isset( $_POST['quiz_label_perfect'] )
-			? sanitize_text_field( wp_unslash( $_POST['quiz_label_perfect'] ) )
-			: '';
-		$raw['quiz_label_well_done']     = isset( $_POST['quiz_label_well_done'] )
-			? sanitize_text_field( wp_unslash( $_POST['quiz_label_well_done'] ) )
-			: '';
-		$raw['quiz_label_retake_prompt'] = isset( $_POST['quiz_label_retake_prompt'] )
-			? sanitize_text_field( wp_unslash( $_POST['quiz_label_retake_prompt'] ) )
-			: '';
-		$raw['quiz_label_correct']       = isset( $_POST['quiz_label_correct'] )
-			? sanitize_text_field( wp_unslash( $_POST['quiz_label_correct'] ) )
-			: '';
-		$raw['quiz_label_your_answer']   = isset( $_POST['quiz_label_your_answer'] )
-			? sanitize_text_field( wp_unslash( $_POST['quiz_label_your_answer'] ) )
-			: '';
+        /* —— Custom HTML & titles —— */
+        $raw['custom_quiz_html_before']  = isset( $_POST['custom_quiz_html_before'] )
+            ? wp_kses_post( wp_unslash( $_POST['custom_quiz_html_before'] ) )
+            : '';
+        $raw['custom_quiz_html_after']   = isset( $_POST['custom_quiz_html_after'] )
+            ? wp_kses_post( wp_unslash( $_POST['custom_quiz_html_after'] ) )
+            : '';
+        $raw['quiz_title']               = isset( $_POST['quiz_title'] ) ? sanitize_text_field( wp_unslash( $_POST['quiz_title'] ) ) : '';
+        $raw['summary_title']            = isset( $_POST['summary_title'] ) ? sanitize_text_field( wp_unslash( $_POST['summary_title'] ) ) : '';
+        $raw['quiz_label_retake_test']   = isset( $_POST['quiz_label_retake_test'] )
+            ? sanitize_text_field( wp_unslash( $_POST['quiz_label_retake_test'] ) )
+            : '';
+        $raw['quiz_label_your_score']    = isset( $_POST['quiz_label_your_score'] )
+            ? sanitize_text_field( wp_unslash( $_POST['quiz_label_your_score'] ) )
+            : '';
+        $raw['quiz_label_perfect']       = isset( $_POST['quiz_label_perfect'] )
+            ? sanitize_text_field( wp_unslash( $_POST['quiz_label_perfect'] ) )
+            : '';
+        $raw['quiz_label_well_done']     = isset( $_POST['quiz_label_well_done'] )
+            ? sanitize_text_field( wp_unslash( $_POST['quiz_label_well_done'] ) )
+            : '';
+        $raw['quiz_label_retake_prompt'] = isset( $_POST['quiz_label_retake_prompt'] )
+            ? sanitize_text_field( wp_unslash( $_POST['quiz_label_retake_prompt'] ) )
+            : '';
+        $raw['quiz_label_correct']       = isset( $_POST['quiz_label_correct'] )
+            ? sanitize_text_field( wp_unslash( $_POST['quiz_label_correct'] ) )
+            : '';
+        $raw['quiz_label_your_answer']   = isset( $_POST['quiz_label_your_answer'] )
+            ? sanitize_text_field( wp_unslash( $_POST['quiz_label_your_answer'] ) )
+            : '';
 
-		/* —— Opt-in block —— */
-		$raw['enable_optin']      = isset( $_POST['enable_optin'] ) ? (bool) wp_unslash( $_POST['enable_optin'] ) : false;
-		$raw['optin_position']    = isset( $_POST['nuclen_optin_position'] )
-			? sanitize_text_field( wp_unslash( $_POST['nuclen_optin_position'] ) )
-			: 'with_results';
-		$raw['optin_mandatory']   = isset( $_POST['optin_mandatory'] ) ? (bool) wp_unslash( $_POST['optin_mandatory'] ) : false;
-		$raw['optin_prompt_text'] = isset( $_POST['optin_prompt_text'] ) ? sanitize_text_field( wp_unslash( $_POST['optin_prompt_text'] ) ) : '';
-		$raw['optin_button_text'] = isset( $_POST['optin_button_text'] ) ? sanitize_text_field( wp_unslash( $_POST['optin_button_text'] ) ) : '';
-		if ( isset( $_POST['optin_webhook'] ) ) {
-			$raw['optin_webhook'] = esc_url_raw( trim( sanitize_text_field( wp_unslash( $_POST['optin_webhook'] ) ) ) );
-		}
+        /* —— Opt-in block —— */
+        $raw['enable_optin']      = isset( $_POST['enable_optin'] ) ? (bool) wp_unslash( $_POST['enable_optin'] ) : false;
+        $raw['optin_position']    = isset( $_POST['nuclen_optin_position'] )
+            ? sanitize_text_field( wp_unslash( $_POST['nuclen_optin_position'] ) )
+            : 'with_results';
+        $raw['optin_mandatory']   = isset( $_POST['optin_mandatory'] ) ? (bool) wp_unslash( $_POST['optin_mandatory'] ) : false;
+        $raw['optin_prompt_text'] = isset( $_POST['optin_prompt_text'] ) ? sanitize_text_field( wp_unslash( $_POST['optin_prompt_text'] ) ) : '';
+        $raw['optin_button_text'] = isset( $_POST['optin_button_text'] ) ? sanitize_text_field( wp_unslash( $_POST['optin_button_text'] ) ) : '';
+        if ( isset( $_POST['optin_webhook'] ) ) {
+            $raw['optin_webhook'] = esc_url_raw( trim( sanitize_text_field( wp_unslash( $_POST['optin_webhook'] ) ) ) );
+        }
 
-		/* —— Flags & generation —— */
-		$raw['update_last_modified']                          = isset( $_POST['update_last_modified'] ) ? (bool) wp_unslash( $_POST['update_last_modified'] ) : false;
-		$raw['auto_generate_quiz_on_publish']                 = isset( $_POST['auto_generate_quiz_on_publish'] ) ? (bool) wp_unslash( $_POST['auto_generate_quiz_on_publish'] ) : false;
-		$raw['auto_generate_summary_on_publish']              = isset( $_POST['auto_generate_summary_on_publish'] ) ? (bool) wp_unslash( $_POST['auto_generate_summary_on_publish'] ) : false;
-				$raw['show_attribution']                      = isset( $_POST['show_attribution'] ) ? (bool) wp_unslash( $_POST['show_attribution'] ) : false;
-				$raw['delete_settings_on_uninstall']          = isset( $_POST['delete_settings_on_uninstall'] ) ? (bool) wp_unslash( $_POST['delete_settings_on_uninstall'] ) : false;
-				$raw['delete_generated_content_on_uninstall'] = isset( $_POST['delete_generated_content_on_uninstall'] ) ? (bool) wp_unslash( $_POST['delete_generated_content_on_uninstall'] ) : false;
-				$raw['delete_optin_data_on_uninstall']        = isset( $_POST['delete_optin_data_on_uninstall'] ) ? (bool) wp_unslash( $_POST['delete_optin_data_on_uninstall'] ) : false;
-				$raw['delete_log_file_on_uninstall']          = isset( $_POST['delete_log_file_on_uninstall'] ) ? (bool) wp_unslash( $_POST['delete_log_file_on_uninstall'] ) : false;
-				$raw['delete_custom_css_on_uninstall']        = isset( $_POST['delete_custom_css_on_uninstall'] ) ? (bool) wp_unslash( $_POST['delete_custom_css_on_uninstall'] ) : false;
+        /* —— Flags & generation —— */
+        $raw['update_last_modified']                          = isset( $_POST['update_last_modified'] ) ? (bool) wp_unslash( $_POST['update_last_modified'] ) : false;
+        $raw['auto_generate_quiz_on_publish']                 = isset( $_POST['auto_generate_quiz_on_publish'] ) ? (bool) wp_unslash( $_POST['auto_generate_quiz_on_publish'] ) : false;
+        $raw['auto_generate_summary_on_publish']              = isset( $_POST['auto_generate_summary_on_publish'] ) ? (bool) wp_unslash( $_POST['auto_generate_summary_on_publish'] ) : false;
+                $raw['show_attribution']                      = isset( $_POST['show_attribution'] ) ? (bool) wp_unslash( $_POST['show_attribution'] ) : false;
+                $raw['delete_settings_on_uninstall']          = isset( $_POST['delete_settings_on_uninstall'] ) ? (bool) wp_unslash( $_POST['delete_settings_on_uninstall'] ) : false;
+                $raw['delete_generated_content_on_uninstall'] = isset( $_POST['delete_generated_content_on_uninstall'] ) ? (bool) wp_unslash( $_POST['delete_generated_content_on_uninstall'] ) : false;
+                $raw['delete_optin_data_on_uninstall']        = isset( $_POST['delete_optin_data_on_uninstall'] ) ? (bool) wp_unslash( $_POST['delete_optin_data_on_uninstall'] ) : false;
+                $raw['delete_log_file_on_uninstall']          = isset( $_POST['delete_log_file_on_uninstall'] ) ? (bool) wp_unslash( $_POST['delete_log_file_on_uninstall'] ) : false;
+                $raw['delete_custom_css_on_uninstall']        = isset( $_POST['delete_custom_css_on_uninstall'] ) ? (bool) wp_unslash( $_POST['delete_custom_css_on_uninstall'] ) : false;
 
-		/* —— Generation post types —— */
-		$posted_types                 = filter_input(
-			INPUT_POST,
-			'nuclen_generation_post_types',
-			FILTER_SANITIZE_FULL_SPECIAL_CHARS,
-			FILTER_REQUIRE_ARRAY
-		);
-		$raw['generation_post_types'] = is_array( $posted_types )
-			? array_map( 'sanitize_text_field', wp_unslash( $posted_types ) )
-			: array( 'post' );
+        /* —— Generation post types —— */
+        $posted_types                 = filter_input(
+            INPUT_POST,
+            'nuclen_generation_post_types',
+            FILTER_SANITIZE_FULL_SPECIAL_CHARS,
+            FILTER_REQUIRE_ARRAY
+        );
+        $raw['generation_post_types'] = is_array( $posted_types )
+            ? array_map( 'sanitize_text_field', wp_unslash( $posted_types ) )
+            : array( 'post' );
 
-		/* ───────── 2) SANITIZE & SAVE ───────── */
-		$new_settings = $this->nuclen_sanitize_settings( $raw );
+        /* ───────── 2) SANITIZE & SAVE ───────── */
+        $new_settings = $this->nuclen_sanitize_settings( $raw );
 
-		/* Keep additional TOC keys that sanitiser may not yet know about */
-		$toc_keys = array(
-			// colours etc.
-			'toc_font_color',
-			'toc_bg_color',
-			'toc_border_color',
-			'toc_border_style',
-			'toc_border_width',
-			'toc_border_radius',
-			'toc_shadow_color',
-			'toc_shadow_blur',
-			'toc_link_color',
-			'toc_heading_levels',
-			// ► NEW ◄ sticky & z-index keys
-			'toc_z_index',
-			'toc_sticky_offset_x',
-			'toc_sticky_offset_y',
-			'toc_sticky_max_width',
-		);
-		foreach ( $toc_keys as $k ) {
-			if ( isset( $raw[ $k ] ) && $raw[ $k ] !== '' ) {
-				$new_settings[ $k ] = $raw[ $k ];
-			}
-		}
+        /* Keep additional TOC keys that sanitiser may not yet know about */
+        $toc_keys = array(
+            // colours etc.
+            'toc_font_color',
+            'toc_bg_color',
+            'toc_border_color',
+            'toc_border_style',
+            'toc_border_width',
+            'toc_border_radius',
+            'toc_shadow_color',
+            'toc_shadow_blur',
+            'toc_link_color',
+            'toc_heading_levels',
+            // ► NEW ◄ sticky & z-index keys
+            'toc_z_index',
+            'toc_sticky_offset_x',
+            'toc_sticky_offset_y',
+            'toc_sticky_max_width',
+        );
+        foreach ( $toc_keys as $k ) {
+            if ( isset( $raw[ $k ] ) && $raw[ $k ] !== '' ) {
+                $new_settings[ $k ] = $raw[ $k ];
+            }
+        }
 
-		// Get the settings repository and save all settings
-		$settings_repo = $this->nuclen_get_settings_repository();
-		foreach ( $new_settings as $key => $value ) {
-			$settings_repo->set( $key, $value );
-		}
+        // Get the settings repository and save all settings
+        $settings_repo = $this->nuclen_get_settings_repository();
+        foreach ( $new_settings as $key => $value ) {
+            $settings_repo->set( $key, $value );
+        }
 
-		// Actually save the settings to the database
-		$settings_repo->save();
+        // Actually save the settings to the database
+        $settings_repo->save();
 
-		// Update the settings array with the saved values
-		// Note: get_all() already merges with defaults internally
-		$settings = $settings_repo->get_all();
+        // Update the settings array with the saved values
+        // Note: get_all() already merges with defaults internally
+        $settings = $settings_repo->get_all();
 
-		/* Immediately regenerate custom CSS when using the custom theme */
-		if ( 'custom' === $settings['theme'] && method_exists( $this, 'nuclen_write_custom_css' ) ) {
-			$this->nuclen_write_custom_css( $settings );
-		}
+        /* Immediately regenerate custom CSS when using the custom theme */
+        if ( 'custom' === $settings['theme'] && method_exists( $this, 'nuclen_write_custom_css' ) ) {
+            $this->nuclen_write_custom_css( $settings );
+        }
 
-		echo '<div class="notice notice-success"><p>' .
-			esc_html__( 'Settings saved.', 'nuclear-engagement' ) .
-			'</p></div>';
+        echo '<div class="notice notice-success"><p>' .
+            esc_html__( 'Settings saved.', 'nuclear-engagement' ) .
+            '</p></div>';
 
-		return true;
-	}
+        return true;
+    }
 }

--- a/nuclear-engagement/admin/Traits/SettingsSanitizeCoreTrait.php
+++ b/nuclear-engagement/admin/Traits/SettingsSanitizeCoreTrait.php
@@ -12,19 +12,19 @@ namespace NuclearEngagement\Admin\Traits;
 
 trait SettingsSanitizeCoreTrait {
 
-	use SettingsSanitizeGeneralTrait;
-	use SettingsSanitizeStyleTrait;
+    use SettingsSanitizeGeneralTrait;
+    use SettingsSanitizeStyleTrait;
 
-	/**
-	 * Aggregate non-opt-in sanitisation.
-	 *
-	 * @param array $input Raw settings.
-	 * @return array       Clean array (still missing Opt-In keys).
-	 */
-	private function nuclen_sanitize_core( array $input ): array {
-		return array_merge(
-			$this->nuclen_sanitize_general( $input ),
-			$this->nuclen_sanitize_style( $input )
-		);
-	}
+    /**
+     * Aggregate non-opt-in sanitisation.
+     *
+     * @param array $input Raw settings.
+     * @return array       Clean array (still missing Opt-In keys).
+     */
+    private function nuclen_sanitize_core( array $input ): array {
+        return array_merge(
+            $this->nuclen_sanitize_general( $input ),
+            $this->nuclen_sanitize_style( $input )
+        );
+    }
 }

--- a/nuclear-engagement/admin/Traits/SettingsSanitizeGeneralTrait.php
+++ b/nuclear-engagement/admin/Traits/SettingsSanitizeGeneralTrait.php
@@ -12,139 +12,139 @@ namespace NuclearEngagement\Admin\Traits;
 
 trait SettingsSanitizeGeneralTrait {
 
-	/**
-	 * Sanitise everything except style & opt-in.
-	 *
-	 * @param array $in Raw settings.
-	 * @return array    Clean keys (no style, no opt-in).
-	 */
-	private function nuclen_sanitize_general( array $in ): array {
+    /**
+     * Sanitise everything except style & opt-in.
+     *
+     * @param array $in Raw settings.
+     * @return array    Clean keys (no style, no opt-in).
+     */
+    private function nuclen_sanitize_general( array $in ): array {
 
-		/* Theme */
-		$themes = array( 'bright', 'dark', 'custom', 'none' );
-		$theme  = in_array( $in['theme'] ?? 'bright', $themes, true ) ? $in['theme'] : 'bright';
+        /* Theme */
+        $themes = array( 'bright', 'dark', 'custom', 'none' );
+        $theme  = in_array( $in['theme'] ?? 'bright', $themes, true ) ? $in['theme'] : 'bright';
 
-		/* Counts */
-		$q_per_quiz = max( 3, min( 10, (int) ( $in['questions_per_quiz'] ?? 3 ) ) );
-		$a_per_q    = max( 2, min( 4, (int) ( $in['answers_per_question'] ?? 2 ) ) );
+        /* Counts */
+        $q_per_quiz = max( 3, min( 10, (int) ( $in['questions_per_quiz'] ?? 3 ) ) );
+        $a_per_q    = max( 2, min( 4, (int) ( $in['answers_per_question'] ?? 2 ) ) );
 
-		/* Placement */
-		$disp  = array( 'manual', 'before', 'after' );
-		$d_sum = in_array( $in['display_summary'] ?? 'manual', $disp, true ) ? $in['display_summary'] : 'manual';
-		$d_q   = in_array( $in['display_quiz'] ?? 'manual', $disp, true ) ? $in['display_quiz'] : 'manual';
-		$d_toc = in_array( $in['display_toc'] ?? 'manual', $disp, true ) ? $in['display_toc'] : 'manual';
+        /* Placement */
+        $disp  = array( 'manual', 'before', 'after' );
+        $d_sum = in_array( $in['display_summary'] ?? 'manual', $disp, true ) ? $in['display_summary'] : 'manual';
+        $d_q   = in_array( $in['display_quiz'] ?? 'manual', $disp, true ) ? $in['display_quiz'] : 'manual';
+        $d_toc = in_array( $in['display_toc'] ?? 'manual', $disp, true ) ? $in['display_toc'] : 'manual';
 
-		$toc_sticky       = ! empty( $in['toc_sticky'] ) ? '1' : '0';
-		$toc_show_toggle  = ! empty( $in['toc_show_toggle'] ) ? '1' : '0';
-		$toc_show_content = ! empty( $in['toc_show_content'] ) ? '1' : '0';
+        $toc_sticky       = ! empty( $in['toc_sticky'] ) ? '1' : '0';
+        $toc_show_toggle  = ! empty( $in['toc_show_toggle'] ) ? '1' : '0';
+        $toc_show_content = ! empty( $in['toc_show_content'] ) ? '1' : '0';
 
-		// Sticky TOC offsets & width
-		$off_x = isset( $in['toc_sticky_offset_x'] ) ? max( 0, min( 1000, (int) $in['toc_sticky_offset_x'] ) ) : 20;
-		$off_y = isset( $in['toc_sticky_offset_y'] ) ? max( 0, min( 1000, (int) $in['toc_sticky_offset_y'] ) ) : 20;
-		$max_w = isset( $in['toc_sticky_max_width'] ) ? max( 200, min( 800, (int) $in['toc_sticky_max_width'] ) ) : 300;
+        // Sticky TOC offsets & width
+        $off_x = isset( $in['toc_sticky_offset_x'] ) ? max( 0, min( 1000, (int) $in['toc_sticky_offset_x'] ) ) : 20;
+        $off_y = isset( $in['toc_sticky_offset_y'] ) ? max( 0, min( 1000, (int) $in['toc_sticky_offset_y'] ) ) : 20;
+        $max_w = isset( $in['toc_sticky_max_width'] ) ? max( 200, min( 800, (int) $in['toc_sticky_max_width'] ) ) : 300;
 
-		// Heading levels
-		$toc_heading_levels = array();
-		if ( isset( $in['toc_heading_levels'] ) && is_array( $in['toc_heading_levels'] ) ) {
-			$toc_heading_levels = array_map( 'intval', $in['toc_heading_levels'] );
-			$toc_heading_levels = array_filter(
-				$toc_heading_levels,
-				static function ( $l ) {
-					return $l >= 2 && $l <= 6;
-				}
-			);
-		}
-		if ( empty( $toc_heading_levels ) ) {
-			$toc_heading_levels = range( 2, 6 );
-		}
-		$toc_heading_levels = array_values( array_unique( $toc_heading_levels ) );
-		sort( $toc_heading_levels );
+        // Heading levels
+        $toc_heading_levels = array();
+        if ( isset( $in['toc_heading_levels'] ) && is_array( $in['toc_heading_levels'] ) ) {
+            $toc_heading_levels = array_map( 'intval', $in['toc_heading_levels'] );
+            $toc_heading_levels = array_filter(
+                $toc_heading_levels,
+                static function ( $l ) {
+                    return $l >= 2 && $l <= 6;
+                }
+            );
+        }
+        if ( empty( $toc_heading_levels ) ) {
+            $toc_heading_levels = range( 2, 6 );
+        }
+        $toc_heading_levels = array_values( array_unique( $toc_heading_levels ) );
+        sort( $toc_heading_levels );
 
-		/* Custom HTML / titles */
-		$html_before = isset( $in['custom_quiz_html_before'] ) ? wp_kses_post( $in['custom_quiz_html_before'] ) : '';
-		$html_after  = isset( $in['custom_quiz_html_after'] ) ? wp_kses_post( $in['custom_quiz_html_after'] ) : '';
+        /* Custom HTML / titles */
+        $html_before = isset( $in['custom_quiz_html_before'] ) ? wp_kses_post( $in['custom_quiz_html_before'] ) : '';
+        $html_after  = isset( $in['custom_quiz_html_after'] ) ? wp_kses_post( $in['custom_quiz_html_after'] ) : '';
 
-		$quiz_title    = sanitize_text_field( $in['quiz_title'] ?? 'Test your knowledge' );
-		$summary_title = sanitize_text_field( $in['summary_title'] ?? 'Key Facts' );
-		$toc_title     = sanitize_text_field( $in['toc_title'] ?? 'Table of Contents' );
+        $quiz_title    = sanitize_text_field( $in['quiz_title'] ?? 'Test your knowledge' );
+        $summary_title = sanitize_text_field( $in['summary_title'] ?? 'Key Facts' );
+        $toc_title     = sanitize_text_field( $in['toc_title'] ?? 'Table of Contents' );
 
-		$label_retake_test   = sanitize_text_field( $in['quiz_label_retake_test'] ?? 'Retake Test' );
-		$label_your_score    = sanitize_text_field( $in['quiz_label_your_score'] ?? 'Your Score' );
-		$label_perfect       = sanitize_text_field( $in['quiz_label_perfect'] ?? 'Perfect!' );
-		$label_well_done     = sanitize_text_field( $in['quiz_label_well_done'] ?? 'Well done!' );
-		$label_retake_prompt = sanitize_text_field( $in['quiz_label_retake_prompt'] ?? 'Why not retake the test?' );
-		$label_correct       = sanitize_text_field( $in['quiz_label_correct'] ?? 'Correct:' );
-		$label_your_answer   = sanitize_text_field( $in['quiz_label_your_answer'] ?? 'Your answer:' );
+        $label_retake_test   = sanitize_text_field( $in['quiz_label_retake_test'] ?? 'Retake Test' );
+        $label_your_score    = sanitize_text_field( $in['quiz_label_your_score'] ?? 'Your Score' );
+        $label_perfect       = sanitize_text_field( $in['quiz_label_perfect'] ?? 'Perfect!' );
+        $label_well_done     = sanitize_text_field( $in['quiz_label_well_done'] ?? 'Well done!' );
+        $label_retake_prompt = sanitize_text_field( $in['quiz_label_retake_prompt'] ?? 'Why not retake the test?' );
+        $label_correct       = sanitize_text_field( $in['quiz_label_correct'] ?? 'Correct:' );
+        $label_your_answer   = sanitize_text_field( $in['quiz_label_your_answer'] ?? 'Your answer:' );
 
-		/* Generation */
-		$gen_pt = is_array( $in['generation_post_types'] ?? null ) ? $in['generation_post_types'] : array( 'post' );
-		$gen_pt = array_map( 'sanitize_text_field', $gen_pt );
+        /* Generation */
+        $gen_pt = is_array( $in['generation_post_types'] ?? null ) ? $in['generation_post_types'] : array( 'post' );
+        $gen_pt = array_map( 'sanitize_text_field', $gen_pt );
 
-		$update_last          = (bool) ( $in['update_last_modified'] ?? false );
-		$auto_quiz            = (bool) ( $in['auto_generate_quiz_on_publish'] ?? false );
-				$auto_summary = (bool) ( $in['auto_generate_summary_on_publish'] ?? false );
+        $update_last          = (bool) ( $in['update_last_modified'] ?? false );
+        $auto_quiz            = (bool) ( $in['auto_generate_quiz_on_publish'] ?? false );
+                $auto_summary = (bool) ( $in['auto_generate_summary_on_publish'] ?? false );
 
-				/* Attribution */
-				$show_attr = (bool) ( $in['show_attribution'] ?? false );
+                /* Attribution */
+                $show_attr = (bool) ( $in['show_attribution'] ?? false );
 
-				/* Uninstall options */
-				$delete_settings  = (bool) ( $in['delete_settings_on_uninstall'] ?? false );
-				$delete_generated = (bool) ( $in['delete_generated_content_on_uninstall'] ?? false );
-				$delete_optin     = (bool) ( $in['delete_optin_data_on_uninstall'] ?? false );
-				$delete_log       = (bool) ( $in['delete_log_file_on_uninstall'] ?? false );
-				$delete_css       = (bool) ( $in['delete_custom_css_on_uninstall'] ?? false );
+                /* Uninstall options */
+                $delete_settings  = (bool) ( $in['delete_settings_on_uninstall'] ?? false );
+                $delete_generated = (bool) ( $in['delete_generated_content_on_uninstall'] ?? false );
+                $delete_optin     = (bool) ( $in['delete_optin_data_on_uninstall'] ?? false );
+                $delete_log       = (bool) ( $in['delete_log_file_on_uninstall'] ?? false );
+                $delete_css       = (bool) ( $in['delete_custom_css_on_uninstall'] ?? false );
 
-		return array(
-			/* theme */
-			'theme'                                 => $theme,
+        return array(
+            /* theme */
+            'theme'                                 => $theme,
 
-			/* quiz items */
-			'questions_per_quiz'                    => $q_per_quiz,
-			'answers_per_question'                  => $a_per_q,
+            /* quiz items */
+            'questions_per_quiz'                    => $q_per_quiz,
+            'answers_per_question'                  => $a_per_q,
 
-			/* display */
-			'display_summary'                       => $d_sum,
-			'display_quiz'                          => $d_q,
-			'display_toc'                           => $d_toc,
-			'toc_sticky'                            => $toc_sticky,
-			'toc_show_toggle'                       => $toc_show_toggle,
-			'toc_show_content'                      => $toc_show_content,
-			'toc_heading_levels'                    => $toc_heading_levels,
+            /* display */
+            'display_summary'                       => $d_sum,
+            'display_quiz'                          => $d_q,
+            'display_toc'                           => $d_toc,
+            'toc_sticky'                            => $toc_sticky,
+            'toc_show_toggle'                       => $toc_show_toggle,
+            'toc_show_content'                      => $toc_show_content,
+            'toc_heading_levels'                    => $toc_heading_levels,
 
-			// ► NEW – sticky offsets & max-width ◄
-			'toc_sticky_offset_x'                   => $off_x,
-			'toc_sticky_offset_y'                   => $off_y,
-			'toc_sticky_max_width'                  => $max_w,
+            // ► NEW – sticky offsets & max-width ◄
+            'toc_sticky_offset_x'                   => $off_x,
+            'toc_sticky_offset_y'                   => $off_y,
+            'toc_sticky_max_width'                  => $max_w,
 
-			'custom_quiz_html_before'               => $html_before,
-			'custom_quiz_html_after'                => $html_after,
+            'custom_quiz_html_before'               => $html_before,
+            'custom_quiz_html_after'                => $html_after,
 
-			'quiz_title'                            => $quiz_title,
-			'summary_title'                         => $summary_title,
-			'toc_title'                             => $toc_title,
-			'quiz_label_retake_test'                => $label_retake_test,
-			'quiz_label_your_score'                 => $label_your_score,
-			'quiz_label_perfect'                    => $label_perfect,
-			'quiz_label_well_done'                  => $label_well_done,
-			'quiz_label_retake_prompt'              => $label_retake_prompt,
-			'quiz_label_correct'                    => $label_correct,
-			'quiz_label_your_answer'                => $label_your_answer,
+            'quiz_title'                            => $quiz_title,
+            'summary_title'                         => $summary_title,
+            'toc_title'                             => $toc_title,
+            'quiz_label_retake_test'                => $label_retake_test,
+            'quiz_label_your_score'                 => $label_your_score,
+            'quiz_label_perfect'                    => $label_perfect,
+            'quiz_label_well_done'                  => $label_well_done,
+            'quiz_label_retake_prompt'              => $label_retake_prompt,
+            'quiz_label_correct'                    => $label_correct,
+            'quiz_label_your_answer'                => $label_your_answer,
 
-			/* generation */
-			'generation_post_types'                 => $gen_pt,
-			'update_last_modified'                  => $update_last,
-			'auto_generate_quiz_on_publish'         => $auto_quiz,
-			'auto_generate_summary_on_publish'      => $auto_summary,
+            /* generation */
+            'generation_post_types'                 => $gen_pt,
+            'update_last_modified'                  => $update_last,
+            'auto_generate_quiz_on_publish'         => $auto_quiz,
+            'auto_generate_summary_on_publish'      => $auto_summary,
 
-			/* attribution */
-			'show_attribution'                      => $show_attr,
+            /* attribution */
+            'show_attribution'                      => $show_attr,
 
-			/* uninstall */
-			'delete_settings_on_uninstall'          => $delete_settings,
-			'delete_generated_content_on_uninstall' => $delete_generated,
-			'delete_optin_data_on_uninstall'        => $delete_optin,
-			'delete_log_file_on_uninstall'          => $delete_log,
-			'delete_custom_css_on_uninstall'        => $delete_css,
-		);
-	}
+            /* uninstall */
+            'delete_settings_on_uninstall'          => $delete_settings,
+            'delete_generated_content_on_uninstall' => $delete_generated,
+            'delete_optin_data_on_uninstall'        => $delete_optin,
+            'delete_log_file_on_uninstall'          => $delete_log,
+            'delete_custom_css_on_uninstall'        => $delete_css,
+        );
+    }
 }

--- a/nuclear-engagement/admin/Traits/SettingsSanitizeOptinTrait.php
+++ b/nuclear-engagement/admin/Traits/SettingsSanitizeOptinTrait.php
@@ -12,47 +12,47 @@ namespace NuclearEngagement\Admin\Traits;
 
 trait SettingsSanitizeOptinTrait {
 
-	/**
-	 * Sanitise Opt-In-related options.
-	 *
-	 * @param array $input Raw settings.
-	 * @return array       Clean Opt-In keys.
-	 */
-	private function nuclen_sanitize_optin( array $input ): array {
+    /**
+     * Sanitise Opt-In-related options.
+     *
+     * @param array $input Raw settings.
+     * @return array       Clean Opt-In keys.
+     */
+    private function nuclen_sanitize_optin( array $input ): array {
 
-		$allowed_optin_positions = array( 'with_results', 'before_results' );
-		$optin_position          = isset( $input['optin_position'] )
-			? sanitize_text_field( $input['optin_position'] )
-			: 'with_results';
-		if ( ! in_array( $optin_position, $allowed_optin_positions, true ) ) {
-			$optin_position = 'with_results';
-		}
+        $allowed_optin_positions = array( 'with_results', 'before_results' );
+        $optin_position          = isset( $input['optin_position'] )
+            ? sanitize_text_field( $input['optin_position'] )
+            : 'with_results';
+        if ( ! in_array( $optin_position, $allowed_optin_positions, true ) ) {
+            $optin_position = 'with_results';
+        }
 
-		$optin_mandatory = isset( $input['optin_mandatory'] ) ? (bool) $input['optin_mandatory'] : false;
-		$enable_optin    = isset( $input['enable_optin'] ) ? (bool) $input['enable_optin'] : false;
-		$optin_webhook   = isset( $input['optin_webhook'] ) ? esc_url_raw( trim( $input['optin_webhook'] ) ) : '';
+        $optin_mandatory = isset( $input['optin_mandatory'] ) ? (bool) $input['optin_mandatory'] : false;
+        $enable_optin    = isset( $input['enable_optin'] ) ? (bool) $input['enable_optin'] : false;
+        $optin_webhook   = isset( $input['optin_webhook'] ) ? esc_url_raw( trim( $input['optin_webhook'] ) ) : '';
 
-		$optin_prompt_text = isset( $input['optin_prompt_text'] )
-			? sanitize_text_field( $input['optin_prompt_text'] )
-			: 'Please enter your details to view your score:';
+        $optin_prompt_text = isset( $input['optin_prompt_text'] )
+            ? sanitize_text_field( $input['optin_prompt_text'] )
+            : 'Please enter your details to view your score:';
 
-		$optin_button_text = isset( $input['optin_button_text'] )
-			? sanitize_text_field( $input['optin_button_text'] )
-			: 'Submit';
+        $optin_button_text = isset( $input['optin_button_text'] )
+            ? sanitize_text_field( $input['optin_button_text'] )
+            : 'Submit';
 
-		$optin_success_message = isset( $input['optin_success_message'] )
-			? sanitize_text_field( $input['optin_success_message'] )
-			: 'Thank you, your submission was successful!';
+        $optin_success_message = isset( $input['optin_success_message'] )
+            ? sanitize_text_field( $input['optin_success_message'] )
+            : 'Thank you, your submission was successful!';
 
-		return array(
-			/* opt-in */
-			'enable_optin'          => $enable_optin,
-			'optin_webhook'         => $optin_webhook,
-			'optin_success_message' => $optin_success_message,
-			'optin_position'        => $optin_position,
-			'optin_mandatory'       => $optin_mandatory,
-			'optin_prompt_text'     => $optin_prompt_text,
-			'optin_button_text'     => $optin_button_text,
-		);
-	}
+        return array(
+            /* opt-in */
+            'enable_optin'          => $enable_optin,
+            'optin_webhook'         => $optin_webhook,
+            'optin_success_message' => $optin_success_message,
+            'optin_position'        => $optin_position,
+            'optin_mandatory'       => $optin_mandatory,
+            'optin_prompt_text'     => $optin_prompt_text,
+            'optin_button_text'     => $optin_button_text,
+        );
+    }
 }

--- a/nuclear-engagement/admin/Traits/SettingsSanitizeStyleTrait.php
+++ b/nuclear-engagement/admin/Traits/SettingsSanitizeStyleTrait.php
@@ -11,160 +11,160 @@ declare(strict_types=1);
 namespace NuclearEngagement\Admin\Traits;
 
 if ( ! defined( 'ABSPATH' ) ) {
-	exit;
+    exit;
 }
 
 trait SettingsSanitizeStyleTrait {
 
-	/*
-	───────────────────────────────────────────────────────────*/
-	/*
-		Helpers                                                  */
-	/*───────────────────────────────────────────────────────────*/
+    /*
+    ───────────────────────────────────────────────────────────*/
+    /*
+        Helpers                                                  */
+    /*───────────────────────────────────────────────────────────*/
 
-	/** Validate a 3/4/6/8-digit HEX code or return an empty string. */
-	private static function nuclen_validate_hex( string $raw ): string {
-		$raw = ltrim( trim( $raw ), '#' );
-		if ( $raw === '' ) {
-			return '';
-		}
-		/* 3/4-digit → expand to 6/8-digit */
-		if ( preg_match( '/^[0-9a-fA-F]{3,4}$/', $raw ) ) {
-			$expanded = '';
-			foreach ( str_split( $raw ) as $c ) {
-				$expanded .= $c . $c;
-			}
-			return '#' . strtolower( $expanded );
-		}
-		/* 6/8-digit – keep as-is */
-		if ( preg_match( '/^[0-9a-fA-F]{6}([0-9a-fA-F]{2})?$/', $raw ) ) {
-			return '#' . strtolower( $raw );
-		}
-		return '';
-	}
+    /** Validate a 3/4/6/8-digit HEX code or return an empty string. */
+    private static function nuclen_validate_hex( string $raw ): string {
+        $raw = ltrim( trim( $raw ), '#' );
+        if ( $raw === '' ) {
+            return '';
+        }
+        /* 3/4-digit → expand to 6/8-digit */
+        if ( preg_match( '/^[0-9a-fA-F]{3,4}$/', $raw ) ) {
+            $expanded = '';
+            foreach ( str_split( $raw ) as $c ) {
+                $expanded .= $c . $c;
+            }
+            return '#' . strtolower( $expanded );
+        }
+        /* 6/8-digit – keep as-is */
+        if ( preg_match( '/^[0-9a-fA-F]{6}([0-9a-fA-F]{2})?$/', $raw ) ) {
+            return '#' . strtolower( $raw );
+        }
+        return '';
+    }
 
-	/**
-	 * Sanitise all style-related keys, returning a clean array
-	 * that **now includes TOC fields**.
-	 */
-	private function nuclen_sanitize_style( array $in ): array {
+    /**
+     * Sanitise all style-related keys, returning a clean array
+     * that **now includes TOC fields**.
+     */
+    private function nuclen_sanitize_style( array $in ): array {
 
-		/* Helper: colour with fallback */
-		$hx = static function ( $val, $fallback ) {
-			$val = (string) $val;
+        /* Helper: colour with fallback */
+        $hx = static function ( $val, $fallback ) {
+            $val = (string) $val;
 
-			/* 1) HEX */
-			$hex = self::nuclen_validate_hex( $val );
-			if ( $hex !== '' ) {
-				return $hex;
-			}
+            /* 1) HEX */
+            $hex = self::nuclen_validate_hex( $val );
+            if ( $hex !== '' ) {
+                return $hex;
+            }
 
-			/* 2) rgb()/rgba() */
-			$rgb_re = '/^rgba?\\(\\s*(?:\\d{1,3}\\s*,\\s*){2}\\d{1,3}(?:\\s*,\\s*(?:0|1|0?\\.\\d+))?\\s*\\)$/i';
-			if ( preg_match( $rgb_re, $val ) ) {
-				return $val;
-			}
-			return $fallback;
-		};
+            /* 2) rgb()/rgba() */
+            $rgb_re = '/^rgba?\\(\\s*(?:\\d{1,3}\\s*,\\s*){2}\\d{1,3}(?:\\s*,\\s*(?:0|1|0?\\.\\d+))?\\s*\\)$/i';
+            if ( preg_match( $rgb_re, $val ) ) {
+                return $val;
+            }
+            return $fallback;
+        };
 
-		/* ───────── Quiz container ───────── */
-		$font_size  = max( 10, min( 50, (int) ( $in['font_size'] ?? 16 ) ) );
-		$font_color = $hx( $in['font_color'] ?? '', '#000000' );
-		$bg_color   = $hx( $in['bg_color'] ?? '', '#ffffff' );
+        /* ───────── Quiz container ───────── */
+        $font_size  = max( 10, min( 50, (int) ( $in['font_size'] ?? 16 ) ) );
+        $font_color = $hx( $in['font_color'] ?? '', '#000000' );
+        $bg_color   = $hx( $in['bg_color'] ?? '', '#ffffff' );
 
-		$border_color  = $hx( $in['quiz_border_color'] ?? ( $in['border_color'] ?? '' ), '#000000' );
-		$border_style  = sanitize_text_field( $in['quiz_border_style'] ?? ( $in['border_style'] ?? 'solid' ) );
-		$border_width  = (int) ( $in['quiz_border_width'] ?? ( $in['border_width'] ?? 1 ) );
-		$border_radius = (int) ( $in['quiz_border_radius'] ?? 6 );
+        $border_color  = $hx( $in['quiz_border_color'] ?? ( $in['border_color'] ?? '' ), '#000000' );
+        $border_style  = sanitize_text_field( $in['quiz_border_style'] ?? ( $in['border_style'] ?? 'solid' ) );
+        $border_width  = (int) ( $in['quiz_border_width'] ?? ( $in['border_width'] ?? 1 ) );
+        $border_radius = (int) ( $in['quiz_border_radius'] ?? 6 );
 
-		$shadow_color = sanitize_text_field( $in['quiz_shadow_color'] ?? 'rgba(0,0,0,0.15)' );
-		$shadow_blur  = (int) ( $in['quiz_shadow_blur'] ?? 8 );
+        $shadow_color = sanitize_text_field( $in['quiz_shadow_color'] ?? 'rgba(0,0,0,0.15)' );
+        $shadow_blur  = (int) ( $in['quiz_shadow_blur'] ?? 8 );
 
-		$btn_bg       = $hx( $in['quiz_answer_button_bg_color'] ?? '', '#94544A' );
-		$btn_border   = $hx( $in['quiz_answer_button_border_color'] ?? '', '#94544A' );
-		$btn_b_width  = (int) ( $in['quiz_answer_button_border_width'] ?? 2 );
-		$btn_b_radius = (int) ( $in['quiz_answer_button_border_radius'] ?? 4 );
+        $btn_bg       = $hx( $in['quiz_answer_button_bg_color'] ?? '', '#94544A' );
+        $btn_border   = $hx( $in['quiz_answer_button_border_color'] ?? '', '#94544A' );
+        $btn_b_width  = (int) ( $in['quiz_answer_button_border_width'] ?? 2 );
+        $btn_b_radius = (int) ( $in['quiz_answer_button_border_radius'] ?? 4 );
 
-		$pb_fg = $hx( $in['quiz_progress_bar_fg_color'] ?? '', '#1B977D' );
-		$pb_bg = $hx( $in['quiz_progress_bar_bg_color'] ?? '', '#e0e0e0' );
-		$pb_ht = (int) ( $in['quiz_progress_bar_height'] ?? 10 );
+        $pb_fg = $hx( $in['quiz_progress_bar_fg_color'] ?? '', '#1B977D' );
+        $pb_bg = $hx( $in['quiz_progress_bar_bg_color'] ?? '', '#e0e0e0' );
+        $pb_ht = (int) ( $in['quiz_progress_bar_height'] ?? 10 );
 
-		/* ───────── Summary container ───────── */
-		$s_font_size  = max( 10, min( 50, (int) ( $in['summary_font_size'] ?? 16 ) ) );
-		$s_font_color = $hx( $in['summary_font_color'] ?? '', '#000000' );
-		$s_bg_color   = $hx( $in['summary_bg_color'] ?? '', '#ffffff' );
+        /* ───────── Summary container ───────── */
+        $s_font_size  = max( 10, min( 50, (int) ( $in['summary_font_size'] ?? 16 ) ) );
+        $s_font_color = $hx( $in['summary_font_color'] ?? '', '#000000' );
+        $s_bg_color   = $hx( $in['summary_bg_color'] ?? '', '#ffffff' );
 
-		$s_border_color  = $hx( $in['summary_border_color'] ?? ( $in['border_color'] ?? '' ), '#000000' );
-		$s_border_style  = sanitize_text_field( $in['summary_border_style'] ?? ( $in['border_style'] ?? 'solid' ) );
-		$s_border_width  = (int) ( $in['summary_border_width'] ?? ( $in['border_width'] ?? 1 ) );
-		$s_border_radius = (int) ( $in['summary_border_radius'] ?? 6 );
+        $s_border_color  = $hx( $in['summary_border_color'] ?? ( $in['border_color'] ?? '' ), '#000000' );
+        $s_border_style  = sanitize_text_field( $in['summary_border_style'] ?? ( $in['border_style'] ?? 'solid' ) );
+        $s_border_width  = (int) ( $in['summary_border_width'] ?? ( $in['border_width'] ?? 1 ) );
+        $s_border_radius = (int) ( $in['summary_border_radius'] ?? 6 );
 
-		$s_shadow_color = sanitize_text_field( $in['summary_shadow_color'] ?? 'rgba(0,0,0,0.15)' );
-		$s_shadow_blur  = (int) ( $in['summary_shadow_blur'] ?? 8 );
+        $s_shadow_color = sanitize_text_field( $in['summary_shadow_color'] ?? 'rgba(0,0,0,0.15)' );
+        $s_shadow_blur  = (int) ( $in['summary_shadow_blur'] ?? 8 );
 
-		/* ───────── TOC container ───────── */
-		$t_font_size  = max( 10, min( 50, (int) ( $in['toc_font_size'] ?? 16 ) ) );
-		$t_font_color = $hx( $in['toc_font_color'] ?? '', '#000000' );
-		$t_bg_color   = $hx( $in['toc_bg_color'] ?? '', '#ffffff' );
+        /* ───────── TOC container ───────── */
+        $t_font_size  = max( 10, min( 50, (int) ( $in['toc_font_size'] ?? 16 ) ) );
+        $t_font_color = $hx( $in['toc_font_color'] ?? '', '#000000' );
+        $t_bg_color   = $hx( $in['toc_bg_color'] ?? '', '#ffffff' );
 
-		$t_border_color  = $hx( $in['toc_border_color'] ?? ( $in['border_color'] ?? '' ), '#000000' );
-		$t_border_style  = sanitize_text_field( $in['toc_border_style'] ?? ( $in['border_style'] ?? 'solid' ) );
-		$t_border_width  = (int) ( $in['toc_border_width'] ?? ( $in['border_width'] ?? 1 ) );
-		$t_border_radius = (int) ( $in['toc_border_radius'] ?? 6 );
+        $t_border_color  = $hx( $in['toc_border_color'] ?? ( $in['border_color'] ?? '' ), '#000000' );
+        $t_border_style  = sanitize_text_field( $in['toc_border_style'] ?? ( $in['border_style'] ?? 'solid' ) );
+        $t_border_width  = (int) ( $in['toc_border_width'] ?? ( $in['border_width'] ?? 1 ) );
+        $t_border_radius = (int) ( $in['toc_border_radius'] ?? 6 );
 
-		$t_shadow_color = sanitize_text_field( $in['toc_shadow_color'] ?? 'rgba(0,0,0,0.05)' );
-		$t_shadow_blur  = (int) ( $in['toc_shadow_blur'] ?? 8 );
-		$t_z_index      = max( 1, min( 9999, (int) ( $in['toc_z_index'] ?? 100 ) ) );
+        $t_shadow_color = sanitize_text_field( $in['toc_shadow_color'] ?? 'rgba(0,0,0,0.05)' );
+        $t_shadow_blur  = (int) ( $in['toc_shadow_blur'] ?? 8 );
+        $t_z_index      = max( 1, min( 9999, (int) ( $in['toc_z_index'] ?? 100 ) ) );
 
-		$t_link_color = $hx( $in['toc_link_color'] ?? '', '#1e73be' );
+        $t_link_color = $hx( $in['toc_link_color'] ?? '', '#1e73be' );
 
-		/*
-		───────────────────────────────────────────────────────────*/
-		/*
-			Return clean array                                       */
-		/*───────────────────────────────────────────────────────────*/
-		return array(
-			/* quiz */
-			'font_size'                        => $font_size,
-			'font_color'                       => $font_color,
-			'bg_color'                         => $bg_color,
-			'quiz_border_color'                => $border_color,
-			'quiz_border_style'                => $border_style,
-			'quiz_border_width'                => $border_width,
-			'quiz_border_radius'               => $border_radius,
-			'quiz_shadow_color'                => $shadow_color,
-			'quiz_shadow_blur'                 => $shadow_blur,
-			'quiz_answer_button_bg_color'      => $btn_bg,
-			'quiz_answer_button_border_color'  => $btn_border,
-			'quiz_answer_button_border_width'  => $btn_b_width,
-			'quiz_answer_button_border_radius' => $btn_b_radius,
-			'quiz_progress_bar_fg_color'       => $pb_fg,
-			'quiz_progress_bar_bg_color'       => $pb_bg,
-			'quiz_progress_bar_height'         => $pb_ht,
+        /*
+        ───────────────────────────────────────────────────────────*/
+        /*
+            Return clean array                                       */
+        /*───────────────────────────────────────────────────────────*/
+        return array(
+            /* quiz */
+            'font_size'                        => $font_size,
+            'font_color'                       => $font_color,
+            'bg_color'                         => $bg_color,
+            'quiz_border_color'                => $border_color,
+            'quiz_border_style'                => $border_style,
+            'quiz_border_width'                => $border_width,
+            'quiz_border_radius'               => $border_radius,
+            'quiz_shadow_color'                => $shadow_color,
+            'quiz_shadow_blur'                 => $shadow_blur,
+            'quiz_answer_button_bg_color'      => $btn_bg,
+            'quiz_answer_button_border_color'  => $btn_border,
+            'quiz_answer_button_border_width'  => $btn_b_width,
+            'quiz_answer_button_border_radius' => $btn_b_radius,
+            'quiz_progress_bar_fg_color'       => $pb_fg,
+            'quiz_progress_bar_bg_color'       => $pb_bg,
+            'quiz_progress_bar_height'         => $pb_ht,
 
-			/* summary */
-			'summary_font_size'                => $s_font_size,
-			'summary_font_color'               => $s_font_color,
-			'summary_bg_color'                 => $s_bg_color,
-			'summary_border_color'             => $s_border_color,
-			'summary_border_style'             => $s_border_style,
-			'summary_border_width'             => $s_border_width,
-			'summary_border_radius'            => $s_border_radius,
-			'summary_shadow_color'             => $s_shadow_color,
-			'summary_shadow_blur'              => $s_shadow_blur,
+            /* summary */
+            'summary_font_size'                => $s_font_size,
+            'summary_font_color'               => $s_font_color,
+            'summary_bg_color'                 => $s_bg_color,
+            'summary_border_color'             => $s_border_color,
+            'summary_border_style'             => $s_border_style,
+            'summary_border_width'             => $s_border_width,
+            'summary_border_radius'            => $s_border_radius,
+            'summary_shadow_color'             => $s_shadow_color,
+            'summary_shadow_blur'              => $s_shadow_blur,
 
-			/* toc */
-			'toc_font_size'                    => $t_font_size,
-			'toc_font_color'                   => $t_font_color,
-			'toc_bg_color'                     => $t_bg_color,
-			'toc_border_color'                 => $t_border_color,
-			'toc_border_style'                 => $t_border_style,
-			'toc_border_width'                 => $t_border_width,
-			'toc_border_radius'                => $t_border_radius,
-			'toc_shadow_color'                 => $t_shadow_color,
-			'toc_shadow_blur'                  => $t_shadow_blur,
-			'toc_z_index'                      => $t_z_index,
-			'toc_link_color'                   => $t_link_color,
-		);
-	}
+            /* toc */
+            'toc_font_size'                    => $t_font_size,
+            'toc_font_color'                   => $t_font_color,
+            'toc_bg_color'                     => $t_bg_color,
+            'toc_border_color'                 => $t_border_color,
+            'toc_border_style'                 => $t_border_style,
+            'toc_border_width'                 => $t_border_width,
+            'toc_border_radius'                => $t_border_radius,
+            'toc_shadow_color'                 => $t_shadow_color,
+            'toc_shadow_blur'                  => $t_shadow_blur,
+            'toc_z_index'                      => $t_z_index,
+            'toc_link_color'                   => $t_link_color,
+        );
+    }
 }

--- a/nuclear-engagement/admin/index.php
+++ b/nuclear-engagement/admin/index.php
@@ -1,5 +1,5 @@
 <?php
 declare(strict_types=1);
 if ( ! defined( 'ABSPATH' ) ) {
-	exit;
+    exit;
 } // Silence is golden

--- a/nuclear-engagement/front/Controller/Rest/ContentController.php
+++ b/nuclear-engagement/front/Controller/Rest/ContentController.php
@@ -16,7 +16,7 @@ use NuclearEngagement\SettingsRepository;
 use NuclearEngagement\Utils;
 
 if ( ! defined( 'ABSPATH' ) ) {
-	exit;
+    exit;
 }
 
 /**
@@ -27,9 +27,9 @@ if ( ! defined( 'ABSPATH' ) ) {
  * admin nonce check when present.
  */
 class ContentController {
-	/**
-	 * @var ContentStorageService
-	 */
+    /**
+     * @var ContentStorageService
+     */
         private ContentStorageService $storage;
 
         /**
@@ -37,28 +37,28 @@ class ContentController {
          */
         private SettingsRepository $settings;
 
-	/**
-	 * @var Utils
-	 */
-	private Utils $utils;
+    /**
+     * @var Utils
+     */
+    private Utils $utils;
 
-	/**
-	 * Constructor
-	 *
-	 * @param ContentStorageService $storage
-	 */
+    /**
+     * Constructor
+     *
+     * @param ContentStorageService $storage
+     */
         public function __construct( ContentStorageService $storage, SettingsRepository $settings ) {
                 $this->storage  = $storage;
                 $this->settings = $settings;
                 $this->utils    = new Utils();
         }
 
-	/**
-	 * Handle content receive request
-	 *
-	 * @param \WP_REST_Request $request
-	 * @return \WP_REST_Response|\WP_Error
-	 */
+    /**
+     * Handle content receive request
+     *
+     * @param \WP_REST_Request $request
+     * @return \WP_REST_Response|\WP_Error
+     */
         public function handle( \WP_REST_Request $request ) {
                 try {
                         // Authentication handled in permissions()
@@ -83,30 +83,30 @@ class ContentController {
                                 )
                         );
 
-			$contentRequest = ContentRequest::fromJson( $data );
+            $contentRequest = ContentRequest::fromJson( $data );
 
-			// Store the results
-			$this->storage->storeResults( $contentRequest->results, $contentRequest->workflow );
+            // Store the results
+            $this->storage->storeResults( $contentRequest->results, $contentRequest->workflow );
 
-			// Get date from first stored item
-			reset( $contentRequest->results );
-			$firstPostId = key( $contentRequest->results );
-			$metaKey     = $contentRequest->workflow === 'quiz' ? 'nuclen-quiz-data' : 'nuclen-summary-data';
-			$stored      = get_post_meta( $firstPostId, $metaKey, true );
-			$date        = is_array( $stored ) && ! empty( $stored['date'] ) ? $stored['date'] : '';
+            // Get date from first stored item
+            reset( $contentRequest->results );
+            $firstPostId = key( $contentRequest->results );
+            $metaKey     = $contentRequest->workflow === 'quiz' ? 'nuclen-quiz-data' : 'nuclen-summary-data';
+            $stored      = get_post_meta( $firstPostId, $metaKey, true );
+            $date        = is_array( $stored ) && ! empty( $stored['date'] ) ? $stored['date'] : '';
 
-			$message = sprintf(
-				__( '%s data received and stored successfully', 'nuclear-engagement' ),
-				ucfirst( $contentRequest->workflow )
-			);
+            $message = sprintf(
+                __( '%s data received and stored successfully', 'nuclear-engagement' ),
+                ucfirst( $contentRequest->workflow )
+            );
 
-			return new \WP_REST_Response(
-				array(
-					'message'   => $message,
-					'finalDate' => $date,
-				),
-				200
-			);
+            return new \WP_REST_Response(
+                array(
+                    'message'   => $message,
+                    'finalDate' => $date,
+                ),
+                200
+            );
 
                } catch ( \InvalidArgumentException $e ) {
                        \NuclearEngagement\Services\LoggingService::log_exception( $e );
@@ -117,11 +117,11 @@ class ContentController {
                }
        }
 
-	/**
-	 * Check permissions
-	 *
-	 * @return bool
-	 */
+    /**
+     * Check permissions
+     *
+     * @return bool
+     */
         public function permissions( \WP_REST_Request $request ): bool {
                 $header_pass = sanitize_text_field( (string) $request->get_header( 'X-WP-App-Password' ) );
                 $stored_pass = $this->settings->get_string( 'plugin_password', '' );

--- a/nuclear-engagement/front/FrontClass.php
+++ b/nuclear-engagement/front/FrontClass.php
@@ -28,61 +28,61 @@ use NuclearEngagement\Container;
 
 class FrontClass {
 
-	use AssetsTrait;
-	use RestTrait;
-	use ShortcodesTrait;
+    use AssetsTrait;
+    use RestTrait;
+    use ShortcodesTrait;
 
-	/** @var string */
-	private $plugin_name;
-	/** @var string */
-	private $version;
-		/** @var Utils */
-		private $utils;
-		/** @var SettingsRepository */
-		private $settings_repository;
-		/** @var Container */
-		private $container;
+    /** @var string */
+    private $plugin_name;
+    /** @var string */
+    private $version;
+        /** @var Utils */
+        private $utils;
+        /** @var SettingsRepository */
+        private $settings_repository;
+        /** @var Container */
+        private $container;
 
-	/**
-	 * Constructor.
-	 *
-	 * @param string             $plugin_name The plugin name.
-	 * @param string             $version The plugin version.
-	 * @param SettingsRepository $settings_repository The settings repository.
-	 */
-	public function __construct( $plugin_name, $version, SettingsRepository $settings_repository, Container $container ) {
-			$this->plugin_name         = $plugin_name;
-			$this->version             = $version;
-			$this->utils               = new Utils();
-			$this->settings_repository = $settings_repository;
-			$this->container           = $container;
-	}
+    /**
+     * Constructor.
+     *
+     * @param string             $plugin_name The plugin name.
+     * @param string             $version The plugin version.
+     * @param SettingsRepository $settings_repository The settings repository.
+     */
+    public function __construct( $plugin_name, $version, SettingsRepository $settings_repository, Container $container ) {
+            $this->plugin_name         = $plugin_name;
+            $this->version             = $version;
+            $this->utils               = new Utils();
+            $this->settings_repository = $settings_repository;
+            $this->container           = $container;
+    }
 
-	/** Allow traits to read internal utils object */
-	/**
-	 * Get the Utils instance.
-	 *
-	 * @return Utils
-	 */
-	public function nuclen_get_utils(): Utils {
-		return $this->utils;
-	}
+    /** Allow traits to read internal utils object */
+    /**
+     * Get the Utils instance.
+     *
+     * @return Utils
+     */
+    public function nuclen_get_utils(): Utils {
+        return $this->utils;
+    }
 
-	/**
-	 * Get the SettingsRepository instance.
-	 *
-	 * @return SettingsRepository
-	 */
-	public function nuclen_get_settings_repository() {
-			return $this->settings_repository;
-	}
+    /**
+     * Get the SettingsRepository instance.
+     *
+     * @return SettingsRepository
+     */
+    public function nuclen_get_settings_repository() {
+            return $this->settings_repository;
+    }
 
-		/**
-		 * Get the container instance.
-		 *
-		 * @return Container
-		 */
-	protected function get_container(): Container {
-			return $this->container;
-	}
+        /**
+         * Get the container instance.
+         *
+         * @return Container
+         */
+    protected function get_container(): Container {
+            return $this->container;
+    }
 }

--- a/nuclear-engagement/front/QuizView.php
+++ b/nuclear-engagement/front/QuizView.php
@@ -3,80 +3,80 @@ declare(strict_types=1);
 namespace NuclearEngagement\Front;
 
 if ( ! defined( 'ABSPATH' ) ) {
-	exit;
+    exit;
 }
 
 class QuizView {
-	public function container( array $settings ): string {
-		$html = '<section id="nuclen-quiz-container" class="nuclen-quiz">';
-		if ( trim( $settings['html_before'] ) !== '' ) {
-			$html .= $this->startMessage( $settings['html_before'] );
-		}
-		$html .= $this->title( $settings['quiz_title'] );
-		$html .= $this->progressBar();
-		$html .= $this->questionContainer();
-		$html .= $this->answersContainer();
-		$html .= $this->resultContainer();
-		$html .= $this->explanationContainer();
-		$html .= $this->nextButton();
-		$html .= $this->finalResultContainer();
-		$html .= '</section>';
-		return $html;
-	}
+    public function container( array $settings ): string {
+        $html = '<section id="nuclen-quiz-container" class="nuclen-quiz">';
+        if ( trim( $settings['html_before'] ) !== '' ) {
+            $html .= $this->startMessage( $settings['html_before'] );
+        }
+        $html .= $this->title( $settings['quiz_title'] );
+        $html .= $this->progressBar();
+        $html .= $this->questionContainer();
+        $html .= $this->answersContainer();
+        $html .= $this->resultContainer();
+        $html .= $this->explanationContainer();
+        $html .= $this->nextButton();
+        $html .= $this->finalResultContainer();
+        $html .= '</section>';
+        return $html;
+    }
 
-	public function attribution( bool $show ): string {
-		if ( ! $show ) {
-			return '';
-		}
-		return sprintf(
-			'<div class="nuclen-attribution">%s <a rel="nofollow" href="https://www.nuclearengagement.com" target="_blank">%s</a></div>',
-			esc_html__( 'Quiz by', 'nuclear-engagement' ),
-			esc_html__( 'Nuclear Engagement', 'nuclear-engagement' )
-		);
-	}
+    public function attribution( bool $show ): string {
+        if ( ! $show ) {
+            return '';
+        }
+        return sprintf(
+            '<div class="nuclen-attribution">%s <a rel="nofollow" href="https://www.nuclearengagement.com" target="_blank">%s</a></div>',
+            esc_html__( 'Quiz by', 'nuclear-engagement' ),
+            esc_html__( 'Nuclear Engagement', 'nuclear-engagement' )
+        );
+    }
 
-	private function startMessage( string $html_before ): string {
-		return sprintf(
-			'<div id="nuclen-quiz-start-message" class="nuclen-fg">%s</div>',
-			shortcode_unautop( $html_before )
-		);
-	}
+    private function startMessage( string $html_before ): string {
+        return sprintf(
+            '<div id="nuclen-quiz-start-message" class="nuclen-fg">%s</div>',
+            shortcode_unautop( $html_before )
+        );
+    }
 
-	private function title( string $title ): string {
-		return sprintf(
-			'<h2 id="nuclen-quiz-title" class="nuclen-fg">%s</h2>',
-			esc_html( $title )
-		);
-	}
+    private function title( string $title ): string {
+        return sprintf(
+            '<h2 id="nuclen-quiz-title" class="nuclen-fg">%s</h2>',
+            esc_html( $title )
+        );
+    }
 
-	private function progressBar(): string {
-		return '<div id="nuclen-quiz-progress-bar-container"><div id="nuclen-quiz-progress-bar"></div></div>';
-	}
+    private function progressBar(): string {
+        return '<div id="nuclen-quiz-progress-bar-container"><div id="nuclen-quiz-progress-bar"></div></div>';
+    }
 
-	private function questionContainer(): string {
-		return '<div id="nuclen-quiz-question-container" class="nuclen-fg"></div>';
-	}
+    private function questionContainer(): string {
+        return '<div id="nuclen-quiz-question-container" class="nuclen-fg"></div>';
+    }
 
-	private function answersContainer(): string {
-		return '<div id="nuclen-quiz-answers-container" class="nuclen-quiz-answers-grid"></div>';
-	}
+    private function answersContainer(): string {
+        return '<div id="nuclen-quiz-answers-container" class="nuclen-quiz-answers-grid"></div>';
+    }
 
-	private function resultContainer(): string {
-		return '<div id="nuclen-quiz-result-container"></div>';
-	}
+    private function resultContainer(): string {
+        return '<div id="nuclen-quiz-result-container"></div>';
+    }
 
-	private function explanationContainer(): string {
-		return '<div id="nuclen-quiz-explanation-container" class="nuclen-fg nuclen-quiz-hidden"></div>';
-	}
+    private function explanationContainer(): string {
+        return '<div id="nuclen-quiz-explanation-container" class="nuclen-fg nuclen-quiz-hidden"></div>';
+    }
 
-	private function nextButton(): string {
-		return sprintf(
-			'<button id="nuclen-quiz-next-button" class="nuclen-quiz-hidden">%s</button>',
-			esc_html__( 'Next', 'nuclear-engagement' )
-		);
-	}
+    private function nextButton(): string {
+        return sprintf(
+            '<button id="nuclen-quiz-next-button" class="nuclen-quiz-hidden">%s</button>',
+            esc_html__( 'Next', 'nuclear-engagement' )
+        );
+    }
 
-	private function finalResultContainer(): string {
-		return '<div id="nuclen-quiz-final-result-container"></div>';
-	}
+    private function finalResultContainer(): string {
+        return '<div id="nuclen-quiz-final-result-container"></div>';
+    }
 }

--- a/nuclear-engagement/front/index.php
+++ b/nuclear-engagement/front/index.php
@@ -1,5 +1,5 @@
 <?php
 declare(strict_types=1);
 if ( ! defined( 'ABSPATH' ) ) {
-	exit;
+    exit;
 } // Silence is golden

--- a/nuclear-engagement/front/traits/AssetsTrait.php
+++ b/nuclear-engagement/front/traits/AssetsTrait.php
@@ -17,13 +17,13 @@ namespace NuclearEngagement\Front;
 use NuclearEngagement\AssetVersions;
 
 if ( ! defined( 'ABSPATH' ) ) {
-	exit;
+    exit;
 }
 
 trait AssetsTrait {
 
-	/** Force asset enqueue regardless of detection checks. */
-	private bool $force_assets = false;
+    /** Force asset enqueue regardless of detection checks. */
+    private bool $force_assets = false;
 
         /**
          * Retrieve URL/version for the custom theme file if selected.
@@ -45,75 +45,75 @@ trait AssetsTrait {
                 );
         }
 
-	/**
-	 * Determine if front-end assets should load on the current request.
-	 *
-	 * @return bool
-	 */
-	private function should_load_assets(): bool {
-		if ( $this->force_assets ) {
-			return true;
-		}
-		if ( is_admin() || ! is_singular() ) {
-			return false;
-		}
+    /**
+     * Determine if front-end assets should load on the current request.
+     *
+     * @return bool
+     */
+    private function should_load_assets(): bool {
+        if ( $this->force_assets ) {
+            return true;
+        }
+        if ( is_admin() || ! is_singular() ) {
+            return false;
+        }
 
-		$post_id = get_the_ID();
-		if ( ! $post_id ) {
-			return false;
-		}
+        $post_id = get_the_ID();
+        if ( ! $post_id ) {
+            return false;
+        }
 
-		$post    = get_post( $post_id );
-		$content = $post ? $post->post_content : '';
+        $post    = get_post( $post_id );
+        $content = $post ? $post->post_content : '';
 
-		if ( function_exists( 'has_block' ) && $post ) {
-			if ( has_block( 'nuclear-engagement/quiz', $post ) || has_block( 'nuclear-engagement/summary', $post ) ) {
-				return true;
-			}
-		}
+        if ( function_exists( 'has_block' ) && $post ) {
+            if ( has_block( 'nuclear-engagement/quiz', $post ) || has_block( 'nuclear-engagement/summary', $post ) ) {
+                return true;
+            }
+        }
 
-		if ( has_shortcode( $content, 'nuclear_engagement_quiz' ) || has_shortcode( $content, 'nuclear_engagement_summary' ) ) {
-			return true;
-		}
+        if ( has_shortcode( $content, 'nuclear_engagement_quiz' ) || has_shortcode( $content, 'nuclear_engagement_summary' ) ) {
+            return true;
+        }
 
-		$settings_repo   = $this->nuclen_get_settings_repository();
-		$display_quiz    = $settings_repo->get( 'display_quiz', 'manual' );
-		$display_summary = $settings_repo->get( 'display_summary', 'manual' );
+        $settings_repo   = $this->nuclen_get_settings_repository();
+        $display_quiz    = $settings_repo->get( 'display_quiz', 'manual' );
+        $display_summary = $settings_repo->get( 'display_summary', 'manual' );
 
-		if ( $display_quiz !== 'manual' && $display_quiz !== 'none' ) {
-			$quiz_meta = maybe_unserialize( get_post_meta( $post_id, 'nuclen-quiz-data', true ) );
-			if ( is_array( $quiz_meta ) && ! empty( $quiz_meta['questions'] ) ) {
-				return true;
-			}
-		}
+        if ( $display_quiz !== 'manual' && $display_quiz !== 'none' ) {
+            $quiz_meta = maybe_unserialize( get_post_meta( $post_id, 'nuclen-quiz-data', true ) );
+            if ( is_array( $quiz_meta ) && ! empty( $quiz_meta['questions'] ) ) {
+                return true;
+            }
+        }
 
-		if ( $display_summary !== 'manual' && $display_summary !== 'none' ) {
-			$summary_meta = get_post_meta( $post_id, 'nuclen-summary-data', true );
-			if ( is_array( $summary_meta ) && ! empty( trim( $summary_meta['summary'] ?? '' ) ) ) {
-				return true;
-			}
-		}
+        if ( $display_summary !== 'manual' && $display_summary !== 'none' ) {
+            $summary_meta = get_post_meta( $post_id, 'nuclen-summary-data', true );
+            if ( is_array( $summary_meta ) && ! empty( trim( $summary_meta['summary'] ?? '' ) ) ) {
+                return true;
+            }
+        }
 
-		return false;
-	}
+        return false;
+    }
 
-	/*
-	────────────────────────────
-		STYLES
-	──────────────────────────── */
-	public function wp_enqueue_styles() {
-		if ( ! $this->should_load_assets() ) {
-			return;
-		}
+    /*
+    ────────────────────────────
+        STYLES
+    ──────────────────────────── */
+    public function wp_enqueue_styles() {
+        if ( ! $this->should_load_assets() ) {
+            return;
+        }
 
-		/* Base CSS */
-		wp_enqueue_style(
-			$this->plugin_name,
-			plugin_dir_url( __FILE__ ) . '../css/nuclen-front.css',
-			array(),
-			AssetVersions::get( 'front_css' ),
-			'all'
-		);
+        /* Base CSS */
+        wp_enqueue_style(
+            $this->plugin_name,
+            plugin_dir_url( __FILE__ ) . '../css/nuclen-front.css',
+            array(),
+            AssetVersions::get( 'front_css' ),
+            'all'
+        );
 
                 /* Custom theme CSS */
                 $settings_repo = $this->nuclen_get_settings_repository();
@@ -133,89 +133,89 @@ trait AssetsTrait {
                 }
         }
 
-	/*
-	────────────────────────────
-		SCRIPTS
-	──────────────────────────── */
-	public function wp_enqueue_scripts() {
-		if ( ! $this->should_load_assets() ) {
-			return;
-		}
+    /*
+    ────────────────────────────
+        SCRIPTS
+    ──────────────────────────── */
+    public function wp_enqueue_scripts() {
+        if ( ! $this->should_load_assets() ) {
+            return;
+        }
 
-		/* Main bundle */
-		wp_enqueue_script(
-			$this->plugin_name . '-front',
-			plugin_dir_url( __DIR__ ) . 'js/nuclen-front.js',
-			array(),
-			AssetVersions::get( 'front_js' ),
-			true
-		);
+        /* Main bundle */
+        wp_enqueue_script(
+            $this->plugin_name . '-front',
+            plugin_dir_url( __DIR__ ) . 'js/nuclen-front.js',
+            array(),
+            AssetVersions::get( 'front_js' ),
+            true
+        );
 
-		$settings_repo = $this->nuclen_get_settings_repository();
+        $settings_repo = $this->nuclen_get_settings_repository();
 
-		/* ───── Inline scalars (booleans & strings) ───── */
-		$inline_js  = '';
-		$inline_js .= 'var NuclenOptinEnabled  = ' . ( $settings_repo->get( 'enable_optin', false ) ? 'true' : 'false' ) . ";\n";
+        /* ───── Inline scalars (booleans & strings) ───── */
+        $inline_js  = '';
+        $inline_js .= 'var NuclenOptinEnabled  = ' . ( $settings_repo->get( 'enable_optin', false ) ? 'true' : 'false' ) . ";\n";
 
-		$raw_mandatory   = $settings_repo->get( 'optin_mandatory', false );
-		$optin_mandatory = ( $raw_mandatory === true || $raw_mandatory === 1 || $raw_mandatory === '1' );
-		$inline_js      .= 'var NuclenOptinMandatory = ' . ( $optin_mandatory ? 'true' : 'false' ) . ";\n";
+        $raw_mandatory   = $settings_repo->get( 'optin_mandatory', false );
+        $optin_mandatory = ( $raw_mandatory === true || $raw_mandatory === 1 || $raw_mandatory === '1' );
+        $inline_js      .= 'var NuclenOptinMandatory = ' . ( $optin_mandatory ? 'true' : 'false' ) . ";\n";
 
-		$inline_js .= 'var NuclenOptinPosition = ' . json_encode( $settings_repo->get( 'optin_position', 'with_results' ) ) . ";\n";
-		$inline_js .= 'var NuclenOptinPromptText = ' . json_encode( $settings_repo->get( 'optin_prompt_text', 'Please enter your details to view your score:' ) ) . ";\n";
-		$inline_js .= 'var NuclenOptinButtonText = ' . json_encode( $settings_repo->get( 'optin_button_text', 'Submit' ) ) . ";\n";
-		$inline_js .= 'var NuclenOptinWebhook = ' . json_encode( $settings_repo->get( 'optin_webhook', '' ) ) . ";\n";
-		$inline_js .= 'var NuclenOptinSuccessMessage = ' . json_encode( $settings_repo->get( 'optin_success_message', '' ) ) . ";\n";
-		$inline_js .= 'var NuclenCustomQuizHtmlAfter = ' . json_encode( $settings_repo->get( 'custom_quiz_html_after', '' ) ) . ";\n";
+        $inline_js .= 'var NuclenOptinPosition = ' . json_encode( $settings_repo->get( 'optin_position', 'with_results' ) ) . ";\n";
+        $inline_js .= 'var NuclenOptinPromptText = ' . json_encode( $settings_repo->get( 'optin_prompt_text', 'Please enter your details to view your score:' ) ) . ";\n";
+        $inline_js .= 'var NuclenOptinButtonText = ' . json_encode( $settings_repo->get( 'optin_button_text', 'Submit' ) ) . ";\n";
+        $inline_js .= 'var NuclenOptinWebhook = ' . json_encode( $settings_repo->get( 'optin_webhook', '' ) ) . ";\n";
+        $inline_js .= 'var NuclenOptinSuccessMessage = ' . json_encode( $settings_repo->get( 'optin_success_message', '' ) ) . ";\n";
+        $inline_js .= 'var NuclenCustomQuizHtmlAfter = ' . json_encode( $settings_repo->get( 'custom_quiz_html_after', '' ) ) . ";\n";
 
-		wp_add_inline_script( $this->plugin_name . '-front', $inline_js, 'before' );
+        wp_add_inline_script( $this->plugin_name . '-front', $inline_js, 'before' );
 
-		/* ► NEW ◄ – endpoint & nonce for AJAX opt-in storage */
-		wp_localize_script(
-			$this->plugin_name . '-front',
-			'NuclenOptinAjax',
-			array(
-				'url'   => admin_url( 'admin-ajax.php' ),
-				'nonce' => wp_create_nonce( 'nuclen_optin_nonce' ),
-			)
-		);
+        /* ► NEW ◄ – endpoint & nonce for AJAX opt-in storage */
+        wp_localize_script(
+            $this->plugin_name . '-front',
+            'NuclenOptinAjax',
+            array(
+                'url'   => admin_url( 'admin-ajax.php' ),
+                'nonce' => wp_create_nonce( 'nuclen_optin_nonce' ),
+            )
+        );
 
-		/* Per-post quiz data */
-		$post_id   = get_the_ID();
-		$quiz_meta = maybe_unserialize( get_post_meta( $post_id, 'nuclen-quiz-data', true ) );
-		$questions = ( is_array( $quiz_meta ) && isset( $quiz_meta['questions'] ) ) ? $quiz_meta['questions'] : array();
-		wp_localize_script( $this->plugin_name . '-front', 'postQuizData', $questions );
+        /* Per-post quiz data */
+        $post_id   = get_the_ID();
+        $quiz_meta = maybe_unserialize( get_post_meta( $post_id, 'nuclen-quiz-data', true ) );
+        $questions = ( is_array( $quiz_meta ) && isset( $quiz_meta['questions'] ) ) ? $quiz_meta['questions'] : array();
+        wp_localize_script( $this->plugin_name . '-front', 'postQuizData', $questions );
 
-		/* Numeric settings */
-		wp_localize_script(
-			$this->plugin_name . '-front',
-			'NuclenSettings',
-			array(
-				'questions_per_quiz'   => $settings_repo->get_int( 'questions_per_quiz', 10 ),
-				'answers_per_question' => $settings_repo->get_int( 'answers_per_question', 4 ),
-			)
-		);
+        /* Numeric settings */
+        wp_localize_script(
+            $this->plugin_name . '-front',
+            'NuclenSettings',
+            array(
+                'questions_per_quiz'   => $settings_repo->get_int( 'questions_per_quiz', 10 ),
+                'answers_per_question' => $settings_repo->get_int( 'answers_per_question', 4 ),
+            )
+        );
 
-		/* Translatable strings for the quiz */
-		$ne_strings = array(
-			'retake_test'   => $settings_repo->get( 'quiz_label_retake_test', __( 'Retake Test', 'nuclear-engagement' ) ),
-			'your_score'    => $settings_repo->get( 'quiz_label_your_score', __( 'Your Score', 'nuclear-engagement' ) ),
-			'perfect'       => $settings_repo->get( 'quiz_label_perfect', __( 'Perfect!', 'nuclear-engagement' ) ),
-			'well_done'     => $settings_repo->get( 'quiz_label_well_done', __( 'Well done!', 'nuclear-engagement' ) ),
-			'retake_prompt' => $settings_repo->get( 'quiz_label_retake_prompt', __( 'Why not retake the test?', 'nuclear-engagement' ) ),
-			'correct'       => $settings_repo->get( 'quiz_label_correct', __( 'Correct:', 'nuclear-engagement' ) ),
-			'your_answer'   => $settings_repo->get( 'quiz_label_your_answer', __( 'Your answer:', 'nuclear-engagement' ) ),
-		);
-		wp_localize_script( $this->plugin_name . '-front', 'NuclenStrings', $ne_strings );
-	}
+        /* Translatable strings for the quiz */
+        $ne_strings = array(
+            'retake_test'   => $settings_repo->get( 'quiz_label_retake_test', __( 'Retake Test', 'nuclear-engagement' ) ),
+            'your_score'    => $settings_repo->get( 'quiz_label_your_score', __( 'Your Score', 'nuclear-engagement' ) ),
+            'perfect'       => $settings_repo->get( 'quiz_label_perfect', __( 'Perfect!', 'nuclear-engagement' ) ),
+            'well_done'     => $settings_repo->get( 'quiz_label_well_done', __( 'Well done!', 'nuclear-engagement' ) ),
+            'retake_prompt' => $settings_repo->get( 'quiz_label_retake_prompt', __( 'Why not retake the test?', 'nuclear-engagement' ) ),
+            'correct'       => $settings_repo->get( 'quiz_label_correct', __( 'Correct:', 'nuclear-engagement' ) ),
+            'your_answer'   => $settings_repo->get( 'quiz_label_your_answer', __( 'Your answer:', 'nuclear-engagement' ) ),
+        );
+        wp_localize_script( $this->plugin_name . '-front', 'NuclenStrings', $ne_strings );
+    }
 
-	/**
-	 * Force asset enqueue when shortcodes run outside post content.
-	 */
-	public function nuclen_force_enqueue_assets(): void {
-		$this->force_assets = true;
-		$this->wp_enqueue_styles();
-		$this->wp_enqueue_scripts();
-		$this->force_assets = false;
-	}
+    /**
+     * Force asset enqueue when shortcodes run outside post content.
+     */
+    public function nuclen_force_enqueue_assets(): void {
+        $this->force_assets = true;
+        $this->wp_enqueue_styles();
+        $this->wp_enqueue_scripts();
+        $this->force_assets = false;
+    }
 }

--- a/nuclear-engagement/front/traits/RestTrait.php
+++ b/nuclear-engagement/front/traits/RestTrait.php
@@ -15,41 +15,41 @@ declare(strict_types=1);
 namespace NuclearEngagement\Front;
 
 if ( ! defined( 'ABSPATH' ) ) {
-	exit;
+    exit;
 }
 
 trait RestTrait {
 
-	/* ---------- REST route registration ---------- */
-	public function nuclen_register_content_endpoint() {
-		// Registration is now handled directly in Plugin::nuclen_define_public_hooks()
-		// This method is kept for backward compatibility but does nothing
-	}
+    /* ---------- REST route registration ---------- */
+    public function nuclen_register_content_endpoint() {
+        // Registration is now handled directly in Plugin::nuclen_define_public_hooks()
+        // This method is kept for backward compatibility but does nothing
+    }
 
-	/* ---------- Legacy methods for backward compatibility ---------- */
-	public function nuclen_receive_content( \WP_REST_Request $request ) {
-			$container  = $this->get_container();
-			$controller = $container->get( 'content_controller' );
-			return $controller->handle( $request );
-	}
+    /* ---------- Legacy methods for backward compatibility ---------- */
+    public function nuclen_receive_content( \WP_REST_Request $request ) {
+            $container  = $this->get_container();
+            $controller = $container->get( 'content_controller' );
+            return $controller->handle( $request );
+    }
 
-	public function nuclen_validate_and_store_quiz_data( $post_id, $quiz_data ): bool {
-		try {
-						$container = $this->get_container();
-						$storage   = $container->get( 'content_storage' );
-			$storage->storeQuizData( $post_id, $quiz_data );
-			return true;
+    public function nuclen_validate_and_store_quiz_data( $post_id, $quiz_data ): bool {
+        try {
+                        $container = $this->get_container();
+                        $storage   = $container->get( 'content_storage' );
+            $storage->storeQuizData( $post_id, $quiz_data );
+            return true;
                } catch ( \Exception $e ) {
                        \NuclearEngagement\Services\LoggingService::log_exception( $e );
                        return false;
                }
        }
 
-	public function nuclen_send_posts_to_app_backend( $data_to_send ) {
-		try {
-						$container = $this->get_container();
-						$api       = $container->get( 'remote_api' );
-						return $api->send_posts_to_generate( $data_to_send );
+    public function nuclen_send_posts_to_app_backend( $data_to_send ) {
+        try {
+                        $container = $this->get_container();
+                        $api       = $container->get( 'remote_api' );
+                        return $api->send_posts_to_generate( $data_to_send );
                } catch ( \RuntimeException $e ) {
                        \NuclearEngagement\Services\LoggingService::log_exception( $e );
                        return false;

--- a/nuclear-engagement/front/traits/ShortcodesTrait.php
+++ b/nuclear-engagement/front/traits/ShortcodesTrait.php
@@ -20,14 +20,14 @@ use NuclearEngagement\Front\SummaryShortcode;
 use NuclearEngagement\Modules\Quiz\Quiz_Service;
 
 if ( ! defined( 'ABSPATH' ) ) {
-	exit;
+    exit;
 }
 
 trait ShortcodesTrait {
-	private ?QuizShortcode $quiz_shortcode       = null;
-	private ?SummaryShortcode $summary_shortcode = null;
+    private ?QuizShortcode $quiz_shortcode       = null;
+    private ?SummaryShortcode $summary_shortcode = null;
 
-	private function get_quiz_shortcode(): QuizShortcode {
+    private function get_quiz_shortcode(): QuizShortcode {
                 if ( $this->quiz_shortcode === null ) {
                         $this->quiz_shortcode = new QuizShortcode(
                                 $this->nuclen_get_settings_repository(),
@@ -35,72 +35,72 @@ trait ShortcodesTrait {
                                 new Quiz_Service()
                         );
                 }
-		return $this->quiz_shortcode;
-	}
+        return $this->quiz_shortcode;
+    }
 
-	private function get_summary_shortcode(): SummaryShortcode {
-		if ( $this->summary_shortcode === null ) {
-			$this->summary_shortcode = new SummaryShortcode(
-				$this->nuclen_get_settings_repository(),
-				$this
-			);
-		}
-		return $this->summary_shortcode;
-	}
+    private function get_summary_shortcode(): SummaryShortcode {
+        if ( $this->summary_shortcode === null ) {
+            $this->summary_shortcode = new SummaryShortcode(
+                $this->nuclen_get_settings_repository(),
+                $this
+            );
+        }
+        return $this->summary_shortcode;
+    }
 
-	/* ---------- Auto-insert into content ---------- */
-	public function nuclen_auto_insert_shortcodes( $content ) {
-		$settings_repo    = $this->nuclen_get_settings_repository();
-		$summary_position = $settings_repo->get( 'display_summary', 'none' );
-		$quiz_position    = $settings_repo->get( 'display_quiz', 'none' );
-		$toc_position     = $settings_repo->get( 'display_toc', 'manual' );
+    /* ---------- Auto-insert into content ---------- */
+    public function nuclen_auto_insert_shortcodes( $content ) {
+        $settings_repo    = $this->nuclen_get_settings_repository();
+        $summary_position = $settings_repo->get( 'display_summary', 'none' );
+        $quiz_position    = $settings_repo->get( 'display_quiz', 'none' );
+        $toc_position     = $settings_repo->get( 'display_toc', 'manual' );
 
-		$elements = array(
-			'summary' => array(
-				'position'  => $summary_position,
-				'shortcode' => '[nuclear_engagement_summary]',
-			),
-			'quiz'    => array(
-				'position'  => $quiz_position,
-				'shortcode' => '[nuclear_engagement_quiz]',
-			),
-			'toc'     => array(
-				'position'  => $toc_position,
-				'shortcode' => '[nuclear_engagement_toc]',
-			),
-		);
+        $elements = array(
+            'summary' => array(
+                'position'  => $summary_position,
+                'shortcode' => '[nuclear_engagement_summary]',
+            ),
+            'quiz'    => array(
+                'position'  => $quiz_position,
+                'shortcode' => '[nuclear_engagement_quiz]',
+            ),
+            'toc'     => array(
+                'position'  => $toc_position,
+                'shortcode' => '[nuclear_engagement_toc]',
+            ),
+        );
 
-		$before_content = '';
-		if ( $elements['summary']['position'] === 'before' ) {
-			$before_content .= do_shortcode( $elements['summary']['shortcode'] );
-		}
-		if ( $elements['toc']['position'] === 'before' ) {
-			$before_content .= do_shortcode( $elements['toc']['shortcode'] );
-		}
-		if ( $elements['quiz']['position'] === 'before' ) {
-			$before_content .= do_shortcode( $elements['quiz']['shortcode'] );
-		}
+        $before_content = '';
+        if ( $elements['summary']['position'] === 'before' ) {
+            $before_content .= do_shortcode( $elements['summary']['shortcode'] );
+        }
+        if ( $elements['toc']['position'] === 'before' ) {
+            $before_content .= do_shortcode( $elements['toc']['shortcode'] );
+        }
+        if ( $elements['quiz']['position'] === 'before' ) {
+            $before_content .= do_shortcode( $elements['quiz']['shortcode'] );
+        }
 
-		$after_content = '';
-		if ( $elements['summary']['position'] === 'after' ) {
-			$after_content .= do_shortcode( $elements['summary']['shortcode'] );
-		}
-		if ( $elements['toc']['position'] === 'after' ) {
-			$after_content .= do_shortcode( $elements['toc']['shortcode'] );
-		}
-		if ( $elements['quiz']['position'] === 'after' ) {
-			$after_content .= do_shortcode( $elements['quiz']['shortcode'] );
-		}
+        $after_content = '';
+        if ( $elements['summary']['position'] === 'after' ) {
+            $after_content .= do_shortcode( $elements['summary']['shortcode'] );
+        }
+        if ( $elements['toc']['position'] === 'after' ) {
+            $after_content .= do_shortcode( $elements['toc']['shortcode'] );
+        }
+        if ( $elements['quiz']['position'] === 'after' ) {
+            $after_content .= do_shortcode( $elements['quiz']['shortcode'] );
+        }
 
-		return $before_content . $content . $after_content;
-	}
+        return $before_content . $content . $after_content;
+    }
 
-	/* ---------- Shortcode registrations ---------- */
-	public function nuclen_register_quiz_shortcode() {
-		$this->get_quiz_shortcode()->register();
-	}
+    /* ---------- Shortcode registrations ---------- */
+    public function nuclen_register_quiz_shortcode() {
+        $this->get_quiz_shortcode()->register();
+    }
 
-	public function nuclen_register_summary_shortcode() {
-		$this->get_summary_shortcode()->register();
-	}
+    public function nuclen_register_summary_shortcode() {
+        $this->get_summary_shortcode()->register();
+    }
 }

--- a/nuclear-engagement/inc/Core/Activator.php
+++ b/nuclear-engagement/inc/Core/Activator.php
@@ -9,29 +9,29 @@ use NuclearEngagement\OptinData;
 use NuclearEngagement\AssetVersions;
 
 if ( ! defined( 'ABSPATH' ) ) {
-	exit;
+    exit;
 }
 
 class Activator {
-	/**
-	 * Plugin activation hook
-	 *
-	 * @param SettingsRepository|null $settings Optional settings repository instance
-	 */
-	public static function nuclen_activate( ?SettingsRepository $settings = null ) {
-		// Set transient for activation redirect
-		set_transient( 'nuclen_plugin_activation_redirect', true, NUCLEN_ACTIVATION_REDIRECT_TTL );
+    /**
+     * Plugin activation hook
+     *
+     * @param SettingsRepository|null $settings Optional settings repository instance
+     */
+    public static function nuclen_activate( ?SettingsRepository $settings = null ) {
+        // Set transient for activation redirect
+        set_transient( 'nuclen_plugin_activation_redirect', true, NUCLEN_ACTIVATION_REDIRECT_TTL );
 
-		// Get default settings
-		$default_settings = Defaults::nuclen_get_default_settings();
+        // Get default settings
+        $default_settings = Defaults::nuclen_get_default_settings();
 
-		// Initialize or update settings repository with defaults
-		$settings = $settings ?: \NuclearEngagement\Container::getInstance()->get( 'settings' );
+        // Initialize or update settings repository with defaults
+        $settings = $settings ?: \NuclearEngagement\Container::getInstance()->get( 'settings' );
 
-		// Only set the setup option if it doesn't already exist
-		if ( false === get_option( 'nuclear_engagement_setup' ) ) {
-			update_option( 'nuclear_engagement_setup', $default_settings );
-		}
+        // Only set the setup option if it doesn't already exist
+        if ( false === get_option( 'nuclear_engagement_setup' ) ) {
+            update_option( 'nuclear_engagement_setup', $default_settings );
+        }
 
                 // Ensure opt-in table exists on activation
                 OptinData::maybe_create_table();

--- a/nuclear-engagement/inc/Core/AssetVersions.php
+++ b/nuclear-engagement/inc/Core/AssetVersions.php
@@ -3,63 +3,63 @@ declare(strict_types=1);
 namespace NuclearEngagement;
 
 if ( ! defined( 'ABSPATH' ) ) {
-	exit;
+    exit;
 }
 
 /**
  * Handles versioning for compiled plugin assets.
  */
 final class AssetVersions {
-	private const OPTION        = 'nuclen_asset_versions';
-	private const PLUGIN_OPTION = 'nuclen_asset_versions_build';
+    private const OPTION        = 'nuclen_asset_versions';
+    private const PLUGIN_OPTION = 'nuclen_asset_versions_build';
 
-	/**
-	 * Recompute asset versions when the stored plugin version differs.
-	 */
-	public static function init(): void {
-		$stored = get_option( self::PLUGIN_OPTION );
-		if ( $stored !== NUCLEN_PLUGIN_VERSION ) {
-			self::update_versions();
-		}
-	}
+    /**
+     * Recompute asset versions when the stored plugin version differs.
+     */
+    public static function init(): void {
+        $stored = get_option( self::PLUGIN_OPTION );
+        if ( $stored !== NUCLEN_PLUGIN_VERSION ) {
+            self::update_versions();
+        }
+    }
 
-	/**
-	 * Compute and store asset version strings.
-	 */
-	public static function update_versions(): void {
-		update_option( self::OPTION, self::compute() );
-		update_option( self::PLUGIN_OPTION, NUCLEN_PLUGIN_VERSION );
-	}
+    /**
+     * Compute and store asset version strings.
+     */
+    public static function update_versions(): void {
+        update_option( self::OPTION, self::compute() );
+        update_option( self::PLUGIN_OPTION, NUCLEN_PLUGIN_VERSION );
+    }
 
-	/**
-	 * Retrieve a version string for the given key.
-	 */
-	public static function get( string $key ): string {
-		$versions = get_option( self::OPTION, array() );
-		return isset( $versions[ $key ] ) ? $versions[ $key ] : NUCLEN_ASSET_VERSION;
-	}
+    /**
+     * Retrieve a version string for the given key.
+     */
+    public static function get( string $key ): string {
+        $versions = get_option( self::OPTION, array() );
+        return isset( $versions[ $key ] ) ? $versions[ $key ] : NUCLEN_ASSET_VERSION;
+    }
 
-	/**
-	 * Build the version map based on file modification times.
-	 */
-	private static function compute(): array {
-		$files = array(
-			'admin_css'        => NUCLEN_PLUGIN_DIR . 'admin/css/nuclen-admin.css',
-			'admin_dashboard'  => NUCLEN_PLUGIN_DIR . 'admin/css/nuclen-admin-dashboard.css',
-			'admin_js'         => NUCLEN_PLUGIN_DIR . 'admin/js/nuclen-admin.js',
-			'onboarding_js'    => NUCLEN_PLUGIN_DIR . 'admin/js/onboarding-pointers.js',
-			'front_css'        => NUCLEN_PLUGIN_DIR . 'front/css/nuclen-front.css',
+    /**
+     * Build the version map based on file modification times.
+     */
+    private static function compute(): array {
+        $files = array(
+            'admin_css'        => NUCLEN_PLUGIN_DIR . 'admin/css/nuclen-admin.css',
+            'admin_dashboard'  => NUCLEN_PLUGIN_DIR . 'admin/css/nuclen-admin-dashboard.css',
+            'admin_js'         => NUCLEN_PLUGIN_DIR . 'admin/js/nuclen-admin.js',
+            'onboarding_js'    => NUCLEN_PLUGIN_DIR . 'admin/js/onboarding-pointers.js',
+            'front_css'        => NUCLEN_PLUGIN_DIR . 'front/css/nuclen-front.css',
                         'front_js'         => NUCLEN_PLUGIN_DIR . 'front/js/nuclen-front.js',
                         'toc_admin_css'    => NUCLEN_PLUGIN_DIR . 'inc/Modules/TOC/assets/css/nuclen-toc-admin.css',
                         'toc_admin_js'     => NUCLEN_PLUGIN_DIR . 'inc/Modules/TOC/assets/js/nuclen-toc-admin.js',
                         'toc_front_css'    => NUCLEN_PLUGIN_DIR . 'inc/Modules/TOC/assets/css/nuclen-toc-front.css',
                         'toc_front_js'     => NUCLEN_PLUGIN_DIR . 'inc/Modules/TOC/assets/js/nuclen-toc-front.js',
-		);
+        );
 
-		$versions = array();
-		foreach ( $files as $key => $path ) {
-			$versions[ $key ] = file_exists( $path ) ? (string) filemtime( $path ) : (string) time();
-		}
-		return $versions;
-	}
+        $versions = array();
+        foreach ( $files as $key => $path ) {
+            $versions[ $key ] = file_exists( $path ) ? (string) filemtime( $path ) : (string) time();
+        }
+        return $versions;
+    }
 }

--- a/nuclear-engagement/inc/Core/Blocks.php
+++ b/nuclear-engagement/inc/Core/Blocks.php
@@ -3,7 +3,7 @@ declare(strict_types=1);
 namespace NuclearEngagement;
 
 if ( ! defined( 'ABSPATH' ) ) {
-	exit;
+    exit;
 }
 
 /**
@@ -12,7 +12,7 @@ if ( ! defined( 'ABSPATH' ) ) {
  * enabling block editor workflows.
  */
 final class Blocks {
-	public static function register(): void {
+    public static function register(): void {
                 if ( ! function_exists( 'register_block_type' ) ) {
                         \NuclearEngagement\Services\LoggingService::log( 'Nuclear Engagement: block registration unavailable.' );
                         return;
@@ -23,40 +23,40 @@ final class Blocks {
                         return;
                 }
 
-		register_block_type(
-			'nuclear-engagement/quiz',
-			array(
-				'api_version'     => 2,
-				'title'           => __( 'Quiz', 'nuclear-engagement' ),
-				'category'        => 'widgets',
-				'icon'            => 'editor-help',
-				'render_callback' => static function (): string {
-					$out = do_shortcode( '[nuclear_engagement_quiz]' );
-					if ( ! is_string( $out ) || trim( $out ) === '' ) {
-						return '<p>' . esc_html__( 'Quiz unavailable.', 'nuclear-engagement' ) . '</p>';
-					}
-					return $out;
-				},
-				'editor_script'   => 'nuclen-admin',
-			)
-		);
+        register_block_type(
+            'nuclear-engagement/quiz',
+            array(
+                'api_version'     => 2,
+                'title'           => __( 'Quiz', 'nuclear-engagement' ),
+                'category'        => 'widgets',
+                'icon'            => 'editor-help',
+                'render_callback' => static function (): string {
+                    $out = do_shortcode( '[nuclear_engagement_quiz]' );
+                    if ( ! is_string( $out ) || trim( $out ) === '' ) {
+                        return '<p>' . esc_html__( 'Quiz unavailable.', 'nuclear-engagement' ) . '</p>';
+                    }
+                    return $out;
+                },
+                'editor_script'   => 'nuclen-admin',
+            )
+        );
 
-		register_block_type(
-			'nuclear-engagement/summary',
-			array(
-				'api_version'     => 2,
-				'title'           => __( 'Summary', 'nuclear-engagement' ),
-				'category'        => 'widgets',
-				'icon'            => 'excerpt-view',
-				'render_callback' => static function (): string {
-					$out = do_shortcode( '[nuclear_engagement_summary]' );
-					if ( ! is_string( $out ) || trim( $out ) === '' ) {
-						return '<p>' . esc_html__( 'Summary unavailable.', 'nuclear-engagement' ) . '</p>';
-					}
-					return $out;
-				},
-				'editor_script'   => 'nuclen-admin',
-			)
-		);
-	}
+        register_block_type(
+            'nuclear-engagement/summary',
+            array(
+                'api_version'     => 2,
+                'title'           => __( 'Summary', 'nuclear-engagement' ),
+                'category'        => 'widgets',
+                'icon'            => 'excerpt-view',
+                'render_callback' => static function (): string {
+                    $out = do_shortcode( '[nuclear_engagement_summary]' );
+                    if ( ! is_string( $out ) || trim( $out ) === '' ) {
+                        return '<p>' . esc_html__( 'Summary unavailable.', 'nuclear-engagement' ) . '</p>';
+                    }
+                    return $out;
+                },
+                'editor_script'   => 'nuclen-admin',
+            )
+        );
+    }
 }

--- a/nuclear-engagement/inc/Core/Container.php
+++ b/nuclear-engagement/inc/Core/Container.php
@@ -11,82 +11,82 @@ declare(strict_types=1);
 namespace NuclearEngagement;
 
 if ( ! defined( 'ABSPATH' ) ) {
-	exit;
+    exit;
 }
 
 /**
  * Simple service container for dependency injection
  */
 class Container {
-	/**
-	 * @var self|null Singleton instance
-	 */
-	private static ?self $instance = null;
+    /**
+     * @var self|null Singleton instance
+     */
+    private static ?self $instance = null;
 
-	/**
-	 * @var array Stored service instances
-	 */
-	private array $services = array();
+    /**
+     * @var array Stored service instances
+     */
+    private array $services = array();
 
-	/**
-	 * @var array Service factory callbacks
-	 */
-	private array $factories = array();
+    /**
+     * @var array Service factory callbacks
+     */
+    private array $factories = array();
 
-	/**
-	 * Get the singleton instance
-	 *
-	 * @return self
-	 */
-	public static function getInstance(): self {
-		if ( self::$instance === null ) {
-			self::$instance = new self();
-		}
-		return self::$instance;
-	}
+    /**
+     * Get the singleton instance
+     *
+     * @return self
+     */
+    public static function getInstance(): self {
+        if ( self::$instance === null ) {
+            self::$instance = new self();
+        }
+        return self::$instance;
+    }
 
-	/**
-	 * Register a service factory
-	 *
-	 * @param string   $id Service identifier
-	 * @param callable $factory Factory callback
-	 */
-	public function register( string $id, callable $factory ): void {
-		$this->factories[ $id ] = $factory;
-	}
+    /**
+     * Register a service factory
+     *
+     * @param string   $id Service identifier
+     * @param callable $factory Factory callback
+     */
+    public function register( string $id, callable $factory ): void {
+        $this->factories[ $id ] = $factory;
+    }
 
-	/**
-	 * Get a service instance
-	 *
-	 * @param string $id Service identifier
-	 * @return mixed Service instance
-	 * @throws \RuntimeException If service not registered
-	 */
-	public function get( string $id ) {
-		if ( ! isset( $this->services[ $id ] ) ) {
-			if ( ! isset( $this->factories[ $id ] ) ) {
-				throw new \RuntimeException( "Service {$id} not registered" );
-			}
-			$this->services[ $id ] = $this->factories[ $id ]( $this );
-		}
-		return $this->services[ $id ];
-	}
+    /**
+     * Get a service instance
+     *
+     * @param string $id Service identifier
+     * @return mixed Service instance
+     * @throws \RuntimeException If service not registered
+     */
+    public function get( string $id ) {
+        if ( ! isset( $this->services[ $id ] ) ) {
+            if ( ! isset( $this->factories[ $id ] ) ) {
+                throw new \RuntimeException( "Service {$id} not registered" );
+            }
+            $this->services[ $id ] = $this->factories[ $id ]( $this );
+        }
+        return $this->services[ $id ];
+    }
 
-	/**
-	 * Check if a service is registered
-	 *
-	 * @param string $id Service identifier
-	 * @return bool
-	 */
-	public function has( string $id ): bool {
-		return isset( $this->factories[ $id ] );
-	}
+    /**
+     * Check if a service is registered
+     *
+     * @param string $id Service identifier
+     * @return bool
+     */
+    public function has( string $id ): bool {
+        return isset( $this->factories[ $id ] );
+    }
 
-	/**
-	 * Reset the container (mainly for testing)
-	 */
-	public function reset(): void {
-		$this->services  = array();
-		$this->factories = array();
-	}
+    /**
+     * Reset the container (mainly for testing)
+     */
+    public function reset(): void {
+        $this->services  = array();
+        $this->factories = array();
+    }
 }

--- a/nuclear-engagement/inc/Core/ContainerRegistrar.php
+++ b/nuclear-engagement/inc/Core/ContainerRegistrar.php
@@ -14,15 +14,15 @@ use NuclearEngagement\Admin\Controller\OptinExportController;
 use NuclearEngagement\Front\Controller\Rest\ContentController;
 
 if ( ! defined( 'ABSPATH' ) ) {
-	exit;
+    exit;
 }
 
 final class ContainerRegistrar {
-	public static function register( Container $container, SettingsRepository $settings ): void {
-		$container->register( 'settings', static fn() => $settings );
+    public static function register( Container $container, SettingsRepository $settings ): void {
+        $container->register( 'settings', static fn() => $settings );
 
-		$container->register( 'remote_api', static fn( $c ) => new RemoteApiService( $c->get( 'settings' ) ) );
-		$container->register( 'content_storage', static fn( $c ) => new ContentStorageService( $c->get( 'settings' ) ) );
+        $container->register( 'remote_api', static fn( $c ) => new RemoteApiService( $c->get( 'settings' ) ) );
+        $container->register( 'content_storage', static fn( $c ) => new ContentStorageService( $c->get( 'settings' ) ) );
 
                 $container->register(
                         'generation_poller',
@@ -48,12 +48,12 @@ final class ContainerRegistrar {
                         )
                 );
 
-		$container->register(
-			'publish_generation_handler',
-			static fn( $c ) => new PublishGenerationHandler(
-				$c->get( 'settings' )
-			)
-		);
+        $container->register(
+            'publish_generation_handler',
+            static fn( $c ) => new PublishGenerationHandler(
+                $c->get( 'settings' )
+            )
+        );
 
                 $container->register(
                         'auto_generation_service',
@@ -65,24 +65,24 @@ final class ContainerRegistrar {
                         )
                 );
 
-		$container->register(
-			'generation_service',
-			static fn( $c ) => new GenerationService(
-				$c->get( 'settings' ),
-				$c->get( 'remote_api' ),
-				$c->get( 'content_storage' )
-			)
-		);
+        $container->register(
+            'generation_service',
+            static fn( $c ) => new GenerationService(
+                $c->get( 'settings' ),
+                $c->get( 'remote_api' ),
+                $c->get( 'content_storage' )
+            )
+        );
 
-		$container->register( 'pointer_service', static fn() => new PointerService() );
+        $container->register( 'pointer_service', static fn() => new PointerService() );
                 $container->register( 'posts_query_service', static fn() => new PostsQueryService() );
                 $container->register( 'dashboard_data_service', static fn() => new DashboardDataService() );
                 $container->register( 'version_service', static fn() => new VersionService() );
 
-		$container->register( 'generate_controller', static fn( $c ) => new GenerateController( $c->get( 'generation_service' ) ) );
-		$container->register( 'updates_controller', static fn( $c ) => new UpdatesController( $c->get( 'remote_api' ), $c->get( 'content_storage' ) ) );
-		$container->register( 'pointer_controller', static fn( $c ) => new PointerController( $c->get( 'pointer_service' ) ) );
-		$container->register( 'posts_count_controller', static fn( $c ) => new PostsCountController( $c->get( 'posts_query_service' ) ) );
+        $container->register( 'generate_controller', static fn( $c ) => new GenerateController( $c->get( 'generation_service' ) ) );
+        $container->register( 'updates_controller', static fn( $c ) => new UpdatesController( $c->get( 'remote_api' ), $c->get( 'content_storage' ) ) );
+        $container->register( 'pointer_controller', static fn( $c ) => new PointerController( $c->get( 'pointer_service' ) ) );
+        $container->register( 'posts_count_controller', static fn( $c ) => new PostsCountController( $c->get( 'posts_query_service' ) ) );
                 $container->register(
                         'content_controller',
                         static fn( $c ) => new ContentController(
@@ -90,6 +90,6 @@ final class ContainerRegistrar {
                                 $c->get( 'settings' )
                         )
                 );
-		$container->register( 'optin_export_controller', static fn() => new OptinExportController() );
-	}
+        $container->register( 'optin_export_controller', static fn() => new OptinExportController() );
+    }
 }

--- a/nuclear-engagement/inc/Core/Deactivator.php
+++ b/nuclear-engagement/inc/Core/Deactivator.php
@@ -7,7 +7,7 @@ use NuclearEngagement\SettingsRepository;
 use NuclearEngagement\Services\AutoGenerationService;
 
 if ( ! defined( 'ABSPATH' ) ) {
-	exit;
+    exit;
 }
 
 /**
@@ -31,12 +31,12 @@ if ( ! defined( 'ABSPATH' ) ) {
  * @author   Stefano Lodola <stefano@nuclearengagement.com>
  */
 class Deactivator {
-	/**
-	 * Handle plugin deactivation
-	 *
-	 * @since 0.3.1
-	 * @param SettingsRepository|null $settings Optional settings repository instance
-	 */
+    /**
+     * Handle plugin deactivation
+     *
+     * @since 0.3.1
+     * @param SettingsRepository|null $settings Optional settings repository instance
+     */
         public static function nuclen_deactivate( ?SettingsRepository $settings = null ) {
                 // Clear scheduled cron hooks
                 wp_clear_scheduled_hook( AutoGenerationService::START_HOOK );
@@ -49,10 +49,10 @@ class Deactivator {
                 // Clear any scheduled hooks or transients if needed
                 delete_transient( 'nuclen_plugin_activation_redirect' );
 
-		// If settings instance is provided, perform any necessary cleanup
-		if ( $settings !== null ) {
-			// Clear any cached settings if needed
-			$settings->clear_cache();
-		}
-	}
+        // If settings instance is provided, perform any necessary cleanup
+        if ( $settings !== null ) {
+            // Clear any cached settings if needed
+            $settings->clear_cache();
+        }
+    }
 }

--- a/nuclear-engagement/inc/Core/Defaults.php
+++ b/nuclear-engagement/inc/Core/Defaults.php
@@ -9,112 +9,112 @@ declare(strict_types=1);
 namespace NuclearEngagement;
 
 if ( ! defined( 'ABSPATH' ) ) {
-	exit;
+    exit;
 }
 
 class Defaults {
 
-	public static function nuclen_get_default_settings() {
-		return array(
-			'theme'                                 => 'bright',
+    public static function nuclen_get_default_settings() {
+        return array(
+            'theme'                                 => 'bright',
 
-			/* ───── Quiz styling ───── */
-			'font_size'                             => '16',
-			'font_color'                            => '#000000',
-			'bg_color'                              => '#ffffff',
-			'quiz_border_color'                     => '#000000',
-			'quiz_border_style'                     => 'solid',
-			'quiz_border_width'                     => '1',
-			'quiz_border_radius'                    => '6',
-			'quiz_shadow_color'                     => 'rgba(0,0,0,0.15)',
-			'quiz_shadow_blur'                      => '8',
+            /* ───── Quiz styling ───── */
+            'font_size'                             => '16',
+            'font_color'                            => '#000000',
+            'bg_color'                              => '#ffffff',
+            'quiz_border_color'                     => '#000000',
+            'quiz_border_style'                     => 'solid',
+            'quiz_border_width'                     => '1',
+            'quiz_border_radius'                    => '6',
+            'quiz_shadow_color'                     => 'rgba(0,0,0,0.15)',
+            'quiz_shadow_blur'                      => '8',
 
-			'quiz_answer_button_bg_color'           => '#94544A',
-			'quiz_answer_button_border_color'       => '#94544A',
-			'quiz_answer_button_border_width'       => '2',
-			'quiz_answer_button_border_radius'      => '4',
+            'quiz_answer_button_bg_color'           => '#94544A',
+            'quiz_answer_button_border_color'       => '#94544A',
+            'quiz_answer_button_border_width'       => '2',
+            'quiz_answer_button_border_radius'      => '4',
 
-			'quiz_progress_bar_fg_color'            => '#1B977D',
-			'quiz_progress_bar_bg_color'            => '#e0e0e0',
-			'quiz_progress_bar_height'              => '10',
+            'quiz_progress_bar_fg_color'            => '#1B977D',
+            'quiz_progress_bar_bg_color'            => '#e0e0e0',
+            'quiz_progress_bar_height'              => '10',
 
-			/* ───── Summary styling ───── */
-			'summary_font_size'                     => '16',
-			'summary_font_color'                    => '#000000',
-			'summary_bg_color'                      => '#ffffff',
-			'summary_border_color'                  => '#000000',
-			'summary_border_style'                  => 'solid',
-			'summary_border_width'                  => '1',
-			'summary_border_radius'                 => '6',
-			'summary_shadow_color'                  => 'rgba(0,0,0,0.15)',
-			'summary_shadow_blur'                   => '8',
+            /* ───── Summary styling ───── */
+            'summary_font_size'                     => '16',
+            'summary_font_color'                    => '#000000',
+            'summary_bg_color'                      => '#ffffff',
+            'summary_border_color'                  => '#000000',
+            'summary_border_style'                  => 'solid',
+            'summary_border_width'                  => '1',
+            'summary_border_radius'                 => '6',
+            'summary_shadow_color'                  => 'rgba(0,0,0,0.15)',
+            'summary_shadow_blur'                   => '8',
 
-			/* ───── TOC styling ───── */
-			'toc_font_size'                         => '16',
-			'toc_font_color'                        => '#000000',
-			'toc_bg_color'                          => '#ffffff',
-			'toc_border_color'                      => '#000000',
-			'toc_border_style'                      => 'solid',
-			'toc_border_width'                      => '1',
-			'toc_border_radius'                     => '6',
-			'toc_shadow_color'                      => 'rgba(0,0,0,0.05)',
-			'toc_shadow_blur'                       => '8',
-			'toc_z_index'                           => '100',
-			'toc_link_color'                        => '#1e73be',
+            /* ───── TOC styling ───── */
+            'toc_font_size'                         => '16',
+            'toc_font_color'                        => '#000000',
+            'toc_bg_color'                          => '#ffffff',
+            'toc_border_color'                      => '#000000',
+            'toc_border_style'                      => 'solid',
+            'toc_border_width'                      => '1',
+            'toc_border_radius'                     => '6',
+            'toc_shadow_color'                      => 'rgba(0,0,0,0.05)',
+            'toc_shadow_blur'                       => '8',
+            'toc_z_index'                           => '100',
+            'toc_link_color'                        => '#1e73be',
 
-			/* ───── Quiz items ───── */
-			'questions_per_quiz'                    => '10',
-			'answers_per_question'                  => '4',
+            /* ───── Quiz items ───── */
+            'questions_per_quiz'                    => '10',
+            'answers_per_question'                  => '4',
 
-			/* ───── Display ───── */
-			'display_summary'                       => 'before',
-			'display_quiz'                          => 'after',
-			'display_toc'                           => 'manual',
-			'toc_sticky'                            => false, // Whether to make TOC sticky when scrolling
-			'toc_sticky_offset_x'                   => '20',   // X offset (left) for sticky TOC in pixels
-			'toc_sticky_offset_y'                   => '20',   // Y offset (top) for sticky TOC in pixels
-			'toc_sticky_max_width'                  => '300',  // Max width for sticky TOC in pixels
-			'toc_show_toggle'                       => true,   // Whether to show the TOC toggle button
-			'toc_show_content'                      => true,   // Whether to show TOC content by default (only used if toggle is enabled)
-			'toc_heading_levels'                    => array( 2, 3, 4, 5, 6 ), // Which heading levels to include in TOC (H2-H6)
-			'custom_quiz_html_before'               => '',
-			'custom_quiz_html_after'                => '',
-			'quiz_title'                            => 'Test your knowledge',
-			'summary_title'                         => 'Key Facts',
-			'toc_title'                             => 'Table of Contents',
+            /* ───── Display ───── */
+            'display_summary'                       => 'before',
+            'display_quiz'                          => 'after',
+            'display_toc'                           => 'manual',
+            'toc_sticky'                            => false, // Whether to make TOC sticky when scrolling
+            'toc_sticky_offset_x'                   => '20',   // X offset (left) for sticky TOC in pixels
+            'toc_sticky_offset_y'                   => '20',   // Y offset (top) for sticky TOC in pixels
+            'toc_sticky_max_width'                  => '300',  // Max width for sticky TOC in pixels
+            'toc_show_toggle'                       => true,   // Whether to show the TOC toggle button
+            'toc_show_content'                      => true,   // Whether to show TOC content by default (only used if toggle is enabled)
+            'toc_heading_levels'                    => array( 2, 3, 4, 5, 6 ), // Which heading levels to include in TOC (H2-H6)
+            'custom_quiz_html_before'               => '',
+            'custom_quiz_html_after'                => '',
+            'quiz_title'                            => 'Test your knowledge',
+            'summary_title'                         => 'Key Facts',
+            'toc_title'                             => 'Table of Contents',
 
-			/* ───── Quiz strings ───── */
-			'quiz_label_retake_test'                => 'Retake Test',
-			'quiz_label_your_score'                 => 'Your Score',
-			'quiz_label_perfect'                    => 'Perfect!',
-			'quiz_label_well_done'                  => 'Well done!',
-			'quiz_label_retake_prompt'              => 'Why not retake the test?',
-			'quiz_label_correct'                    => 'Correct:',
-			'quiz_label_your_answer'                => 'Your answer:',
+            /* ───── Quiz strings ───── */
+            'quiz_label_retake_test'                => 'Retake Test',
+            'quiz_label_your_score'                 => 'Your Score',
+            'quiz_label_perfect'                    => 'Perfect!',
+            'quiz_label_well_done'                  => 'Well done!',
+            'quiz_label_retake_prompt'              => 'Why not retake the test?',
+            'quiz_label_correct'                    => 'Correct:',
+            'quiz_label_your_answer'                => 'Your answer:',
 
-			/* ───── Opt-in ───── */
-			'enable_optin'                          => false,
-			'optin_webhook'                         => '',
-			'optin_position'                        => 'with_results',
-			'optin_mandatory'                       => false,
-			'optin_prompt_text'                     => 'Please enter your details to view your score:',
-			'optin_button_text'                     => 'Submit',
+            /* ───── Opt-in ───── */
+            'enable_optin'                          => false,
+            'optin_webhook'                         => '',
+            'optin_position'                        => 'with_results',
+            'optin_mandatory'                       => false,
+            'optin_prompt_text'                     => 'Please enter your details to view your score:',
+            'optin_button_text'                     => 'Submit',
 
-			/* ───── Generation ───── */
-			'update_last_modified'                  => false,
-			'auto_generate_quiz_on_publish'         => 0,
-			'auto_generate_summary_on_publish'      => 0,
-			'generation_post_types'                 => array( 'post' ),
+            /* ───── Generation ───── */
+            'update_last_modified'                  => false,
+            'auto_generate_quiz_on_publish'         => 0,
+            'auto_generate_summary_on_publish'      => 0,
+            'generation_post_types'                 => array( 'post' ),
 
-			/* ───── Attribution ───── */
-			'show_attribution'                      => false,
+            /* ───── Attribution ───── */
+            'show_attribution'                      => false,
 
-			/* ───── Uninstall ───── */
-			'delete_settings_on_uninstall'          => false,
-			'delete_generated_content_on_uninstall' => false,
-			'delete_optin_data_on_uninstall'        => false,
-			'delete_log_file_on_uninstall'          => false,
-			'delete_custom_css_on_uninstall'        => false,
-		);
-	}
+            /* ───── Uninstall ───── */
+            'delete_settings_on_uninstall'          => false,
+            'delete_generated_content_on_uninstall' => false,
+            'delete_optin_data_on_uninstall'        => false,
+            'delete_log_file_on_uninstall'          => false,
+            'delete_custom_css_on_uninstall'        => false,
+        );
+    }
 }

--- a/nuclear-engagement/inc/Core/InventoryCache.php
+++ b/nuclear-engagement/inc/Core/InventoryCache.php
@@ -11,15 +11,15 @@ declare(strict_types=1);
 namespace NuclearEngagement;
 
 if ( ! defined( 'ABSPATH' ) ) {
-	exit;
+    exit;
 }
 
 final class InventoryCache {
-	/** Cache key base for inventory data. */
-	public const CACHE_KEY = 'nuclen_inventory_data';
+    /** Cache key base for inventory data. */
+    public const CACHE_KEY = 'nuclen_inventory_data';
 
-	/** Cache group used for inventory. */
-	public const CACHE_GROUP = 'nuclen_inventory';
+    /** Cache group used for inventory. */
+    public const CACHE_GROUP = 'nuclen_inventory';
 
         /** Default cache lifetime. */
         public const CACHE_EXPIRATION = HOUR_IN_SECONDS;
@@ -30,53 +30,53 @@ final class InventoryCache {
        /** Seconds to debounce consecutive clears. */
        public const CLEAR_DEBOUNCE = 2;
 
-	/**
-	 * Register hooks to automatically clear the cache when posts change.
-	 */
-	public static function register_hooks(): void {
-		$cb = array( self::class, 'clear' );
-		foreach ( array(
-			'save_post',
-			'delete_post',
-			'deleted_post',
-			'trashed_post',
-			'untrashed_post',
-			'transition_post_status',
-			'clean_post_cache',
-		) as $hook ) {
-			add_action( $hook, $cb );
-		}
-		foreach ( array( 'added_post_meta', 'updated_post_meta', 'deleted_post_meta' ) as $hook ) {
-			add_action( $hook, $cb );
-		}
-		foreach ( array(
-			'create_term',
-			'created_term',
-			'edit_term',
-			'edited_term',
-			'delete_term',
-			'deleted_term',
-			'set_object_terms',
-			'added_term_relationship',
-			'deleted_term_relationships',
-			'edited_terms',
-		) as $hook ) {
-			add_action( $hook, $cb );
-		}
-		add_action( 'switch_blog', $cb );
-	}
+    /**
+     * Register hooks to automatically clear the cache when posts change.
+     */
+    public static function register_hooks(): void {
+        $cb = array( self::class, 'clear' );
+        foreach ( array(
+            'save_post',
+            'delete_post',
+            'deleted_post',
+            'trashed_post',
+            'untrashed_post',
+            'transition_post_status',
+            'clean_post_cache',
+        ) as $hook ) {
+            add_action( $hook, $cb );
+        }
+        foreach ( array( 'added_post_meta', 'updated_post_meta', 'deleted_post_meta' ) as $hook ) {
+            add_action( $hook, $cb );
+        }
+        foreach ( array(
+            'create_term',
+            'created_term',
+            'edit_term',
+            'edited_term',
+            'delete_term',
+            'deleted_term',
+            'set_object_terms',
+            'added_term_relationship',
+            'deleted_term_relationships',
+            'edited_terms',
+        ) as $hook ) {
+            add_action( $hook, $cb );
+        }
+        add_action( 'switch_blog', $cb );
+    }
 
-	/**
-	 * Get the cache key for the current site.
-	 */
-	private static function get_cache_key(): string {
-		return self::CACHE_KEY . '_' . get_current_blog_id();
-	}
+    /**
+     * Get the cache key for the current site.
+     */
+    private static function get_cache_key(): string {
+        return self::CACHE_KEY . '_' . get_current_blog_id();
+    }
 
-	/**
-	 * Get cached inventory data.
-	 */
-	public static function get(): ?array {
+    /**
+     * Get cached inventory data.
+     */
+    public static function get(): ?array {
                 $key    = self::get_cache_key();
                 $found  = false;
                 $cached = wp_cache_get( $key, self::CACHE_GROUP, false, $found );
@@ -87,19 +87,19 @@ final class InventoryCache {
                 return is_array( $cached ) ? $cached : null;
         }
 
-	/**
-	 * Store inventory data in cache.
-	 */
-	public static function set( array $data ): void {
+    /**
+     * Store inventory data in cache.
+     */
+    public static function set( array $data ): void {
                 $key = self::get_cache_key();
 
                 wp_cache_set( $key, $data, self::CACHE_GROUP, self::CACHE_EXPIRATION );
                 set_transient( $key, $data, self::CACHE_EXPIRATION );
         }
 
-	/**
-	 * Clear the inventory cache.
-	 */
+    /**
+     * Clear the inventory cache.
+     */
         public static function clear(): void {
                $now  = time();
                $last = (int) wp_cache_get( self::CLEAR_TS_KEY, self::CACHE_GROUP );

--- a/nuclear-engagement/inc/Core/Loader.php
+++ b/nuclear-engagement/inc/Core/Loader.php
@@ -3,42 +3,42 @@ declare(strict_types=1);
 namespace NuclearEngagement;
 
 if ( ! defined( 'ABSPATH' ) ) {
-	exit;
+    exit;
 }
 
 
 class Loader {
-	protected $actions = array();
-	protected $filters = array();
+    protected $actions = array();
+    protected $filters = array();
 
-	public function nuclen_add_action( $hook, $component, $callback, $priority = 10, $accepted_args = 1 ) {
-		$this->actions = $this->nuclen_add( $this->actions, $hook, $component, $callback, $priority, $accepted_args );
-	}
+    public function nuclen_add_action( $hook, $component, $callback, $priority = 10, $accepted_args = 1 ) {
+        $this->actions = $this->nuclen_add( $this->actions, $hook, $component, $callback, $priority, $accepted_args );
+    }
 
-	public function nuclen_add_filter( $hook, $component, $callback, $priority = 10, $accepted_args = 1 ) {
-		$this->filters = $this->nuclen_add( $this->filters, $hook, $component, $callback, $priority, $accepted_args );
-	}
+    public function nuclen_add_filter( $hook, $component, $callback, $priority = 10, $accepted_args = 1 ) {
+        $this->filters = $this->nuclen_add( $this->filters, $hook, $component, $callback, $priority, $accepted_args );
+    }
 
-	private function nuclen_add( $hooks, $hook, $component, $callback, $priority, $accepted_args ) {
-		$hooks[] = array(
-			'hook'          => $hook,
-			'component'     => $component,
-			'callback'      => $callback,
-			'priority'      => $priority,
-			'accepted_args' => $accepted_args,
-		);
-		return $hooks;
-	}
+    private function nuclen_add( $hooks, $hook, $component, $callback, $priority, $accepted_args ) {
+        $hooks[] = array(
+            'hook'          => $hook,
+            'component'     => $component,
+            'callback'      => $callback,
+            'priority'      => $priority,
+            'accepted_args' => $accepted_args,
+        );
+        return $hooks;
+    }
 
-	public function nuclen_run() {
-		// Register all filters
-		foreach ( $this->filters as $hook ) {
-			add_filter( $hook['hook'], array( $hook['component'], $hook['callback'] ), $hook['priority'], $hook['accepted_args'] );
-		}
+    public function nuclen_run() {
+        // Register all filters
+        foreach ( $this->filters as $hook ) {
+            add_filter( $hook['hook'], array( $hook['component'], $hook['callback'] ), $hook['priority'], $hook['accepted_args'] );
+        }
 
-		// Register all actions
-		foreach ( $this->actions as $hook ) {
-			add_action( $hook['hook'], array( $hook['component'], $hook['callback'] ), $hook['priority'], $hook['accepted_args'] );
-		}
-	}
+        // Register all actions
+        foreach ( $this->actions as $hook ) {
+            add_action( $hook['hook'], array( $hook['component'], $hook['callback'] ), $hook['priority'], $hook['accepted_args'] );
+        }
+    }
 }

--- a/nuclear-engagement/inc/Core/MetaRegistration.php
+++ b/nuclear-engagement/inc/Core/MetaRegistration.php
@@ -11,7 +11,7 @@ declare(strict_types=1);
 namespace NuclearEngagement;
 
 if ( ! defined( 'ABSPATH' ) ) {
-	exit;
+    exit;
 }
 
 /**
@@ -21,171 +21,171 @@ if ( ! defined( 'ABSPATH' ) ) {
  */
 class MetaRegistration {
 
-	/**
-	 * Initialize meta registration
-	 */
-	public static function init(): void {
-		add_action( 'init', array( self::class, 'register_meta_keys' ), 5 );
-	}
+    /**
+     * Initialize meta registration
+     */
+    public static function init(): void {
+        add_action( 'init', array( self::class, 'register_meta_keys' ), 5 );
+    }
 
-	/**
-	 * Register all plugin meta keys
-	 */
-	public static function register_meta_keys(): void {
-		// Get allowed post types from settings
-		$settings   = \NuclearEngagement\Container::getInstance()->get( 'settings' );
-		$post_types = $settings->get_array( 'generation_post_types', array( 'post' ) );
+    /**
+     * Register all plugin meta keys
+     */
+    public static function register_meta_keys(): void {
+        // Get allowed post types from settings
+        $settings   = \NuclearEngagement\Container::getInstance()->get( 'settings' );
+        $post_types = $settings->get_array( 'generation_post_types', array( 'post' ) );
 
-		// Register quiz data meta
-		foreach ( $post_types as $post_type ) {
-			register_post_meta(
-				$post_type,
-				'nuclen-quiz-data',
-				array(
-					'type'              => 'string',
-					'description'       => 'Nuclear Engagement quiz data',
-					'single'            => true,
-					'show_in_rest'      => false,
-					'sanitize_callback' => array( self::class, 'sanitize_quiz_data' ),
-					'auth_callback'     => array( self::class, 'auth_callback' ),
-				)
-			);
+        // Register quiz data meta
+        foreach ( $post_types as $post_type ) {
+            register_post_meta(
+                $post_type,
+                'nuclen-quiz-data',
+                array(
+                    'type'              => 'string',
+                    'description'       => 'Nuclear Engagement quiz data',
+                    'single'            => true,
+                    'show_in_rest'      => false,
+                    'sanitize_callback' => array( self::class, 'sanitize_quiz_data' ),
+                    'auth_callback'     => array( self::class, 'auth_callback' ),
+                )
+            );
 
-			register_post_meta(
-				$post_type,
-				'nuclen_quiz_protected',
-				array(
-					'type'              => 'boolean',
-					'description'       => 'Nuclear Engagement quiz protection flag',
-					'single'            => true,
-					'show_in_rest'      => false,
-					'default'           => false,
-					'sanitize_callback' => 'rest_sanitize_boolean',
-					'auth_callback'     => array( self::class, 'auth_callback' ),
-				)
-			);
+            register_post_meta(
+                $post_type,
+                'nuclen_quiz_protected',
+                array(
+                    'type'              => 'boolean',
+                    'description'       => 'Nuclear Engagement quiz protection flag',
+                    'single'            => true,
+                    'show_in_rest'      => false,
+                    'default'           => false,
+                    'sanitize_callback' => 'rest_sanitize_boolean',
+                    'auth_callback'     => array( self::class, 'auth_callback' ),
+                )
+            );
 
-			// Register summary data meta
-			register_post_meta(
-				$post_type,
-				'nuclen-summary-data',
-				array(
-					'type'              => 'string',
-					'description'       => 'Nuclear Engagement summary data',
-					'single'            => true,
-					'show_in_rest'      => false,
-					'sanitize_callback' => array( self::class, 'sanitize_summary_data' ),
-					'auth_callback'     => array( self::class, 'auth_callback' ),
-				)
-			);
+            // Register summary data meta
+            register_post_meta(
+                $post_type,
+                'nuclen-summary-data',
+                array(
+                    'type'              => 'string',
+                    'description'       => 'Nuclear Engagement summary data',
+                    'single'            => true,
+                    'show_in_rest'      => false,
+                    'sanitize_callback' => array( self::class, 'sanitize_summary_data' ),
+                    'auth_callback'     => array( self::class, 'auth_callback' ),
+                )
+            );
 
-			register_post_meta(
-				$post_type,
-				'nuclen_summary_protected',
-				array(
-					'type'              => 'boolean',
-					'description'       => 'Nuclear Engagement summary protection flag',
-					'single'            => true,
-					'show_in_rest'      => false,
-					'default'           => false,
-					'sanitize_callback' => 'rest_sanitize_boolean',
-					'auth_callback'     => array( self::class, 'auth_callback' ),
-				)
-			);
-		}
-	}
+            register_post_meta(
+                $post_type,
+                'nuclen_summary_protected',
+                array(
+                    'type'              => 'boolean',
+                    'description'       => 'Nuclear Engagement summary protection flag',
+                    'single'            => true,
+                    'show_in_rest'      => false,
+                    'default'           => false,
+                    'sanitize_callback' => 'rest_sanitize_boolean',
+                    'auth_callback'     => array( self::class, 'auth_callback' ),
+                )
+            );
+        }
+    }
 
-	/**
-	 * Sanitize quiz data before saving
-	 *
-	 * @param mixed $meta_value
-	 * @return mixed
-	 */
-	public static function sanitize_quiz_data( $meta_value ) {
-		if ( ! is_array( $meta_value ) ) {
-			return '';
-		}
+    /**
+     * Sanitize quiz data before saving
+     *
+     * @param mixed $meta_value
+     * @return mixed
+     */
+    public static function sanitize_quiz_data( $meta_value ) {
+        if ( ! is_array( $meta_value ) ) {
+            return '';
+        }
 
-		// Ensure required structure
-		$sanitized = array(
-			'date'      => '',
-			'questions' => array(),
-		);
+        // Ensure required structure
+        $sanitized = array(
+            'date'      => '',
+            'questions' => array(),
+        );
 
-		if ( isset( $meta_value['date'] ) ) {
-			$sanitized['date'] = sanitize_text_field( $meta_value['date'] );
-		}
+        if ( isset( $meta_value['date'] ) ) {
+            $sanitized['date'] = sanitize_text_field( $meta_value['date'] );
+        }
 
-		if ( isset( $meta_value['questions'] ) && is_array( $meta_value['questions'] ) ) {
-			foreach ( $meta_value['questions'] as $question ) {
-				if ( is_array( $question ) ) {
-					$sanitized['questions'][] = array(
-						'question'    => wp_kses_post( $question['question'] ?? '' ),
-						'answers'     => array_map( 'wp_kses_post', (array) ( $question['answers'] ?? array() ) ),
-						'explanation' => wp_kses_post( $question['explanation'] ?? '' ),
-					);
-				}
-			}
-		}
+        if ( isset( $meta_value['questions'] ) && is_array( $meta_value['questions'] ) ) {
+            foreach ( $meta_value['questions'] as $question ) {
+                if ( is_array( $question ) ) {
+                    $sanitized['questions'][] = array(
+                        'question'    => wp_kses_post( $question['question'] ?? '' ),
+                        'answers'     => array_map( 'wp_kses_post', (array) ( $question['answers'] ?? array() ) ),
+                        'explanation' => wp_kses_post( $question['explanation'] ?? '' ),
+                    );
+                }
+            }
+        }
 
-		return $sanitized;
-	}
+        return $sanitized;
+    }
 
-	/**
-	 * Sanitize summary data before saving
-	 *
-	 * @param mixed $meta_value
-	 * @return mixed
-	 */
-	public static function sanitize_summary_data( $meta_value ) {
-		if ( ! is_array( $meta_value ) ) {
-			return '';
-		}
+    /**
+     * Sanitize summary data before saving
+     *
+     * @param mixed $meta_value
+     * @return mixed
+     */
+    public static function sanitize_summary_data( $meta_value ) {
+        if ( ! is_array( $meta_value ) ) {
+            return '';
+        }
 
-		$allowed_html = array(
-			'a'      => array(
-				'href'   => array(),
-				'title'  => array(),
-				'target' => array(),
-			),
-			'br'     => array(),
-			'em'     => array(),
-			'strong' => array(),
-			'p'      => array(),
-			'ul'     => array(),
-			'ol'     => array(),
-			'li'     => array(),
-			'h1'     => array(),
-			'h2'     => array(),
-			'h3'     => array(),
-			'h4'     => array(),
-			'div'    => array( 'class' => array() ),
-			'span'   => array( 'class' => array() ),
-		);
+        $allowed_html = array(
+            'a'      => array(
+                'href'   => array(),
+                'title'  => array(),
+                'target' => array(),
+            ),
+            'br'     => array(),
+            'em'     => array(),
+            'strong' => array(),
+            'p'      => array(),
+            'ul'     => array(),
+            'ol'     => array(),
+            'li'     => array(),
+            'h1'     => array(),
+            'h2'     => array(),
+            'h3'     => array(),
+            'h4'     => array(),
+            'div'    => array( 'class' => array() ),
+            'span'   => array( 'class' => array() ),
+        );
 
-		return array(
-			'date'    => sanitize_text_field( $meta_value['date'] ?? '' ),
-			'summary' => wp_kses( $meta_value['summary'] ?? '', $allowed_html ),
-		);
-	}
+        return array(
+            'date'    => sanitize_text_field( $meta_value['date'] ?? '' ),
+            'summary' => wp_kses( $meta_value['summary'] ?? '', $allowed_html ),
+        );
+    }
 
-	/**
-	 * Authorization callback for meta updates
-	 *
-	 * @param bool   $allowed
-	 * @param string $meta_key
-	 * @param int    $object_id
-	 * @param int    $user_id
-	 * @param string $cap
-	 * @param array  $caps
-	 * @return bool
-	 */
-	public static function auth_callback( $allowed, $meta_key, $object_id, $user_id, $cap, $caps ) {
-		// Check if user can edit this post
-		if ( ! user_can( $user_id, 'edit_post', $object_id ) ) {
-			return false;
-		}
+    /**
+     * Authorization callback for meta updates
+     *
+     * @param bool   $allowed
+     * @param string $meta_key
+     * @param int    $object_id
+     * @param int    $user_id
+     * @param string $cap
+     * @param array  $caps
+     * @return bool
+     */
+    public static function auth_callback( $allowed, $meta_key, $object_id, $user_id, $cap, $caps ) {
+        // Check if user can edit this post
+        if ( ! user_can( $user_id, 'edit_post', $object_id ) ) {
+            return false;
+        }
 
-		return $allowed;
-	}
+        return $allowed;
+    }
 }

--- a/nuclear-engagement/inc/Core/Plugin.php
+++ b/nuclear-engagement/inc/Core/Plugin.php
@@ -11,7 +11,7 @@ declare(strict_types=1);
 namespace NuclearEngagement;
 
 if ( ! defined( 'ABSPATH' ) ) {
-	exit;
+    exit;
 }
 
 use NuclearEngagement\Admin\Admin;
@@ -33,176 +33,176 @@ class Plugin {
         protected string $version;
         protected SettingsRepository $settings_repository;
 
-	/**
-	 * @var Container
-	 */
-	private Container $container;
+    /**
+     * @var Container
+     */
+    private Container $container;
 
-	public function __construct() {
-		$this->version     = defined( 'NUCLEN_PLUGIN_VERSION' ) ? NUCLEN_PLUGIN_VERSION : '1.0.0';
-		$this->plugin_name = 'nuclear-engagement';
+    public function __construct() {
+        $this->version     = defined( 'NUCLEN_PLUGIN_VERSION' ) ? NUCLEN_PLUGIN_VERSION : '1.0.0';
+        $this->plugin_name = 'nuclear-engagement';
 
-		// Initialize settings repository with defaults
-		$defaults                  = Defaults::nuclen_get_default_settings();
-		$this->settings_repository = SettingsRepository::get_instance( $defaults );
+        // Initialize settings repository with defaults
+        $defaults                  = Defaults::nuclen_get_default_settings();
+        $this->settings_repository = SettingsRepository::get_instance( $defaults );
 
-		/* ───── Ensure DB table exists on activation ───── */
-		register_activation_hook(
-			dirname( __DIR__ ) . '/nuclear-engagement.php',
-			function () {
-				if ( ! \NuclearEngagement\OptinData::table_exists() ) {
-					$created = \NuclearEngagement\OptinData::maybe_create_table();
-					if ( ! $created ) {
-						\NuclearEngagement\Services\LoggingService::notify_admin(
-							'Nuclear Engagement could not create required database tables.'
-						);
-					}
-				}
-			}
-		);
+        /* ───── Ensure DB table exists on activation ───── */
+        register_activation_hook(
+            dirname( __DIR__ ) . '/nuclear-engagement.php',
+            function () {
+                if ( ! \NuclearEngagement\OptinData::table_exists() ) {
+                    $created = \NuclearEngagement\OptinData::maybe_create_table();
+                    if ( ! $created ) {
+                        \NuclearEngagement\Services\LoggingService::notify_admin(
+                            'Nuclear Engagement could not create required database tables.'
+                        );
+                    }
+                }
+            }
+        );
 
-		$this->nuclen_load_dependencies();
-		$this->container = Container::getInstance();
-		ContainerRegistrar::register( $this->container, $this->settings_repository );
-		// Register hooks for auto-generation on every request
-		$auto_generation_service = $this->container->get( 'auto_generation_service' );
-		$auto_generation_service->register_hooks();
-		$this->nuclen_define_admin_hooks();
-		$this->nuclen_define_public_hooks();
-	}
+        $this->nuclen_load_dependencies();
+        $this->container = Container::getInstance();
+        ContainerRegistrar::register( $this->container, $this->settings_repository );
+        // Register hooks for auto-generation on every request
+        $auto_generation_service = $this->container->get( 'auto_generation_service' );
+        $auto_generation_service->register_hooks();
+        $this->nuclen_define_admin_hooks();
+        $this->nuclen_define_public_hooks();
+    }
 
-	/*
-	─────────────────────────────────────────────
-		Dependencies & Loader
-	──────────────────────────────────────────── */
-	private function nuclen_load_dependencies() {
+    /*
+    ─────────────────────────────────────────────
+        Dependencies & Loader
+    ──────────────────────────────────────────── */
+    private function nuclen_load_dependencies() {
 
-		/* ► Ensure OptinData hooks are registered */
-		OptinData::init();
+        /* ► Ensure OptinData hooks are registered */
+        OptinData::init();
 
                 ( new ModuleLoader() )->load_all();
                 $this->loader = new Loader();
         }
 
-	/*
-	─────────────────────────────────────────────
-		Admin-side hooks
-	──────────────────────────────────────────── */
-	private function nuclen_define_admin_hooks() {
+    /*
+    ─────────────────────────────────────────────
+        Admin-side hooks
+    ──────────────────────────────────────────── */
+    private function nuclen_define_admin_hooks() {
 
-		$plugin_admin = new Admin( $this->nuclen_get_plugin_name(), $this->nuclen_get_version(), $this->settings_repository, $this->container );
+        $plugin_admin = new Admin( $this->nuclen_get_plugin_name(), $this->nuclen_get_version(), $this->settings_repository, $this->container );
 
-		// Enqueue
-		$this->loader->nuclen_add_action( 'admin_enqueue_scripts', $plugin_admin, 'wp_enqueue_styles' );
-		$this->loader->nuclen_add_action( 'admin_enqueue_scripts', $plugin_admin, 'wp_enqueue_scripts' );
-		$this->loader->nuclen_add_action( 'admin_enqueue_scripts', $plugin_admin, 'nuclen_enqueue_dashboard_styles' );
-		$this->loader->nuclen_add_action( 'admin_enqueue_scripts', $plugin_admin, 'nuclen_enqueue_generate_page_scripts' );
+        // Enqueue
+        $this->loader->nuclen_add_action( 'admin_enqueue_scripts', $plugin_admin, 'wp_enqueue_styles' );
+        $this->loader->nuclen_add_action( 'admin_enqueue_scripts', $plugin_admin, 'wp_enqueue_scripts' );
+        $this->loader->nuclen_add_action( 'admin_enqueue_scripts', $plugin_admin, 'nuclen_enqueue_dashboard_styles' );
+        $this->loader->nuclen_add_action( 'admin_enqueue_scripts', $plugin_admin, 'nuclen_enqueue_generate_page_scripts' );
 
-		// Admin Menu
-		$this->loader->nuclen_add_action( 'admin_menu', $plugin_admin, 'nuclen_add_admin_menu' );
+        // Admin Menu
+        $this->loader->nuclen_add_action( 'admin_menu', $plugin_admin, 'nuclen_add_admin_menu' );
 
-		// AJAX - now using controllers
-		$generate_controller    = $this->container->get( 'generate_controller' );
-		$updates_controller     = $this->container->get( 'updates_controller' );
-		$posts_count_controller = $this->container->get( 'posts_count_controller' );
+        // AJAX - now using controllers
+        $generate_controller    = $this->container->get( 'generate_controller' );
+        $updates_controller     = $this->container->get( 'updates_controller' );
+        $posts_count_controller = $this->container->get( 'posts_count_controller' );
 
-		$this->loader->nuclen_add_action( 'wp_ajax_nuclen_trigger_generation', $generate_controller, 'handle' );
-		$this->loader->nuclen_add_action( 'wp_ajax_nuclen_fetch_app_updates', $updates_controller, 'handle' );
-		$this->loader->nuclen_add_action( 'wp_ajax_nuclen_get_posts_count', $posts_count_controller, 'handle' );
+        $this->loader->nuclen_add_action( 'wp_ajax_nuclen_trigger_generation', $generate_controller, 'handle' );
+        $this->loader->nuclen_add_action( 'wp_ajax_nuclen_fetch_app_updates', $updates_controller, 'handle' );
+        $this->loader->nuclen_add_action( 'wp_ajax_nuclen_get_posts_count', $posts_count_controller, 'handle' );
 
-		// Setup actions
-		$setup = new \NuclearEngagement\Admin\Setup();
-		$this->loader->nuclen_add_action( 'admin_menu', $setup, 'nuclen_add_setup_page' );
-		$this->loader->nuclen_add_action( 'admin_post_nuclen_connect_app', $setup, 'nuclen_handle_connect_app' );
-		$this->loader->nuclen_add_action( 'admin_post_nuclen_generate_app_password', $setup, 'nuclen_handle_generate_app_password' );
-		$this->loader->nuclen_add_action( 'admin_post_nuclen_reset_api_key', $setup, 'nuclen_handle_reset_api_key' );
-		$this->loader->nuclen_add_action( 'admin_post_nuclen_reset_wp_app_connection', $setup, 'nuclen_handle_reset_wp_app_connection' );
+        // Setup actions
+        $setup = new \NuclearEngagement\Admin\Setup();
+        $this->loader->nuclen_add_action( 'admin_menu', $setup, 'nuclen_add_setup_page' );
+        $this->loader->nuclen_add_action( 'admin_post_nuclen_connect_app', $setup, 'nuclen_handle_connect_app' );
+        $this->loader->nuclen_add_action( 'admin_post_nuclen_generate_app_password', $setup, 'nuclen_handle_generate_app_password' );
+        $this->loader->nuclen_add_action( 'admin_post_nuclen_reset_api_key', $setup, 'nuclen_handle_reset_api_key' );
+        $this->loader->nuclen_add_action( 'admin_post_nuclen_reset_wp_app_connection', $setup, 'nuclen_handle_reset_wp_app_connection' );
 
-		// Onboarding pointers - use controller
-		$onboarding = new Onboarding();
-		$onboarding->nuclen_register_hooks();
+        // Onboarding pointers - use controller
+        $onboarding = new Onboarding();
+        $onboarding->nuclen_register_hooks();
 
-		// Replace pointer dismiss with controller
-		$pointer_controller = $this->container->get( 'pointer_controller' );
-		remove_action( 'wp_ajax_nuclen_dismiss_pointer', array( $onboarding, 'nuclen_ajax_dismiss_pointer' ) );
-		$this->loader->nuclen_add_action( 'wp_ajax_nuclen_dismiss_pointer', $pointer_controller, 'dismiss' );
+        // Replace pointer dismiss with controller
+        $pointer_controller = $this->container->get( 'pointer_controller' );
+        remove_action( 'wp_ajax_nuclen_dismiss_pointer', array( $onboarding, 'nuclen_ajax_dismiss_pointer' ) );
+        $this->loader->nuclen_add_action( 'wp_ajax_nuclen_dismiss_pointer', $pointer_controller, 'dismiss' );
 
-		/* Opt-in CSV export */
-		$optin_export_controller = $this->container->get( 'optin_export_controller' );
-		$this->loader->nuclen_add_action( 'admin_post_nuclen_export_optin', $optin_export_controller, 'handle' );
-		$this->loader->nuclen_add_action( 'wp_ajax_nuclen_export_optin', $optin_export_controller, 'handle' );
-	}
+        /* Opt-in CSV export */
+        $optin_export_controller = $this->container->get( 'optin_export_controller' );
+        $this->loader->nuclen_add_action( 'admin_post_nuclen_export_optin', $optin_export_controller, 'handle' );
+        $this->loader->nuclen_add_action( 'wp_ajax_nuclen_export_optin', $optin_export_controller, 'handle' );
+    }
 
-	/*
-	─────────────────────────────────────────────
-		Front-end hooks
-	──────────────────────────────────────────── */
-	private function nuclen_define_public_hooks() {
-		$plugin_public = new FrontClass( $this->nuclen_get_plugin_name(), $this->nuclen_get_version(), $this->settings_repository, $this->container );
+    /*
+    ─────────────────────────────────────────────
+        Front-end hooks
+    ──────────────────────────────────────────── */
+    private function nuclen_define_public_hooks() {
+        $plugin_public = new FrontClass( $this->nuclen_get_plugin_name(), $this->nuclen_get_version(), $this->settings_repository, $this->container );
 
-		$this->loader->nuclen_add_action( 'wp_enqueue_scripts', $plugin_public, 'wp_enqueue_styles' );
-		$this->loader->nuclen_add_action( 'wp_enqueue_scripts', $plugin_public, 'wp_enqueue_scripts' );
+        $this->loader->nuclen_add_action( 'wp_enqueue_scripts', $plugin_public, 'wp_enqueue_styles' );
+        $this->loader->nuclen_add_action( 'wp_enqueue_scripts', $plugin_public, 'wp_enqueue_scripts' );
 
-		// REST API - use controller
-		add_action(
-			'rest_api_init',
-			function () {
-				$contentController = $this->container->get( 'content_controller' );
-				register_rest_route(
-					'nuclear-engagement/v1',
-					'/receive-content',
-					array(
-						'methods'             => 'POST',
-						'callback'            => array( $contentController, 'handle' ),
-						'permission_callback' => array( $contentController, 'permissions' ),
-					)
-				);
-			}
-		);
+        // REST API - use controller
+        add_action(
+            'rest_api_init',
+            function () {
+                $contentController = $this->container->get( 'content_controller' );
+                register_rest_route(
+                    'nuclear-engagement/v1',
+                    '/receive-content',
+                    array(
+                        'methods'             => 'POST',
+                        'callback'            => array( $contentController, 'handle' ),
+                        'permission_callback' => array( $contentController, 'permissions' ),
+                    )
+                );
+            }
+        );
 
-		$this->loader->nuclen_add_action( 'init', $plugin_public, 'nuclen_register_quiz_shortcode' );
-		$this->loader->nuclen_add_action( 'init', $plugin_public, 'nuclen_register_summary_shortcode' );
-		$this->loader->nuclen_add_filter( 'the_content', $plugin_public, 'nuclen_auto_insert_shortcodes', 50 );
-		$this->loader->nuclen_add_action( 'init', '\\NuclearEngagement\\Blocks', 'register' );
-	}
+        $this->loader->nuclen_add_action( 'init', $plugin_public, 'nuclen_register_quiz_shortcode' );
+        $this->loader->nuclen_add_action( 'init', $plugin_public, 'nuclen_register_summary_shortcode' );
+        $this->loader->nuclen_add_filter( 'the_content', $plugin_public, 'nuclen_auto_insert_shortcodes', 50 );
+        $this->loader->nuclen_add_action( 'init', '\\NuclearEngagement\\Blocks', 'register' );
+    }
 
-	/*
-	─────────────────────────────────────────────
-		Boilerplate
-	──────────────────────────────────────────── */
-	public function nuclen_run() {
-		$this->loader->nuclen_run();
-	}
+    /*
+    ─────────────────────────────────────────────
+        Boilerplate
+    ──────────────────────────────────────────── */
+    public function nuclen_run() {
+        $this->loader->nuclen_run();
+    }
 
-	public function nuclen_get_plugin_name() {
-		return $this->plugin_name;
-	}
+    public function nuclen_get_plugin_name() {
+        return $this->plugin_name;
+    }
 
-	public function nuclen_get_loader() {
-		return $this->loader;
-	}
+    public function nuclen_get_loader() {
+        return $this->loader;
+    }
 
-	public function nuclen_get_version() {
-		return $this->version;
-	}
+    public function nuclen_get_version() {
+        return $this->version;
+    }
 
-	/**
-	 * Get the settings repository instance.
-	 *
-	 * @return SettingsRepository
-	 */
-	public function nuclen_get_settings_repository() {
-		return $this->settings_repository;
-	}
+    /**
+     * Get the settings repository instance.
+     *
+     * @return SettingsRepository
+     */
+    public function nuclen_get_settings_repository() {
+        return $this->settings_repository;
+    }
 
-	/**
-	 * Get the container instance (mainly for testing)
-	 *
-	 * @return Container
-	 */
-	public function get_container(): Container {
-		return $this->container;
-	}
+    /**
+     * Get the container instance (mainly for testing)
+     *
+     * @return Container
+     */
+    public function get_container(): Container {
+        return $this->container;
+    }
 
        function load_nuclear_engagement_admin_display() {
                include_once NUCLEN_PLUGIN_DIR . 'templates/admin/nuclen-admin-display.php';

--- a/nuclear-engagement/inc/Core/SettingsCache.php
+++ b/nuclear-engagement/inc/Core/SettingsCache.php
@@ -15,7 +15,7 @@ namespace NuclearEngagement;
 
 // If this file is called directly, abort.
 if ( ! defined( 'ABSPATH' ) ) {
-	exit;
+    exit;
 }
 
 /**
@@ -28,102 +28,102 @@ if ( ! defined( 'ABSPATH' ) ) {
  */
 final class SettingsCache {
 
-	/**
-	 * Cache group used for settings.
-	 *
-	 * @since 1.0.0
-	 * @var string
-	 */
-	public const CACHE_GROUP = 'nuclen_settings';
+    /**
+     * Cache group used for settings.
+     *
+     * @since 1.0.0
+     * @var string
+     */
+    public const CACHE_GROUP = 'nuclen_settings';
 
-	/**
-	 * Default cache lifetime in seconds.
-	 *
-	 * @since 1.0.0
-	 * @var int
-	 */
-	public const CACHE_EXPIRATION = HOUR_IN_SECONDS; // 1 hour.
+    /**
+     * Default cache lifetime in seconds.
+     *
+     * @since 1.0.0
+     * @var int
+     */
+    public const CACHE_EXPIRATION = HOUR_IN_SECONDS; // 1 hour.
 
 
-	/**
-	 * Register WordPress hooks.
-	 *
-	 * @since 1.0.0
-	 */
-	public function register_hooks(): void {
-		add_action( 'updated_option', array( $this, 'maybe_invalidate_cache' ), 10, 3 );
-		add_action( 'deleted_option', array( $this, 'maybe_invalidate_cache' ), 10, 1 );
-		add_action( 'switch_blog', array( $this, 'invalidate_cache' ) );
-	}
+    /**
+     * Register WordPress hooks.
+     *
+     * @since 1.0.0
+     */
+    public function register_hooks(): void {
+        add_action( 'updated_option', array( $this, 'maybe_invalidate_cache' ), 10, 3 );
+        add_action( 'deleted_option', array( $this, 'maybe_invalidate_cache' ), 10, 1 );
+        add_action( 'switch_blog', array( $this, 'invalidate_cache' ) );
+    }
 
-	/**
-	 * Generate a cache key for the current site.
-	 *
-	 * @since 1.0.0
-	 *
-	 * @return string The cache key.
-	 */
-	public function get_cache_key(): string {
-		return 'settings_' . get_current_blog_id();
-	}
+    /**
+     * Generate a cache key for the current site.
+     *
+     * @since 1.0.0
+     *
+     * @return string The cache key.
+     */
+    public function get_cache_key(): string {
+        return 'settings_' . get_current_blog_id();
+    }
 
-	/**
-	 * Get cached settings.
-	 *
-	 * @since 1.0.0
-	 *
-	 * @return array|null Cached settings array or null if not found.
-	 */
-	public function get(): ?array {
-		$cached = wp_cache_get( $this->get_cache_key(), self::CACHE_GROUP );
-		return is_array( $cached ) ? $cached : null;
-	}
+    /**
+     * Get cached settings.
+     *
+     * @since 1.0.0
+     *
+     * @return array|null Cached settings array or null if not found.
+     */
+    public function get(): ?array {
+        $cached = wp_cache_get( $this->get_cache_key(), self::CACHE_GROUP );
+        return is_array( $cached ) ? $cached : null;
+    }
 
-	/**
-	 * Cache settings.
-	 *
-	 * @since 1.0.0
-	 *
-	 * @param array $settings Settings array to cache.
-	 */
-	public function set( array $settings ): void {
-		wp_cache_set( $this->get_cache_key(), $settings, self::CACHE_GROUP, self::CACHE_EXPIRATION );
-	}
+    /**
+     * Cache settings.
+     *
+     * @since 1.0.0
+     *
+     * @param array $settings Settings array to cache.
+     */
+    public function set( array $settings ): void {
+        wp_cache_set( $this->get_cache_key(), $settings, self::CACHE_GROUP, self::CACHE_EXPIRATION );
+    }
 
-	/**
-	 * Invalidate the settings cache.
-	 *
-	 * @since 1.0.0
-	 */
-	public function invalidate_cache(): void {
-		$key = $this->get_cache_key();
-		wp_cache_delete( $key, self::CACHE_GROUP );
-		if ( function_exists( 'wp_cache_flush_group' ) ) {
-			wp_cache_flush_group( self::CACHE_GROUP );
-		} else {
-			wp_cache_flush();
-		}
-	}
+    /**
+     * Invalidate the settings cache.
+     *
+     * @since 1.0.0
+     */
+    public function invalidate_cache(): void {
+        $key = $this->get_cache_key();
+        wp_cache_delete( $key, self::CACHE_GROUP );
+        if ( function_exists( 'wp_cache_flush_group' ) ) {
+            wp_cache_flush_group( self::CACHE_GROUP );
+        } else {
+            wp_cache_flush();
+        }
+    }
 
-	/**
-	 * Invalidate cache when relevant options are updated.
-	 *
-	 * @since 1.0.0
-	 *
-	 * @param string $option Name of the option being updated.
-	 */
-	public function maybe_invalidate_cache( $option ): void {
-		if ( SettingsRepository::OPTION === $option ) {
-			$this->invalidate_cache();
-		}
-	}
+    /**
+     * Invalidate cache when relevant options are updated.
+     *
+     * @since 1.0.0
+     *
+     * @param string $option Name of the option being updated.
+     */
+    public function maybe_invalidate_cache( $option ): void {
+        if ( SettingsRepository::OPTION === $option ) {
+            $this->invalidate_cache();
+        }
+    }
 
-	/**
-	 * Clear all cached settings.
-	 *
-	 * @since 1.0.0
-	 */
-	public function clear(): void {
-		$this->invalidate_cache();
-	}
+    /**
+     * Clear all cached settings.
+     *
+     * @since 1.0.0
+     */
+    public function clear(): void {
+        $this->invalidate_cache();
+    }
 }

--- a/nuclear-engagement/inc/Core/SettingsRepository.php
+++ b/nuclear-engagement/inc/Core/SettingsRepository.php
@@ -18,7 +18,7 @@ use NuclearEngagement\SettingsCache;
 
 // If this file is called directly, abort.
 if ( ! defined( 'ABSPATH' ) ) {
-	exit;
+    exit;
 }
 
 /**
@@ -31,91 +31,91 @@ if ( ! defined( 'ABSPATH' ) ) {
  */
 final class SettingsRepository {
 
-	/**
-	 * The option name used to store settings in the database.
-	 *
-	 * @since 1.0.0
-	 * @var string
-	 */
-	const OPTION = 'nuclear_engagement_settings';
+    /**
+     * The option name used to store settings in the database.
+     *
+     * @since 1.0.0
+     * @var string
+     */
+    const OPTION = 'nuclear_engagement_settings';
 
-	/**
-	 * Maximum size (in bytes) for settings to be autoloaded.
-	 *
-	 * @since 1.0.0
-	 * @var int
-	 */
-	const MAX_AUTOLOAD_SIZE = 512000;
-
-
-	/**
-	 * Singleton instance.
-	 *
-	 * @since 1.0.0
-	 * @var SettingsRepository|null
-	 */
-	private static $instance = null;
-
-	/**
-	 * Default settings values.
-	 *
-	 * @since 1.0.0
-	 * @var array
-	 */
-	private $defaults = array();
-
-	/**
-	 * Pending changes not yet saved.
-	 *
-	 * @since 1.0.0
-	 * @var array
-	 */
-	private $pending = array();
-
-	/**
-	 * Cache handler.
-	 *
-	 * @since 1.0.0
-	 * @var SettingsCache
-	 */
-	private SettingsCache $cache;
+    /**
+     * Maximum size (in bytes) for settings to be autoloaded.
+     *
+     * @since 1.0.0
+     * @var int
+     */
+    const MAX_AUTOLOAD_SIZE = 512000;
 
 
-	/**
-	 * Get the singleton instance.
-	 *
-	 * @since 1.0.0
-	 *
-	 * @param array $defaults Optional. Default settings to use if not already set.
-	 * @return self The singleton instance.
-	 */
-	public static function get_instance( array $defaults = array() ): self {
-		if ( null === self::$instance ) {
-			self::$instance = new self( $defaults );
-		}
-		return self::$instance;
-	}
+    /**
+     * Singleton instance.
+     *
+     * @since 1.0.0
+     * @var SettingsRepository|null
+     */
+    private static $instance = null;
 
-	/**
-	 * Private constructor - use get_instance() instead.
-	 *
-	 * @since 1.0.0
-	 *
-	 * @param array $defaults Optional. Default settings to use.
-	 */
-	private function __construct( array $defaults = array() ) {
-		// Merge provided defaults with built-in defaults.
-		$this->defaults = wp_parse_args( $defaults, Defaults::nuclen_get_default_settings() );
-		$this->cache    = new SettingsCache();
-		$this->cache->register_hooks();
-	}
+    /**
+     * Default settings values.
+     *
+     * @since 1.0.0
+     * @var array
+     */
+    private $defaults = array();
+
+    /**
+     * Pending changes not yet saved.
+     *
+     * @since 1.0.0
+     * @var array
+     */
+    private $pending = array();
+
+    /**
+     * Cache handler.
+     *
+     * @since 1.0.0
+     * @var SettingsCache
+     */
+    private SettingsCache $cache;
 
 
-		/*
-		===================================================================
-		* GETTERS
-		* ===================================================================
-		*/
+    /**
+     * Get the singleton instance.
+     *
+     * @since 1.0.0
+     *
+     * @param array $defaults Optional. Default settings to use if not already set.
+     * @return self The singleton instance.
+     */
+    public static function get_instance( array $defaults = array() ): self {
+        if ( null === self::$instance ) {
+            self::$instance = new self( $defaults );
+        }
+        return self::$instance;
+    }
+
+    /**
+     * Private constructor - use get_instance() instead.
+     *
+     * @since 1.0.0
+     *
+     * @param array $defaults Optional. Default settings to use.
+     */
+    private function __construct( array $defaults = array() ) {
+        // Merge provided defaults with built-in defaults.
+        $this->defaults = wp_parse_args( $defaults, Defaults::nuclen_get_default_settings() );
+        $this->cache    = new SettingsCache();
+        $this->cache->register_hooks();
+    }
+
+
+        /*
+        ===================================================================
+        * GETTERS
+        * ===================================================================
+        */
 
 use \NuclearEngagement\Traits\SettingsGettersTrait;
 use \NuclearEngagement\Traits\SettingsPersistenceTrait;
@@ -136,17 +136,17 @@ use PendingSettingsTrait;
 
 
 
-	/**
-	 * Reset singleton instance (for testing).
-	 *
-	 * @since 1.0.0
-	 */
-	public static function reset_for_tests(): void {
-			self::$instance = null;
-		if ( function_exists( 'wp_cache_flush_group' ) ) {
-				wp_cache_flush_group( SettingsCache::CACHE_GROUP );
-		} else {
-					wp_cache_flush();
-		}
-	}
+    /**
+     * Reset singleton instance (for testing).
+     *
+     * @since 1.0.0
+     */
+    public static function reset_for_tests(): void {
+            self::$instance = null;
+        if ( function_exists( 'wp_cache_flush_group' ) ) {
+                wp_cache_flush_group( SettingsCache::CACHE_GROUP );
+        } else {
+                    wp_cache_flush();
+        }
+    }
 }

--- a/nuclear-engagement/inc/Core/SettingsSanitizer.php
+++ b/nuclear-engagement/inc/Core/SettingsSanitizer.php
@@ -15,7 +15,7 @@ namespace NuclearEngagement;
 
 // If this file is called directly, abort.
 if ( ! defined( 'ABSPATH' ) ) {
-	exit;
+    exit;
 }
 
 /**
@@ -27,153 +27,153 @@ if ( ! defined( 'ABSPATH' ) ) {
  * @since 1.0.0
  */
 final class SettingsSanitizer {
-	/**
-	 * Sanitization rules for settings.
-	 *
-	 * Maps setting keys to their respective sanitization callbacks.
-	 *
-	 * @since 1.0.0
-	 * @var array<string, callable|string>
-	private const SANITIZATION_RULES = array(
-		'api_key'                              => 'sanitize_text_field',
-		'theme'                              => 'sanitize_text_field',
-		'font_size'                          => 'absint',
-		'font_color'                            => 'sanitize_hex_color',
-		'bg_color'                            => 'sanitize_hex_color',
-		'border_color'                        => 'sanitize_hex_color',
-		'border_style'                        => 'sanitize_text_field',
-		'border_width'                        => 'absint',
-		'quiz_title'                            => 'sanitize_text_field',
-		'summary_title'                      => 'sanitize_text_field',
-		'toc_title'                          => 'sanitize_text_field',
-		'quiz_label_retake_test'                => 'sanitize_text_field',
-		'quiz_label_your_score'              => 'sanitize_text_field',
-		'quiz_label_perfect'                    => 'sanitize_text_field',
-		'quiz_label_well_done'                => 'sanitize_text_field',
-		'quiz_label_retake_prompt'            => 'sanitize_text_field',
-		'quiz_label_correct'                    => 'sanitize_text_field',
-		'quiz_label_your_answer'                => 'sanitize_text_field',
-		'show_attribution'                    => 'rest_sanitize_boolean',
-		'display_summary'                      => 'sanitize_text_field',
-		'display_quiz'                        => 'sanitize_text_field',
-		'display_toc'                          => 'sanitize_text_field',
-		'connected'                          => 'rest_sanitize_boolean',
-		'wp_app_pass_created'                  => 'rest_sanitize_boolean',
-		'wp_app_pass_uuid'                    => 'sanitize_text_field',
-		'plugin_password'                      => 'sanitize_text_field',
-		'delete_settings_on_uninstall'        => 'rest_sanitize_boolean',
-		'delete_generated_content_on_uninstall' => 'rest_sanitize_boolean',
-		'delete_optin_data_on_uninstall'        => 'rest_sanitize_boolean',
-		'delete_log_file_on_uninstall'        => 'rest_sanitize_boolean',
-		'delete_custom_css_on_uninstall'        => 'rest_sanitize_boolean',
-		'toc_heading_levels'                    => array( self::class, 'sanitize_heading_levels' ),
-		'generation_post_types'              => array( self::class, 'sanitize_post_types' ),
-	);
+    /**
+     * Sanitization rules for settings.
+     *
+     * Maps setting keys to their respective sanitization callbacks.
+     *
+     * @since 1.0.0
+     * @var array<string, callable|string>
+    private const SANITIZATION_RULES = array(
+        'api_key'                              => 'sanitize_text_field',
+        'theme'                              => 'sanitize_text_field',
+        'font_size'                          => 'absint',
+        'font_color'                            => 'sanitize_hex_color',
+        'bg_color'                            => 'sanitize_hex_color',
+        'border_color'                        => 'sanitize_hex_color',
+        'border_style'                        => 'sanitize_text_field',
+        'border_width'                        => 'absint',
+        'quiz_title'                            => 'sanitize_text_field',
+        'summary_title'                      => 'sanitize_text_field',
+        'toc_title'                          => 'sanitize_text_field',
+        'quiz_label_retake_test'                => 'sanitize_text_field',
+        'quiz_label_your_score'              => 'sanitize_text_field',
+        'quiz_label_perfect'                    => 'sanitize_text_field',
+        'quiz_label_well_done'                => 'sanitize_text_field',
+        'quiz_label_retake_prompt'            => 'sanitize_text_field',
+        'quiz_label_correct'                    => 'sanitize_text_field',
+        'quiz_label_your_answer'                => 'sanitize_text_field',
+        'show_attribution'                    => 'rest_sanitize_boolean',
+        'display_summary'                      => 'sanitize_text_field',
+        'display_quiz'                        => 'sanitize_text_field',
+        'display_toc'                          => 'sanitize_text_field',
+        'connected'                          => 'rest_sanitize_boolean',
+        'wp_app_pass_created'                  => 'rest_sanitize_boolean',
+        'wp_app_pass_uuid'                    => 'sanitize_text_field',
+        'plugin_password'                      => 'sanitize_text_field',
+        'delete_settings_on_uninstall'        => 'rest_sanitize_boolean',
+        'delete_generated_content_on_uninstall' => 'rest_sanitize_boolean',
+        'delete_optin_data_on_uninstall'        => 'rest_sanitize_boolean',
+        'delete_log_file_on_uninstall'        => 'rest_sanitize_boolean',
+        'delete_custom_css_on_uninstall'        => 'rest_sanitize_boolean',
+        'toc_heading_levels'                    => array( self::class, 'sanitize_heading_levels' ),
+        'generation_post_types'              => array( self::class, 'sanitize_post_types' ),
+    );
 
-	/**
-	 * Sanitize an array of settings values.
-	 *
-	 * @since 1.0.0
-	 *
-	 * @param array $settings Raw settings array to sanitize.
-	 * @return array Sanitized settings array.
-	 */
-	public static function sanitize_settings( array $settings ): array {
-		$sanitized = array();
-		foreach ( $settings as $key => $value ) {
-			if ( ! is_string( $key ) ) {
-				continue;
-			}
-			$sanitized[ $key ] = self::sanitize_setting( $key, $value );
-		}
-		return $sanitized;
-	}
+    /**
+     * Sanitize an array of settings values.
+     *
+     * @since 1.0.0
+     *
+     * @param array $settings Raw settings array to sanitize.
+     * @return array Sanitized settings array.
+     */
+    public static function sanitize_settings( array $settings ): array {
+        $sanitized = array();
+        foreach ( $settings as $key => $value ) {
+            if ( ! is_string( $key ) ) {
+                continue;
+            }
+            $sanitized[ $key ] = self::sanitize_setting( $key, $value );
+        }
+        return $sanitized;
+    }
 
-	/**
-	 * Sanitize a single setting value.
-	 *
-	 * @since 1.0.0
-	 *
-	 * @param string $key   Setting key to identify the sanitization rule.
-	 * @param mixed  $value Setting value to sanitize.
-	 * @return mixed Sanitized value.
-	 */
-	public static function sanitize_setting( string $key, $value ) {
-		if ( isset( self::SANITIZATION_RULES[ $key ] ) ) {
-			$rule = self::SANITIZATION_RULES[ $key ];
-			return is_callable( $rule ) ? call_user_func( $rule, $value ) : $value;
-		}
+    /**
+     * Sanitize a single setting value.
+     *
+     * @since 1.0.0
+     *
+     * @param string $key   Setting key to identify the sanitization rule.
+     * @param mixed  $value Setting value to sanitize.
+     * @return mixed Sanitized value.
+     */
+    public static function sanitize_setting( string $key, $value ) {
+        if ( isset( self::SANITIZATION_RULES[ $key ] ) ) {
+            $rule = self::SANITIZATION_RULES[ $key ];
+            return is_callable( $rule ) ? call_user_func( $rule, $value ) : $value;
+        }
 
-		if ( is_array( $value ) ) {
-			return self::sanitize_array( $value );
-		}
+        if ( is_array( $value ) ) {
+            return self::sanitize_array( $value );
+        }
 
-		if ( is_bool( $value ) ) {
-			return (bool) $value;
-		}
+        if ( is_bool( $value ) ) {
+            return (bool) $value;
+        }
 
-		if ( is_numeric( $value ) ) {
-			return is_float( $value ) ? (float) $value : (int) $value;
-		}
+        if ( is_numeric( $value ) ) {
+            return is_float( $value ) ? (float) $value : (int) $value;
+        }
 
-		return sanitize_text_field( (string) $value );
-	}
+        return sanitize_text_field( (string) $value );
+    }
 
-	/**
-	 * Recursively sanitize an array of values.
-	 *
-	 * @since 1.0.0
-	 * @access private
-	 *
-	 * @param array $values Values to sanitize.
-	 * @return array Sanitized values with all strings properly escaped.
-	 */
-	private static function sanitize_array( array $values ): array {
-		return array_map(
-			function ( $value ) {
-				if ( is_array( $value ) ) {
-						return self::sanitize_array( $value );
-				}
-				return is_string( $value ) ? sanitize_text_field( $value ) : $value;
-			},
-			$values
-		);
-	}
+    /**
+     * Recursively sanitize an array of values.
+     *
+     * @since 1.0.0
+     * @access private
+     *
+     * @param array $values Values to sanitize.
+     * @return array Sanitized values with all strings properly escaped.
+     */
+    private static function sanitize_array( array $values ): array {
+        return array_map(
+            function ( $value ) {
+                if ( is_array( $value ) ) {
+                        return self::sanitize_array( $value );
+                }
+                return is_string( $value ) ? sanitize_text_field( $value ) : $value;
+            },
+            $values
+        );
+    }
 
-	/**
-	 * Sanitize heading levels array.
-	 *
-	 * @since 1.0.0
-	 *
-	 * @param mixed $value Raw value to sanitize as heading levels.
-	 * @return array<int> Sanitized array of heading levels (1-6).
-	 */
-	public static function sanitize_heading_levels( $value ): array {
-		if ( ! is_array( $value ) ) {
-			return array( 2, 3, 4, 5, 6 );
-		}
-		return array_values(
-			array_filter(
-				array_map( 'absint', $value ),
-				function ( $level ) {
-					return $level >= 1 && $level <= 6;
-				}
-			)
-		);
-	}
+    /**
+     * Sanitize heading levels array.
+     *
+     * @since 1.0.0
+     *
+     * @param mixed $value Raw value to sanitize as heading levels.
+     * @return array<int> Sanitized array of heading levels (1-6).
+     */
+    public static function sanitize_heading_levels( $value ): array {
+        if ( ! is_array( $value ) ) {
+            return array( 2, 3, 4, 5, 6 );
+        }
+        return array_values(
+            array_filter(
+                array_map( 'absint', $value ),
+                function ( $level ) {
+                    return $level >= 1 && $level <= 6;
+                }
+            )
+        );
+    }
 
-	/**
-	 * Sanitize post types array.
-	 *
-	 * @since 1.0.0
-	 *
-	 * @param mixed $value Raw value to sanitize as post types.
-	 * @return array<int,string> Sanitized array of valid post type slugs.
-	 */
-	public static function sanitize_post_types( $value ): array {
-		if ( ! is_array( $value ) ) {
-			return array( 'post' );
-		}
-		return array_values( array_filter( array_map( 'sanitize_key', $value ), 'post_type_exists' ) );
-	}
+    /**
+     * Sanitize post types array.
+     *
+     * @since 1.0.0
+     *
+     * @param mixed $value Raw value to sanitize as post types.
+     * @return array<int,string> Sanitized array of valid post type slugs.
+     */
+    public static function sanitize_post_types( $value ): array {
+        if ( ! is_array( $value ) ) {
+            return array( 'post' );
+        }
+        return array_values( array_filter( array_map( 'sanitize_key', $value ), 'post_type_exists' ) );
+    }
 }

--- a/nuclear-engagement/inc/Core/Themes.php
+++ b/nuclear-engagement/inc/Core/Themes.php
@@ -11,49 +11,49 @@ declare(strict_types=1);
 namespace NuclearEngagement;
 
 if ( ! defined( 'ABSPATH' ) ) {
-	exit;
+    exit;
 }
 
 /**
  * Central theme definitions to avoid duplication.
  */
 final class ThemeRegistry {
-		/**
-		 * Map of registered theme names to CSS files.
-		 *
-		 * @var array<string,string>
-		 */
-	private static array $themes = array(
-		'bright' => 'nuclen-theme-bright.css',
-		'dark'   => 'nuclen-theme-dark.css',
-	);
+        /**
+         * Map of registered theme names to CSS files.
+         *
+         * @var array<string,string>
+         */
+    private static array $themes = array(
+        'bright' => 'nuclen-theme-bright.css',
+        'dark'   => 'nuclen-theme-dark.css',
+    );
 
-		/**
-		 * Register a theme stylesheet.
-		 *
-		 * @param string $name      Theme slug.
-		 * @param string $stylesheet Stylesheet filename.
-		 */
-	public static function register( string $name, string $stylesheet ): void {
-			self::$themes[ $name ] = $stylesheet;
-	}
+        /**
+         * Register a theme stylesheet.
+         *
+         * @param string $name      Theme slug.
+         * @param string $stylesheet Stylesheet filename.
+         */
+    public static function register( string $name, string $stylesheet ): void {
+            self::$themes[ $name ] = $stylesheet;
+    }
 
-		/**
-		 * Retrieve the registered themes.
-		 *
-		 * @return array<string,string> Map of theme names to stylesheets.
-		 */
-	public static function get_themes(): array {
-			return self::$themes;
-	}
+        /**
+         * Retrieve the registered themes.
+         *
+         * @return array<string,string> Map of theme names to stylesheets.
+         */
+    public static function get_themes(): array {
+            return self::$themes;
+    }
 
-		/**
-		 * Get the stylesheet for a theme name.
-		 *
-		 * @param string $name Theme slug.
-		 * @return string|null Stylesheet filename if registered.
-		 */
-	public static function get( string $name ): ?string {
-			return self::$themes[ $name ] ?? null;
-	}
+        /**
+         * Get the stylesheet for a theme name.
+         *
+         * @param string $name Theme slug.
+         * @return string|null Stylesheet filename if registered.
+         */
+    public static function get( string $name ): ?string {
+            return self::$themes[ $name ] ?? null;
+    }
 }

--- a/nuclear-engagement/inc/Core/constants.php
+++ b/nuclear-engagement/inc/Core/constants.php
@@ -1,7 +1,7 @@
 <?php
 declare(strict_types=1);
 if ( ! defined( 'ABSPATH' ) ) {
-	exit;
+    exit;
 }
 
 /**

--- a/nuclear-engagement/inc/Core/helpers.php
+++ b/nuclear-engagement/inc/Core/helpers.php
@@ -9,100 +9,100 @@ declare(strict_types=1);
 use NuclearEngagement\Container;
 
 if ( ! function_exists( 'nuclen_settings' ) ) {
-	/**
-	 * Get or set Nuclear Engagement settings.
-	 *
-	 * @param string|null $key   Optional. The setting key to retrieve.
-	 * @param mixed       $default Optional. Default value if setting doesn't exist.
-	 * @return mixed The setting value, or all settings if no key provided.
-	 */
-	function nuclen_settings( ?string $key = null, $default = null ) {
-		static $repo = null;
+    /**
+     * Get or set Nuclear Engagement settings.
+     *
+     * @param string|null $key   Optional. The setting key to retrieve.
+     * @param mixed       $default Optional. Default value if setting doesn't exist.
+     * @return mixed The setting value, or all settings if no key provided.
+     */
+    function nuclen_settings( ?string $key = null, $default = null ) {
+        static $repo = null;
 
-		if ( $repo === null ) {
-			$repo = Container::getInstance()->get( 'settings' );
-		}
+        if ( $repo === null ) {
+            $repo = Container::getInstance()->get( 'settings' );
+        }
 
-		if ( $key === null ) {
-			return $repo->all();
-		}
+        if ( $key === null ) {
+            return $repo->all();
+        }
 
-		return $repo->get( $key, $default );
-	}
+        return $repo->get( $key, $default );
+    }
 }
 
 if ( ! function_exists( 'nuclen_settings_bool' ) ) {
-	/**
-	 * Get a boolean setting.
-	 *
-	 * @param string $key    The setting key.
-	 * @param bool   $default Default value if not set.
-	 * @return bool
-	 */
-	function nuclen_settings_bool( string $key, bool $default = false ): bool {
-		static $repo = null;
+    /**
+     * Get a boolean setting.
+     *
+     * @param string $key    The setting key.
+     * @param bool   $default Default value if not set.
+     * @return bool
+     */
+    function nuclen_settings_bool( string $key, bool $default = false ): bool {
+        static $repo = null;
 
-		if ( $repo === null ) {
-			$repo = Container::getInstance()->get( 'settings' );
-		}
+        if ( $repo === null ) {
+            $repo = Container::getInstance()->get( 'settings' );
+        }
 
-		return $repo->get_bool( $key, $default );
-	}
+        return $repo->get_bool( $key, $default );
+    }
 }
 
 if ( ! function_exists( 'nuclen_settings_int' ) ) {
-	/**
-	 * Get an integer setting.
-	 *
-	 * @param string $key    The setting key.
-	 * @param int    $default Default value if not set.
-	 * @return int
-	 */
-	function nuclen_settings_int( string $key, int $default = 0 ): int {
-		static $repo = null;
+    /**
+     * Get an integer setting.
+     *
+     * @param string $key    The setting key.
+     * @param int    $default Default value if not set.
+     * @return int
+     */
+    function nuclen_settings_int( string $key, int $default = 0 ): int {
+        static $repo = null;
 
-		if ( $repo === null ) {
-			$repo = Container::getInstance()->get( 'settings' );
-		}
+        if ( $repo === null ) {
+            $repo = Container::getInstance()->get( 'settings' );
+        }
 
-		return $repo->get_int( $key, $default );
-	}
+        return $repo->get_int( $key, $default );
+    }
 }
 
 if ( ! function_exists( 'nuclen_settings_string' ) ) {
-	/**
-	 * Get a string setting.
-	 *
-	 * @param string $key    The setting key.
-	 * @param string $default Default value if not set.
-	 * @return string
-	 */
-	function nuclen_settings_string( string $key, string $default = '' ): string {
-		static $repo = null;
+    /**
+     * Get a string setting.
+     *
+     * @param string $key    The setting key.
+     * @param string $default Default value if not set.
+     * @return string
+     */
+    function nuclen_settings_string( string $key, string $default = '' ): string {
+        static $repo = null;
 
-		if ( $repo === null ) {
-			$repo = Container::getInstance()->get( 'settings' );
-		}
+        if ( $repo === null ) {
+            $repo = Container::getInstance()->get( 'settings' );
+        }
 
-		return $repo->get_string( $key, $default );
-	}
+        return $repo->get_string( $key, $default );
+    }
 }
 
 if ( ! function_exists( 'nuclen_settings_array' ) ) {
-	/**
-	 * Get an array setting.
-	 *
-	 * @param string $key    The setting key.
-	 * @param array  $default Default value if not set.
-	 * @return array
-	 */
-	function nuclen_settings_array( string $key, array $default = array() ): array {
-		static $repo = null;
+    /**
+     * Get an array setting.
+     *
+     * @param string $key    The setting key.
+     * @param array  $default Default value if not set.
+     * @return array
+     */
+    function nuclen_settings_array( string $key, array $default = array() ): array {
+        static $repo = null;
 
-		if ( $repo === null ) {
-			$repo = Container::getInstance()->get( 'settings' );
-		}
+        if ( $repo === null ) {
+            $repo = Container::getInstance()->get( 'settings' );
+        }
 
-		return $repo->get_array( $key, $default );
-	}
+        return $repo->get_array( $key, $default );
+    }
 }

--- a/nuclear-engagement/inc/Core/index.php
+++ b/nuclear-engagement/inc/Core/index.php
@@ -1,5 +1,5 @@
 <?php
 declare(strict_types=1);
 if ( ! defined( 'ABSPATH' ) ) {
-	exit;
+    exit;
 } // Silence is golden

--- a/nuclear-engagement/inc/Modules/Summary/includes/class-nuclen-summary-metabox.php
+++ b/nuclear-engagement/inc/Modules/Summary/includes/class-nuclen-summary-metabox.php
@@ -29,91 +29,91 @@ final class Nuclen_Summary_Metabox {
                 return $this->settings;
         }
 
-	/*
-	-------------------------------------------------------------------------
-	 *  Meta-box registration
-	 * ---------------------------------------------------------------------- */
+    /*
+    -------------------------------------------------------------------------
+     *  Meta-box registration
+     * ---------------------------------------------------------------------- */
 
-	public function nuclen_add_summary_data_meta_box() {
-		$settings_repo = $this->nuclen_get_settings_repository();
-		$post_types    = $settings_repo->get( 'generation_post_types', array( 'post' ) );
-		$post_types    = is_array( $post_types ) ? $post_types : array( 'post' );
+    public function nuclen_add_summary_data_meta_box() {
+        $settings_repo = $this->nuclen_get_settings_repository();
+        $post_types    = $settings_repo->get( 'generation_post_types', array( 'post' ) );
+        $post_types    = is_array( $post_types ) ? $post_types : array( 'post' );
 
-		foreach ( $post_types as $post_type ) {
-			add_meta_box(
-				'nuclen-summary-data-meta-box',
-				'Summary',
-				array( $this, 'nuclen_render_summary_data_meta_box' ),
-				$post_type,
-				'normal',
-				'default'
-			);
-		}
-	}
+        foreach ( $post_types as $post_type ) {
+            add_meta_box(
+                'nuclen-summary-data-meta-box',
+                'Summary',
+                array( $this, 'nuclen_render_summary_data_meta_box' ),
+                $post_type,
+                'normal',
+                'default'
+            );
+        }
+    }
 
-	/*
-	-------------------------------------------------------------------------
-	 *  Summary meta-box – render
-	 * ---------------------------------------------------------------------- */
+    /*
+    -------------------------------------------------------------------------
+     *  Summary meta-box – render
+     * ---------------------------------------------------------------------- */
 
-	public function nuclen_render_summary_data_meta_box( $post ) {
-		$summary_data = get_post_meta( $post->ID, 'nuclen-summary-data', true );
-		if ( ! empty( $summary_data ) ) {
-			$summary_data = maybe_unserialize( $summary_data );
-		} else {
-			$summary_data = array(
-				'summary'         => '',
-				'date'            => '',
-				'format'          => 'paragraph',
+    public function nuclen_render_summary_data_meta_box( $post ) {
+        $summary_data = get_post_meta( $post->ID, 'nuclen-summary-data', true );
+        if ( ! empty( $summary_data ) ) {
+            $summary_data = maybe_unserialize( $summary_data );
+        } else {
+            $summary_data = array(
+                'summary'         => '',
+                'date'            => '',
+                'format'          => 'paragraph',
                                 'length'          => NUCLEN_SUMMARY_LENGTH_DEFAULT,
                                 'number_of_items' => NUCLEN_SUMMARY_ITEMS_DEFAULT,
                         );
-		}
+        }
 
-		$summary = $summary_data['summary'] ?? '';
-		$date    = $summary_data['date'] ?? '';
+        $summary = $summary_data['summary'] ?? '';
+        $date    = $summary_data['date'] ?? '';
 
-		$summary_protected = get_post_meta( $post->ID, 'nuclen_summary_protected', true );
+        $summary_protected = get_post_meta( $post->ID, 'nuclen_summary_protected', true );
 
                 require NUCLEN_PLUGIN_DIR . 'templates/admin/summary-metabox.php';
         }
 
-	/*
-	-------------------------------------------------------------------------
-	 *  Summary meta-box – save (FIXED to preserve HTML)
-	 * ---------------------------------------------------------------------- */
+    /*
+    -------------------------------------------------------------------------
+     *  Summary meta-box – save (FIXED to preserve HTML)
+     * ---------------------------------------------------------------------- */
 
-	public function nuclen_save_summary_data_meta( $post_id ) {
+    public function nuclen_save_summary_data_meta( $post_id ) {
 
-		/* ---- Capability / nonce / autosave checks ------------------------ */
-		$nonce = $_POST['nuclen_summary_data_nonce'] ?? '';
-		if ( ! wp_verify_nonce( $nonce, 'nuclen_summary_data_nonce' ) ) {
-			return;
-		}
-		if ( defined( 'DOING_AUTOSAVE' ) && DOING_AUTOSAVE ) {
-			return;
-		}
-		if ( ! current_user_can( 'edit_post', $post_id ) ) {
-			return;
-		}
+        /* ---- Capability / nonce / autosave checks ------------------------ */
+        $nonce = $_POST['nuclen_summary_data_nonce'] ?? '';
+        if ( ! wp_verify_nonce( $nonce, 'nuclen_summary_data_nonce' ) ) {
+            return;
+        }
+        if ( defined( 'DOING_AUTOSAVE' ) && DOING_AUTOSAVE ) {
+            return;
+        }
+        if ( ! current_user_can( 'edit_post', $post_id ) ) {
+            return;
+        }
 
-		/* ---- Raw input ---------------------------------------------------- */
-		$raw = $_POST['nuclen_summary_data'] ?? array();
-		$raw = is_array( $raw ) ? wp_unslash( $raw ) : array();
+        /* ---- Raw input ---------------------------------------------------- */
+        $raw = $_POST['nuclen_summary_data'] ?? array();
+        $raw = is_array( $raw ) ? wp_unslash( $raw ) : array();
 
-		/* ---- Sanitise & format ------------------------------------------- */
-		$formatted = array(
-			'date'    => sanitize_text_field( $raw['date'] ?? gmdate( 'Y-m-d H:i:s' ) ),
-			'summary' => wp_kses_post( $raw['summary'] ?? '' ),
-		);
+        /* ---- Sanitise & format ------------------------------------------- */
+        $formatted = array(
+            'date'    => sanitize_text_field( $raw['date'] ?? gmdate( 'Y-m-d H:i:s' ) ),
+            'summary' => wp_kses_post( $raw['summary'] ?? '' ),
+        );
 
-		/* ---- Save to DB --------------------------------------------------- */
-		update_post_meta( $post_id, 'nuclen-summary-data', $formatted );
-		clean_post_cache( $post_id );
+        /* ---- Save to DB --------------------------------------------------- */
+        update_post_meta( $post_id, 'nuclen-summary-data', $formatted );
+        clean_post_cache( $post_id );
 
-		/* ---- Update post_modified if enabled ----------------------------- */
-		$settings_repo = $this->nuclen_get_settings_repository();
-		$settings      = $settings_repo->get( 'update_last_modified', 0 );
+        /* ---- Update post_modified if enabled ----------------------------- */
+        $settings_repo = $this->nuclen_get_settings_repository();
+        $settings      = $settings_repo->get( 'update_last_modified', 0 );
                 if ( ! empty( $settings ) && (int) $settings === 1 ) {
                         remove_action( 'save_post', array( $this, 'nuclen_save_summary_data_meta' ), 10 );
 
@@ -133,13 +133,13 @@ final class Nuclen_Summary_Metabox {
                         }
 
                         add_action( 'save_post', array( $this, 'nuclen_save_summary_data_meta' ), 10, 1 );
-		}
+        }
 
-		/* ---- Protected flag ---------------------------------------------- */
-		if ( isset( $_POST['nuclen_summary_protected'] ) && $_POST['nuclen_summary_protected'] === '1' ) {
-			update_post_meta( $post_id, 'nuclen_summary_protected', 1 );
-		} else {
-			delete_post_meta( $post_id, 'nuclen_summary_protected' );
-		}
-	}
+        /* ---- Protected flag ---------------------------------------------- */
+        if ( isset( $_POST['nuclen_summary_protected'] ) && $_POST['nuclen_summary_protected'] === '1' ) {
+            update_post_meta( $post_id, 'nuclen_summary_protected', 1 );
+        } else {
+            delete_post_meta( $post_id, 'nuclen_summary_protected' );
+        }
+    }
 }

--- a/nuclear-engagement/inc/Modules/TOC/includes/class-nuclen-toc-admin.php
+++ b/nuclear-engagement/inc/Modules/TOC/includes/class-nuclen-toc-admin.php
@@ -23,156 +23,156 @@ if ( ! defined( 'ABSPATH' ) ) {
  */
 final class Nuclen_TOC_Admin {
 
-	/**
-	 * Hook suffix for the options page.
-	 *
-	 * @var string
-	 */
-	private string $hook = '';
+    /**
+     * Hook suffix for the options page.
+     *
+     * @var string
+     */
+    private string $hook = '';
 
-	/**
-	 * Register admin hooks.
-	 */
-	public function __construct() {
-		add_action( 'admin_menu', array( $this, 'menu' ) );
-		add_action( 'admin_enqueue_scripts', array( $this, 'assets' ) );
-	}
+    /**
+     * Register admin hooks.
+     */
+    public function __construct() {
+        add_action( 'admin_menu', array( $this, 'menu' ) );
+        add_action( 'admin_enqueue_scripts', array( $this, 'assets' ) );
+    }
 
-	/**
-	 * Register the settings page.
-	 *
-	 * @return void
-	 */
-	public function menu(): void {
-		$this->hook = add_options_page(
-			__( 'Nuclen TOC', 'nuclen-toc-shortcode' ),
-			__( 'Nuclen TOC', 'nuclen-toc-shortcode' ),
-			'manage_options',
-			'nuclen-toc-shortcode',
-			array( $this, 'page' )
-		);
-	}
+    /**
+     * Register the settings page.
+     *
+     * @return void
+     */
+    public function menu(): void {
+        $this->hook = add_options_page(
+            __( 'Nuclen TOC', 'nuclen-toc-shortcode' ),
+            __( 'Nuclen TOC', 'nuclen-toc-shortcode' ),
+            'manage_options',
+            'nuclen-toc-shortcode',
+            array( $this, 'page' )
+        );
+    }
 
-	/**
-	 * Enqueue scripts and styles for the admin page.
-	 *
-	 * @param string $hook Current admin page hook.
-	 * @return void
-	 */
-	public function assets( string $hook ): void {
-		if ( $hook !== $this->hook ) {
-			return;
-		}
+    /**
+     * Enqueue scripts and styles for the admin page.
+     *
+     * @param string $hook Current admin page hook.
+     * @return void
+     */
+    public function assets( string $hook ): void {
+        if ( $hook !== $this->hook ) {
+            return;
+        }
 
-		$css_p = NUCLEN_TOC_DIR . 'assets/css/nuclen-toc-admin.css';
-		$js_p  = NUCLEN_TOC_DIR . 'assets/js/nuclen-toc-admin.js';
+        $css_p = NUCLEN_TOC_DIR . 'assets/css/nuclen-toc-admin.css';
+        $js_p  = NUCLEN_TOC_DIR . 'assets/js/nuclen-toc-admin.js';
 
-		$css_v = AssetVersions::get( 'toc_admin_css' );
-		$js_v  = AssetVersions::get( 'toc_admin_js' );
+        $css_v = AssetVersions::get( 'toc_admin_css' );
+        $js_v  = AssetVersions::get( 'toc_admin_js' );
 
-		wp_register_style(
-			'nuclen-toc-admin',
-			NUCLEN_TOC_URL . 'assets/css/nuclen-toc-admin.css',
-			array(),
-			$css_v
-		);
+        wp_register_style(
+            'nuclen-toc-admin',
+            NUCLEN_TOC_URL . 'assets/css/nuclen-toc-admin.css',
+            array(),
+            $css_v
+        );
 
-		wp_register_script(
-			'nuclen-toc-admin',
-			NUCLEN_TOC_URL . 'assets/js/nuclen-toc-admin.js',
-			array(),
-			$js_v,
-			true
-		);
+        wp_register_script(
+            'nuclen-toc-admin',
+            NUCLEN_TOC_URL . 'assets/js/nuclen-toc-admin.js',
+            array(),
+            $js_v,
+            true
+        );
 
-		wp_localize_script(
-			'nuclen-toc-admin',
-			'nuclenTocAdmin',
-			array(
-				'copy' => __( 'Copy', 'nuclen-toc-shortcode' ),
-				'done' => __( 'Copied!', 'nuclen-toc-shortcode' ),
-			)
-		);
+        wp_localize_script(
+            'nuclen-toc-admin',
+            'nuclenTocAdmin',
+            array(
+                'copy' => __( 'Copy', 'nuclen-toc-shortcode' ),
+                'done' => __( 'Copied!', 'nuclen-toc-shortcode' ),
+            )
+        );
 
-		wp_enqueue_style( 'nuclen-toc-admin' );
-		wp_enqueue_script( 'nuclen-toc-admin' );
-	}
+        wp_enqueue_style( 'nuclen-toc-admin' );
+        wp_enqueue_script( 'nuclen-toc-admin' );
+    }
 
-	/**
-	 * Render the settings page markup.
-	 *
-	 * @return void
-	 */
-	public function page(): void {
-		if ( ! current_user_can( 'manage_options' ) ) {
-			return;
-		}
+    /**
+     * Render the settings page markup.
+     *
+     * @return void
+     */
+    public function page(): void {
+        if ( ! current_user_can( 'manage_options' ) ) {
+            return;
+        }
 
-		echo '<div class="wrap"><h1>' .
-			esc_html__( 'Nuclen TOC Shortcode Generator', 'nuclen-toc-shortcode' ) . '</h1>';
+        echo '<div class="wrap"><h1>' .
+            esc_html__( 'Nuclen TOC Shortcode Generator', 'nuclen-toc-shortcode' ) . '</h1>';
 
-		echo '<table class="form-table"><tbody>';
-		$this->select_row( 'nuclen-min', __( 'Minimum heading level', 'nuclen-toc-shortcode' ), 2 );
-		$this->select_row( 'nuclen-max', __( 'Maximum heading level', 'nuclen-toc-shortcode' ), 6 );
+        echo '<table class="form-table"><tbody>';
+        $this->select_row( 'nuclen-min', __( 'Minimum heading level', 'nuclen-toc-shortcode' ), 2 );
+        $this->select_row( 'nuclen-max', __( 'Maximum heading level', 'nuclen-toc-shortcode' ), 6 );
 
-		echo '<tr><th>' . esc_html__( 'List type', 'nuclen-toc-shortcode' ) .
-			'</th><td><select id="nuclen-list"><option value="ul">' .
-			esc_html__( 'Unordered', 'nuclen-toc-shortcode' ) . '</option><option value="ol">' .
-			esc_html__( 'Ordered', 'nuclen-toc-shortcode' ) . '</option></select></td></tr>';
+        echo '<tr><th>' . esc_html__( 'List type', 'nuclen-toc-shortcode' ) .
+            '</th><td><select id="nuclen-list"><option value="ul">' .
+            esc_html__( 'Unordered', 'nuclen-toc-shortcode' ) . '</option><option value="ol">' .
+            esc_html__( 'Ordered', 'nuclen-toc-shortcode' ) . '</option></select></td></tr>';
 
-		echo '<tr><th><label for="nuclen-title">' . esc_html__( 'Title', 'nuclen-toc-shortcode' ) .
-			'</label></th><td><input id="nuclen-title" class="regular-text" value="' .
-			esc_attr__( 'Table of Contents', 'nuclen-toc-shortcode' ) . '"></td></tr>';
+        echo '<tr><th><label for="nuclen-title">' . esc_html__( 'Title', 'nuclen-toc-shortcode' ) .
+            '</label></th><td><input id="nuclen-title" class="regular-text" value="' .
+            esc_attr__( 'Table of Contents', 'nuclen-toc-shortcode' ) . '"></td></tr>';
 
-		$this->checkbox_row( 'nuclen-tog', __( 'Collapsible', 'nuclen-toc-shortcode' ), true );
-		$this->checkbox_row( 'nuclen-col', __( 'Start collapsed', 'nuclen-toc-shortcode' ), false );
-		$this->checkbox_row( 'nuclen-smo', __( 'Smooth scroll', 'nuclen-toc-shortcode' ), true );
-		$this->checkbox_row( 'nuclen-hil', __( 'Highlight current section', 'nuclen-toc-shortcode' ), true );
+        $this->checkbox_row( 'nuclen-tog', __( 'Collapsible', 'nuclen-toc-shortcode' ), true );
+        $this->checkbox_row( 'nuclen-col', __( 'Start collapsed', 'nuclen-toc-shortcode' ), false );
+        $this->checkbox_row( 'nuclen-smo', __( 'Smooth scroll', 'nuclen-toc-shortcode' ), true );
+        $this->checkbox_row( 'nuclen-hil', __( 'Highlight current section', 'nuclen-toc-shortcode' ), true );
 
-		echo '<tr><th><label for="nuclen-off">' .
-			esc_html__( 'Scroll offset (px)', 'nuclen-toc-shortcode' ) .
-			'</label></th><td><input id="nuclen-off" type="number" min="0" value="' .
-			esc_attr( Nuclen_TOC_Assets::DEFAULT_SCROLL_OFFSET ) . '" style="width:80px"></td></tr>';
+        echo '<tr><th><label for="nuclen-off">' .
+            esc_html__( 'Scroll offset (px)', 'nuclen-toc-shortcode' ) .
+            '</label></th><td><input id="nuclen-off" type="number" min="0" value="' .
+            esc_attr( Nuclen_TOC_Assets::DEFAULT_SCROLL_OFFSET ) . '" style="width:80px"></td></tr>';
 
-		echo '</tbody></table><p><strong>' .
-			esc_html__( 'Generated shortcode:', 'nuclen-toc-shortcode' ) .
-			'</strong> <code id="nuclen-shortcode-preview"></code> ' .
-			'<button class="button" id="nuclen-copy">' .
-			esc_html__( 'Copy', 'nuclen-toc-shortcode' ) .
-			'</button></p></div>';
-	}
+        echo '</tbody></table><p><strong>' .
+            esc_html__( 'Generated shortcode:', 'nuclen-toc-shortcode' ) .
+            '</strong> <code id="nuclen-shortcode-preview"></code> ' .
+            '<button class="button" id="nuclen-copy">' .
+            esc_html__( 'Copy', 'nuclen-toc-shortcode' ) .
+            '</button></p></div>';
+    }
 
-	/**
-	 * Output a select row for heading levels.
-	 *
-	 * @param string $id    DOM id for the select element.
-	 * @param string $label Row label.
-	 * @param int    $def   Default selected heading level.
-	 * @return void
-	 */
-	private function select_row( string $id, string $label, int $def ): void {
-		echo '<tr><th><label for="' . esc_attr( $id ) . '">' . esc_html( $label ) .
-			'</label></th><td><select id="' . esc_attr( $id ) . '">';
+    /**
+     * Output a select row for heading levels.
+     *
+     * @param string $id    DOM id for the select element.
+     * @param string $label Row label.
+     * @param int    $def   Default selected heading level.
+     * @return void
+     */
+    private function select_row( string $id, string $label, int $def ): void {
+        echo '<tr><th><label for="' . esc_attr( $id ) . '">' . esc_html( $label ) .
+            '</label></th><td><select id="' . esc_attr( $id ) . '">';
 
-		for ( $i = 1; $i <= 6; $i++ ) {
-			echo '<option value="' . esc_attr( $i ) . '"' . selected( $def, $i, false ) . '>H' .
-				esc_html( $i ) . '</option>';
-		}
+        for ( $i = 1; $i <= 6; $i++ ) {
+            echo '<option value="' . esc_attr( $i ) . '"' . selected( $def, $i, false ) . '>H' .
+                esc_html( $i ) . '</option>';
+        }
 
-		echo '</select></td></tr>';
-	}
+        echo '</select></td></tr>';
+    }
 
-	/**
-	 * Output a checkbox row.
-	 *
-	 * @param string $id      DOM id for the checkbox.
-	 * @param string $label   Row label.
-	 * @param bool   $checked Whether the checkbox should be checked.
-	 * @return void
-	 */
-	private function checkbox_row( string $id, string $label, bool $checked ): void {
-		echo '<tr><th>' . esc_html( $label ) . '</th><td><label><input type="checkbox" id="' .
-			esc_attr( $id ) . '"' . checked( $checked, true, false ) . '> ' .
-			esc_html( $label ) . '</label></td></tr>';
-	}
+    /**
+     * Output a checkbox row.
+     *
+     * @param string $id      DOM id for the checkbox.
+     * @param string $label   Row label.
+     * @param bool   $checked Whether the checkbox should be checked.
+     * @return void
+     */
+    private function checkbox_row( string $id, string $label, bool $checked ): void {
+        echo '<tr><th>' . esc_html( $label ) . '</th><td><label><input type="checkbox" id="' .
+            esc_attr( $id ) . '"' . checked( $checked, true, false ) . '> ' .
+            esc_html( $label ) . '</label></td></tr>';
+    }
 }

--- a/nuclear-engagement/inc/Modules/TOC/includes/class-nuclen-toc-assets.php
+++ b/nuclear-engagement/inc/Modules/TOC/includes/class-nuclen-toc-assets.php
@@ -19,86 +19,86 @@ if ( ! defined( 'ABSPATH' ) ) {
  * Front-end assets helper for the TOC module.
  */
 final class Nuclen_TOC_Assets {
-	/** Default vertical offset for scroll-to behaviour. */
-	public const DEFAULT_SCROLL_OFFSET = NUCLEN_TOC_SCROLL_OFFSET_DEFAULT;
+    /** Default vertical offset for scroll-to behaviour. */
+    public const DEFAULT_SCROLL_OFFSET = NUCLEN_TOC_SCROLL_OFFSET_DEFAULT;
 
-	/**
-	 * Whether assets have been registered.
-	 *
-	 * @var bool
-	 */
-	private bool $registered = false;
+    /**
+     * Whether assets have been registered.
+     *
+     * @var bool
+     */
+    private bool $registered = false;
 
-	/**
-	 * Current scroll offset in pixels.
-	 *
-	 * @var int
-	 */
-	private int $scroll_offset = self::DEFAULT_SCROLL_OFFSET;
+    /**
+     * Current scroll offset in pixels.
+     *
+     * @var int
+     */
+    private int $scroll_offset = self::DEFAULT_SCROLL_OFFSET;
 
-	/**
-	 * Enqueue assets and apply runtime tweaks.
-	 *
-	 * @param array $a Shortcode attributes.
-	 */
-	public function enqueue( array $a ): void {
-		if ( ! is_singular() ) {
-			return;
-		}
-		if ( ! $this->registered ) {
-			$this->register();
-		}
-		wp_enqueue_style( 'nuclen-toc-front' );
-		if ( 'true' === $a['toggle'] || 'true' === $a['highlight'] ) {
-			wp_enqueue_script( 'nuclen-toc-front' );
-		}
-		$off = max( 0, min( 500, (int) $a['offset'] ) );
-		if ( $this->scroll_offset !== $off ) {
-			wp_add_inline_style( 'nuclen-toc-front', ':root{--nuclen-toc-offset:' . $off . 'px}' );
-			$this->scroll_offset = $off;
-		}
-		if ( 'true' === $a['smooth'] ) {
-			wp_add_inline_style( 'nuclen-toc-front', 'html{scroll-behavior:smooth}' );
-		}
-	}
+    /**
+     * Enqueue assets and apply runtime tweaks.
+     *
+     * @param array $a Shortcode attributes.
+     */
+    public function enqueue( array $a ): void {
+        if ( ! is_singular() ) {
+            return;
+        }
+        if ( ! $this->registered ) {
+            $this->register();
+        }
+        wp_enqueue_style( 'nuclen-toc-front' );
+        if ( 'true' === $a['toggle'] || 'true' === $a['highlight'] ) {
+            wp_enqueue_script( 'nuclen-toc-front' );
+        }
+        $off = max( 0, min( 500, (int) $a['offset'] ) );
+        if ( $this->scroll_offset !== $off ) {
+            wp_add_inline_style( 'nuclen-toc-front', ':root{--nuclen-toc-offset:' . $off . 'px}' );
+            $this->scroll_offset = $off;
+        }
+        if ( 'true' === $a['smooth'] ) {
+            wp_add_inline_style( 'nuclen-toc-front', 'html{scroll-behavior:smooth}' );
+        }
+    }
 
-	/**
-	 * Register scripts and styles.
-	 */
-	private function register(): void {
-		if ( $this->registered ) {
-			return;
-		}
-		$this->registered = true;
+    /**
+     * Register scripts and styles.
+     */
+    private function register(): void {
+        if ( $this->registered ) {
+            return;
+        }
+        $this->registered = true;
 
-		$css_p = NUCLEN_TOC_DIR . 'assets/css/nuclen-toc-front.css';
-		$js_p  = NUCLEN_TOC_DIR . 'assets/js/nuclen-toc-front.js';
+        $css_p = NUCLEN_TOC_DIR . 'assets/css/nuclen-toc-front.css';
+        $js_p  = NUCLEN_TOC_DIR . 'assets/js/nuclen-toc-front.js';
 
-		$css_v = AssetVersions::get( 'toc_front_css' );
-		$js_v  = AssetVersions::get( 'toc_front_js' );
+        $css_v = AssetVersions::get( 'toc_front_css' );
+        $js_v  = AssetVersions::get( 'toc_front_js' );
 
-		wp_register_style(
-			'nuclen-toc-front',
-			NUCLEN_TOC_URL . 'assets/css/nuclen-toc-front.css',
-			array(),
-			$css_v
-		);
+        wp_register_style(
+            'nuclen-toc-front',
+            NUCLEN_TOC_URL . 'assets/css/nuclen-toc-front.css',
+            array(),
+            $css_v
+        );
 
-		wp_register_script(
-			'nuclen-toc-front',
-			NUCLEN_TOC_URL . 'assets/js/nuclen-toc-front.js',
-			array(),
-			$js_v,
-			true
-		);
+        wp_register_script(
+            'nuclen-toc-front',
+            NUCLEN_TOC_URL . 'assets/js/nuclen-toc-front.js',
+            array(),
+            $js_v,
+            true
+        );
 
-		wp_localize_script(
-			'nuclen-toc-front',
-			'nuclenTocL10n',
-			array(
-				'hide' => __( 'Hide', 'nuclen-toc-shortcode' ),
-				'show' => __( 'Show', 'nuclen-toc-shortcode' ),
-			)
-		);
-	}
+        wp_localize_script(
+            'nuclen-toc-front',
+            'nuclenTocL10n',
+            array(
+                'hide' => __( 'Hide', 'nuclen-toc-shortcode' ),
+                'show' => __( 'Show', 'nuclen-toc-shortcode' ),
+            )
+        );
+    }
 }

--- a/nuclear-engagement/inc/Modules/TOC/includes/class-nuclen-toc-headings.php
+++ b/nuclear-engagement/inc/Modules/TOC/includes/class-nuclen-toc-headings.php
@@ -17,50 +17,50 @@ if ( ! defined( 'ABSPATH' ) ) {
  * Adds unique IDs to headings within post content.
  */
 final class Nuclen_TOC_Headings {
-		/**
-		 * Hook into content filters.
-		 */
-	public function __construct() {
-			add_filter( 'the_content', array( $this, 'nuclen_add_heading_ids' ), 99 );
-	}
+        /**
+         * Hook into content filters.
+         */
+    public function __construct() {
+            add_filter( 'the_content', array( $this, 'nuclen_add_heading_ids' ), 99 );
+    }
 
-		/**
-		 * Back-compat wrapper for legacy callback name.
-		 *
-		 * @param string $content Post content to filter.
-		 * @return string Filtered content.
-		 */
-	public function nuclen_add_heading_ids( string $content ): string {
-			return $this->add_heading_ids( $content );
-	}
+        /**
+         * Back-compat wrapper for legacy callback name.
+         *
+         * @param string $content Post content to filter.
+         * @return string Filtered content.
+         */
+    public function nuclen_add_heading_ids( string $content ): string {
+            return $this->add_heading_ids( $content );
+    }
 
-		/**
-		 * Inject IDs into headings that lack them.
-		 *
-		 * @param string $content HTML content to modify.
-		 * @return string Modified HTML content.
-		 */
-	public function add_heading_ids( string $content ): string {
-		if ( ! apply_filters( 'nuclen_toc_enable_heading_ids', true ) ) {
-				return $content;
-		}
-		if ( ! nuclen_str_contains( $content, '<h' ) ) {
-			return $content; }
+        /**
+         * Inject IDs into headings that lack them.
+         *
+         * @param string $content HTML content to modify.
+         * @return string Modified HTML content.
+         */
+    public function add_heading_ids( string $content ): string {
+        if ( ! apply_filters( 'nuclen_toc_enable_heading_ids', true ) ) {
+                return $content;
+        }
+        if ( ! nuclen_str_contains( $content, '<h' ) ) {
+            return $content; }
 
-		foreach ( Nuclen_TOC_Utils::extract( $content, range( 1, 6 ) ) as $h ) {
-			$pat         = sprintf(
-				'/(<%1$s\b(?![^>]*\bid=)[^>]*>)(%2$s)(<\/%1$s>)/is',
-				$h['tag'],
-				preg_quote( $h['inner'], '/' )
-			);
-				$rep     = sprintf(
-					'<%1$s id="%2$s">%3$s</%1$s>',
-					$h['tag'],
-					esc_attr( $h['id'] ),
-					$h['inner']
-				);
-				$content = preg_replace( $pat, $rep, $content, 1 );
-		}
-		return $content;
-	}
+        foreach ( Nuclen_TOC_Utils::extract( $content, range( 1, 6 ) ) as $h ) {
+            $pat         = sprintf(
+                '/(<%1$s\b(?![^>]*\bid=)[^>]*>)(%2$s)(<\/%1$s>)/is',
+                $h['tag'],
+                preg_quote( $h['inner'], '/' )
+            );
+                $rep     = sprintf(
+                    '<%1$s id="%2$s">%3$s</%1$s>',
+                    $h['tag'],
+                    esc_attr( $h['id'] ),
+                    $h['inner']
+                );
+                $content = preg_replace( $pat, $rep, $content, 1 );
+        }
+        return $content;
+    }
 }

--- a/nuclear-engagement/inc/Modules/TOC/includes/class-nuclen-toc-render.php
+++ b/nuclear-engagement/inc/Modules/TOC/includes/class-nuclen-toc-render.php
@@ -17,208 +17,208 @@ if ( ! defined( 'ABSPATH' ) ) {
     exit;
 }
 
-	/**
-	 * Handle the [nuclear_engagement_toc] shortcode output.
-	 */
+    /**
+     * Handle the [nuclear_engagement_toc] shortcode output.
+     */
 final class Nuclen_TOC_Render {
-	/**
-	 * Assets manager instance.
-	 *
-	 * @var Nuclen_TOC_Assets
-	 */
-	private Nuclen_TOC_Assets $assets;
+    /**
+     * Assets manager instance.
+     *
+     * @var Nuclen_TOC_Assets
+     */
+    private Nuclen_TOC_Assets $assets;
 
-	/**
-	 * View helper instance.
-	 *
-	 * @var Nuclen_TOC_View
-	 */
-	private Nuclen_TOC_View $view;
+    /**
+     * View helper instance.
+     *
+     * @var Nuclen_TOC_View
+     */
+    private Nuclen_TOC_View $view;
 
-	/** Class constructor. */
-	public function __construct() {
-		$this->assets = new Nuclen_TOC_Assets();
-		$this->view   = new Nuclen_TOC_View();
+    /** Class constructor. */
+    public function __construct() {
+        $this->assets = new Nuclen_TOC_Assets();
+        $this->view   = new Nuclen_TOC_View();
 
-		add_shortcode( 'nuclear_engagement_toc', array( $this, 'nuclen_toc_shortcode' ) );
+        add_shortcode( 'nuclear_engagement_toc', array( $this, 'nuclen_toc_shortcode' ) );
 
-		// i18n for strings inside this class.
-		add_action(
-			'init',
-			static function () {
-				load_plugin_textdomain(
-					'nuclen-toc-shortcode',
-					false,
-					dirname( plugin_basename( NUCLEN_TOC_DIR ) ) . '/languages'
-				);
-			}
-		);
-	}
+        // i18n for strings inside this class.
+        add_action(
+            'init',
+            static function () {
+                load_plugin_textdomain(
+                    'nuclen-toc-shortcode',
+                    false,
+                    dirname( plugin_basename( NUCLEN_TOC_DIR ) ) . '/languages'
+                );
+            }
+        );
+    }
 
-	/**
-	 * Sanitize and sort heading levels.
-	 *
-	 * @param array|string $heading_levels Provided heading levels.
-	 * @return array Sanitized heading levels array.
-	 */
-	private function validate_heading_levels( $heading_levels ): array {
-		if ( ! is_array( $heading_levels ) ) {
-			if ( is_string( $heading_levels ) ) {
-				$heading_levels = explode( ',', $heading_levels );
-			} else {
-				return range( 2, 6 );
-			}
-		}
-		$heading_levels = array_map( 'intval', $heading_levels );
-		$heading_levels = array_filter(
-			$heading_levels,
-			static function ( $level ) {
-				return $level >= 2 && $level <= 6;
-			}
-		);
-		if ( empty( $heading_levels ) ) {
-			return range( 2, 6 );
-		}
-		$heading_levels = array_unique( $heading_levels );
-		sort( $heading_levels );
-		return array_values( $heading_levels );
-	}
+    /**
+     * Sanitize and sort heading levels.
+     *
+     * @param array|string $heading_levels Provided heading levels.
+     * @return array Sanitized heading levels array.
+     */
+    private function validate_heading_levels( $heading_levels ): array {
+        if ( ! is_array( $heading_levels ) ) {
+            if ( is_string( $heading_levels ) ) {
+                $heading_levels = explode( ',', $heading_levels );
+            } else {
+                return range( 2, 6 );
+            }
+        }
+        $heading_levels = array_map( 'intval', $heading_levels );
+        $heading_levels = array_filter(
+            $heading_levels,
+            static function ( $level ) {
+                return $level >= 2 && $level <= 6;
+            }
+        );
+        if ( empty( $heading_levels ) ) {
+            return range( 2, 6 );
+        }
+        $heading_levels = array_unique( $heading_levels );
+        sort( $heading_levels );
+        return array_values( $heading_levels );
+    }
 
-	/**
-	 * Sanitize shortcode attributes.
-	 *
-	 * @param array $atts Raw shortcode attributes.
-	 * @return array Validated attributes.
-	 */
-	private function validate_shortcode_atts( array $atts ): array {
-		$valid_lists    = array( 'ul', 'ol' );
-		$valid_booleans = array( 'true', 'false' );
-		$valid_themes   = array( 'light', 'dark', 'auto' );
+    /**
+     * Sanitize shortcode attributes.
+     *
+     * @param array $atts Raw shortcode attributes.
+     * @return array Validated attributes.
+     */
+    private function validate_shortcode_atts( array $atts ): array {
+        $valid_lists    = array( 'ul', 'ol' );
+        $valid_booleans = array( 'true', 'false' );
+        $valid_themes   = array( 'light', 'dark', 'auto' );
 
-		if ( isset( $atts['list'] ) && ! in_array( strtolower( $atts['list'] ), $valid_lists, true ) ) {
-			$atts['list'] = 'ul';
-		}
-		foreach ( array( 'toggle', 'collapsed', 'smooth', 'highlight' ) as $bool_attr ) {
-			if ( isset( $atts[ $bool_attr ] ) && ! in_array( strtolower( $atts[ $bool_attr ] ), $valid_booleans, true ) ) {
-				$atts[ $bool_attr ] = 'true';
-			}
-		}
-		if ( isset( $atts['offset'] ) ) {
-			$atts['offset'] = max( 0, min( 500, intval( $atts['offset'] ) ) );
-		}
-		if ( isset( $atts['theme'] ) && ! in_array( strtolower( $atts['theme'] ), $valid_themes, true ) ) {
-			$atts['theme'] = 'light';
-		}
-		if ( isset( $atts['title'] ) ) {
-			$atts['title'] = sanitize_text_field( $atts['title'] );
-		}
-		if ( isset( $atts['show_text'] ) ) {
-			$atts['show_text'] = sanitize_text_field( $atts['show_text'] );
-		}
-		if ( isset( $atts['hide_text'] ) ) {
-			$atts['hide_text'] = sanitize_text_field( $atts['hide_text'] );
-		}
-		return $atts;
-	}
+        if ( isset( $atts['list'] ) && ! in_array( strtolower( $atts['list'] ), $valid_lists, true ) ) {
+            $atts['list'] = 'ul';
+        }
+        foreach ( array( 'toggle', 'collapsed', 'smooth', 'highlight' ) as $bool_attr ) {
+            if ( isset( $atts[ $bool_attr ] ) && ! in_array( strtolower( $atts[ $bool_attr ] ), $valid_booleans, true ) ) {
+                $atts[ $bool_attr ] = 'true';
+            }
+        }
+        if ( isset( $atts['offset'] ) ) {
+            $atts['offset'] = max( 0, min( 500, intval( $atts['offset'] ) ) );
+        }
+        if ( isset( $atts['theme'] ) && ! in_array( strtolower( $atts['theme'] ), $valid_themes, true ) ) {
+            $atts['theme'] = 'light';
+        }
+        if ( isset( $atts['title'] ) ) {
+            $atts['title'] = sanitize_text_field( $atts['title'] );
+        }
+        if ( isset( $atts['show_text'] ) ) {
+            $atts['show_text'] = sanitize_text_field( $atts['show_text'] );
+        }
+        if ( isset( $atts['hide_text'] ) ) {
+            $atts['hide_text'] = sanitize_text_field( $atts['hide_text'] );
+        }
+        return $atts;
+    }
 
-	/**
-	 * Merge defaults with shortcode attributes and settings.
-	 *
-	 * @param array              $atts     Shortcode attributes.
-	 * @param SettingsRepository $settings Settings API wrapper.
-	 * @return array Prepared attributes.
-	 */
-	private function prepare_shortcode_attributes( array $atts, SettingsRepository $settings ): array {
-		$heading_levels = $settings->get_array( 'toc_heading_levels', range( 2, 6 ) );
-		$heading_levels = $this->validate_heading_levels( $heading_levels );
+    /**
+     * Merge defaults with shortcode attributes and settings.
+     *
+     * @param array              $atts     Shortcode attributes.
+     * @param SettingsRepository $settings Settings API wrapper.
+     * @return array Prepared attributes.
+     */
+    private function prepare_shortcode_attributes( array $atts, SettingsRepository $settings ): array {
+        $heading_levels = $settings->get_array( 'toc_heading_levels', range( 2, 6 ) );
+        $heading_levels = $this->validate_heading_levels( $heading_levels );
 
-		$defaults = array(
-			'heading_levels' => $heading_levels,
-			'list'           => 'ul',
-			'title'          => '',
-			'toggle'         => 'true',
-			'collapsed'      => 'false',
-			'smooth'         => 'true',
-			'highlight'      => 'true',
-			'offset'         => Nuclen_TOC_Assets::DEFAULT_SCROLL_OFFSET,
-			'theme'          => 'light',
-			'show_text'      => __( 'Show table of contents', 'nuclear-engagement' ),
-			'hide_text'      => __( 'Hide table of contents', 'nuclear-engagement' ),
-		);
+        $defaults = array(
+            'heading_levels' => $heading_levels,
+            'list'           => 'ul',
+            'title'          => '',
+            'toggle'         => 'true',
+            'collapsed'      => 'false',
+            'smooth'         => 'true',
+            'highlight'      => 'true',
+            'offset'         => Nuclen_TOC_Assets::DEFAULT_SCROLL_OFFSET,
+            'theme'          => 'light',
+            'show_text'      => __( 'Show table of contents', 'nuclear-engagement' ),
+            'hide_text'      => __( 'Hide table of contents', 'nuclear-engagement' ),
+        );
 
-		$atts = shortcode_atts( $defaults, array_intersect_key( $atts, $defaults ), 'nuclear_engagement_toc' );
-		$atts = $this->validate_shortcode_atts( $atts );
+        $atts = shortcode_atts( $defaults, array_intersect_key( $atts, $defaults ), 'nuclear_engagement_toc' );
+        $atts = $this->validate_shortcode_atts( $atts );
 
-		if ( isset( $atts['heading_levels'] ) ) {
-				$atts['heading_levels'] = $this->validate_heading_levels( $atts['heading_levels'] );
-		}
-		if ( ! isset( $atts['sticky'] ) ) {
-				$atts['sticky'] = $settings->get_bool( 'toc_sticky' );
-		}
-		return $atts;
-	}
+        if ( isset( $atts['heading_levels'] ) ) {
+                $atts['heading_levels'] = $this->validate_heading_levels( $atts['heading_levels'] );
+        }
+        if ( ! isset( $atts['sticky'] ) ) {
+                $atts['sticky'] = $settings->get_bool( 'toc_sticky' );
+        }
+        return $atts;
+    }
 
-	/**
-	 * Shortcode callback for rendering the table of contents.
-	 *
-	 * @param array $atts Shortcode attributes.
-	 * @return string Generated HTML markup.
-	 */
+    /**
+     * Shortcode callback for rendering the table of contents.
+     *
+     * @param array $atts Shortcode attributes.
+     * @return string Generated HTML markup.
+     */
         public function nuclen_toc_shortcode( array $atts ): string {
                 $post = get_post( get_the_ID() );
                 if ( null === $post ) {
                         return '';
                 }
 
-		$settings = \NuclearEngagement\Container::getInstance()->get( 'settings' );
-		$atts     = $this->prepare_shortcode_attributes( $atts, $settings );
+        $settings = \NuclearEngagement\Container::getInstance()->get( 'settings' );
+        $atts     = $this->prepare_shortcode_attributes( $atts, $settings );
 
-		$list  = ( strtolower( $atts['list'] ) === 'ol' ) ? 'ol' : 'ul';
-		$heads = Nuclen_TOC_Utils::extract( $post->post_content, $atts['heading_levels'] );
-		if ( ! $heads ) {
-			return '';
-		}
+        $list  = ( strtolower( $atts['list'] ) === 'ol' ) ? 'ol' : 'ul';
+        $heads = Nuclen_TOC_Utils::extract( $post->post_content, $atts['heading_levels'] );
+        if ( ! $heads ) {
+            return '';
+        }
 
-		$this->assets->enqueue( $atts );
+        $this->assets->enqueue( $atts );
 
-		$toc_title = $this->view->get_toc_title( $settings );
-		if ( empty( $atts['title'] ) ) {
-			$atts['title'] = $toc_title;
-		}
+        $toc_title = $this->view->get_toc_title( $settings );
+        if ( empty( $atts['title'] ) ) {
+            $atts['title'] = $toc_title;
+        }
 
-		$nav_id  = esc_attr( wp_unique_id( 'nuclen-toc-' ) );
-		$wrapper = $this->view->build_wrapper_props( $atts, $settings );
-		$classes = $wrapper['classes'];
-		$sticky  = $wrapper['sticky_attrs'];
-		$show    = $wrapper['show_toggle'];
-		$hidden  = $wrapper['hidden'];
+        $nav_id  = esc_attr( wp_unique_id( 'nuclen-toc-' ) );
+        $wrapper = $this->view->build_wrapper_props( $atts, $settings );
+        $classes = $wrapper['classes'];
+        $sticky  = $wrapper['sticky_attrs'];
+        $show    = $wrapper['show_toggle'];
+        $hidden  = $wrapper['hidden'];
 
                 $theme = $settings->get_string( 'theme', 'bright' );
                 $out  = '<div class="nuclen-root" data-theme="' . esc_attr( $theme ) . '">';
-		$out .= sprintf(
-			'<section id="%s-wrapper" class="%s"%s>',
-			esc_attr( $nav_id ),
-			esc_attr( implode( ' ', $classes ) ),
-			$sticky
-		);
+        $out .= sprintf(
+            '<section id="%s-wrapper" class="%s"%s>',
+            esc_attr( $nav_id ),
+            esc_attr( implode( ' ', $classes ) ),
+            $sticky
+        );
 
-		if ( ! empty( $atts['sticky'] ) ) {
-			$out .= '<div class="nuclen-toc-content">';
-		}
+        if ( ! empty( $atts['sticky'] ) ) {
+            $out .= '<div class="nuclen-toc-content">';
+        }
 
-		$out .= $this->view->build_toggle_button( $show, $hidden, $atts, $nav_id );
-		$out .= $this->view->build_nav_markup( $heads, $list, $atts, $nav_id, $toc_title, $hidden );
+        $out .= $this->view->build_toggle_button( $show, $hidden, $atts, $nav_id );
+        $out .= $this->view->build_nav_markup( $heads, $list, $atts, $nav_id, $toc_title, $hidden );
 
-		if ( ! empty( $atts['sticky'] ) ) {
-			$out .= '</div>';
-		}
+        if ( ! empty( $atts['sticky'] ) ) {
+            $out .= '</div>';
+        }
 
-		$out .= '</section></div>';
+        $out .= '</section></div>';
 
-		if ( ! wp_script_is( 'nuclen-toc-front', 'enqueued' ) ) {
-			wp_enqueue_script( 'nuclen-toc-front' );
-		}
+        if ( ! wp_script_is( 'nuclen-toc-front', 'enqueued' ) ) {
+            wp_enqueue_script( 'nuclen-toc-front' );
+        }
 
-		return $out;
-	}
+        return $out;
+    }
 }

--- a/nuclear-engagement/inc/Modules/TOC/includes/class-nuclen-toc-utils.php
+++ b/nuclear-engagement/inc/Modules/TOC/includes/class-nuclen-toc-utils.php
@@ -23,7 +23,7 @@ if ( ! defined( 'ABSPATH' ) ) {
  */
 final class Nuclen_TOC_Utils {
 
-	private const CACHE_GROUP = 'nuclen_toc';
+    private const CACHE_GROUP = 'nuclen_toc';
         private const CACHE_TTL   = 6 * HOUR_IN_SECONDS;          // 6 hours.
 
         /**
@@ -40,21 +40,21 @@ final class Nuclen_TOC_Utils {
         */
        private static array $ids_in_post = array();
 
-	/**
-	 * Parse H1–H6 headings from raw HTML, respecting heading levels array,
-	 * .no‑toc class, data‑toc="false", and cache the result.
-	 *
-	 * @param string $html The HTML content to parse for headings.
-	 * @param array  $heading_levels Array of specific heading levels to include (e.g., [2, 4] for H2 and H4 only).
-	 *
-	 * @return array[] [
-	 *     'tag'   => 'h2',
-	 *     'level' => 2,
-	 *     'text'  => 'Heading text',
-	 *     'inner' => 'Heading <em>HTML</em>',
-	 *     'id'    => 'slugified-id'
-	 * ]
-	 */
+    /**
+     * Parse H1–H6 headings from raw HTML, respecting heading levels array,
+     * .no‑toc class, data‑toc="false", and cache the result.
+     *
+     * @param string $html The HTML content to parse for headings.
+     * @param array  $heading_levels Array of specific heading levels to include (e.g., [2, 4] for H2 and H4 only).
+     *
+     * @return array[] [
+     *     'tag'   => 'h2',
+     *     'level' => 2,
+     *     'text'  => 'Heading text',
+     *     'inner' => 'Heading <em>HTML</em>',
+     *     'id'    => 'slugified-id'
+     * ]
+     */
         public static function extract( string $html, array $heading_levels ): array {
                 $t0 = microtime( true );
 
@@ -63,22 +63,22 @@ final class Nuclen_TOC_Utils {
                         $heading_levels = range( 2, 6 );
                 }
 
-		// Sanitize and validate heading levels.
-		$heading_levels = array_filter(
-			array_map( 'intval', $heading_levels ),
-			function ( $level ) {
-				return $level >= 1 && $level <= 6;
-			}
-		);
+        // Sanitize and validate heading levels.
+        $heading_levels = array_filter(
+            array_map( 'intval', $heading_levels ),
+            function ( $level ) {
+                return $level >= 1 && $level <= 6;
+            }
+        );
 
-		// If still no valid levels, use defaults (2-6).
-		if ( empty( $heading_levels ) ) {
-			$heading_levels = range( 2, 6 );
-		}
+        // If still no valid levels, use defaults (2-6).
+        if ( empty( $heading_levels ) ) {
+            $heading_levels = range( 2, 6 );
+        }
 
-		// Sort and make unique.
-		sort( $heading_levels );
-		$heading_levels = array_unique( $heading_levels );
+        // Sort and make unique.
+        sort( $heading_levels );
+        $heading_levels = array_unique( $heading_levels );
 
                 // Generate cache key based on content and heading levels.
                 $key          = md5( $html ) . '_' . implode( '', $heading_levels );
@@ -148,18 +148,18 @@ final class Nuclen_TOC_Utils {
                 return $out;
         }
 
-		/*
-		 * ----------------------------------------------------------
-		 * Helpers
-		 * ----------------------------------------------------------
-		 */
+        /*
+         * ----------------------------------------------------------
+         * Helpers
+         * ----------------------------------------------------------
+         */
 
-		/**
-		 * Generate a unique slug from heading text.
-		 *
-		 * @param string $txt Heading text.
-		 * @return string Unique slug.
-		 */
+        /**
+         * Generate a unique slug from heading text.
+         *
+         * @param string $txt Heading text.
+         * @return string Unique slug.
+         */
        private static function unique_id_from_text( string $txt ): string {
                $base = sanitize_title( $txt );
                $id   = $base;
@@ -225,14 +225,14 @@ final class Nuclen_TOC_Utils {
                delete_transient( $transient );
        }
 
-		/**
-		 * Tiny wrapper so callers can import just one name.
-		 *
-		 * @param string $haystack The string to search in.
-		 * @param string $needle   The substring to look for.
-		 * @return bool Whether the haystack contains the needle.
-		 */
-	public static function str_contains( string $haystack, string $needle ): bool {
-			return nuclen_str_contains( $haystack, $needle );
-	}
+        /**
+         * Tiny wrapper so callers can import just one name.
+         *
+         * @param string $haystack The string to search in.
+         * @param string $needle   The substring to look for.
+         * @return bool Whether the haystack contains the needle.
+         */
+    public static function str_contains( string $haystack, string $needle ): bool {
+            return nuclen_str_contains( $haystack, $needle );
+    }
 }

--- a/nuclear-engagement/inc/Modules/TOC/includes/class-nuclen-toc-view.php
+++ b/nuclear-engagement/inc/Modules/TOC/includes/class-nuclen-toc-view.php
@@ -21,164 +21,164 @@ use NuclearEngagement\SettingsRepository;
  * Output builder for the front-end table of contents.
  */
 final class Nuclen_TOC_View {
-	private const DEFAULT_STICKY_OFFSET_X  = 20;
-	private const DEFAULT_STICKY_OFFSET_Y  = 20;
-	private const DEFAULT_STICKY_MAX_WIDTH = 300;
+    private const DEFAULT_STICKY_OFFSET_X  = 20;
+    private const DEFAULT_STICKY_OFFSET_Y  = 20;
+    private const DEFAULT_STICKY_MAX_WIDTH = 300;
 
-	/**
-	 * Retrieve the translated TOC title with a fallback.
-	 *
-	 * @param SettingsRepository $settings Plugin settings repository.
-	 * @return string Sanitized title string.
-	 */
-	public function get_toc_title( SettingsRepository $settings ): string {
-		$title = $settings->get_string( 'toc_title' );
-		if ( empty( $title ) ) {
-			return esc_html__( 'Table of Contents', 'nuclen-toc-shortcode' );
-		}
-		return esc_html( $title );
-	}
+    /**
+     * Retrieve the translated TOC title with a fallback.
+     *
+     * @param SettingsRepository $settings Plugin settings repository.
+     * @return string Sanitized title string.
+     */
+    public function get_toc_title( SettingsRepository $settings ): string {
+        $title = $settings->get_string( 'toc_title' );
+        if ( empty( $title ) ) {
+            return esc_html__( 'Table of Contents', 'nuclen-toc-shortcode' );
+        }
+        return esc_html( $title );
+    }
 
-	/**
-	 * Build wrapper classes and sticky attributes.
-	 *
-	 * @param array              $atts     Shortcode attributes.
-	 * @param SettingsRepository $settings Settings repository.
-	 * @return array{classes:array,sticky_attrs:string,show_toggle:bool,hidden:bool}
-	 */
-	public function build_wrapper_props( array $atts, SettingsRepository $settings ): array {
-		$classes = array( 'nuclen-toc-wrapper' );
+    /**
+     * Build wrapper classes and sticky attributes.
+     *
+     * @param array              $atts     Shortcode attributes.
+     * @param SettingsRepository $settings Settings repository.
+     * @return array{classes:array,sticky_attrs:string,show_toggle:bool,hidden:bool}
+     */
+    public function build_wrapper_props( array $atts, SettingsRepository $settings ): array {
+        $classes = array( 'nuclen-toc-wrapper' );
 
-		if ( in_array( $atts['theme'], array( 'dark', 'auto' ), true ) ) {
-			$classes[] = 'nuclen-toc-' . $atts['theme'];
-		}
+        if ( in_array( $atts['theme'], array( 'dark', 'auto' ), true ) ) {
+            $classes[] = 'nuclen-toc-' . $atts['theme'];
+        }
 
-		$show_toggle = $settings->get_bool( 'toc_show_toggle' );
-		$hidden      = $show_toggle && ! $settings->get_bool( 'toc_show_content' );
+        $show_toggle = $settings->get_bool( 'toc_show_toggle' );
+        $hidden      = $show_toggle && ! $settings->get_bool( 'toc_show_content' );
 
-		if ( $show_toggle ) {
-			$classes[] = 'nuclen-toc-has-toggle';
-			if ( $hidden ) {
-				$classes[] = 'nuclen-toc-collapsed';
-			}
-		}
+        if ( $show_toggle ) {
+            $classes[] = 'nuclen-toc-has-toggle';
+            if ( $hidden ) {
+                $classes[] = 'nuclen-toc-collapsed';
+            }
+        }
 
-		$sticky_attrs = '';
-		if ( ! empty( $atts['sticky'] ) ) {
-			$classes[] = 'nuclen-toc-sticky';
+        $sticky_attrs = '';
+        if ( ! empty( $atts['sticky'] ) ) {
+            $classes[] = 'nuclen-toc-sticky';
 
-			$sticky_offset_x  = $settings->get_int( 'toc_sticky_offset_x', self::DEFAULT_STICKY_OFFSET_X );
-			$sticky_offset_y  = $settings->get_int( 'toc_sticky_offset_y', self::DEFAULT_STICKY_OFFSET_Y );
-			$sticky_max_width = $settings->get_int( 'toc_sticky_max_width', self::DEFAULT_STICKY_MAX_WIDTH );
+            $sticky_offset_x  = $settings->get_int( 'toc_sticky_offset_x', self::DEFAULT_STICKY_OFFSET_X );
+            $sticky_offset_y  = $settings->get_int( 'toc_sticky_offset_y', self::DEFAULT_STICKY_OFFSET_Y );
+            $sticky_max_width = $settings->get_int( 'toc_sticky_max_width', self::DEFAULT_STICKY_MAX_WIDTH );
 
-			$sticky_offset_x  = max( 0, min( 1000, $sticky_offset_x ) );
-			$sticky_offset_y  = max( 0, min( 1000, $sticky_offset_y ) );
-			$sticky_max_width = min( 1000, max( 100, $sticky_max_width ) );
+            $sticky_offset_x  = max( 0, min( 1000, $sticky_offset_x ) );
+            $sticky_offset_y  = max( 0, min( 1000, $sticky_offset_y ) );
+            $sticky_max_width = min( 1000, max( 100, $sticky_max_width ) );
 
-			$sticky_attrs = sprintf(
-				' data-offset-x="%d" data-offset-y="%d" data-max-width="%d" data-show-content="%s" data-heading-levels="%s"',
-				$sticky_offset_x,
-				$sticky_offset_y,
-				$sticky_max_width,
-				$settings->get_bool( 'toc_show_content' ) ? 'true' : 'false',
-				esc_attr( implode( ',', $atts['heading_levels'] ) )
-			);
-		}
+            $sticky_attrs = sprintf(
+                ' data-offset-x="%d" data-offset-y="%d" data-max-width="%d" data-show-content="%s" data-heading-levels="%s"',
+                $sticky_offset_x,
+                $sticky_offset_y,
+                $sticky_max_width,
+                $settings->get_bool( 'toc_show_content' ) ? 'true' : 'false',
+                esc_attr( implode( ',', $atts['heading_levels'] ) )
+            );
+        }
 
-		if ( 'true' === $atts['highlight'] ) {
-			$classes[] = 'nuclen-has-highlight';
-		}
+        if ( 'true' === $atts['highlight'] ) {
+            $classes[] = 'nuclen-has-highlight';
+        }
 
-		$z_index = $settings->get_int( 'toc_z_index', 100 );
-		$z_index = max( 1, min( 9999, $z_index ) );
+        $z_index = $settings->get_int( 'toc_z_index', 100 );
+        $z_index = max( 1, min( 9999, $z_index ) );
 
-			return array(
-				'classes'      => $classes,
-				'sticky_attrs' => $sticky_attrs,
-				'show_toggle'  => $show_toggle,
-				'hidden'       => $hidden,
-			);
-	}
+            return array(
+                'classes'      => $classes,
+                'sticky_attrs' => $sticky_attrs,
+                'show_toggle'  => $show_toggle,
+                'hidden'       => $hidden,
+            );
+    }
 
-	/**
-	 * Build the toggle button HTML if toggling is enabled.
-	 *
-	 * @param bool   $show    Whether to show the toggle.
-	 * @param bool   $hidden  Whether the content is hidden.
-	 * @param array  $atts    Shortcode attributes.
-	 * @param string $nav_id  Navigation element ID.
-	 * @return string Button markup or empty string.
-	 */
-	public function build_toggle_button( bool $show, bool $hidden, array $atts, string $nav_id ): string {
-		if ( ! $show ) {
-			return '';
-		}
-		$toggle_text = $hidden ? $atts['show_text'] : $atts['hide_text'];
-		return sprintf(
-			'<button type="button" class="nuclen-toc-toggle" aria-expanded="%s" aria-controls="%s">%s</button>',
-			$hidden ? 'false' : 'true',
-			esc_attr( $nav_id ),
-			esc_html( $toggle_text )
-		);
-	}
+    /**
+     * Build the toggle button HTML if toggling is enabled.
+     *
+     * @param bool   $show    Whether to show the toggle.
+     * @param bool   $hidden  Whether the content is hidden.
+     * @param array  $atts    Shortcode attributes.
+     * @param string $nav_id  Navigation element ID.
+     * @return string Button markup or empty string.
+     */
+    public function build_toggle_button( bool $show, bool $hidden, array $atts, string $nav_id ): string {
+        if ( ! $show ) {
+            return '';
+        }
+        $toggle_text = $hidden ? $atts['show_text'] : $atts['hide_text'];
+        return sprintf(
+            '<button type="button" class="nuclen-toc-toggle" aria-expanded="%s" aria-controls="%s">%s</button>',
+            $hidden ? 'false' : 'true',
+            esc_attr( $nav_id ),
+            esc_html( $toggle_text )
+        );
+    }
 
-	/**
-	 * Render the nested heading list.
-	 *
-	 * @param array  $heads     Parsed heading data.
-	 * @param string $list_tag  Tag name for list wrapper.
-	 * @return string HTML list markup.
-	 */
-	public function render_headings_list( array $heads, string $list_tag ): string {
-			$out = '';
-		$stack   = array();
-		foreach ( $heads as $h ) {
-			$l = $h['level'];
-			while ( $stack && end( $stack ) > $l ) {
-				$out .= '</li></' . $list_tag . '>';
-				array_pop( $stack );
-			}
-			if ( ! $stack || end( $stack ) < $l ) {
-				$out    .= '<' . $list_tag . '>';
-				$stack[] = $l;
-			} else {
-				$out .= '</li>';
-			}
-			$out .= '<li><a href="#' . esc_attr( $h['id'] ) . '">' . esc_html( $h['text'] ) . '</a>';
-		}
-		while ( $stack ) {
-			$out .= '</li></' . $list_tag . '>';
-			array_pop( $stack );
-		}
-		return $out;
-	}
+    /**
+     * Render the nested heading list.
+     *
+     * @param array  $heads     Parsed heading data.
+     * @param string $list_tag  Tag name for list wrapper.
+     * @return string HTML list markup.
+     */
+    public function render_headings_list( array $heads, string $list_tag ): string {
+            $out = '';
+        $stack   = array();
+        foreach ( $heads as $h ) {
+            $l = $h['level'];
+            while ( $stack && end( $stack ) > $l ) {
+                $out .= '</li></' . $list_tag . '>';
+                array_pop( $stack );
+            }
+            if ( ! $stack || end( $stack ) < $l ) {
+                $out    .= '<' . $list_tag . '>';
+                $stack[] = $l;
+            } else {
+                $out .= '</li>';
+            }
+            $out .= '<li><a href="#' . esc_attr( $h['id'] ) . '">' . esc_html( $h['text'] ) . '</a>';
+        }
+        while ( $stack ) {
+            $out .= '</li></' . $list_tag . '>';
+            array_pop( $stack );
+        }
+        return $out;
+    }
 
-	/**
-	 * Build the navigation markup containing the heading list.
-	 *
-	 * @param array  $heads     Parsed heading data.
-	 * @param string $list_tag  Tag name for list wrapper.
-	 * @param array  $atts      Shortcode attributes.
-	 * @param string $nav_id    Navigation element ID.
-	 * @param string $toc_title Title for accessibility label.
-	 * @param bool   $hidden    Whether the list starts hidden.
-	 * @return string HTML navigation markup.
-	 */
-	public function build_nav_markup( array $heads, string $list_tag, array $atts, string $nav_id, string $toc_title, bool $hidden ): string {
-			$nav = sprintf(
-				'<nav id="%s" class="nuclen-toc" aria-label="%s"%s%s>',
-				esc_attr( $nav_id ),
-				esc_attr( $toc_title ),
-				$hidden ? ' style="display:none"' : '',
-				'true' === $atts['highlight'] ? ' data-highlight="true"' : ''
-			);
+    /**
+     * Build the navigation markup containing the heading list.
+     *
+     * @param array  $heads     Parsed heading data.
+     * @param string $list_tag  Tag name for list wrapper.
+     * @param array  $atts      Shortcode attributes.
+     * @param string $nav_id    Navigation element ID.
+     * @param string $toc_title Title for accessibility label.
+     * @param bool   $hidden    Whether the list starts hidden.
+     * @return string HTML navigation markup.
+     */
+    public function build_nav_markup( array $heads, string $list_tag, array $atts, string $nav_id, string $toc_title, bool $hidden ): string {
+            $nav = sprintf(
+                '<nav id="%s" class="nuclen-toc" aria-label="%s"%s%s>',
+                esc_attr( $nav_id ),
+                esc_attr( $toc_title ),
+                $hidden ? ' style="display:none"' : '',
+                'true' === $atts['highlight'] ? ' data-highlight="true"' : ''
+            );
 
-		if ( '' !== $atts['title'] ) {
-				$nav .= '<strong class="toc-title">' . esc_html( $atts['title'] ) . '</strong>';
-		}
+        if ( '' !== $atts['title'] ) {
+                $nav .= '<strong class="toc-title">' . esc_html( $atts['title'] ) . '</strong>';
+        }
 
-			$nav .= $this->render_headings_list( $heads, $list_tag ) . '</nav>';
+            $nav .= $this->render_headings_list( $heads, $list_tag ) . '</nav>';
 
-		return $nav;
-	}
+        return $nav;
+    }
 }

--- a/nuclear-engagement/inc/Modules/TOC/includes/polyfills.php
+++ b/nuclear-engagement/inc/Modules/TOC/includes/polyfills.php
@@ -11,33 +11,33 @@
 declare(strict_types=1);
 
 if ( ! defined( 'ABSPATH' ) ) {
-	exit;
+    exit;
 }
 
 if ( ! function_exists( 'nuclen_str_contains' ) ) {
-		/**
-		 * Prefixed back‑port of PHP 8 str_contains().
-		 *
-		 * @param string $haystack String to search in.
-		 * @param string $needle   Substring to search for.
-		 *
-		 * @return bool Whether the needle exists in the haystack.
-		 */
-	function nuclen_str_contains( string $haystack, string $needle ): bool {
-			return '' === $needle || false !== strpos( $haystack, $needle );
-	}
+        /**
+         * Prefixed back‑port of PHP 8 str_contains().
+         *
+         * @param string $haystack String to search in.
+         * @param string $needle   Substring to search for.
+         *
+         * @return bool Whether the needle exists in the haystack.
+         */
+    function nuclen_str_contains( string $haystack, string $needle ): bool {
+            return '' === $needle || false !== strpos( $haystack, $needle );
+    }
 }
 
 if ( ! function_exists( 'nuclen_str_ends_with' ) ) {
-		/**
-		 * Prefixed back‑port of PHP 8 str_ends_with().
-		 *
-		 * @param string $haystack String to check.
-		 * @param string $needle   Expected ending.
-		 *
-		 * @return bool Whether the haystack ends with the needle.
-		 */
-	function nuclen_str_ends_with( string $haystack, string $needle ): bool {
-			return '' === $needle || substr( $haystack, -strlen( $needle ) ) === $needle;
-	}
+        /**
+         * Prefixed back‑port of PHP 8 str_ends_with().
+         *
+         * @param string $haystack String to check.
+         * @param string $needle   Expected ending.
+         *
+         * @return bool Whether the haystack ends with the needle.
+         */
+    function nuclen_str_ends_with( string $haystack, string $needle ): bool {
+            return '' === $needle || substr( $haystack, -strlen( $needle ) ) === $needle;
+    }
 }

--- a/nuclear-engagement/inc/Modules/TOC/loader.php
+++ b/nuclear-engagement/inc/Modules/TOC/loader.php
@@ -51,12 +51,12 @@ add_action( 'delete_post', array( 'Nuclen_TOC_Utils', 'clear_cache_for_post' ) )
  * ------------------------------------------------------------------
  */
 add_action(
-	'plugins_loaded',
-	static function () {
-		new Nuclen_TOC_Headings();  // filter for heading IDs.
-		new Nuclen_TOC_Render();    // shortcode handler.
-		if ( is_admin() ) {
-			new Nuclen_TOC_Admin();    // settings page.
-		}
-	}
+    'plugins_loaded',
+    static function () {
+        new Nuclen_TOC_Headings();  // filter for heading IDs.
+        new Nuclen_TOC_Render();    // shortcode handler.
+        if ( is_admin() ) {
+            new Nuclen_TOC_Admin();    // settings page.
+        }
+    }
 );

--- a/nuclear-engagement/inc/OptinData.php
+++ b/nuclear-engagement/inc/OptinData.php
@@ -16,176 +16,176 @@ namespace NuclearEngagement;
 use NuclearEngagement\Services\LoggingService;
 
 if ( ! defined( 'ABSPATH' ) ) {
-	exit;
+    exit;
 }
 
 class OptinData {
 
-	const TABLE_SLUG = 'nuclen_optins';
+    const TABLE_SLUG = 'nuclen_optins';
 
-	/*
-	---------------------------------------------------------------------
-	 *  Bootstrap
-	 * ------------------------------------------------------------------- */
-	public static function init(): void {
-		/* Table creation handled on plugin activation. */
+    /*
+    ---------------------------------------------------------------------
+     *  Bootstrap
+     * ------------------------------------------------------------------- */
+    public static function init(): void {
+        /* Table creation handled on plugin activation. */
 
-		/* Save via AJAX – front-end */
-		add_action( 'wp_ajax_nuclen_save_optin', array( self::class, 'handle_ajax' ) );
-		add_action( 'wp_ajax_nopriv_nuclen_save_optin', array( self::class, 'handle_ajax' ) );
+        /* Save via AJAX – front-end */
+        add_action( 'wp_ajax_nuclen_save_optin', array( self::class, 'handle_ajax' ) );
+        add_action( 'wp_ajax_nopriv_nuclen_save_optin', array( self::class, 'handle_ajax' ) );
 
-				// CSV export handled via OptinExportController
-	}
+                // CSV export handled via OptinExportController
+    }
 
-	/*
-	---------------------------------------------------------------------
-	 *  Helpers
-	 * ------------------------------------------------------------------- */
-	private static function table_name(): string {
-		global $wpdb;
-		return $wpdb->prefix . self::TABLE_SLUG;
-	}
-	/**
-	 * Cached flag to avoid repeated SHOW TABLES queries.
-	 *
-	 * @var bool|null
-	 */
-	private static ?bool $table_exists_cache = null;
+    /*
+    ---------------------------------------------------------------------
+     *  Helpers
+     * ------------------------------------------------------------------- */
+    private static function table_name(): string {
+        global $wpdb;
+        return $wpdb->prefix . self::TABLE_SLUG;
+    }
+    /**
+     * Cached flag to avoid repeated SHOW TABLES queries.
+     *
+     * @var bool|null
+     */
+    private static ?bool $table_exists_cache = null;
 
-	/**
-	 * Check whether the opt-in table already exists.
-	 */
-	public static function table_exists(): bool {
-		if ( null !== self::$table_exists_cache ) {
-			return self::$table_exists_cache;
-		}
+    /**
+     * Check whether the opt-in table already exists.
+     */
+    public static function table_exists(): bool {
+        if ( null !== self::$table_exists_cache ) {
+            return self::$table_exists_cache;
+        }
 
-		global $wpdb;
-		$table                    = self::table_name();
-		self::$table_exists_cache = $wpdb->get_var( $wpdb->prepare( 'SHOW TABLES LIKE %s', $table ) ) === $table;
-		return self::$table_exists_cache;
-	}
+        global $wpdb;
+        $table                    = self::table_name();
+        self::$table_exists_cache = $wpdb->get_var( $wpdb->prepare( 'SHOW TABLES LIKE %s', $table ) ) === $table;
+        return self::$table_exists_cache;
+    }
 
-	/**
-	 * Create the opt-in table if it doesn't already exist.
-	 * Safe to run many times – dbDelta() is idempotent but skipped when not needed.
-	 */
-	public static function maybe_create_table(): bool {
-		if ( self::table_exists() ) {
-			return true;
-		}
+    /**
+     * Create the opt-in table if it doesn't already exist.
+     * Safe to run many times – dbDelta() is idempotent but skipped when not needed.
+     */
+    public static function maybe_create_table(): bool {
+        if ( self::table_exists() ) {
+            return true;
+        }
 
-		global $wpdb;
+        global $wpdb;
 
-		$charset = $wpdb->get_charset_collate();
-		$table   = self::table_name();
+        $charset = $wpdb->get_charset_collate();
+        $table   = self::table_name();
 
-		$sql = "
-			CREATE TABLE {$table} (
-				id			BIGINT(20) UNSIGNED NOT NULL AUTO_INCREMENT,
-				submitted_at  DATETIME			NOT NULL,
-				url		   TEXT				NOT NULL,
-				name		  TEXT				NOT NULL,
-				email		 VARCHAR(255)		NOT NULL,
-				PRIMARY KEY  (id),
-				KEY email (email)
-			) {$charset};";
+        $sql = "
+            CREATE TABLE {$table} (
+                id            BIGINT(20) UNSIGNED NOT NULL AUTO_INCREMENT,
+                submitted_at  DATETIME            NOT NULL,
+                url           TEXT                NOT NULL,
+                name          TEXT                NOT NULL,
+                email         VARCHAR(255)        NOT NULL,
+                PRIMARY KEY  (id),
+                KEY email (email)
+            ) {$charset};";
 
-		require_once ABSPATH . 'wp-admin/includes/upgrade.php';
-		$result = dbDelta( $sql );
-		if ( ! empty( $wpdb->last_error ) ) {
-			LoggingService::log( 'dbDelta error: ' . $wpdb->last_error );
-			LoggingService::notify_admin( 'Nuclear Engagement table creation failed. Check logs.' );
-			return false;
-		}
-		if ( empty( $result ) ) {
-			LoggingService::log( 'dbDelta executed with no changes.' );
-		}
+        require_once ABSPATH . 'wp-admin/includes/upgrade.php';
+        $result = dbDelta( $sql );
+        if ( ! empty( $wpdb->last_error ) ) {
+            LoggingService::log( 'dbDelta error: ' . $wpdb->last_error );
+            LoggingService::notify_admin( 'Nuclear Engagement table creation failed. Check logs.' );
+            return false;
+        }
+        if ( empty( $result ) ) {
+            LoggingService::log( 'dbDelta executed with no changes.' );
+        }
 
-		self::$table_exists_cache = true;
-		return true;
-	}
+        self::$table_exists_cache = true;
+        return true;
+    }
 
-	/**
-	 * Insert one submission.
-	 *
-	 * @return bool  True on success, false on failure.
-	 */
-	public static function insert( string $name, string $email, string $url ): bool {
+    /**
+     * Insert one submission.
+     *
+     * @return bool  True on success, false on failure.
+     */
+    public static function insert( string $name, string $email, string $url ): bool {
 
-		/* Validate email */
-		if ( empty( $email ) || ! is_email( $email ) ) {
-			return false;
-		}
+        /* Validate email */
+        if ( empty( $email ) || ! is_email( $email ) ) {
+            return false;
+        }
 
-		global $wpdb;
-		$ok = $wpdb->insert(
-			self::table_name(),
-			array(
-				'submitted_at' => current_time( 'mysql', true ),
-				'url'          => esc_url_raw( $url ),
-				'name'         => sanitize_text_field( $name ),
-				'email'        => sanitize_email( $email ),
-			),
-			array( '%s', '%s', '%s', '%s' )
-		);
+        global $wpdb;
+        $ok = $wpdb->insert(
+            self::table_name(),
+            array(
+                'submitted_at' => current_time( 'mysql', true ),
+                'url'          => esc_url_raw( $url ),
+                'name'         => sanitize_text_field( $name ),
+                'email'        => sanitize_email( $email ),
+            ),
+            array( '%s', '%s', '%s', '%s' )
+        );
 
-		if ( false === $ok ) {
-			LoggingService::log( 'Insert error: ' . $wpdb->last_error );
-		}
+        if ( false === $ok ) {
+            LoggingService::log( 'Insert error: ' . $wpdb->last_error );
+        }
 
-		return (bool) $ok;
-	}
+        return (bool) $ok;
+    }
 
-	/**
-	 * Escape potential spreadsheet formulas in a CSV field.
-	 *
-	 * Spreadsheet applications may interpret values starting with =,+,-,@ as
-	 * formulas. Prefix with a single quote so the value is treated as text.
-	 */
-	private static function escape_csv_field( string $value ): string {
-		return preg_match( '/^[=+\-@]/', $value ) ? "'{$value}" : $value;
-	}
+    /**
+     * Escape potential spreadsheet formulas in a CSV field.
+     *
+     * Spreadsheet applications may interpret values starting with =,+,-,@ as
+     * formulas. Prefix with a single quote so the value is treated as text.
+     */
+    private static function escape_csv_field( string $value ): string {
+        return preg_match( '/^[=+\-@]/', $value ) ? "'{$value}" : $value;
+    }
 
-	/*
-	---------------------------------------------------------------------
-	 *  AJAX insert
-	 * ------------------------------------------------------------------- */
-	public static function handle_ajax(): void {
+    /*
+    ---------------------------------------------------------------------
+     *  AJAX insert
+     * ------------------------------------------------------------------- */
+    public static function handle_ajax(): void {
 
-		check_ajax_referer( 'nuclen_optin_nonce', 'nonce' );
+        check_ajax_referer( 'nuclen_optin_nonce', 'nonce' );
 
-		$name  = sanitize_text_field( wp_unslash( $_POST['name'] ?? '' ) );
-		$email = sanitize_email( wp_unslash( $_POST['email'] ?? '' ) );
-		$url   = esc_url_raw( wp_unslash( $_POST['url'] ?? '' ) );
+        $name  = sanitize_text_field( wp_unslash( $_POST['name'] ?? '' ) );
+        $email = sanitize_email( wp_unslash( $_POST['email'] ?? '' ) );
+        $url   = esc_url_raw( wp_unslash( $_POST['url'] ?? '' ) );
 
-		if ( empty( $email ) || ! is_email( $email ) ) {
-			wp_send_json_error( array( 'message' => 'Please enter a valid email address.' ), 400 );
-		}
+        if ( empty( $email ) || ! is_email( $email ) ) {
+            wp_send_json_error( array( 'message' => 'Please enter a valid email address.' ), 400 );
+        }
 
-		if ( ! self::insert( $name, $email, $url ) ) {
-			wp_send_json_error( array( 'message' => 'Unable to save your submission. Please try again later.' ), 500 );
-		}
+        if ( ! self::insert( $name, $email, $url ) ) {
+            wp_send_json_error( array( 'message' => 'Unable to save your submission. Please try again later.' ), 500 );
+        }
 
-		wp_send_json_success();
-	}
+        wp_send_json_success();
+    }
 
-	/*
-	---------------------------------------------------------------------
-	 *  CSV export  (admin-only)
-	 * ------------------------------------------------------------------- */
-	public static function handle_export(): void {
+    /*
+    ---------------------------------------------------------------------
+     *  CSV export  (admin-only)
+     * ------------------------------------------------------------------- */
+    public static function handle_export(): void {
 
-		/* Permission check */
-		if ( ! current_user_can( 'manage_options' ) ) {
-			wp_die( __( 'Insufficient permissions.', 'nuclear-engagement' ), 403 );
-		}
+        /* Permission check */
+        if ( ! current_user_can( 'manage_options' ) ) {
+            wp_die( __( 'Insufficient permissions.', 'nuclear-engagement' ), 403 );
+        }
 
-		/* Nonce check – accept from GET or POST */
-		$nonce = $_REQUEST['_wpnonce'] ?? '';
-		if ( ! wp_verify_nonce( $nonce, 'nuclen_export_optin' ) ) {
-			wp_die( __( 'Invalid nonce.', 'nuclear-engagement' ), 400 );
-		}
+        /* Nonce check – accept from GET or POST */
+        $nonce = $_REQUEST['_wpnonce'] ?? '';
+        if ( ! wp_verify_nonce( $nonce, 'nuclen_export_optin' ) ) {
+            wp_die( __( 'Invalid nonce.', 'nuclear-engagement' ), 400 );
+        }
 
                global $wpdb;
 

--- a/nuclear-engagement/inc/PendingSettingsTrait.php
+++ b/nuclear-engagement/inc/PendingSettingsTrait.php
@@ -11,41 +11,41 @@ declare(strict_types=1);
 namespace NuclearEngagement;
 
 if ( ! defined( 'ABSPATH' ) ) {
-	exit;
+    exit;
 }
 
 trait PendingSettingsTrait {
-	/**
-	 * Remove a setting.
-	 */
-	public function remove( string $key ): self {
-		if ( isset( $this->pending[ $key ] ) ) {
-			unset( $this->pending[ $key ] );
-		}
-		// Set to null to indicate removal
-		$this->pending[ $key ] = null;
-		return $this;
-	}
+    /**
+     * Remove a setting.
+     */
+    public function remove( string $key ): self {
+        if ( isset( $this->pending[ $key ] ) ) {
+            unset( $this->pending[ $key ] );
+        }
+        // Set to null to indicate removal
+        $this->pending[ $key ] = null;
+        return $this;
+    }
 
-	/**
-	 * Check if there are pending changes.
-	 */
-	public function has_pending(): bool {
-		return ! empty( $this->pending );
-	}
+    /**
+     * Check if there are pending changes.
+     */
+    public function has_pending(): bool {
+        return ! empty( $this->pending );
+    }
 
-	/**
-	 * Get all pending changes.
-	 */
-	public function get_pending(): array {
-		return $this->pending;
-	}
+    /**
+     * Get all pending changes.
+     */
+    public function get_pending(): array {
+        return $this->pending;
+    }
 
-	/**
-	 * Clear pending changes without saving.
-	 */
-	public function clear_pending(): self {
-		$this->pending = array();
-		return $this;
-	}
+    /**
+     * Clear pending changes without saving.
+     */
+    public function clear_pending(): self {
+        $this->pending = array();
+        return $this;
+    }
 }

--- a/nuclear-engagement/inc/Requests/ContentRequest.php
+++ b/nuclear-engagement/inc/Requests/ContentRequest.php
@@ -11,50 +11,50 @@ declare(strict_types=1);
 namespace NuclearEngagement\Requests;
 
 if ( ! defined( 'ABSPATH' ) ) {
-	exit;
+    exit;
 }
 
 /**
  * Data transfer object for content receive requests
  */
 class ContentRequest {
-	/**
-	 * @var string Workflow type (quiz|summary)
-	 */
-	public string $workflow = '';
+    /**
+     * @var string Workflow type (quiz|summary)
+     */
+    public string $workflow = '';
 
-	/**
-	 * @var array Results data from remote API
-	 */
-	public array $results = array();
+    /**
+     * @var array Results data from remote API
+     */
+    public array $results = array();
 
-	/**
-	 * Create from JSON data
-	 *
-	 * @param array $data JSON data
-	 * @return self
-	 * @throws \InvalidArgumentException On validation errors
-	 */
-	public static function fromJson( array $data ): self {
-		$request = new self();
+    /**
+     * Create from JSON data
+     *
+     * @param array $data JSON data
+     * @return self
+     * @throws \InvalidArgumentException On validation errors
+     */
+    public static function fromJson( array $data ): self {
+        $request = new self();
 
-		if ( empty( $data['workflow'] ) ) {
-			throw new \InvalidArgumentException( 'No workflow found in request' );
-		}
+        if ( empty( $data['workflow'] ) ) {
+            throw new \InvalidArgumentException( 'No workflow found in request' );
+        }
 
-		if ( empty( $data['results'] ) || ! is_array( $data['results'] ) ) {
-			throw new \InvalidArgumentException( 'No results data found in request' );
-		}
+        if ( empty( $data['results'] ) || ! is_array( $data['results'] ) ) {
+            throw new \InvalidArgumentException( 'No results data found in request' );
+        }
 
-		$request->workflow = sanitize_text_field( $data['workflow'] );
+        $request->workflow = sanitize_text_field( $data['workflow'] );
 
-		// Validate workflow
-		if ( ! in_array( $request->workflow, array( 'quiz', 'summary' ), true ) ) {
-			throw new \InvalidArgumentException( 'Invalid workflow type: ' . $request->workflow );
-		}
+        // Validate workflow
+        if ( ! in_array( $request->workflow, array( 'quiz', 'summary' ), true ) ) {
+            throw new \InvalidArgumentException( 'Invalid workflow type: ' . $request->workflow );
+        }
 
-		$request->results = $data['results'];
+        $request->results = $data['results'];
 
-		return $request;
-	}
+        return $request;
+    }
 }

--- a/nuclear-engagement/inc/Requests/GenerateRequest.php
+++ b/nuclear-engagement/inc/Requests/GenerateRequest.php
@@ -11,129 +11,129 @@ declare(strict_types=1);
 namespace NuclearEngagement\Requests;
 
 if ( ! defined( 'ABSPATH' ) ) {
-	exit;
+    exit;
 }
 
 /**
  * Data transfer object for generation requests
  */
 class GenerateRequest {
-	/**
-	 * @var array Post IDs to generate content for
-	 */
-	public array $postIds = array();
+    /**
+     * @var array Post IDs to generate content for
+     */
+    public array $postIds = array();
 
-	/**
-	 * @var string Workflow type (quiz|summary)
-	 */
-	public string $workflowType = '';
+    /**
+     * @var string Workflow type (quiz|summary)
+     */
+    public string $workflowType = '';
 
-	/**
-	 * @var string Summary format (paragraph|bullet_list)
-	 */
-	public string $summaryFormat = 'paragraph';
+    /**
+     * @var string Summary format (paragraph|bullet_list)
+     */
+    public string $summaryFormat = 'paragraph';
 
-	/**
-	 * @var int Summary length in words
-	 */
-	public int $summaryLength = NUCLEN_SUMMARY_LENGTH_DEFAULT;
+    /**
+     * @var int Summary length in words
+     */
+    public int $summaryLength = NUCLEN_SUMMARY_LENGTH_DEFAULT;
 
-	/**
-	 * @var int Number of summary items
-	 */
-	public int $summaryItems = NUCLEN_SUMMARY_ITEMS_DEFAULT;
+    /**
+     * @var int Number of summary items
+     */
+    public int $summaryItems = NUCLEN_SUMMARY_ITEMS_DEFAULT;
 
-	/**
-	 * @var string Generation ID for tracking
-	 */
-	public string $generationId = '';
+    /**
+     * @var string Generation ID for tracking
+     */
+    public string $generationId = '';
 
-	/**
-	 * @var string Post status filter
-	 */
-	public string $postStatus = 'any';
+    /**
+     * @var string Post status filter
+     */
+    public string $postStatus = 'any';
 
-	/**
-	 * @var string Post type filter
-	 */
-	public string $postType = 'post';
+    /**
+     * @var string Post type filter
+     */
+    public string $postType = 'post';
 
-	/**
-	 * Create from POST data
-	 *
-	 * @param array $post POST data
-	 * @return self
-	 * @throws \InvalidArgumentException On validation errors
-	 */
-	public static function fromPost( array $post ): self {
-		$request = new self();
+    /**
+     * Create from POST data
+     *
+     * @param array $post POST data
+     * @return self
+     * @throws \InvalidArgumentException On validation errors
+     */
+    public static function fromPost( array $post ): self {
+        $request = new self();
 
-		// Parse the payload
-		$payload = array();
-		if ( ! empty( $post['payload'] ) ) {
-			$payload = json_decode( wp_unslash( $post['payload'] ), true );
-			if ( json_last_error() !== JSON_ERROR_NONE ) {
-				throw new \InvalidArgumentException( 'Invalid JSON payload: ' . json_last_error_msg() );
-			}
-		}
+        // Parse the payload
+        $payload = array();
+        if ( ! empty( $post['payload'] ) ) {
+            $payload = json_decode( wp_unslash( $post['payload'] ), true );
+            if ( json_last_error() !== JSON_ERROR_NONE ) {
+                throw new \InvalidArgumentException( 'Invalid JSON payload: ' . json_last_error_msg() );
+            }
+        }
 
-		// Extract and validate post IDs
-		$postIdsJson      = $payload['nuclen_selected_post_ids'] ?? '';
-		$request->postIds = json_decode( $postIdsJson, true ) ?: array();
+        // Extract and validate post IDs
+        $postIdsJson      = $payload['nuclen_selected_post_ids'] ?? '';
+        $request->postIds = json_decode( $postIdsJson, true ) ?: array();
 
-		if ( empty( $request->postIds ) || ! is_array( $request->postIds ) ) {
-			throw new \InvalidArgumentException( 'No valid posts selected' );
-		}
+        if ( empty( $request->postIds ) || ! is_array( $request->postIds ) ) {
+            throw new \InvalidArgumentException( 'No valid posts selected' );
+        }
 
-		// Sanitize post IDs
-		$request->postIds = array_map( 'intval', $request->postIds );
-		$request->postIds = array_filter(
-			$request->postIds,
-			function ( $id ) {
-				return $id > 0;
-			}
-		);
+        // Sanitize post IDs
+        $request->postIds = array_map( 'intval', $request->postIds );
+        $request->postIds = array_filter(
+            $request->postIds,
+            function ( $id ) {
+                return $id > 0;
+            }
+        );
 
-		if ( empty( $request->postIds ) ) {
-			throw new \InvalidArgumentException( 'No valid post IDs after sanitization' );
-		}
+        if ( empty( $request->postIds ) ) {
+            throw new \InvalidArgumentException( 'No valid post IDs after sanitization' );
+        }
 
-		// Map other fields
-		$request->postStatus   = sanitize_text_field( $payload['nuclen_selected_post_status'] ?? 'any' );
-		$request->postType     = sanitize_text_field( $payload['nuclen_selected_post_type'] ?? 'post' );
-		$request->workflowType = sanitize_text_field( $payload['nuclen_selected_generate_workflow'] ?? '' );
+        // Map other fields
+        $request->postStatus   = sanitize_text_field( $payload['nuclen_selected_post_status'] ?? 'any' );
+        $request->postType     = sanitize_text_field( $payload['nuclen_selected_post_type'] ?? 'post' );
+        $request->workflowType = sanitize_text_field( $payload['nuclen_selected_generate_workflow'] ?? '' );
 
-		// Validate workflow type
-		if ( ! in_array( $request->workflowType, array( 'quiz', 'summary' ), true ) ) {
-			throw new \InvalidArgumentException( 'Invalid workflow type: ' . $request->workflowType );
-		}
+        // Validate workflow type
+        if ( ! in_array( $request->workflowType, array( 'quiz', 'summary' ), true ) ) {
+            throw new \InvalidArgumentException( 'Invalid workflow type: ' . $request->workflowType );
+        }
 
-		// Summary specific fields
-		$request->summaryFormat = sanitize_text_field( $payload['nuclen_selected_summary_format'] ?? 'paragraph' );
-		if ( ! in_array( $request->summaryFormat, array( 'paragraph', 'bullet_list' ), true ) ) {
-			$request->summaryFormat = 'paragraph';
-		}
+        // Summary specific fields
+        $request->summaryFormat = sanitize_text_field( $payload['nuclen_selected_summary_format'] ?? 'paragraph' );
+        if ( ! in_array( $request->summaryFormat, array( 'paragraph', 'bullet_list' ), true ) ) {
+            $request->summaryFormat = 'paragraph';
+        }
 
-		$request->summaryLength = max(
-			NUCLEN_SUMMARY_LENGTH_MIN,
-			min(
-				NUCLEN_SUMMARY_LENGTH_MAX,
-				(int) ( $payload['nuclen_selected_summary_length'] ?? NUCLEN_SUMMARY_LENGTH_DEFAULT )
-			)
-		);
-		$request->summaryItems  = max(
-			NUCLEN_SUMMARY_ITEMS_MIN,
-			min(
-				NUCLEN_SUMMARY_ITEMS_MAX,
-				(int) ( $payload['nuclen_selected_summary_number_of_items'] ?? NUCLEN_SUMMARY_ITEMS_DEFAULT )
-			)
-		);
+        $request->summaryLength = max(
+            NUCLEN_SUMMARY_LENGTH_MIN,
+            min(
+                NUCLEN_SUMMARY_LENGTH_MAX,
+                (int) ( $payload['nuclen_selected_summary_length'] ?? NUCLEN_SUMMARY_LENGTH_DEFAULT )
+            )
+        );
+        $request->summaryItems  = max(
+            NUCLEN_SUMMARY_ITEMS_MIN,
+            min(
+                NUCLEN_SUMMARY_ITEMS_MAX,
+                (int) ( $payload['nuclen_selected_summary_number_of_items'] ?? NUCLEN_SUMMARY_ITEMS_DEFAULT )
+            )
+        );
 
-		// Generation ID
-		$request->generationId = ! empty( $payload['generation_id'] )
-			? sanitize_text_field( $payload['generation_id'] )
-			: 'gen_' . uniqid( 'manual_', true );
+        // Generation ID
+        $request->generationId = ! empty( $payload['generation_id'] )
+            ? sanitize_text_field( $payload['generation_id'] )
+            : 'gen_' . uniqid( 'manual_', true );
 
-		return $request;
-	}
+        return $request;
+    }
 }

--- a/nuclear-engagement/inc/Requests/PostsCountRequest.php
+++ b/nuclear-engagement/inc/Requests/PostsCountRequest.php
@@ -11,40 +11,40 @@ declare(strict_types=1);
 namespace NuclearEngagement\Requests;
 
 if ( ! defined( 'ABSPATH' ) ) {
-	exit;
+    exit;
 }
 
 /**
  * Data transfer object for posts count requests
  */
 class PostsCountRequest {
-	public string $postStatus        = 'any';
-	public int $categoryId           = 0;
-	public int $authorId             = 0;
-	public string $postType          = '';
-	public string $workflow          = '';
-	public bool $allowRegenerate     = false;
-	public bool $regenerateProtected = false;
+    public string $postStatus        = 'any';
+    public int $categoryId           = 0;
+    public int $authorId             = 0;
+    public string $postType          = '';
+    public string $workflow          = '';
+    public bool $allowRegenerate     = false;
+    public bool $regenerateProtected = false;
 
-	/**
-	 * Create from POST data
-	 *
-	 * @param array $post POST data
-	 * @return self
-	 */
-	public static function fromPost( array $post ): self {
-		$request = new self();
+    /**
+     * Create from POST data
+     *
+     * @param array $post POST data
+     * @return self
+     */
+    public static function fromPost( array $post ): self {
+        $request = new self();
 
-		$unslashed = wp_unslash( $post );
+        $unslashed = wp_unslash( $post );
 
-		$request->postStatus          = sanitize_text_field( $unslashed['nuclen_post_status'] ?? 'any' );
-		$request->categoryId          = absint( $unslashed['nuclen_category'] ?? 0 );
-		$request->authorId            = absint( $unslashed['nuclen_author'] ?? 0 );
-		$request->postType            = sanitize_text_field( $unslashed['nuclen_post_type'] ?? '' );
-		$request->workflow            = sanitize_text_field( $unslashed['nuclen_generate_workflow'] ?? '' );
-		$request->allowRegenerate     = (bool) absint( $unslashed['nuclen_allow_regenerate_data'] ?? 0 );
-		$request->regenerateProtected = (bool) absint( $unslashed['nuclen_regenerate_protected_data'] ?? 0 );
+        $request->postStatus          = sanitize_text_field( $unslashed['nuclen_post_status'] ?? 'any' );
+        $request->categoryId          = absint( $unslashed['nuclen_category'] ?? 0 );
+        $request->authorId            = absint( $unslashed['nuclen_author'] ?? 0 );
+        $request->postType            = sanitize_text_field( $unslashed['nuclen_post_type'] ?? '' );
+        $request->workflow            = sanitize_text_field( $unslashed['nuclen_generate_workflow'] ?? '' );
+        $request->allowRegenerate     = (bool) absint( $unslashed['nuclen_allow_regenerate_data'] ?? 0 );
+        $request->regenerateProtected = (bool) absint( $unslashed['nuclen_regenerate_protected_data'] ?? 0 );
 
-		return $request;
-	}
+        return $request;
+    }
 }

--- a/nuclear-engagement/inc/Requests/UpdatesRequest.php
+++ b/nuclear-engagement/inc/Requests/UpdatesRequest.php
@@ -11,29 +11,29 @@ declare(strict_types=1);
 namespace NuclearEngagement\Requests;
 
 if ( ! defined( 'ABSPATH' ) ) {
-	exit;
+    exit;
 }
 
 /**
  * Data transfer object for update polling requests
  */
 class UpdatesRequest {
-	/**
-	 * @var string Generation ID to check
-	 */
-	public string $generationId = '';
+    /**
+     * @var string Generation ID to check
+     */
+    public string $generationId = '';
 
-	/**
-	 * Create from POST data
-	 *
-	 * @param array $post POST data
-	 * @return self
-	 */
-	public static function fromPost( array $post ): self {
-		$request               = new self();
-		$request->generationId = isset( $post['generation_id'] )
-			? sanitize_text_field( wp_unslash( $post['generation_id'] ) )
-			: '';
-		return $request;
-	}
+    /**
+     * Create from POST data
+     *
+     * @param array $post POST data
+     * @return self
+     */
+    public static function fromPost( array $post ): self {
+        $request               = new self();
+        $request->generationId = isset( $post['generation_id'] )
+            ? sanitize_text_field( wp_unslash( $post['generation_id'] ) )
+            : '';
+        return $request;
+    }
 }

--- a/nuclear-engagement/inc/Responses/GenerationResponse.php
+++ b/nuclear-engagement/inc/Responses/GenerationResponse.php
@@ -11,67 +11,67 @@ declare(strict_types=1);
 namespace NuclearEngagement\Responses;
 
 if ( ! defined( 'ABSPATH' ) ) {
-	exit;
+    exit;
 }
 
 /**
  * Response object for generation requests
  */
 class GenerationResponse {
-	/**
-	 * @var string Generation ID for tracking
-	 */
-	public string $generationId;
+    /**
+     * @var string Generation ID for tracking
+     */
+    public string $generationId;
 
-	/**
-	 * @var array Generated results
-	 */
-	public array $results = array();
+    /**
+     * @var array Generated results
+     */
+    public array $results = array();
 
-	/**
-	 * @var bool Success status
-	 */
-	public bool $success = true;
+    /**
+     * @var bool Success status
+     */
+    public bool $success = true;
 
-	/**
-	 * @var string|null Error message if any
-	 */
-	public ?string $error = null;
+    /**
+     * @var string|null Error message if any
+     */
+    public ?string $error = null;
 
-	/**
-	 * @var string|null Error code if any
-	 */
-	public ?string $errorCode = null;
+    /**
+     * @var string|null Error code if any
+     */
+    public ?string $errorCode = null;
 
-	/**
-	 * @var int|null HTTP status code from remote API
-	 */
-	public ?int $statusCode = null;
+    /**
+     * @var int|null HTTP status code from remote API
+     */
+    public ?int $statusCode = null;
 
-	/**
-	 * Convert to array for JSON response
-	 *
-	 * @return array
-	 */
-	public function toArray(): array {
-		$data = array(
-			'generation_id' => $this->generationId,
-			'results'       => $this->results,
-			'success'       => $this->success,
-		);
+    /**
+     * Convert to array for JSON response
+     *
+     * @return array
+     */
+    public function toArray(): array {
+        $data = array(
+            'generation_id' => $this->generationId,
+            'results'       => $this->results,
+            'success'       => $this->success,
+        );
 
-		if ( $this->error !== null ) {
-			$data['error'] = $this->error;
-		}
+        if ( $this->error !== null ) {
+            $data['error'] = $this->error;
+        }
 
-		if ( $this->errorCode !== null ) {
-			$data['error_code'] = $this->errorCode;
-		}
+        if ( $this->errorCode !== null ) {
+            $data['error_code'] = $this->errorCode;
+        }
 
-		if ( $this->statusCode !== null ) {
-			$data['status_code'] = $this->statusCode;
-		}
+        if ( $this->statusCode !== null ) {
+            $data['status_code'] = $this->statusCode;
+        }
 
-		return $data;
-	}
+        return $data;
+    }
 }

--- a/nuclear-engagement/inc/Responses/UpdatesResponse.php
+++ b/nuclear-engagement/inc/Responses/UpdatesResponse.php
@@ -11,7 +11,7 @@ declare(strict_types=1);
 namespace NuclearEngagement\Responses;
 
 if ( ! defined( 'ABSPATH' ) ) {
-	exit;
+    exit;
 }
 
 /**
@@ -19,45 +19,45 @@ if ( ! defined( 'ABSPATH' ) ) {
  */
 class UpdatesResponse {
 
-	public bool $success          = true;
-	public ?int $processed        = null;
-	public ?int $total            = null;
-	public ?array $results        = null;
-	public ?string $workflow      = null; // NEW
-	public ?int $remainingCredits = null;
-	public ?string $message       = null;
-	public ?int $statusCode       = null;
+    public bool $success          = true;
+    public ?int $processed        = null;
+    public ?int $total            = null;
+    public ?array $results        = null;
+    public ?string $workflow      = null; // NEW
+    public ?int $remainingCredits = null;
+    public ?string $message       = null;
+    public ?int $statusCode       = null;
 
-	/**
-	 * Convert to array for JSON response.
-	 *
-	 * @return array
-	 */
-	public function toArray(): array {
-		$data = array( 'success' => $this->success );
+    /**
+     * Convert to array for JSON response.
+     *
+     * @return array
+     */
+    public function toArray(): array {
+        $data = array( 'success' => $this->success );
 
-		if ( null !== $this->processed ) {
-			$data['processed'] = $this->processed;
-		}
-		if ( null !== $this->total ) {
-			$data['total'] = $this->total;
-		}
-		if ( null !== $this->results ) {
-			$data['results'] = $this->results;
-		}
-		if ( null !== $this->workflow ) {
-			$data['workflow'] = $this->workflow;
-		}
-		if ( null !== $this->remainingCredits ) {
-			$data['remaining_credits'] = $this->remainingCredits;
-		}
-		if ( null !== $this->message ) {
-			$data['message'] = $this->message;
-		}
-		if ( null !== $this->statusCode ) {
-			$data['status_code'] = $this->statusCode;
-		}
+        if ( null !== $this->processed ) {
+            $data['processed'] = $this->processed;
+        }
+        if ( null !== $this->total ) {
+            $data['total'] = $this->total;
+        }
+        if ( null !== $this->results ) {
+            $data['results'] = $this->results;
+        }
+        if ( null !== $this->workflow ) {
+            $data['workflow'] = $this->workflow;
+        }
+        if ( null !== $this->remainingCredits ) {
+            $data['remaining_credits'] = $this->remainingCredits;
+        }
+        if ( null !== $this->message ) {
+            $data['message'] = $this->message;
+        }
+        if ( null !== $this->statusCode ) {
+            $data['status_code'] = $this->statusCode;
+        }
 
-		return $data;
-	}
+        return $data;
+    }
 }

--- a/nuclear-engagement/inc/Services/ApiException.php
+++ b/nuclear-engagement/inc/Services/ApiException.php
@@ -9,18 +9,18 @@ declare(strict_types=1);
 namespace NuclearEngagement\Services;
 
 if ( ! defined( 'ABSPATH' ) ) {
-	exit;
+    exit;
 }
 
 class ApiException extends \RuntimeException {
-	private ?string $errorCode;
+    private ?string $errorCode;
 
-	public function __construct( string $message, int $code = 500, ?string $errorCode = null ) {
-		parent::__construct( $message, $code );
-		$this->errorCode = $errorCode;
-	}
+    public function __construct( string $message, int $code = 500, ?string $errorCode = null ) {
+        parent::__construct( $message, $code );
+        $this->errorCode = $errorCode;
+    }
 
-	public function getErrorCode(): ?string {
-		return $this->errorCode;
-	}
+    public function getErrorCode(): ?string {
+        return $this->errorCode;
+    }
 }

--- a/nuclear-engagement/inc/Services/AutoGenerationService.php
+++ b/nuclear-engagement/inc/Services/AutoGenerationService.php
@@ -15,7 +15,7 @@ use NuclearEngagement\Services\GenerationPoller;
 use NuclearEngagement\Services\PublishGenerationHandler;
 
 if ( ! defined( 'ABSPATH' ) ) {
-	exit;
+    exit;
 }
 
 class AutoGenerationService {
@@ -27,10 +27,10 @@ class AutoGenerationService {
 
 
 
-	/**
-	 * @var SettingsRepository
-	 */
-	private $settings_repository;
+    /**
+     * @var SettingsRepository
+     */
+    private $settings_repository;
 
 
         private AutoGenerationQueue $queue;
@@ -38,20 +38,20 @@ class AutoGenerationService {
         private AutoGenerationScheduler $scheduler;
 
 
-	/**
-	 * @var PublishGenerationHandler
-	 */
-	private PublishGenerationHandler $publish_handler;
+    /**
+     * @var PublishGenerationHandler
+     */
+    private PublishGenerationHandler $publish_handler;
 
-	/**
-	 * Constructor
-	 *
-	 * @param SettingsRepository    $settings_repository
+    /**
+     * Constructor
+     *
+     * @param SettingsRepository    $settings_repository
         * @param AutoGenerationQueue      $queue
         * @param AutoGenerationScheduler  $scheduler
-	 */
-	public function __construct(
-		SettingsRepository $settings_repository,
+     */
+    public function __construct(
+        SettingsRepository $settings_repository,
                 AutoGenerationQueue $queue,
                 AutoGenerationScheduler $scheduler,
                 PublishGenerationHandler $publish_handler
@@ -62,9 +62,9 @@ class AutoGenerationService {
                 $this->publish_handler     = $publish_handler;
         }
 
-	/**
-	 * Register WordPress hooks
-	 */
+    /**
+     * Register WordPress hooks
+     */
         public function register_hooks(): void {
                 $this->scheduler->register_hooks();
 
@@ -77,26 +77,26 @@ class AutoGenerationService {
 
                 add_action( self::QUEUE_HOOK, array( $this, 'process_queue' ) );
 
-		$this->publish_handler->register_hooks();
-	}
+        $this->publish_handler->register_hooks();
+    }
 
-	/**
-	 * Handle post publish transition
-	 *
-	 * @param string   $new_status New post status
-	 * @param string   $old_status Old post status
-	 * @param \WP_Post $post Post object
-	 */
-	public function handle_post_publish( $new_status, $old_status, $post ): void {
-		$this->publish_handler->handle_post_publish( $new_status, $old_status, $post );
-	}
+    /**
+     * Handle post publish transition
+     *
+     * @param string   $new_status New post status
+     * @param string   $old_status Old post status
+     * @param \WP_Post $post Post object
+     */
+    public function handle_post_publish( $new_status, $old_status, $post ): void {
+        $this->publish_handler->handle_post_publish( $new_status, $old_status, $post );
+    }
 
-	/**
-	 * Generate content for a single post
-	 *
-	 * @param int    $post_id Post ID
-	 * @param string $workflow_type Type of content to generate (quiz/summary)
-	 */
+    /**
+     * Generate content for a single post
+     *
+     * @param int    $post_id Post ID
+     * @param string $workflow_type Type of content to generate (quiz/summary)
+     */
     public function generate_single( int $post_id, string $workflow_type ): void {
         $this->queue->queue_post( $post_id, $workflow_type );
     }
@@ -109,11 +109,11 @@ class AutoGenerationService {
     }
 
 
-	/**
-	 * Poll for generation updates
-	 *
-	 * @param string $generation_id Generation ID
-	 * @param string $workflow_type Type of workflow (quiz/summary)
+    /**
+     * Poll for generation updates
+     *
+     * @param string $generation_id Generation ID
+     * @param string $workflow_type Type of workflow (quiz/summary)
          * @param array $post_ids List of post IDs
          * @param int   $attempt  Current attempt number
          */
@@ -121,23 +121,23 @@ class AutoGenerationService {
         $this->scheduler->poll_generation( $generation_id, $workflow_type, $post_ids, $attempt );
     }
 
-	/**
-	 * Cron callback to start a generation task for a post.
-	 *
-	 * @param int    $post_id       Post ID
-	 * @param string $workflow_type Type of content to generate
-	 */
-	public function run_generation( int $post_id, string $workflow_type ): void {
-		$this->generate_single( $post_id, $workflow_type );
-	}
+    /**
+     * Cron callback to start a generation task for a post.
+     *
+     * @param int    $post_id       Post ID
+     * @param string $workflow_type Type of content to generate
+     */
+    public function run_generation( int $post_id, string $workflow_type ): void {
+        $this->generate_single( $post_id, $workflow_type );
+    }
 
-	/**
-	 * Generate content for a single post (public alias for backward compatibility)
-	 *
-	 * @param int    $post_id Post ID
-	 * @param string $workflow_type Type of content to generate (quiz/summary)
-	 */
-	public function generateSingle( int $post_id, string $workflow_type ): void {
-		$this->generate_single( $post_id, $workflow_type );
-	}
+    /**
+     * Generate content for a single post (public alias for backward compatibility)
+     *
+     * @param int    $post_id Post ID
+     * @param string $workflow_type Type of content to generate (quiz/summary)
+     */
+    public function generateSingle( int $post_id, string $workflow_type ): void {
+        $this->generate_single( $post_id, $workflow_type );
+    }
 }

--- a/nuclear-engagement/inc/Services/ContentStorageService.php
+++ b/nuclear-engagement/inc/Services/ContentStorageService.php
@@ -14,80 +14,80 @@ use NuclearEngagement\SettingsRepository;
 use NuclearEngagement\Utils;
 
 if ( ! defined( 'ABSPATH' ) ) {
-	exit;
+    exit;
 }
 
 /**
  * Service for storing generated content
  */
 class ContentStorageService {
-	/**
-	 * @var SettingsRepository
-	 */
-	private SettingsRepository $settings;
+    /**
+     * @var SettingsRepository
+     */
+    private SettingsRepository $settings;
 
-	/**
-	 * @var Utils
-	 */
-	private Utils $utils;
+    /**
+     * @var Utils
+     */
+    private Utils $utils;
 
-	/**
-	 * Constructor
-	 *
-	 * @param SettingsRepository $settings
-	 */
-	public function __construct( SettingsRepository $settings ) {
-		$this->settings = $settings;
-		$this->utils    = new Utils();
-	}
+    /**
+     * Constructor
+     *
+     * @param SettingsRepository $settings
+     */
+    public function __construct( SettingsRepository $settings ) {
+        $this->settings = $settings;
+        $this->utils    = new Utils();
+    }
 
-	/**
-	 * Store generation results
-	 *
-	 * @param array  $results
-	 * @param string $workflowType
-	 */
-	public function storeResults( array $results, string $workflowType ): void {
-		$updateLastModified = $this->settings->get_bool( 'update_last_modified', false );
-		$dateNow            = current_time( 'mysql' );
+    /**
+     * Store generation results
+     *
+     * @param array  $results
+     * @param string $workflowType
+     */
+    public function storeResults( array $results, string $workflowType ): void {
+        $updateLastModified = $this->settings->get_bool( 'update_last_modified', false );
+        $dateNow            = current_time( 'mysql' );
 
-		foreach ( $results as $postIdString => $data ) {
-			$postId = (int) $postIdString;
+        foreach ( $results as $postIdString => $data ) {
+            $postId = (int) $postIdString;
 
-			// Ensure date is set
-			if ( empty( $data['date'] ) ) {
-				$data['date'] = $dateNow;
-			}
+            // Ensure date is set
+            if ( empty( $data['date'] ) ) {
+                $data['date'] = $dateNow;
+            }
 
-			try {
-				if ( $workflowType === 'quiz' ) {
-					$this->storeQuizData( $postId, $data );
-				} else {
-					$this->storeSummaryData( $postId, $data );
-				}
+            try {
+                if ( $workflowType === 'quiz' ) {
+                    $this->storeQuizData( $postId, $data );
+                } else {
+                    $this->storeSummaryData( $postId, $data );
+                }
 
-				// Update post modified time if enabled
-				if ( $updateLastModified ) {
-					$this->updatePostModifiedTime( $postId );
-				} else {
-					clean_post_cache( $postId );
-				}
+                // Update post modified time if enabled
+                if ( $updateLastModified ) {
+                    $this->updatePostModifiedTime( $postId );
+                } else {
+                    clean_post_cache( $postId );
+                }
 
-				\NuclearEngagement\Services\LoggingService::log( "Stored {$workflowType} data for post {$postId}" );
+                \NuclearEngagement\Services\LoggingService::log( "Stored {$workflowType} data for post {$postId}" );
 
-			} catch ( \Exception $e ) {
-				\NuclearEngagement\Services\LoggingService::log( "Error storing {$workflowType} for post {$postId}: " . $e->getMessage() );
-			}
-		}
-	}
+            } catch ( \Exception $e ) {
+                \NuclearEngagement\Services\LoggingService::log( "Error storing {$workflowType} for post {$postId}: " . $e->getMessage() );
+            }
+        }
+    }
 
-	/**
-	 * Store quiz data
-	 *
-	 * @param int   $postId
-	 * @param array $data
-	 * @throws \InvalidArgumentException On invalid data
-	 */
+    /**
+     * Store quiz data
+     *
+     * @param int   $postId
+     * @param array $data
+     * @throws \InvalidArgumentException On invalid data
+     */
         public function storeQuizData( int $postId, array $data ): void {
                 if ( empty( $data['questions'] ) || ! is_array( $data['questions'] ) ) {
                         throw new \InvalidArgumentException( "Invalid quiz data for post {$postId}" );
@@ -134,73 +134,73 @@ class ContentStorageService {
                 }
         }
 
-	/**
-	 * Store summary data
-	 *
-	 * @param int   $postId
-	 * @param array $data
-	 * @throws \InvalidArgumentException On invalid data
-	 */
-	public function storeSummaryData( int $postId, array $data ): void {
-		if ( ! isset( $data['summary'] ) || ! is_string( $data['summary'] ) ) {
-			// Legacy support for 'content' key
-			if ( isset( $data['content'] ) && is_string( $data['content'] ) ) {
-				$data['summary'] = $data['content'];
-			} else {
-				throw new \InvalidArgumentException( "Invalid summary data for post {$postId}" );
-			}
-		}
+    /**
+     * Store summary data
+     *
+     * @param int   $postId
+     * @param array $data
+     * @throws \InvalidArgumentException On invalid data
+     */
+    public function storeSummaryData( int $postId, array $data ): void {
+        if ( ! isset( $data['summary'] ) || ! is_string( $data['summary'] ) ) {
+            // Legacy support for 'content' key
+            if ( isset( $data['content'] ) && is_string( $data['content'] ) ) {
+                $data['summary'] = $data['content'];
+            } else {
+                throw new \InvalidArgumentException( "Invalid summary data for post {$postId}" );
+            }
+        }
 
-		$allowedHtml = array(
-			'a'      => array(
-				'href'   => array(),
-				'title'  => array(),
-				'target' => array(),
-			),
-			'br'     => array(),
-			'em'     => array(),
-			'strong' => array(),
-			'p'      => array(),
-			'ul'     => array(),
-			'ol'     => array(),
-			'li'     => array(),
-			'h1'     => array(),
-			'h2'     => array(),
-			'h3'     => array(),
-			'h4'     => array(),
-			'div'    => array( 'class' => array() ),
-			'span'   => array( 'class' => array() ),
-		);
+        $allowedHtml = array(
+            'a'      => array(
+                'href'   => array(),
+                'title'  => array(),
+                'target' => array(),
+            ),
+            'br'     => array(),
+            'em'     => array(),
+            'strong' => array(),
+            'p'      => array(),
+            'ul'     => array(),
+            'ol'     => array(),
+            'li'     => array(),
+            'h1'     => array(),
+            'h2'     => array(),
+            'h3'     => array(),
+            'h4'     => array(),
+            'div'    => array( 'class' => array() ),
+            'span'   => array( 'class' => array() ),
+        );
 
-		$formatted = array(
-			'summary' => wp_kses( $data['summary'], $allowedHtml ),
-			'date'    => $data['date'] ?? current_time( 'mysql' ),
-		);
+        $formatted = array(
+            'summary' => wp_kses( $data['summary'], $allowedHtml ),
+            'date'    => $data['date'] ?? current_time( 'mysql' ),
+        );
 
-		if ( ! update_post_meta( $postId, 'nuclen-summary-data', $formatted ) ) {
-			throw new \RuntimeException( "Failed to update summary data for post {$postId}" );
-		}
-	}
+        if ( ! update_post_meta( $postId, 'nuclen-summary-data', $formatted ) ) {
+            throw new \RuntimeException( "Failed to update summary data for post {$postId}" );
+        }
+    }
 
-	/**
-	 * Update post modified time
-	 *
-	 * @param int $postId
-	 */
-	private function updatePostModifiedTime( int $postId ): void {
-		$time   = current_time( 'mysql' );
-		$result = wp_update_post(
-			array(
-				'ID'                => $postId,
-				'post_modified'     => $time,
-				'post_modified_gmt' => get_gmt_from_date( $time ),
-			)
-		);
+    /**
+     * Update post modified time
+     *
+     * @param int $postId
+     */
+    private function updatePostModifiedTime( int $postId ): void {
+        $time   = current_time( 'mysql' );
+        $result = wp_update_post(
+            array(
+                'ID'                => $postId,
+                'post_modified'     => $time,
+                'post_modified_gmt' => get_gmt_from_date( $time ),
+            )
+        );
 
-		if ( is_wp_error( $result ) ) {
-			\NuclearEngagement\Services\LoggingService::log( "Failed to update modified time for post {$postId}: " . $result->get_error_message() );
-		}
+        if ( is_wp_error( $result ) ) {
+            \NuclearEngagement\Services\LoggingService::log( "Failed to update modified time for post {$postId}: " . $result->get_error_message() );
+        }
 
-		clean_post_cache( $postId );
-	}
+        clean_post_cache( $postId );
+    }
 }

--- a/nuclear-engagement/inc/Services/GenerationPoller.php
+++ b/nuclear-engagement/inc/Services/GenerationPoller.php
@@ -14,52 +14,52 @@ use NuclearEngagement\Services\ContentStorageService;
 use NuclearEngagement\Services\ApiException;
 
 if ( ! defined( 'ABSPATH' ) ) {
-	exit;
+    exit;
 }
 
 class GenerationPoller {
-	/**
-	 * @var SettingsRepository
-	 */
-	private SettingsRepository $settings_repository;
+    /**
+     * @var SettingsRepository
+     */
+    private SettingsRepository $settings_repository;
 
-	/**
-	 * @var RemoteApiService
-	 */
-	private RemoteApiService $remote_api;
+    /**
+     * @var RemoteApiService
+     */
+    private RemoteApiService $remote_api;
 
-	/**
-	 * @var ContentStorageService
-	 */
-	private ContentStorageService $content_storage;
+    /**
+     * @var ContentStorageService
+     */
+    private ContentStorageService $content_storage;
 
-	public function __construct(
-		SettingsRepository $settings_repository,
-		RemoteApiService $remote_api,
-		ContentStorageService $content_storage
-	) {
-		$this->settings_repository = $settings_repository;
-		$this->remote_api          = $remote_api;
-		$this->content_storage     = $content_storage;
-	}
+    public function __construct(
+        SettingsRepository $settings_repository,
+        RemoteApiService $remote_api,
+        ContentStorageService $content_storage
+    ) {
+        $this->settings_repository = $settings_repository;
+        $this->remote_api          = $remote_api;
+        $this->content_storage     = $content_storage;
+    }
 
-	/**
-	 * Register WordPress hook for polling events.
-	 */
-	public function register_hooks(): void {
+    /**
+     * Register WordPress hook for polling events.
+     */
+    public function register_hooks(): void {
         add_action(
                         'nuclen_poll_generation',
                         array( $this, 'poll_generation' ),
                         10,
                         4 // generation_id, workflow_type, post_ids, attempt
                 );
-	}
+    }
 
-	/**
-	 * Poll for generation updates.
-	 *
-	 * @param string $generation_id Generation ID
-	 * @param string $workflow_type  Type of workflow (quiz/summary)
+    /**
+     * Poll for generation updates.
+     *
+     * @param string $generation_id Generation ID
+     * @param string $workflow_type  Type of workflow (quiz/summary)
          * @param array $post_ids      List of post IDs in this batch
          * @param int   $attempt       Current attempt number
          */
@@ -67,46 +67,46 @@ class GenerationPoller {
                 $max_attempts = NUCLEN_MAX_POLL_ATTEMPTS;
                 $retry_delay  = NUCLEN_POLL_RETRY_DELAY * $attempt;
 
-		try {
-			$connected      = $this->settings_repository->get( 'connected', false );
-			$wp_app_created = $this->settings_repository->get( 'wp_app_pass_created', false );
-			if ( ! $connected || ! $wp_app_created ) {
-				return;
-			}
+        try {
+            $connected      = $this->settings_repository->get( 'connected', false );
+            $wp_app_created = $this->settings_repository->get( 'wp_app_pass_created', false );
+            if ( ! $connected || ! $wp_app_created ) {
+                return;
+            }
 
-						$data = $this->remote_api->fetch_updates( $generation_id );
+                        $data = $this->remote_api->fetch_updates( $generation_id );
 
-			if ( ! empty( $data['results'] ) && is_array( $data['results'] ) ) {
-				$this->content_storage->storeResults( $data['results'], $workflow_type );
+            if ( ! empty( $data['results'] ) && is_array( $data['results'] ) ) {
+                $this->content_storage->storeResults( $data['results'], $workflow_type );
                                 \NuclearEngagement\Services\LoggingService::log(
                                         "Poll success for generation {$generation_id}"
                                 );
-				$this->cleanup_generation( $generation_id );
-				return;
-			}
+                $this->cleanup_generation( $generation_id );
+                return;
+            }
 
-			if ( isset( $data['success'] ) && $data['success'] === true ) {
+            if ( isset( $data['success'] ) && $data['success'] === true ) {
                                 \NuclearEngagement\Services\LoggingService::log(
                                         "Still processing generation {$generation_id}, attempt {$attempt}/{$max_attempts}"
                                 );
-			}
-		} catch ( ApiException $e ) {
+            }
+        } catch ( ApiException $e ) {
                                 \NuclearEngagement\Services\LoggingService::log(
                                         "Polling error for generation {$generation_id}: " . $e->getMessage()
                                 );
-			if ( $attempt >= $max_attempts ) {
-				$this->cleanup_generation( $generation_id );
-				return;
-			}
-		} catch ( \Throwable $e ) {
+            if ( $attempt >= $max_attempts ) {
+                $this->cleanup_generation( $generation_id );
+                return;
+            }
+        } catch ( \Throwable $e ) {
                                 \NuclearEngagement\Services\LoggingService::log(
                                         "Polling error for generation {$generation_id}: " . $e->getMessage()
                                 );
-			if ( $attempt >= $max_attempts ) {
-				$this->cleanup_generation( $generation_id );
-				return;
-			}
-		}
+            if ( $attempt >= $max_attempts ) {
+                $this->cleanup_generation( $generation_id );
+                return;
+            }
+        }
 
                 if ( $attempt < $max_attempts ) {
                         $event_args = array( $generation_id, $workflow_type, $post_ids, $attempt + 1 );
@@ -127,31 +127,31 @@ class GenerationPoller {
                                 );
                         }
                 } else {
-			\NuclearEngagement\Services\LoggingService::log(
+            \NuclearEngagement\Services\LoggingService::log(
                                 "Polling aborted after {$max_attempts} attempts for generation {$generation_id}"
-			);
-			$this->cleanup_generation( $generation_id );
-		}
-	}
+            );
+            $this->cleanup_generation( $generation_id );
+        }
+    }
 
-	/**
-	 * Remove a completed or failed generation from the tracking option.
-	 *
-	 * @param string $generation_id Generation ID to remove
-	 */
-	private function cleanup_generation( string $generation_id ): void {
-		for ( $i = 0; $i < 3; $i++ ) {
-			$generations = get_option( 'nuclen_active_generations', array() );
-			if ( ! isset( $generations[ $generation_id ] ) ) {
-				return;
-			}
-			unset( $generations[ $generation_id ] );
-			$updated = empty( $generations )
-				? delete_option( 'nuclen_active_generations' )
-				: update_option( 'nuclen_active_generations', $generations, 'no' );
-			if ( $updated ) {
-				break;
-			}
-		}
-	}
+    /**
+     * Remove a completed or failed generation from the tracking option.
+     *
+     * @param string $generation_id Generation ID to remove
+     */
+    private function cleanup_generation( string $generation_id ): void {
+        for ( $i = 0; $i < 3; $i++ ) {
+            $generations = get_option( 'nuclen_active_generations', array() );
+            if ( ! isset( $generations[ $generation_id ] ) ) {
+                return;
+            }
+            unset( $generations[ $generation_id ] );
+            $updated = empty( $generations )
+                ? delete_option( 'nuclen_active_generations' )
+                : update_option( 'nuclen_active_generations', $generations, 'no' );
+            if ( $updated ) {
+                break;
+            }
+        }
+    }
 }

--- a/nuclear-engagement/inc/Services/GenerationService.php
+++ b/nuclear-engagement/inc/Services/GenerationService.php
@@ -17,7 +17,7 @@ use NuclearEngagement\Utils;
 use NuclearEngagement\Services\ApiException;
 
 if ( ! defined( 'ABSPATH' ) ) {
-	exit;
+    exit;
 }
 
 /**
@@ -28,33 +28,33 @@ class GenerationService {
     private const DEFAULT_POLL_DELAY = 30;
 
     private int $pollDelay = self::DEFAULT_POLL_DELAY;
-	/**
-	 * @var SettingsRepository
-	 */
-	private SettingsRepository $settings;
+    /**
+     * @var SettingsRepository
+     */
+    private SettingsRepository $settings;
 
-	/**
-	 * @var RemoteApiService
-	 */
-	private RemoteApiService $api;
+    /**
+     * @var RemoteApiService
+     */
+    private RemoteApiService $api;
 
-	/**
-	 * @var ContentStorageService
-	 */
-	private ContentStorageService $storage;
+    /**
+     * @var ContentStorageService
+     */
+    private ContentStorageService $storage;
 
-	/**
-	 * @var Utils
-	 */
-	private Utils $utils;
+    /**
+     * @var Utils
+     */
+    private Utils $utils;
 
-	/**
-	 * Constructor
-	 *
-	 * @param SettingsRepository    $settings
-	 * @param RemoteApiService      $api
-	 * @param ContentStorageService $storage
-	 */
+    /**
+     * Constructor
+     *
+     * @param SettingsRepository    $settings
+     * @param RemoteApiService      $api
+     * @param ContentStorageService $storage
+     */
         public function __construct(
                 SettingsRepository $settings,
                 RemoteApiService $api,
@@ -69,101 +69,101 @@ class GenerationService {
                 }
         }
 
-	/**
-	 * Generate content for multiple posts
-	 *
-	 * @param GenerateRequest $request
-	 * @return GenerationResponse
-	 * @throws \RuntimeException On API errors
-	 */
-	public function generateContent( GenerateRequest $request ): GenerationResponse {
-		// Get posts data
-		$posts = $this->getPostsData( $request->postIds, $request->postType, $request->postStatus );
-		if ( empty( $posts ) ) {
-			throw new \RuntimeException( 'No matching posts found' );
-		}
+    /**
+     * Generate content for multiple posts
+     *
+     * @param GenerateRequest $request
+     * @return GenerationResponse
+     * @throws \RuntimeException On API errors
+     */
+    public function generateContent( GenerateRequest $request ): GenerationResponse {
+        // Get posts data
+        $posts = $this->getPostsData( $request->postIds, $request->postType, $request->postStatus );
+        if ( empty( $posts ) ) {
+            throw new \RuntimeException( 'No matching posts found' );
+        }
 
-		// Build workflow data
-		$workflow = array(
-			'type'                    => $request->workflowType,
-			'summary_format'          => $request->summaryFormat,
-			'summary_length'          => $request->summaryLength,
-			'summary_number_of_items' => $request->summaryItems,
-		);
+        // Build workflow data
+        $workflow = array(
+            'type'                    => $request->workflowType,
+            'summary_format'          => $request->summaryFormat,
+            'summary_length'          => $request->summaryLength,
+            'summary_number_of_items' => $request->summaryItems,
+        );
 
-		// Send to API
-		try {
-				$result = $this->api->send_posts_to_generate(
-					array(
-						'posts'         => $posts,
-						'workflow'      => $workflow,
-						'generation_id' => $request->generationId,
-					)
-				);
-		} catch ( \Throwable $e ) {
-			$response               = new GenerationResponse();
-			$response->generationId = $request->generationId;
-			$response->success      = false;
-			$response->error        = $e->getMessage();
-			$code                   = $e->getCode();
-			$response->statusCode   = is_numeric( $code ) ? (int) $code : 0;
-			if ( $e instanceof ApiException ) {
-				$response->errorCode = $e->getErrorCode();
-			}
-			return $response;
-		}
+        // Send to API
+        try {
+                $result = $this->api->send_posts_to_generate(
+                    array(
+                        'posts'         => $posts,
+                        'workflow'      => $workflow,
+                        'generation_id' => $request->generationId,
+                    )
+                );
+        } catch ( \Throwable $e ) {
+            $response               = new GenerationResponse();
+            $response->generationId = $request->generationId;
+            $response->success      = false;
+            $response->error        = $e->getMessage();
+            $code                   = $e->getCode();
+            $response->statusCode   = is_numeric( $code ) ? (int) $code : 0;
+            if ( $e instanceof ApiException ) {
+                $response->errorCode = $e->getErrorCode();
+            }
+            return $response;
+        }
 
-		// Create response
-		$response               = new GenerationResponse();
-		$response->generationId = $request->generationId;
+        // Create response
+        $response               = new GenerationResponse();
+        $response->generationId = $request->generationId;
 
-		// Process immediate results if any
-		if ( ! empty( $result['results'] ) && is_array( $result['results'] ) ) {
-			$this->storage->storeResults( $result['results'], $request->workflowType );
-			$response->results = $result['results'];
-		}
+        // Process immediate results if any
+        if ( ! empty( $result['results'] ) && is_array( $result['results'] ) ) {
+            $this->storage->storeResults( $result['results'], $request->workflowType );
+            $response->results = $result['results'];
+        }
 
-		return $response;
-	}
+        return $response;
+    }
 
-	/**
-	 * Generate content for a single post
-	 *
-	 * @param int    $postId
-	 * @param string $workflowType
-	 * @throws \InvalidArgumentException If post not found
-	 */
-	public function generateSingle( int $postId, string $workflowType ): void {
-		$post = get_post( $postId );
-		if ( ! $post ) {
-			throw new \InvalidArgumentException( "Post {$postId} not found" );
-		}
+    /**
+     * Generate content for a single post
+     *
+     * @param int    $postId
+     * @param string $workflowType
+     * @throws \InvalidArgumentException If post not found
+     */
+    public function generateSingle( int $postId, string $workflowType ): void {
+        $post = get_post( $postId );
+        if ( ! $post ) {
+            throw new \InvalidArgumentException( "Post {$postId} not found" );
+        }
 
-		// Check if protected
-		if ( $this->isProtected( $postId, $workflowType ) ) {
-			\NuclearEngagement\Services\LoggingService::log( "Skipping protected {$workflowType} for post {$postId}" );
-			return;
-		}
+        // Check if protected
+        if ( $this->isProtected( $postId, $workflowType ) ) {
+            \NuclearEngagement\Services\LoggingService::log( "Skipping protected {$workflowType} for post {$postId}" );
+            return;
+        }
 
-		$request               = new GenerateRequest();
-		$request->postIds      = array( $postId );
-		$request->workflowType = $workflowType;
-		$request->generationId = 'auto_' . $postId . '_' . time();
-		$request->postType     = $post->post_type;
-		$request->postStatus   = $post->post_status;
+        $request               = new GenerateRequest();
+        $request->postIds      = array( $postId );
+        $request->workflowType = $workflowType;
+        $request->generationId = 'auto_' . $postId . '_' . time();
+        $request->postType     = $post->post_type;
+        $request->postStatus   = $post->post_status;
 
-		try {
-			$response = $this->generateContent( $request );
+        try {
+            $response = $this->generateContent( $request );
 
-			if ( ! $response->success ) {
-				throw new ApiException(
-					$response->error ?? 'Generation failed',
-					$response->statusCode ?? 0,
-					$response->errorCode
-				);
-			}
+            if ( ! $response->success ) {
+                throw new ApiException(
+                    $response->error ?? 'Generation failed',
+                    $response->statusCode ?? 0,
+                    $response->errorCode
+                );
+            }
 
-			// If no immediate results, schedule polling
+            // If no immediate results, schedule polling
                         if ( empty( $response->results ) ) {
                                 $scheduled = wp_schedule_single_event(
                                         time() + $this->pollDelay,
@@ -177,20 +177,20 @@ class GenerationService {
                                 }
                                 \NuclearEngagement\Services\LoggingService::log( "Scheduled polling for post {$postId}, generation {$response->generationId}" );
                         }
-		} catch ( \Exception $e ) {
-			\NuclearEngagement\Services\LoggingService::log( "Error generating {$workflowType} for post {$postId}: " . $e->getMessage() );
-			throw $e;
-		}
-	}
+        } catch ( \Exception $e ) {
+            \NuclearEngagement\Services\LoggingService::log( "Error generating {$workflowType} for post {$postId}: " . $e->getMessage() );
+            throw $e;
+        }
+    }
 
-	/**
-	 * Get posts data for generation
-	 *
-	 * @param array  $postIds
-	 * @param string $postType
-	 * @param string $postStatus
-	 * @return array
-	 */
+    /**
+     * Get posts data for generation
+     *
+     * @param array  $postIds
+     * @param string $postType
+     * @param string $postStatus
+     * @return array
+     */
     private function getPostsData( array $postIds, string $postType, string $postStatus ): array {
         global $wpdb;
 
@@ -228,15 +228,15 @@ class GenerationService {
         return $data;
     }
 
-	/**
-	 * Check if content is protected from regeneration
-	 *
-	 * @param int    $postId
-	 * @param string $workflowType
-	 * @return bool
-	 */
-	private function isProtected( int $postId, string $workflowType ): bool {
-		$metaKey = $workflowType === 'quiz' ? 'nuclen_quiz_protected' : 'nuclen_summary_protected';
-		return (bool) get_post_meta( $postId, $metaKey, true );
-	}
+    /**
+     * Check if content is protected from regeneration
+     *
+     * @param int    $postId
+     * @param string $workflowType
+     * @return bool
+     */
+    private function isProtected( int $postId, string $workflowType ): bool {
+        $metaKey = $workflowType === 'quiz' ? 'nuclen_quiz_protected' : 'nuclen_summary_protected';
+        return (bool) get_post_meta( $postId, $metaKey, true );
+    }
 }

--- a/nuclear-engagement/inc/Services/LoggingService.php
+++ b/nuclear-engagement/inc/Services/LoggingService.php
@@ -11,13 +11,13 @@ declare(strict_types=1);
 namespace NuclearEngagement\Services;
 
 if ( ! defined( 'ABSPATH' ) ) {
-	exit;
+    exit;
 }
 
 class LoggingService {
-	/**
-	 * @var array<string>
-	 */
+    /**
+     * @var array<string>
+     */
         private static array $admin_notices = array();
 
         /**
@@ -30,9 +30,9 @@ class LoggingService {
          */
         private static bool $shutdown_registered = false;
 
-	/**
-	 * Get directory, path and URL for the log file.
-	 */
+    /**
+     * Get directory, path and URL for the log file.
+     */
         public static function get_log_file_info(): array {
                 $upload_dir = wp_upload_dir();
 
@@ -58,26 +58,26 @@ class LoggingService {
                 );
         }
 
-	/**
-	 * Store an admin notice and ensure the hook is registered.
-	 */
-	private static function add_admin_notice( string $message ): void {
-		self::$admin_notices[] = $message;
-		if ( count( self::$admin_notices ) === 1 ) {
-			add_action( 'admin_notices', array( self::class, 'render_admin_notices' ) );
-		}
-	}
+    /**
+     * Store an admin notice and ensure the hook is registered.
+     */
+    private static function add_admin_notice( string $message ): void {
+        self::$admin_notices[] = $message;
+        if ( count( self::$admin_notices ) === 1 ) {
+            add_action( 'admin_notices', array( self::class, 'render_admin_notices' ) );
+        }
+    }
 
-	/**
-	 * Public helper to show an admin error notice.
-	 */
-	public static function notify_admin( string $message ): void {
-		self::add_admin_notice( $message );
-	}
+    /**
+     * Public helper to show an admin error notice.
+     */
+    public static function notify_admin( string $message ): void {
+        self::add_admin_notice( $message );
+    }
 
-	/**
-	 * Debug level logging, only when WP_DEBUG is true.
-	 */
+    /**
+     * Debug level logging, only when WP_DEBUG is true.
+     */
         public static function debug( string $message ): void {
                 if ( defined( 'WP_DEBUG' ) && WP_DEBUG ) {
                         self::log( '[DEBUG] ' . $message );
@@ -98,18 +98,18 @@ class LoggingService {
                self::log( $msg );
        }
 
-	/**
-	 * Output stored admin notices.
-	 */
-	public static function render_admin_notices(): void {
-		foreach ( self::$admin_notices as $notice ) {
-			echo '<div class="notice notice-error"><p>' . esc_html( $notice ) . '</p></div>';
-		}
-	}
+    /**
+     * Output stored admin notices.
+     */
+    public static function render_admin_notices(): void {
+        foreach ( self::$admin_notices as $notice ) {
+            echo '<div class="notice notice-error"><p>' . esc_html( $notice ) . '</p></div>';
+        }
+    }
 
-	/**
-	 * Fallback when writing to the log fails.
-	 */
+    /**
+     * Fallback when writing to the log fails.
+     */
         private static function fallback( string $original, string $error ): void {
                 $timestamp = gmdate( 'Y-m-d H:i:s' );
                 error_log( "[Nuclear Engagement] [$timestamp] {$original} - {$error}" );
@@ -204,9 +204,9 @@ class LoggingService {
                 }
         }
 
-	/**
-	 * Append a message to the plugin log file.
-	 */
+    /**
+     * Append a message to the plugin log file.
+     */
         public static function log( string $message ): void {
                 if ( $message === '' ) {
                         return;

--- a/nuclear-engagement/inc/Services/PointerService.php
+++ b/nuclear-engagement/inc/Services/PointerService.php
@@ -11,49 +11,49 @@ declare(strict_types=1);
 namespace NuclearEngagement\Services;
 
 if ( ! defined( 'ABSPATH' ) ) {
-	exit;
+    exit;
 }
 
 /**
  * Service for managing admin pointers
  */
 class PointerService {
-	/**
-	 * Dismiss a pointer for a user
-	 *
-	 * @param string $pointerId
-	 * @param int    $userId
-	 * @throws \InvalidArgumentException On empty pointer ID
-	 */
-	public function dismissPointer( string $pointerId, int $userId ): void {
-		if ( empty( $pointerId ) ) {
-			throw new \InvalidArgumentException( 'No pointer ID provided' );
-		}
+    /**
+     * Dismiss a pointer for a user
+     *
+     * @param string $pointerId
+     * @param int    $userId
+     * @throws \InvalidArgumentException On empty pointer ID
+     */
+    public function dismissPointer( string $pointerId, int $userId ): void {
+        if ( empty( $pointerId ) ) {
+            throw new \InvalidArgumentException( 'No pointer ID provided' );
+        }
 
-		update_user_meta( $userId, 'nuclen_pointer_dismissed_' . $pointerId, true );
-	}
+        update_user_meta( $userId, 'nuclen_pointer_dismissed_' . $pointerId, true );
+    }
 
-	/**
-	 * Get undismissed pointers for a user
-	 *
-	 * @param array $pointers All pointers
-	 * @param int   $userId
-	 * @return array Undismissed pointers
-	 */
-	public function getUndismissedPointers( array $pointers, int $userId ): array {
-		$undismissed = array();
+    /**
+     * Get undismissed pointers for a user
+     *
+     * @param array $pointers All pointers
+     * @param int   $userId
+     * @return array Undismissed pointers
+     */
+    public function getUndismissedPointers( array $pointers, int $userId ): array {
+        $undismissed = array();
 
-		foreach ( $pointers as $pointer ) {
-			if ( ! isset( $pointer['id'] ) ) {
-				continue;
-			}
+        foreach ( $pointers as $pointer ) {
+            if ( ! isset( $pointer['id'] ) ) {
+                continue;
+            }
 
-			$dismissed = get_user_meta( $userId, 'nuclen_pointer_dismissed_' . $pointer['id'], true );
-			if ( ! $dismissed ) {
-				$undismissed[] = $pointer;
-			}
-		}
+            $dismissed = get_user_meta( $userId, 'nuclen_pointer_dismissed_' . $pointer['id'], true );
+            if ( ! $dismissed ) {
+                $undismissed[] = $pointer;
+            }
+        }
 
-		return $undismissed;
-	}
+        return $undismissed;
+    }
 }

--- a/nuclear-engagement/inc/Services/PostsQueryService.php
+++ b/nuclear-engagement/inc/Services/PostsQueryService.php
@@ -14,7 +14,7 @@ use NuclearEngagement\Requests\PostsCountRequest;
 use NuclearEngagement\Services\LoggingService;
 
 if ( ! defined( 'ABSPATH' ) ) {
-	exit;
+    exit;
 }
 
 /**
@@ -110,75 +110,75 @@ class PostsQueryService {
                 return md5( wp_json_encode( $data ) );
         }
 
-	/**
-	 * Build query args from request
-	 *
-	 * @param PostsCountRequest $request
-	 * @return array
-	 */
-	public function buildQueryArgs( PostsCountRequest $request ): array {
-		$metaQuery = array( 'relation' => 'AND' );
+    /**
+     * Build query args from request
+     *
+     * @param PostsCountRequest $request
+     * @return array
+     */
+    public function buildQueryArgs( PostsCountRequest $request ): array {
+        $metaQuery = array( 'relation' => 'AND' );
 
-		$queryArgs = array(
-			'post_type'      => $request->postType,
-			'posts_per_page' => -1,
-			'post_status'    => $request->postStatus,
-			'fields'         => 'ids',
-		);
+        $queryArgs = array(
+            'post_type'      => $request->postType,
+            'posts_per_page' => -1,
+            'post_status'    => $request->postStatus,
+            'fields'         => 'ids',
+        );
 
-		if ( $request->categoryId ) {
-			$queryArgs['cat'] = $request->categoryId;
-		}
+        if ( $request->categoryId ) {
+            $queryArgs['cat'] = $request->categoryId;
+        }
 
-		if ( $request->authorId ) {
-			$queryArgs['author'] = $request->authorId;
-		}
+        if ( $request->authorId ) {
+            $queryArgs['author'] = $request->authorId;
+        }
 
-		// Skip existing data if not allowing regeneration
-		if ( ! $request->allowRegenerate ) {
-			$metaKey     = $request->workflow === 'quiz' ? 'nuclen-quiz-data' : 'nuclen-summary-data';
-			$metaQuery[] = array(
-				'key'     => $metaKey,
-				'compare' => 'NOT EXISTS',
-			);
-		}
+        // Skip existing data if not allowing regeneration
+        if ( ! $request->allowRegenerate ) {
+            $metaKey     = $request->workflow === 'quiz' ? 'nuclen-quiz-data' : 'nuclen-summary-data';
+            $metaQuery[] = array(
+                'key'     => $metaKey,
+                'compare' => 'NOT EXISTS',
+            );
+        }
 
-		// Skip protected data if not allowed
-		if ( ! $request->regenerateProtected ) {
-			$protectedKey = $request->workflow === 'quiz' ? 'nuclen_quiz_protected' : 'nuclen_summary_protected';
-			$metaQuery[]  = array(
-				'relation' => 'OR',
-				array(
-					'key'     => $protectedKey,
-					'compare' => 'NOT EXISTS',
-				),
-				array(
-					'key'     => $protectedKey,
-					'value'   => '1',
-					'compare' => '!=',
-				),
-			);
-		}
+        // Skip protected data if not allowed
+        if ( ! $request->regenerateProtected ) {
+            $protectedKey = $request->workflow === 'quiz' ? 'nuclen_quiz_protected' : 'nuclen_summary_protected';
+            $metaQuery[]  = array(
+                'relation' => 'OR',
+                array(
+                    'key'     => $protectedKey,
+                    'compare' => 'NOT EXISTS',
+                ),
+                array(
+                    'key'     => $protectedKey,
+                    'value'   => '1',
+                    'compare' => '!=',
+                ),
+            );
+        }
 
-		// Only add meta_query if we have conditions
-		if ( count( $metaQuery ) > 1 ) {
-			$queryArgs['meta_query'] = $metaQuery;
-		}
+        // Only add meta_query if we have conditions
+        if ( count( $metaQuery ) > 1 ) {
+            $queryArgs['meta_query'] = $metaQuery;
+        }
 
-		// Disable caching for performance during counts
-		$queryArgs['update_post_meta_cache'] = false;
-		$queryArgs['update_post_term_cache'] = false;
-		$queryArgs['cache_results']          = false;
+        // Disable caching for performance during counts
+        $queryArgs['update_post_meta_cache'] = false;
+        $queryArgs['update_post_term_cache'] = false;
+        $queryArgs['cache_results']          = false;
 
-		return $queryArgs;
-	}
+        return $queryArgs;
+    }
 
-	/**
-	 * Get posts count and IDs
-	 *
-	 * @param PostsCountRequest $request
-	 * @return array
-	 */
+    /**
+     * Get posts count and IDs
+     *
+     * @param PostsCountRequest $request
+     * @return array
+     */
        public function getPostsCount( PostsCountRequest $request ): array {
                $cache_key      = $this->getCacheKey( $request );
                $transient_key  = 'nuclen_pq_' . $cache_key;

--- a/nuclear-engagement/inc/Services/PublishGenerationHandler.php
+++ b/nuclear-engagement/inc/Services/PublishGenerationHandler.php
@@ -15,67 +15,67 @@ namespace NuclearEngagement\Services;
 use NuclearEngagement\SettingsRepository;
 
 if ( ! defined( 'ABSPATH' ) ) {
-		exit;
+        exit;
 }
 
 /**
  * Handles generation events when a post is published.
  */
 class PublishGenerationHandler {
-	/**
-	 * @var SettingsRepository
-	 */
-	private SettingsRepository $settings_repository;
+    /**
+     * @var SettingsRepository
+     */
+    private SettingsRepository $settings_repository;
 
-		/**
-		 * Constructor.
-		 *
-		 * @param SettingsRepository $settings_repository Repository of plugin settings.
-		 */
-	public function __construct( SettingsRepository $settings_repository ) {
-			$this->settings_repository = $settings_repository;
-	}
+        /**
+         * Constructor.
+         *
+         * @param SettingsRepository $settings_repository Repository of plugin settings.
+         */
+    public function __construct( SettingsRepository $settings_repository ) {
+            $this->settings_repository = $settings_repository;
+    }
 
-	/**
-	 * Register the publish transition hook.
-	 */
-	public function register_hooks(): void {
-		add_action( 'transition_post_status', array( $this, 'handle_post_publish' ), 10, 3 );
-	}
+    /**
+     * Register the publish transition hook.
+     */
+    public function register_hooks(): void {
+        add_action( 'transition_post_status', array( $this, 'handle_post_publish' ), 10, 3 );
+    }
 
-		/**
-		 * Handle post publish transition.
-		 *
-		 * @param string   $new_status New post status.
-		 * @param string   $old_status Old post status.
-		 * @param \WP_Post $post    Post object.
-		 */
-	public function handle_post_publish( $new_status, $old_status, $post ): void {
-		if ( 'publish' === $old_status || 'publish' !== $new_status ) {
-				return;
-		}
+        /**
+         * Handle post publish transition.
+         *
+         * @param string   $new_status New post status.
+         * @param string   $old_status Old post status.
+         * @param \WP_Post $post    Post object.
+         */
+    public function handle_post_publish( $new_status, $old_status, $post ): void {
+        if ( 'publish' === $old_status || 'publish' !== $new_status ) {
+                return;
+        }
 
-			// Prevent unauthorized users from triggering generation.
-		if ( ! wp_doing_cron() && ! current_user_can( 'publish_post', $post->ID ) ) {
-					return;
-		}
+            // Prevent unauthorized users from triggering generation.
+        if ( ! wp_doing_cron() && ! current_user_can( 'publish_post', $post->ID ) ) {
+                    return;
+        }
 
-				$allowed_post_types = $this->settings_repository->get( 'generation_post_types', array( 'post' ) );
-		if ( ! in_array( $post->post_type, (array) $allowed_post_types, true ) ) {
-			return;
-		}
+                $allowed_post_types = $this->settings_repository->get( 'generation_post_types', array( 'post' ) );
+        if ( ! in_array( $post->post_type, (array) $allowed_post_types, true ) ) {
+            return;
+        }
 
-				$gen_quiz    = (bool) $this->settings_repository->get( 'auto_generate_quiz_on_publish', false );
-				$gen_summary = (bool) $this->settings_repository->get( 'auto_generate_summary_on_publish', false );
+                $gen_quiz    = (bool) $this->settings_repository->get( 'auto_generate_quiz_on_publish', false );
+                $gen_summary = (bool) $this->settings_repository->get( 'auto_generate_summary_on_publish', false );
 
-		if ( ! $gen_quiz && ! $gen_summary ) {
-			return;
-		}
+        if ( ! $gen_quiz && ! $gen_summary ) {
+            return;
+        }
 
-		if ( $gen_quiz ) {
-			$protected = get_post_meta( $post->ID, 'nuclen_quiz_protected', true );
-			if ( ! $protected ) {
-				$args = array( $post->ID, 'quiz' );
+        if ( $gen_quiz ) {
+            $protected = get_post_meta( $post->ID, 'nuclen_quiz_protected', true );
+            if ( ! $protected ) {
+                $args = array( $post->ID, 'quiz' );
                                 if ( ! wp_next_scheduled( AutoGenerationService::START_HOOK, $args ) ) {
                                         $scheduled = wp_schedule_single_event( time(), AutoGenerationService::START_HOOK, $args );
                                         if ( false === $scheduled ) {
@@ -84,13 +84,13 @@ class PublishGenerationHandler {
                                                 );
                                         }
                                 }
-			}
-		}
+            }
+        }
 
-		if ( $gen_summary ) {
-			$protected = get_post_meta( $post->ID, 'nuclen_summary_protected', true );
-			if ( ! $protected ) {
-				$args = array( $post->ID, 'summary' );
+        if ( $gen_summary ) {
+            $protected = get_post_meta( $post->ID, 'nuclen_summary_protected', true );
+            if ( ! $protected ) {
+                $args = array( $post->ID, 'summary' );
                                 if ( ! wp_next_scheduled( AutoGenerationService::START_HOOK, $args ) ) {
                                         $scheduled = wp_schedule_single_event( time(), AutoGenerationService::START_HOOK, $args );
                                         if ( false === $scheduled ) {
@@ -99,7 +99,7 @@ class PublishGenerationHandler {
                                                 );
                                         }
                                 }
-			}
-		}
-	}
+            }
+        }
+    }
 }

--- a/nuclear-engagement/inc/Services/RemoteApiService.php
+++ b/nuclear-engagement/inc/Services/RemoteApiService.php
@@ -19,109 +19,109 @@ use NuclearEngagement\Utils;
 use NuclearEngagement\Services\ApiException;
 
 if ( ! defined( 'ABSPATH' ) ) {
-	exit;
+    exit;
 }
 
 /**
  * Service for communicating with Nuclear Engagement remote API
  */
 class RemoteApiService {
-	/**
-	 * @var string Base API URL
-	 */
-	private const API_BASE = 'https://app.nuclearengagement.com/api';
+    /**
+     * @var string Base API URL
+     */
+    private const API_BASE = 'https://app.nuclearengagement.com/api';
 
-	/**
-	 * @var SettingsRepository
-	 */
-	private SettingsRepository $settings;
+    /**
+     * @var SettingsRepository
+     */
+    private SettingsRepository $settings;
 
-	/**
-	 * @var Utils
-	 */
-	private Utils $utils;
+    /**
+     * @var Utils
+     */
+    private Utils $utils;
 
-	/**
-	 * Constructor
-	 *
-	 * @param SettingsRepository $settings
-	 */
-	public function __construct( SettingsRepository $settings ) {
-		$this->settings = $settings;
-		$this->utils    = new Utils();
-	}
+    /**
+     * Constructor
+     *
+     * @param SettingsRepository $settings
+     */
+    public function __construct( SettingsRepository $settings ) {
+        $this->settings = $settings;
+        $this->utils    = new Utils();
+    }
 
-	/**
-	 * Parse an error response body.
-	 *
-	 * @param string $body HTTP response body.
-	 * @return array{message:string|null,error_code:?string}
-	 */
-	private function parse_error_response( string $body ): array {
-		$data = json_decode( $body, true );
-		$msg  = null;
-		$code = null;
-		if ( is_array( $data ) ) {
-			if ( isset( $data['error'] ) ) {
-				$msg = (string) $data['error'];
-			} elseif ( isset( $data['message'] ) ) {
-				$msg = (string) $data['message'];
-			}
-			if ( isset( $data['error_code'] ) ) {
-				$code = (string) $data['error_code'];
-			}
-		}
-		return array(
-			'message'    => $msg,
-			'error_code' => $code,
-		);
-	}
+    /**
+     * Parse an error response body.
+     *
+     * @param string $body HTTP response body.
+     * @return array{message:string|null,error_code:?string}
+     */
+    private function parse_error_response( string $body ): array {
+        $data = json_decode( $body, true );
+        $msg  = null;
+        $code = null;
+        if ( is_array( $data ) ) {
+            if ( isset( $data['error'] ) ) {
+                $msg = (string) $data['error'];
+            } elseif ( isset( $data['message'] ) ) {
+                $msg = (string) $data['message'];
+            }
+            if ( isset( $data['error_code'] ) ) {
+                $code = (string) $data['error_code'];
+            }
+        }
+        return array(
+            'message'    => $msg,
+            'error_code' => $code,
+        );
+    }
 
-	/**
-	 * Send posts to remote API for content generation
-	 *
-	 * @param array $data Data to send.
-	 * @return array Response data on success
-	 * @throws \RuntimeException On API errors
-	 */
-	public function send_posts_to_generate( array $data ): array {
-		$api_key = $this->settings->get_string( 'api_key', '' );
+    /**
+     * Send posts to remote API for content generation
+     *
+     * @param array $data Data to send.
+     * @return array Response data on success
+     * @throws \RuntimeException On API errors
+     */
+    public function send_posts_to_generate( array $data ): array {
+        $api_key = $this->settings->get_string( 'api_key', '' );
 
-		if ( empty( $api_key ) ) {
-			throw new \RuntimeException( 'API key not configured' );
-		}
+        if ( empty( $api_key ) ) {
+            throw new \RuntimeException( 'API key not configured' );
+        }
 
-		$payload = array(
-			'generation_id' => $data['generation_id'] ?? '',
-			'api_key'       => $api_key,
-			'siteUrl'       => get_site_url(),
-			'posts'         => array_values(
-				array_filter(
-					$data['posts'] ?? array(),
-					function ( $p ) {
-						return ! empty( $p['id'] ) && ! empty( $p['title'] ) && ! empty( $p['content'] );
-					}
-				)
-			),
-			'workflow'      => $data['workflow'] ?? array(),
-		);
+        $payload = array(
+            'generation_id' => $data['generation_id'] ?? '',
+            'api_key'       => $api_key,
+            'siteUrl'       => get_site_url(),
+            'posts'         => array_values(
+                array_filter(
+                    $data['posts'] ?? array(),
+                    function ( $p ) {
+                        return ! empty( $p['id'] ) && ! empty( $p['title'] ) && ! empty( $p['content'] );
+                    }
+                )
+            ),
+            'workflow'      => $data['workflow'] ?? array(),
+        );
 
-		\NuclearEngagement\Services\LoggingService::log( 'Sending generation request: ' . $data['generation_id'] ); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
+        \NuclearEngagement\Services\LoggingService::log( 'Sending generation request: ' . $data['generation_id'] ); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
 
-		$response = wp_remote_post(
-			self::API_BASE . '/process-posts',
-			array(
-				'method'             => 'POST',
-				'headers'            => array(
-					'Content-Type' => 'application/json',
-					'X-API-Key'    => $api_key,
-				),
-				'body'               => wp_json_encode( $payload ),
-				'timeout'            => NUCLEN_API_TIMEOUT,
-				'reject_unsafe_urls' => true,
-				'user-agent'         => 'NuclearEngagement/' . NUCLEN_PLUGIN_VERSION,
-			)
-		);
+        $response = wp_remote_post(
+            self::API_BASE . '/process-posts',
+            array(
+                'method'             => 'POST',
+                'headers'            => array(
+                    'Content-Type' => 'application/json',
+                    'X-API-Key'    => $api_key,
+                ),
+                'body'               => wp_json_encode( $payload ),
+                'timeout'            => NUCLEN_API_TIMEOUT,
+                'reject_unsafe_urls' => true,
+                'user-agent'         => 'NuclearEngagement/' . NUCLEN_PLUGIN_VERSION,
+            )
+        );
 
                 if ( is_wp_error( $response ) ) {
                         $error = 'API request failed: ' . $response->get_error_message();
@@ -130,77 +130,77 @@ class RemoteApiService {
                         throw new ApiException( $error );
                 }
 
-		$code = wp_remote_retrieve_response_code( $response );
-		$body = wp_remote_retrieve_body( $response );
-		\NuclearEngagement\Services\LoggingService::debug( "API response body: {$body}" );
+        $code = wp_remote_retrieve_response_code( $response );
+        $body = wp_remote_retrieve_body( $response );
+        \NuclearEngagement\Services\LoggingService::debug( "API response body: {$body}" );
 
-		\NuclearEngagement\Services\LoggingService::log( "API response code: {$code}" ); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
+        \NuclearEngagement\Services\LoggingService::log( "API response code: {$code}" ); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
 
-		// Check for auth errors
-		if ( 401 === $code || 403 === $code ) {
-			$auth_result = $this->handle_auth_error( $body, $code );
-			throw new ApiException( $auth_result['error'], $auth_result['status_code'], $auth_result['error_code'] ?? null );
-		}
+        // Check for auth errors
+        if ( 401 === $code || 403 === $code ) {
+            $auth_result = $this->handle_auth_error( $body, $code );
+            throw new ApiException( $auth_result['error'], $auth_result['status_code'], $auth_result['error_code'] ?? null );
+        }
 
-		if ( 200 !== $code ) {
-						\NuclearEngagement\Services\LoggingService::log( "Unexpected response code: {$code}, body: {$body}" ); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
-					$parsed = $this->parse_error_response( $body );
-			$msg            = $parsed['message'] ?? "Failed to fetch updates, code: {$code}";
-			throw new ApiException( $msg, $code, $parsed['error_code'] );
-		}
+        if ( 200 !== $code ) {
+                        \NuclearEngagement\Services\LoggingService::log( "Unexpected response code: {$code}, body: {$body}" ); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
+                    $parsed = $this->parse_error_response( $body );
+            $msg            = $parsed['message'] ?? "Failed to fetch updates, code: {$code}";
+            throw new ApiException( $msg, $code, $parsed['error_code'] );
+        }
 
-		$data = json_decode( $body, true );
-		if ( ! is_array( $data ) ) {
-						\NuclearEngagement\Services\LoggingService::log( "Invalid JSON response: {$body}" ); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
-			throw new ApiException( 'Invalid data received from API', $code );
-		}
-		if ( isset( $data['success'] ) && false === $data['success'] ) {
-			$msg = $data['error'] ?? 'API error';
-			throw new ApiException( $msg, $code, $data['error_code'] ?? null );
-		}
+        $data = json_decode( $body, true );
+        if ( ! is_array( $data ) ) {
+                        \NuclearEngagement\Services\LoggingService::log( "Invalid JSON response: {$body}" ); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
+            throw new ApiException( 'Invalid data received from API', $code );
+        }
+        if ( isset( $data['success'] ) && false === $data['success'] ) {
+            $msg = $data['error'] ?? 'API error';
+            throw new ApiException( $msg, $code, $data['error_code'] ?? null );
+        }
 
-		return $data;
-	}
+        return $data;
+    }
 
-	/**
-	 * Fetch generation updates from remote API
-	 *
-	 * @param string $generation_id Generation identifier.
-	 * @return array API response data.
-	 * @throws \RuntimeException On API errors
-	 */
-	public function fetch_updates( string $generation_id ): array {
-		$api_key = $this->settings->get_string( 'api_key', '' );
+    /**
+     * Fetch generation updates from remote API
+     *
+     * @param string $generation_id Generation identifier.
+     * @return array API response data.
+     * @throws \RuntimeException On API errors
+     */
+    public function fetch_updates( string $generation_id ): array {
+        $api_key = $this->settings->get_string( 'api_key', '' );
 
-		if ( empty( $api_key ) ) {
-			throw new \RuntimeException( 'API key not configured' );
-		}
+        if ( empty( $api_key ) ) {
+            throw new \RuntimeException( 'API key not configured' );
+        }
 
-		$payload = array(
-			'siteUrl'       => get_site_url(),
-			'generation_id' => $generation_id,
-		);
+        $payload = array(
+            'siteUrl'       => get_site_url(),
+            'generation_id' => $generation_id,
+        );
 
-		if ( empty( $generation_id ) ) {
-			\NuclearEngagement\Services\LoggingService::log( 'Fetching credits only (no generation_id)' ); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
-		} else {
-			\NuclearEngagement\Services\LoggingService::log( "Fetching updates for generation: {$generation_id}" ); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
-		}
+        if ( empty( $generation_id ) ) {
+            \NuclearEngagement\Services\LoggingService::log( 'Fetching credits only (no generation_id)' ); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
+        } else {
+            \NuclearEngagement\Services\LoggingService::log( "Fetching updates for generation: {$generation_id}" ); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
+        }
 
-		$response = wp_remote_post(
-			self::API_BASE . '/updates',
-			array(
-				'method'             => 'POST',
-				'headers'            => array(
-					'Content-Type' => 'application/json',
-					'X-API-Key'    => $api_key,
-				),
-				'body'               => wp_json_encode( $payload ),
-				'timeout'            => NUCLEN_API_TIMEOUT,
-				'reject_unsafe_urls' => true,
-				'user-agent'         => 'NuclearEngagement/' . NUCLEN_PLUGIN_VERSION,
-			)
-		);
+        $response = wp_remote_post(
+            self::API_BASE . '/updates',
+            array(
+                'method'             => 'POST',
+                'headers'            => array(
+                    'Content-Type' => 'application/json',
+                    'X-API-Key'    => $api_key,
+                ),
+                'body'               => wp_json_encode( $payload ),
+                'timeout'            => NUCLEN_API_TIMEOUT,
+                'reject_unsafe_urls' => true,
+                'user-agent'         => 'NuclearEngagement/' . NUCLEN_PLUGIN_VERSION,
+            )
+        );
 
                 if ( is_wp_error( $response ) ) {
                         $error = 'API request failed: ' . $response->get_error_message();
@@ -209,71 +209,71 @@ class RemoteApiService {
                         throw new ApiException( $error );
                 }
 
-		$code = wp_remote_retrieve_response_code( $response );
-		$body = wp_remote_retrieve_body( $response );
+        $code = wp_remote_retrieve_response_code( $response );
+        $body = wp_remote_retrieve_body( $response );
 
-		// Check for auth errors
-		if ( 401 === $code || 403 === $code ) {
-			$auth_result = $this->handle_auth_error( $body, $code );
-			throw new ApiException( $auth_result['error'], $auth_result['status_code'], $auth_result['error_code'] ?? null );
-		}
+        // Check for auth errors
+        if ( 401 === $code || 403 === $code ) {
+            $auth_result = $this->handle_auth_error( $body, $code );
+            throw new ApiException( $auth_result['error'], $auth_result['status_code'], $auth_result['error_code'] ?? null );
+        }
 
-		if ( 200 !== $code ) {
-						\NuclearEngagement\Services\LoggingService::log( "Unexpected response code: {$code}, body: {$body}" ); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
-					$parsed = $this->parse_error_response( $body );
-			$msg            = $parsed['message'] ?? "Failed to fetch updates, code: {$code}";
-			throw new ApiException( $msg, $code, $parsed['error_code'] );
-		}
+        if ( 200 !== $code ) {
+                        \NuclearEngagement\Services\LoggingService::log( "Unexpected response code: {$code}, body: {$body}" ); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
+                    $parsed = $this->parse_error_response( $body );
+            $msg            = $parsed['message'] ?? "Failed to fetch updates, code: {$code}";
+            throw new ApiException( $msg, $code, $parsed['error_code'] );
+        }
 
-		$data = json_decode( $body, true );
-		if ( ! is_array( $data ) ) {
-						\NuclearEngagement\Services\LoggingService::log( "Invalid JSON response: {$body}" ); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
-			throw new ApiException( 'Invalid data received from API', $code );
-		}
-		if ( isset( $data['success'] ) && false === $data['success'] ) {
-			$msg = $data['error'] ?? 'API error';
-			throw new ApiException( $msg, $code, $data['error_code'] ?? null );
-		}
+        $data = json_decode( $body, true );
+        if ( ! is_array( $data ) ) {
+                        \NuclearEngagement\Services\LoggingService::log( "Invalid JSON response: {$body}" ); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
+            throw new ApiException( 'Invalid data received from API', $code );
+        }
+        if ( isset( $data['success'] ) && false === $data['success'] ) {
+            $msg = $data['error'] ?? 'API error';
+            throw new ApiException( $msg, $code, $data['error_code'] ?? null );
+        }
 
-		return $data;
-	}
+        return $data;
+    }
 
-	/**
-	 * Handle authentication errors from API
-	 *
-	 * @param string $body Response body.
-	 * @param int    $code HTTP status code.
-	 * @return array Error data.
-	 */
-	private function handle_auth_error( string $body, int $code ): array {
-		$data = json_decode( $body, true );
+    /**
+     * Handle authentication errors from API
+     *
+     * @param string $body Response body.
+     * @param int    $code HTTP status code.
+     * @return array Error data.
+     */
+    private function handle_auth_error( string $body, int $code ): array {
+        $data = json_decode( $body, true );
 
-		if ( is_array( $data ) && isset( $data['error_code'] ) ) {
-			$error_code = $data['error_code'];
-			if ( 'invalid_api_key' === $error_code ) {
-				return array(
-					'error'       => 'Invalid API key. Please update it on the Setup page.',
-					'error_code'  => 'invalid_api_key',
-					'status_code' => $code,
-				);
-			}
+        if ( is_array( $data ) && isset( $data['error_code'] ) ) {
+            $error_code = $data['error_code'];
+            if ( 'invalid_api_key' === $error_code ) {
+                return array(
+                    'error'       => 'Invalid API key. Please update it on the Setup page.',
+                    'error_code'  => 'invalid_api_key',
+                    'status_code' => $code,
+                );
+            }
 
-			if ( 'invalid_wp_app_pass' === $error_code ) {
+            if ( 'invalid_wp_app_pass' === $error_code ) {
                                return array(
                                        'error'       => 'Invalid plugin password. Please re-generate on the Setup page.',
                                        'error_code'  => 'invalid_wp_app_pass',
                                        'status_code' => $code,
                                );
-			}
-		}
+            }
+        }
 
-		if ( false !== strpos( $body, 'invalid_api_key' ) ) {
-			return array(
-				'error'       => 'Invalid API key. Please update it on the Setup page.',
-				'error_code'  => 'invalid_api_key',
-				'status_code' => $code,
-			);
-		}
+        if ( false !== strpos( $body, 'invalid_api_key' ) ) {
+            return array(
+                'error'       => 'Invalid API key. Please update it on the Setup page.',
+                'error_code'  => 'invalid_api_key',
+                'status_code' => $code,
+            );
+        }
 
                 if ( false !== strpos( $body, 'invalid_wp_app_pass' ) ) {
                         return array(
@@ -287,5 +287,5 @@ class RemoteApiService {
                         'error'       => 'Authentication error (API key or plugin password may be invalid).',
                         'status_code' => $code,
                 );
-	}
+    }
 }

--- a/nuclear-engagement/inc/Services/SetupService.php
+++ b/nuclear-engagement/inc/Services/SetupService.php
@@ -17,7 +17,7 @@ use NuclearEngagement\Utils;
 
 // If this file is called directly, abort.
 if ( ! defined( 'ABSPATH' ) ) {
-	exit;
+    exit;
 }
 
 /**
@@ -30,99 +30,99 @@ if ( ! defined( 'ABSPATH' ) ) {
  */
 class SetupService {
 
-	/**
-	 * Base URL for remote API.
-	 *
-	 * @since 1.0.0
-	 * @var string
-	 */
-	private const API_BASE = 'https://app.nuclearengagement.com/api';
+    /**
+     * Base URL for remote API.
+     *
+     * @since 1.0.0
+     * @var string
+     */
+    private const API_BASE = 'https://app.nuclearengagement.com/api';
 
-	/**
-	 * Default timeout for API requests in seconds.
-	 *
-	 * @since 1.0.0
-	 * @var int
-	 */
-	private const DEFAULT_TIMEOUT = 30;
+    /**
+     * Default timeout for API requests in seconds.
+     *
+     * @since 1.0.0
+     * @var int
+     */
+    private const DEFAULT_TIMEOUT = 30;
 
-	/**
-	 * Utilities instance.
-	 *
-	 * @since 1.0.0
-	 * @var Utils
-	 */
-	private Utils $utils;
+    /**
+     * Utilities instance.
+     *
+     * @since 1.0.0
+     * @var Utils
+     */
+    private Utils $utils;
 
-	/**
-	 * Constructor.
-	 *
-	 * @since 1.0.0
-	 */
-	public function __construct() {
-		$this->utils = new Utils();
-	}
+    /**
+     * Constructor.
+     *
+     * @since 1.0.0
+     */
+    public function __construct() {
+        $this->utils = new Utils();
+    }
 
-	/**
-	 * Validate the provided API key with the SaaS.
-	 *
-	 * @since 1.0.0
-	 *
-	 * @param string $api_key API key to validate.
-	 * @return bool Whether the key is valid.
-	 */
-	public function validate_api_key( string $api_key ): bool {
-		if ( '' === $api_key ) {
-			return false;
-		}
+    /**
+     * Validate the provided API key with the SaaS.
+     *
+     * @since 1.0.0
+     *
+     * @param string $api_key API key to validate.
+     * @return bool Whether the key is valid.
+     */
+    public function validate_api_key( string $api_key ): bool {
+        if ( '' === $api_key ) {
+            return false;
+        }
 
-		$timeout = defined( 'NUCLEN_API_TIMEOUT' ) ? NUCLEN_API_TIMEOUT : self::DEFAULT_TIMEOUT;
+        $timeout = defined( 'NUCLEN_API_TIMEOUT' ) ? NUCLEN_API_TIMEOUT : self::DEFAULT_TIMEOUT;
 
-		$response = wp_remote_post(
-			self::API_BASE . '/check-api-key',
-			array(
-				'method'             => 'POST',
-				'headers'            => array( 'Content-Type' => 'application/json' ),
-				'body'               => wp_json_encode( array( 'appApiKey' => $api_key ) ),
-				'timeout'            => $timeout,
-				'reject_unsafe_urls' => true,
-				'user-agent'         => 'NuclearEngagement/' . ( defined( 'NUCLEN_PLUGIN_VERSION' ) ? NUCLEN_PLUGIN_VERSION : '1.0.0' ),
-			)
-		);
+        $response = wp_remote_post(
+            self::API_BASE . '/check-api-key',
+            array(
+                'method'             => 'POST',
+                'headers'            => array( 'Content-Type' => 'application/json' ),
+                'body'               => wp_json_encode( array( 'appApiKey' => $api_key ) ),
+                'timeout'            => $timeout,
+                'reject_unsafe_urls' => true,
+                'user-agent'         => 'NuclearEngagement/' . ( defined( 'NUCLEN_PLUGIN_VERSION' ) ? NUCLEN_PLUGIN_VERSION : '1.0.0' ),
+            )
+        );
 
-		if ( is_wp_error( $response ) ) {
-			LoggingService::log( 'API-key validation error: ' . $response->get_error_message() );
-			return false;
-		}
+        if ( is_wp_error( $response ) ) {
+            LoggingService::log( 'API-key validation error: ' . $response->get_error_message() );
+            return false;
+        }
 
-		LoggingService::debug( 'API key validation response: ' . wp_remote_retrieve_body( $response ) );
-		return 200 === wp_remote_retrieve_response_code( $response );
-	}
+        LoggingService::debug( 'API key validation response: ' . wp_remote_retrieve_body( $response ) );
+        return 200 === wp_remote_retrieve_response_code( $response );
+    }
 
-	/**
-	 * Send the generated WordPress credentials to the SaaS.
-	 *
-	 * @since 1.0.0
-	 *
-	 * @param array $data Credential payload containing appApiKey and other credentials.
+    /**
+     * Send the generated WordPress credentials to the SaaS.
+     *
+     * @since 1.0.0
+     *
+     * @param array $data Credential payload containing appApiKey and other credentials.
          * @return bool True on success, false on failure.
-	 */
-	public function send_app_password( array $data ): bool {
-		if ( empty( $data['appApiKey'] ) ) {
-			return false;
-		}
+     */
+    public function send_app_password( array $data ): bool {
+        if ( empty( $data['appApiKey'] ) ) {
+            return false;
+        }
 
-		$response = wp_remote_post(
-			self::API_BASE . '/store-wp-creds',
-			array(
-				'method'             => 'POST',
-				'headers'            => array( 'Content-Type' => 'application/json' ),
-				'body'               => wp_json_encode( $data ),
-				'timeout'            => NUCLEN_API_TIMEOUT,
-				'reject_unsafe_urls' => true,
-				'user-agent'         => 'NuclearEngagement/' . NUCLEN_PLUGIN_VERSION,
-			)
-		);
+        $response = wp_remote_post(
+            self::API_BASE . '/store-wp-creds',
+            array(
+                'method'             => 'POST',
+                'headers'            => array( 'Content-Type' => 'application/json' ),
+                'body'               => wp_json_encode( $data ),
+                'timeout'            => NUCLEN_API_TIMEOUT,
+                'reject_unsafe_urls' => true,
+                'user-agent'         => 'NuclearEngagement/' . NUCLEN_PLUGIN_VERSION,
+            )
+        );
 
                 if ( is_wp_error( $response ) ) {
                         \NuclearEngagement\Services\LoggingService::log( 'Error sending creds: ' . $response->get_error_message() );

--- a/nuclear-engagement/inc/Services/VersionService.php
+++ b/nuclear-engagement/inc/Services/VersionService.php
@@ -17,7 +17,7 @@ use NuclearEngagement\AssetVersions;
 
 // If this file is called directly, abort.
 if ( ! defined( 'ABSPATH' ) ) {
-	exit;
+    exit;
 }
 
 /**
@@ -30,33 +30,33 @@ if ( ! defined( 'ABSPATH' ) ) {
  */
 final class VersionService {
 
-	/**
-	 * Retrieve a version string for the given asset key.
-	 *
-	 * @since 1.0.0
-	 *
-	 * @param string $key The unique identifier for the asset (e.g., 'admin-css', 'frontend-js').
-	 * @return string The version string for the given asset key, or empty string if not found.
-	 *
-	 * @throws \InvalidArgumentException If the provided key is empty.
-	 */
-	public function get( string $key ): string {
-		if ( '' === trim( $key ) ) {
-			throw new \InvalidArgumentException( 'Asset key cannot be empty.' );
-		}
+    /**
+     * Retrieve a version string for the given asset key.
+     *
+     * @since 1.0.0
+     *
+     * @param string $key The unique identifier for the asset (e.g., 'admin-css', 'frontend-js').
+     * @return string The version string for the given asset key, or empty string if not found.
+     *
+     * @throws \InvalidArgumentException If the provided key is empty.
+     */
+    public function get( string $key ): string {
+        if ( '' === trim( $key ) ) {
+            throw new \InvalidArgumentException( 'Asset key cannot be empty.' );
+        }
 
-		/**
-		 * Filters the version string for a given asset.
-		 *
-		 * @since 1.0.0
-		 *
-		 * @param string $version The version string for the asset.
-		 * @param string $key    The asset key being requested.
-		 */
-		return (string) apply_filters(
-			'nuclen_asset_version',
-			AssetVersions::get( $key ),
-			$key
-		);
-	}
+        /**
+         * Filters the version string for a given asset.
+         *
+         * @since 1.0.0
+         *
+         * @param string $version The version string for the asset.
+         * @param string $key    The asset key being requested.
+         */
+        return (string) apply_filters(
+            'nuclen_asset_version',
+            AssetVersions::get( $key ),
+            $key
+        );
+    }
 }

--- a/nuclear-engagement/inc/Traits/SettingsAccessTrait.php
+++ b/nuclear-engagement/inc/Traits/SettingsAccessTrait.php
@@ -15,7 +15,7 @@ namespace NuclearEngagement\Traits;
 
 // If this file is called directly, abort.
 if ( ! defined( 'ABSPATH' ) ) {
-	exit;
+    exit;
 }
 
 /**
@@ -27,124 +27,124 @@ if ( ! defined( 'ABSPATH' ) ) {
  */
 trait SettingsAccessTrait {
 
-	/**
-	 * Get a string setting.
-	 *
-	 * @since 1.0.0
-	 *
-	 * @param string $key          Setting key.
-	 * @param string $default_value Default value if setting doesn't exist. Default empty string.
-	 * @return string Setting value.
-	 */
-	public function get_string( string $key, string $default_value = '' ): string {
-			$value = $this->get( $key, $default_value );
-		return is_string( $value ) ? $value : (string) $value;
-	}
+    /**
+     * Get a string setting.
+     *
+     * @since 1.0.0
+     *
+     * @param string $key          Setting key.
+     * @param string $default_value Default value if setting doesn't exist. Default empty string.
+     * @return string Setting value.
+     */
+    public function get_string( string $key, string $default_value = '' ): string {
+            $value = $this->get( $key, $default_value );
+        return is_string( $value ) ? $value : (string) $value;
+    }
 
-	/**
-	 * Get an integer setting.
-	 *
-	 * @since 1.0.0
-	 *
-	 * @param string $key          Setting key.
-	 * @param int    $default_value Default value if setting doesn't exist. Default 0.
-	 * @return int Setting value.
-	 */
-	public function get_int( string $key, int $default_value = 0 ): int {
-			$value = $this->get( $key, $default_value );
-			return is_numeric( $value ) ? (int) $value : $default_value;
-	}
+    /**
+     * Get an integer setting.
+     *
+     * @since 1.0.0
+     *
+     * @param string $key          Setting key.
+     * @param int    $default_value Default value if setting doesn't exist. Default 0.
+     * @return int Setting value.
+     */
+    public function get_int( string $key, int $default_value = 0 ): int {
+            $value = $this->get( $key, $default_value );
+            return is_numeric( $value ) ? (int) $value : $default_value;
+    }
 
-	/**
-	 * Get a boolean setting.
-	 *
-	 * @since 1.0.0
-	 *
-	 * @param string $key          Setting key.
-	 * @param bool   $default_value Default value if setting doesn't exist. Default false.
-	 * @return bool Setting value.
-	 */
-	public function get_bool( string $key, bool $default_value = false ): bool {
-			return (bool) $this->get( $key, $default_value );
-	}
+    /**
+     * Get a boolean setting.
+     *
+     * @since 1.0.0
+     *
+     * @param string $key          Setting key.
+     * @param bool   $default_value Default value if setting doesn't exist. Default false.
+     * @return bool Setting value.
+     */
+    public function get_bool( string $key, bool $default_value = false ): bool {
+            return (bool) $this->get( $key, $default_value );
+    }
 
-	/**
-	 * Get an array setting.
-	 *
-	 * @since 1.0.0
-	 *
-	 * @param string $key          Setting key.
-	 * @param array  $default_value Default value if setting doesn't exist. Default empty array.
-	 * @return array Setting value.
-	 */
-	public function get_array( string $key, array $default_value = array() ): array {
-			$value = $this->get( $key, $default_value );
-			return is_array( $value ) ? $value : $default_value;
-	}
+    /**
+     * Get an array setting.
+     *
+     * @since 1.0.0
+     *
+     * @param string $key          Setting key.
+     * @param array  $default_value Default value if setting doesn't exist. Default empty array.
+     * @return array Setting value.
+     */
+    public function get_array( string $key, array $default_value = array() ): array {
+            $value = $this->get( $key, $default_value );
+            return is_array( $value ) ? $value : $default_value;
+    }
 
-	/**
-	 * Set a setting value to be saved later.
-	 *
-	 * @since 1.0.0
-	 *
-	 * @param string $key   Setting key.
-	 * @param mixed  $value Setting value.
-	 * @return self
-	 */
-	public function set( string $key, $value ): self {
-		$this->pending[ $key ] = $value;
-		return $this;
-	}
+    /**
+     * Set a setting value to be saved later.
+     *
+     * @since 1.0.0
+     *
+     * @param string $key   Setting key.
+     * @param mixed  $value Setting value.
+     * @return self
+     */
+    public function set( string $key, $value ): self {
+        $this->pending[ $key ] = $value;
+        return $this;
+    }
 
-	/**
-	 * Set a string setting.
-	 *
-	 * @since 1.0.0
-	 *
-	 * @param string $key   Setting key.
-	 * @param string $value Setting value.
-	 * @return self
-	 */
-	public function set_string( string $key, string $value ): self {
-		return $this->set( $key, sanitize_text_field( $value ) );
-	}
+    /**
+     * Set a string setting.
+     *
+     * @since 1.0.0
+     *
+     * @param string $key   Setting key.
+     * @param string $value Setting value.
+     * @return self
+     */
+    public function set_string( string $key, string $value ): self {
+        return $this->set( $key, sanitize_text_field( $value ) );
+    }
 
-	/**
-	 * Set an integer setting.
-	 *
-	 * @since 1.0.0
-	 *
-	 * @param string $key   Setting key.
-	 * @param int    $value Setting value.
-	 * @return self
-	 */
-	public function set_int( string $key, int $value ): self {
-		return $this->set( $key, (int) $value );
-	}
+    /**
+     * Set an integer setting.
+     *
+     * @since 1.0.0
+     *
+     * @param string $key   Setting key.
+     * @param int    $value Setting value.
+     * @return self
+     */
+    public function set_int( string $key, int $value ): self {
+        return $this->set( $key, (int) $value );
+    }
 
-	/**
-	 * Set a boolean setting.
-	 *
-	 * @since 1.0.0
-	 *
-	 * @param string $key   Setting key.
-	 * @param bool   $value Setting value.
-	 * @return self
-	 */
-	public function set_bool( string $key, bool $value ): self {
-		return $this->set( $key, (bool) $value );
-	}
+    /**
+     * Set a boolean setting.
+     *
+     * @since 1.0.0
+     *
+     * @param string $key   Setting key.
+     * @param bool   $value Setting value.
+     * @return self
+     */
+    public function set_bool( string $key, bool $value ): self {
+        return $this->set( $key, (bool) $value );
+    }
 
-	/**
-	 * Set an array setting.
-	 *
-	 * @since 1.0.0
-	 *
-	 * @param string $key   Setting key.
-	 * @param array  $value Setting value.
-	 * @return self
-	 */
-	public function set_array( string $key, array $value ): self {
-		return $this->set( $key, SettingsSanitizer::sanitize_setting( $key, $value ) );
-	}
+    /**
+     * Set an array setting.
+     *
+     * @since 1.0.0
+     *
+     * @param string $key   Setting key.
+     * @param array  $value Setting value.
+     * @return self
+     */
+    public function set_array( string $key, array $value ): self {
+        return $this->set( $key, SettingsSanitizer::sanitize_setting( $key, $value ) );
+    }
 }

--- a/nuclear-engagement/index.php
+++ b/nuclear-engagement/index.php
@@ -10,5 +10,5 @@
 declare(strict_types=1);
 
 if ( ! defined( 'ABSPATH' ) ) {
-	exit;
+    exit;
 } // Silence is golden

--- a/nuclear-engagement/templates/admin/dashboard/analytics.php
+++ b/nuclear-engagement/templates/admin/dashboard/analytics.php
@@ -2,28 +2,28 @@
 declare(strict_types=1);
 // File: admin/partials/dashboard/analytics.php
 if ( ! defined( 'ABSPATH' ) ) {
-	exit;
+    exit;
 }
 ?>
 <!-- Analytics -->
 <h2><?php esc_html_e( 'Analytics', 'nuclear-engagement' ); ?></h2>
 <p>
-	<?php
-	printf(
-		wp_kses(
-			/* translators: %s is a link */
-			__( 'Engagement analytics are available on the Nuclear Engagement web app (create a free account %s).', 'nuclear-engagement' ),
-			array(
-				'a' => array(
-					'href'   => array(),
-					'target' => array(),
-				),
-			)
-		),
-		'<a href="https://app.nuclearengagement.com/signup" target="_blank">' . esc_html__( 'here', 'nuclear-engagement' ) . '</a>'
-	);
-	?>
+    <?php
+    printf(
+        wp_kses(
+            /* translators: %s is a link */
+            __( 'Engagement analytics are available on the Nuclear Engagement web app (create a free account %s).', 'nuclear-engagement' ),
+            array(
+                'a' => array(
+                    'href'   => array(),
+                    'target' => array(),
+                ),
+            )
+        ),
+        '<a href="https://app.nuclearengagement.com/signup" target="_blank">' . esc_html__( 'here', 'nuclear-engagement' ) . '</a>'
+    );
+    ?>
 </p>
 <button class="button button-secondary" onclick="window.open('https://app.nuclearengagement.com/sites', '_blank');">
-	<?php esc_html_e( 'View Analytics', 'nuclear-engagement' ); ?>
+    <?php esc_html_e( 'View Analytics', 'nuclear-engagement' ); ?>
 </button>

--- a/nuclear-engagement/templates/admin/dashboard/credits.php
+++ b/nuclear-engagement/templates/admin/dashboard/credits.php
@@ -2,44 +2,44 @@
 declare(strict_types=1);
 // File: admin/partials/dashboard/credits.php
 if ( ! defined( 'ABSPATH' ) ) {
-	exit;
+    exit;
 }
 ?>
 <?php if ( $fully_setup ) : // Only show credits if plugin setup is complete ?>
-	<!-- Show the user’s current credits -->
-	<h2 style="margin-top:30px;"><?php esc_html_e( 'Your Credits', 'nuclear-engagement' ); ?></h2>
-	<p id="nuclen-credits-dashboard-msg"><?php esc_html_e( 'Loading your credits...', 'nuclear-engagement' ); ?></p>
-	<script>
-	document.addEventListener('DOMContentLoaded', async () => {
-		const msgEl = document.getElementById('nuclen-credits-dashboard-msg');
-		if (!msgEl) return;
-		try {
-		// We'll reuse the same "nuclen_fetch_app_updates" action with no generation_id
-		const formData = new FormData();
-		formData.append('action', 'nuclen_fetch_app_updates');
-		formData.append('security', '<?php echo esc_js( wp_create_nonce( 'nuclen_admin_ajax_nonce' ) ); ?>');
-		// We do not append generation_id => let the SaaS interpret it as "just return credits"
-		const resp = await fetch("<?php echo esc_url( admin_url( 'admin-ajax.php' ) ); ?>", {
-			method: 'POST',
-			body: formData
-		});
-		const data = await resp.json();
-		if (!data.success) {
-			throw new Error(data.data?.message || 'Failed to fetch credits');
-		}
-		const remoteData = data.data;
-		if (remoteData && typeof remoteData.remaining_credits !== 'undefined') {
-			msgEl.textContent = '<?php echo esc_js( __( 'You have', 'nuclear-engagement' ) ); ?> '
-			+ remoteData.remaining_credits
-			+ ' <?php echo esc_js( __( 'credits left.', 'nuclear-engagement' ) ); ?>';
-		} else {
-			msgEl.textContent = '<?php echo esc_js( __( 'No credits info returned.', 'nuclear-engagement' ) ); ?>';
-		}
-		} catch (err) {
-		msgEl.textContent = 'Error: ' + err;
-		}
-	});
-	</script>
+    <!-- Show the user’s current credits -->
+    <h2 style="margin-top:30px;"><?php esc_html_e( 'Your Credits', 'nuclear-engagement' ); ?></h2>
+    <p id="nuclen-credits-dashboard-msg"><?php esc_html_e( 'Loading your credits...', 'nuclear-engagement' ); ?></p>
+    <script>
+    document.addEventListener('DOMContentLoaded', async () => {
+        const msgEl = document.getElementById('nuclen-credits-dashboard-msg');
+        if (!msgEl) return;
+        try {
+        // We'll reuse the same "nuclen_fetch_app_updates" action with no generation_id
+        const formData = new FormData();
+        formData.append('action', 'nuclen_fetch_app_updates');
+        formData.append('security', '<?php echo esc_js( wp_create_nonce( 'nuclen_admin_ajax_nonce' ) ); ?>');
+        // We do not append generation_id => let the SaaS interpret it as "just return credits"
+        const resp = await fetch("<?php echo esc_url( admin_url( 'admin-ajax.php' ) ); ?>", {
+            method: 'POST',
+            body: formData
+        });
+        const data = await resp.json();
+        if (!data.success) {
+            throw new Error(data.data?.message || 'Failed to fetch credits');
+        }
+        const remoteData = data.data;
+        if (remoteData && typeof remoteData.remaining_credits !== 'undefined') {
+            msgEl.textContent = '<?php echo esc_js( __( 'You have', 'nuclear-engagement' ) ); ?> '
+            + remoteData.remaining_credits
+            + ' <?php echo esc_js( __( 'credits left.', 'nuclear-engagement' ) ); ?>';
+        } else {
+            msgEl.textContent = '<?php echo esc_js( __( 'No credits info returned.', 'nuclear-engagement' ) ); ?>';
+        }
+        } catch (err) {
+        msgEl.textContent = 'Error: ' + err;
+        }
+    });
+    </script>
 <?php else : ?>
-	<!-- Credits hidden: user has not completed plugin setup -->
+    <!-- Credits hidden: user has not completed plugin setup -->
 <?php endif; ?>

--- a/nuclear-engagement/templates/admin/dashboard/inventory.php
+++ b/nuclear-engagement/templates/admin/dashboard/inventory.php
@@ -2,91 +2,91 @@
 declare(strict_types=1);
 // File: admin/partials/dashboard/inventory.php
 if ( ! defined( 'ABSPATH' ) ) {
-	exit;
+    exit;
 }
 ?>
 <!-- Post inventory -->
 <h2><?php esc_html_e( 'Post Inventory', 'nuclear-engagement' ); ?></h2>
 <p><?php esc_html_e( 'Counts are cached for faster page loads.', 'nuclear-engagement' ); ?></p>
 <p>
-	<a href="
-	<?php
-	echo esc_url(
-		add_query_arg(
-			array(
-				'nuclen_refresh_inventory'       => '1',
-				'nuclen_refresh_inventory_nonce' => wp_create_nonce( 'nuclen_refresh_inventory' ),
-			)
-		)
-	);
-	?>
-	" class="button button-secondary">
-		<?php esc_html_e( 'Refresh', 'nuclear-engagement' ); ?>
-	</a>
+    <a href="
+    <?php
+    echo esc_url(
+        add_query_arg(
+            array(
+                'nuclen_refresh_inventory'       => '1',
+                'nuclen_refresh_inventory_nonce' => wp_create_nonce( 'nuclen_refresh_inventory' ),
+            )
+        )
+    );
+    ?>
+    " class="button button-secondary">
+        <?php esc_html_e( 'Refresh', 'nuclear-engagement' ); ?>
+    </a>
 </p>
 <!-- Post inventory Navigation Tabs -->
 <div class="nav-tab-wrapper">
-	<a href="#post-status" id="post-status-tab" class="nav-tab nav-tab-active"><?php esc_html_e( 'Post Status', 'nuclear-engagement' ); ?></a>
-	<a href="#category" class="nav-tab"><?php esc_html_e( 'Categories', 'nuclear-engagement' ); ?></a>
-	<a href="#author" class="nav-tab"><?php esc_html_e( 'Authors', 'nuclear-engagement' ); ?></a>
-	<a href="#post-type" id="post-type-tab" class="nav-tab"><?php esc_html_e( 'Post Types', 'nuclear-engagement' ); ?></a>
+    <a href="#post-status" id="post-status-tab" class="nav-tab nav-tab-active"><?php esc_html_e( 'Post Status', 'nuclear-engagement' ); ?></a>
+    <a href="#category" class="nav-tab"><?php esc_html_e( 'Categories', 'nuclear-engagement' ); ?></a>
+    <a href="#author" class="nav-tab"><?php esc_html_e( 'Authors', 'nuclear-engagement' ); ?></a>
+    <a href="#post-type" id="post-type-tab" class="nav-tab"><?php esc_html_e( 'Post Types', 'nuclear-engagement' ); ?></a>
 </div>
 <!-- Post inventory Main Content -->
 <div class="nuclen-dashboard-content">
-	<!-- POST STATUS TAB -->
-	<div id="post-status" class="nuclen-tab-content nuclen-section" style="display:block; margin-top:20px;">
-		<h2 class="nuclen-subheading"><?php esc_html_e( 'Post Status', 'nuclear-engagement' ); ?></h2>
-		<div class="nuclen-row">
-			<div class="nuclen-col">
-				<h3><?php esc_html_e( 'Quizzes', 'nuclear-engagement' ); ?></h3>
+    <!-- POST STATUS TAB -->
+    <div id="post-status" class="nuclen-tab-content nuclen-section" style="display:block; margin-top:20px;">
+        <h2 class="nuclen-subheading"><?php esc_html_e( 'Post Status', 'nuclear-engagement' ); ?></h2>
+        <div class="nuclen-row">
+            <div class="nuclen-col">
+                <h3><?php esc_html_e( 'Quizzes', 'nuclear-engagement' ); ?></h3>
                 <?php echo $this->nuclen_render_dashboard_stats_table( $by_status_quiz ); // phpcs:ignore ?>
-			</div>
-			<div class="nuclen-col">
-				<h3><?php esc_html_e( 'Summaries', 'nuclear-engagement' ); ?></h3>
+            </div>
+            <div class="nuclen-col">
+                <h3><?php esc_html_e( 'Summaries', 'nuclear-engagement' ); ?></h3>
                 <?php echo $this->nuclen_render_dashboard_stats_table( $by_status_summary ); // phpcs:ignore ?>
-			</div>
-		</div>
-	</div>
-	<!-- CATEGORY TAB -->
-	<div id="category" class="nuclen-tab-content nuclen-section" style="display:none; margin-top:20px;">
-		<h2 class="nuclen-subheading"><?php esc_html_e( 'Categories', 'nuclear-engagement' ); ?></h2>
-		<div class="nuclen-row">
-			<div class="nuclen-col">
-				<h3><?php esc_html_e( 'Quizzes', 'nuclear-engagement' ); ?></h3>
+            </div>
+        </div>
+    </div>
+    <!-- CATEGORY TAB -->
+    <div id="category" class="nuclen-tab-content nuclen-section" style="display:none; margin-top:20px;">
+        <h2 class="nuclen-subheading"><?php esc_html_e( 'Categories', 'nuclear-engagement' ); ?></h2>
+        <div class="nuclen-row">
+            <div class="nuclen-col">
+                <h3><?php esc_html_e( 'Quizzes', 'nuclear-engagement' ); ?></h3>
                 <?php echo $this->nuclen_render_dashboard_stats_table( $by_category_quiz ); // phpcs:ignore ?>
-			</div>
-			<div class="nuclen-col">
-				<h3><?php esc_html_e( 'Summaries', 'nuclear-engagement' ); ?></h3>
+            </div>
+            <div class="nuclen-col">
+                <h3><?php esc_html_e( 'Summaries', 'nuclear-engagement' ); ?></h3>
                 <?php echo $this->nuclen_render_dashboard_stats_table( $by_category_summary ); // phpcs:ignore ?>
-			</div>
-		</div>
-	</div>
-	<!-- AUTHOR TAB -->
-	<div id="author" class="nuclen-tab-content nuclen-section" style="display:none; margin-top:20px;">
-		<h2 class="nuclen-subheading"><?php esc_html_e( 'Authors', 'nuclear-engagement' ); ?></h2>
-		<div class="nuclen-row">
-			<div class="nuclen-col">
-				<h3><?php esc_html_e( 'Quizzes', 'nuclear-engagement' ); ?></h3>
+            </div>
+        </div>
+    </div>
+    <!-- AUTHOR TAB -->
+    <div id="author" class="nuclen-tab-content nuclen-section" style="display:none; margin-top:20px;">
+        <h2 class="nuclen-subheading"><?php esc_html_e( 'Authors', 'nuclear-engagement' ); ?></h2>
+        <div class="nuclen-row">
+            <div class="nuclen-col">
+                <h3><?php esc_html_e( 'Quizzes', 'nuclear-engagement' ); ?></h3>
                 <?php echo $this->nuclen_render_dashboard_stats_table( $by_author_quiz ); // phpcs:ignore ?>
-			</div>
-			<div class="nuclen-col">
-				<h3><?php esc_html_e( 'Summaries', 'nuclear-engagement' ); ?></h3>
+            </div>
+            <div class="nuclen-col">
+                <h3><?php esc_html_e( 'Summaries', 'nuclear-engagement' ); ?></h3>
                 <?php echo $this->nuclen_render_dashboard_stats_table( $by_author_summary ); // phpcs:ignore ?>
-			</div>
-		</div>
-	</div>
-	<!-- POST TYPE TAB -->
-	<div id="post-type" class="nuclen-tab-content nuclen-section" style="display:none; margin-top:20px;">
-		<h2 class="nuclen-subheading"><?php esc_html_e( 'Post Types', 'nuclear-engagement' ); ?></h2>
-		<div class="nuclen-row">
-			<div class="nuclen-col">
-				<h3><?php esc_html_e( 'Quizzes', 'nuclear-engagement' ); ?></h3>
+            </div>
+        </div>
+    </div>
+    <!-- POST TYPE TAB -->
+    <div id="post-type" class="nuclen-tab-content nuclen-section" style="display:none; margin-top:20px;">
+        <h2 class="nuclen-subheading"><?php esc_html_e( 'Post Types', 'nuclear-engagement' ); ?></h2>
+        <div class="nuclen-row">
+            <div class="nuclen-col">
+                <h3><?php esc_html_e( 'Quizzes', 'nuclear-engagement' ); ?></h3>
                 <?php echo $this->nuclen_render_dashboard_stats_table( $by_post_type_quiz ); // phpcs:ignore ?>
-			</div>
-			<div class="nuclen-col">
-				<h3><?php esc_html_e( 'Summaries', 'nuclear-engagement' ); ?></h3>
+            </div>
+            <div class="nuclen-col">
+                <h3><?php esc_html_e( 'Summaries', 'nuclear-engagement' ); ?></h3>
                 <?php echo $this->nuclen_render_dashboard_stats_table( $by_post_type_summary ); // phpcs:ignore ?>
-			</div>
-		</div>
-	</div>
+            </div>
+        </div>
+    </div>
 </div><!-- .nuclen-dashboard-content -->

--- a/nuclear-engagement/templates/admin/dashboard/scheduled.php
+++ b/nuclear-engagement/templates/admin/dashboard/scheduled.php
@@ -2,29 +2,29 @@
 declare(strict_types=1);
 // File: admin/partials/dashboard/scheduled.php
 if ( ! defined( 'ABSPATH' ) ) {
-	exit;
+    exit;
 }
 ?>
 <h2><?php esc_html_e( 'Scheduled Generations', 'nuclear-engagement' ); ?></h2>
 <div class="nuclen-dashboard-content">
 <?php if ( empty( $scheduled_tasks ) ) : ?>
-	<p><?php esc_html_e( 'No scheduled generation tasks.', 'nuclear-engagement' ); ?></p>
+    <p><?php esc_html_e( 'No scheduled generation tasks.', 'nuclear-engagement' ); ?></p>
 <?php else : ?>
-	<table class="nuclen-stats-table">
-		<tr>
-			<th><?php esc_html_e( 'Post', 'nuclear-engagement' ); ?></th>
-			<th><?php esc_html_e( 'Type', 'nuclear-engagement' ); ?></th>
-			<th><?php esc_html_e( 'Attempt', 'nuclear-engagement' ); ?></th>
-			<th><?php esc_html_e( 'Next Check', 'nuclear-engagement' ); ?></th>
-		</tr>
-		<?php foreach ( $scheduled_tasks as $t ) : ?>
-		<tr>
-			<td><?php echo esc_html( $t['post_title'] ); ?></td>
-			<td><?php echo esc_html( ucfirst( $t['workflow_type'] ) ); ?></td>
-			<td><?php echo esc_html( $t['attempt'] ); ?></td>
-			<td><?php echo esc_html( $t['next_poll'] ); ?></td>
-		</tr>
-		<?php endforeach; ?>
-	</table>
+    <table class="nuclen-stats-table">
+        <tr>
+            <th><?php esc_html_e( 'Post', 'nuclear-engagement' ); ?></th>
+            <th><?php esc_html_e( 'Type', 'nuclear-engagement' ); ?></th>
+            <th><?php esc_html_e( 'Attempt', 'nuclear-engagement' ); ?></th>
+            <th><?php esc_html_e( 'Next Check', 'nuclear-engagement' ); ?></th>
+        </tr>
+        <?php foreach ( $scheduled_tasks as $t ) : ?>
+        <tr>
+            <td><?php echo esc_html( $t['post_title'] ); ?></td>
+            <td><?php echo esc_html( ucfirst( $t['workflow_type'] ) ); ?></td>
+            <td><?php echo esc_html( $t['attempt'] ); ?></td>
+            <td><?php echo esc_html( $t['next_poll'] ); ?></td>
+        </tr>
+        <?php endforeach; ?>
+    </table>
 <?php endif; ?>
 </div>

--- a/nuclear-engagement/templates/admin/generate/confirm.php
+++ b/nuclear-engagement/templates/admin/generate/confirm.php
@@ -1,30 +1,30 @@
-	<!-- Step 2 Section (hidden by default) -->
-	<div id="nuclen-step-2" class="nuclen-section nuclen-hidden">
-		<h2 class="nuclen-subheading"><?php esc_html_e( '2. Confirm and Generate', 'nuclear-engagement' ); ?></h2>
+    <!-- Step 2 Section (hidden by default) -->
+    <div id="nuclen-step-2" class="nuclen-section nuclen-hidden">
+        <h2 class="nuclen-subheading"><?php esc_html_e( '2. Confirm and Generate', 'nuclear-engagement' ); ?></h2>
 
-		<!-- New line to display credit info -->
-		<p id="nuclen-credits-info" style="font-weight: bold; margin-bottom: 1em;"></p>
+        <!-- New line to display credit info -->
+        <p id="nuclen-credits-info" style="font-weight: bold; margin-bottom: 1em;"></p>
 
-		<p id="nuclen-posts-count"></p>
-		<form id="nuclen-generate-form" method="post" action="<?php echo esc_url( admin_url( 'admin-ajax.php' ) ); ?>">
-			<?php
-			wp_nonce_field( 'nuclen_admin_ajax_nonce', 'security' );
-			?>
-			<input type="hidden" name="action" value="nuclen_trigger_generation" />
-			<!-- Hidden fields to preserve user selections -->
-			<input type="hidden" name="nuclen_selected_post_ids" id="nuclen_selected_post_ids" />
-			<input type="hidden" name="nuclen_selected_generate_workflow" id="nuclen_selected_generate_workflow" />
-			<input type="hidden" name="nuclen_selected_summary_format" id="nuclen_selected_summary_format" />
-			<input type="hidden" name="nuclen_selected_summary_length" id="nuclen_selected_summary_length" />
-			<input type="hidden" name="nuclen_selected_summary_number_of_items" id="nuclen_selected_summary_number_of_items" />
-			<input type="hidden" name="nuclen_selected_post_status" id="nuclen_selected_post_status" />
-			<input type="hidden" name="nuclen_selected_post_type" id="nuclen_selected_post_type" />
+        <p id="nuclen-posts-count"></p>
+        <form id="nuclen-generate-form" method="post" action="<?php echo esc_url( admin_url( 'admin-ajax.php' ) ); ?>">
+            <?php
+            wp_nonce_field( 'nuclen_admin_ajax_nonce', 'security' );
+            ?>
+            <input type="hidden" name="action" value="nuclen_trigger_generation" />
+            <!-- Hidden fields to preserve user selections -->
+            <input type="hidden" name="nuclen_selected_post_ids" id="nuclen_selected_post_ids" />
+            <input type="hidden" name="nuclen_selected_generate_workflow" id="nuclen_selected_generate_workflow" />
+            <input type="hidden" name="nuclen_selected_summary_format" id="nuclen_selected_summary_format" />
+            <input type="hidden" name="nuclen_selected_summary_length" id="nuclen_selected_summary_length" />
+            <input type="hidden" name="nuclen_selected_summary_number_of_items" id="nuclen_selected_summary_number_of_items" />
+            <input type="hidden" name="nuclen_selected_post_status" id="nuclen_selected_post_status" />
+            <input type="hidden" name="nuclen_selected_post_type" id="nuclen_selected_post_type" />
 
-			<button type="submit" id="nuclen-submit-btn" class="button button-primary nuclen-button-primary">
-				<?php esc_html_e( 'Generate Content', 'nuclear-engagement' ); ?>
-			</button>
-			<button type="button" id="nuclen-go-back-btn" class="button">
-				<?php esc_html_e( 'Back to post selection', 'nuclear-engagement' ); ?>
-			</button>
-		</form>
-	</div>
+            <button type="submit" id="nuclen-submit-btn" class="button button-primary nuclen-button-primary">
+                <?php esc_html_e( 'Generate Content', 'nuclear-engagement' ); ?>
+            </button>
+            <button type="button" id="nuclen-go-back-btn" class="button">
+                <?php esc_html_e( 'Back to post selection', 'nuclear-engagement' ); ?>
+            </button>
+        </form>
+    </div>

--- a/nuclear-engagement/templates/admin/generate/filters.php
+++ b/nuclear-engagement/templates/admin/generate/filters.php
@@ -1,157 +1,157 @@
-	<div id="nuclen-step-1" class="nuclen-section">
-		<h2 class="nuclen-subheading"><?php esc_html_e( '1. Select filters for posts', 'nuclear-engagement' ); ?></h2>
-		<form id="nuclen-filters-form" class="nuclen-section" method="post">
-			<table class="form-table">
-				<tr class="nuclen-form-group">
-					<th><label for="nuclen_post_status" class="nuclen-label"><?php esc_html_e( 'Post Status', 'nuclear-engagement' ); ?></label></th>
-					<td>
-						<select name="nuclen_post_status" id="nuclen_post_status" class="nuclen-input">
-							<option value="any"><?php esc_html_e( 'All', 'nuclear-engagement' ); ?></option>
-							<?php
-							foreach ( $statuses as $status_key => $st_obj ) :
-								if ( ! in_array( $status_key, array( 'trash', 'private', 'inherit' ) ) ) :
-									?>
-									<option value="<?php echo esc_attr( $status_key ); ?>">
-										<?php echo esc_html( $st_obj->label ); ?>
-									</option>
-									<?php
-								endif;
-						endforeach;
-							?>
-						</select>
-					</td>
-				</tr>
+    <div id="nuclen-step-1" class="nuclen-section">
+        <h2 class="nuclen-subheading"><?php esc_html_e( '1. Select filters for posts', 'nuclear-engagement' ); ?></h2>
+        <form id="nuclen-filters-form" class="nuclen-section" method="post">
+            <table class="form-table">
+                <tr class="nuclen-form-group">
+                    <th><label for="nuclen_post_status" class="nuclen-label"><?php esc_html_e( 'Post Status', 'nuclear-engagement' ); ?></label></th>
+                    <td>
+                        <select name="nuclen_post_status" id="nuclen_post_status" class="nuclen-input">
+                            <option value="any"><?php esc_html_e( 'All', 'nuclear-engagement' ); ?></option>
+                            <?php
+                            foreach ( $statuses as $status_key => $st_obj ) :
+                                if ( ! in_array( $status_key, array( 'trash', 'private', 'inherit' ) ) ) :
+                                    ?>
+                                    <option value="<?php echo esc_attr( $status_key ); ?>">
+                                        <?php echo esc_html( $st_obj->label ); ?>
+                                    </option>
+                                    <?php
+                                endif;
+                        endforeach;
+                            ?>
+                        </select>
+                    </td>
+                </tr>
 
-				<tr class="nuclen-form-group">
-					<th><label for="nuclen_category" class="nuclen-label"><?php esc_html_e( 'Category', 'nuclear-engagement' ); ?></label></th>
-					<td>
-						<select name="nuclen_category" id="nuclen_category" class="nuclen-input">
-							<option value=""><?php esc_html_e( 'All', 'nuclear-engagement' ); ?></option>
-							<?php
-							foreach ( $categories as $cat ) :
-								?>
-								<option value="<?php echo esc_attr( $cat->term_id ); ?>">
-									<?php echo esc_html( $cat->name ); ?>
-								</option>
-							<?php endforeach; ?>
-						</select>
-					</td>
-				</tr>
+                <tr class="nuclen-form-group">
+                    <th><label for="nuclen_category" class="nuclen-label"><?php esc_html_e( 'Category', 'nuclear-engagement' ); ?></label></th>
+                    <td>
+                        <select name="nuclen_category" id="nuclen_category" class="nuclen-input">
+                            <option value=""><?php esc_html_e( 'All', 'nuclear-engagement' ); ?></option>
+                            <?php
+                            foreach ( $categories as $cat ) :
+                                ?>
+                                <option value="<?php echo esc_attr( $cat->term_id ); ?>">
+                                    <?php echo esc_html( $cat->name ); ?>
+                                </option>
+                            <?php endforeach; ?>
+                        </select>
+                    </td>
+                </tr>
 
-				<tr class="nuclen-form-group">
-					<th><label for="nuclen_author" class="nuclen-label"><?php esc_html_e( 'Author', 'nuclear-engagement' ); ?></label></th>
-					<td>
-						<select name="nuclen_author" id="nuclen_author" class="nuclen-input">
-							<option value=""><?php esc_html_e( 'All', 'nuclear-engagement' ); ?></option>
-							<?php
-							foreach ( $authors as $author ) :
-								?>
-								<option value="<?php echo esc_attr( $author->ID ); ?>">
-									<?php echo esc_html( $author->display_name ); ?>
-								</option>
-							<?php endforeach; ?>
-						</select>
-					</td>
-				</tr>
+                <tr class="nuclen-form-group">
+                    <th><label for="nuclen_author" class="nuclen-label"><?php esc_html_e( 'Author', 'nuclear-engagement' ); ?></label></th>
+                    <td>
+                        <select name="nuclen_author" id="nuclen_author" class="nuclen-input">
+                            <option value=""><?php esc_html_e( 'All', 'nuclear-engagement' ); ?></option>
+                            <?php
+                            foreach ( $authors as $author ) :
+                                ?>
+                                <option value="<?php echo esc_attr( $author->ID ); ?>">
+                                    <?php echo esc_html( $author->display_name ); ?>
+                                </option>
+                            <?php endforeach; ?>
+                        </select>
+                    </td>
+                </tr>
 
-				<!-- Post Type row -->
-				<tr class="nuclen-form-group">
-					<th><label for="nuclen_post_type" class="nuclen-label"><?php esc_html_e( 'Post Type', 'nuclear-engagement' ); ?></label></th>
-					<td>
-						<select name="nuclen_post_type" id="nuclen_post_type" class="nuclen-input">
-							<?php
-							foreach ( $post_types as $pt_key => $pt_obj ) {
-								if ( in_array( $pt_key, $allowed_post_types ) ) {
-									echo '<option value="' . esc_attr( $pt_key ) . '">' . esc_html( $pt_obj->labels->name ) . '</option>';
-								}
-							}
-							?>
-						</select>
-					</td>
-				</tr>
-				<!-- End Post Type row -->
+                <!-- Post Type row -->
+                <tr class="nuclen-form-group">
+                    <th><label for="nuclen_post_type" class="nuclen-label"><?php esc_html_e( 'Post Type', 'nuclear-engagement' ); ?></label></th>
+                    <td>
+                        <select name="nuclen_post_type" id="nuclen_post_type" class="nuclen-input">
+                            <?php
+                            foreach ( $post_types as $pt_key => $pt_obj ) {
+                                if ( in_array( $pt_key, $allowed_post_types ) ) {
+                                    echo '<option value="' . esc_attr( $pt_key ) . '">' . esc_html( $pt_obj->labels->name ) . '</option>';
+                                }
+                            }
+                            ?>
+                        </select>
+                    </td>
+                </tr>
+                <!-- End Post Type row -->
 
-				<tr class="nuclen-form-group">
-					<th><label for="nuclen_generate_workflow" class="nuclen-label"><?php esc_html_e( 'Generate Type', 'nuclear-engagement' ); ?></label></th>
-					<td>
-						<select name="nuclen_generate_workflow" id="nuclen_generate_workflow" class="nuclen-input">
-							<option value="quiz" selected><?php esc_html_e( 'Quiz', 'nuclear-engagement' ); ?></option>
-							<option value="summary"><?php esc_html_e( 'Summary', 'nuclear-engagement' ); ?></option>
-						</select>
-					</td>
-				</tr>
+                <tr class="nuclen-form-group">
+                    <th><label for="nuclen_generate_workflow" class="nuclen-label"><?php esc_html_e( 'Generate Type', 'nuclear-engagement' ); ?></label></th>
+                    <td>
+                        <select name="nuclen_generate_workflow" id="nuclen_generate_workflow" class="nuclen-input">
+                            <option value="quiz" selected><?php esc_html_e( 'Quiz', 'nuclear-engagement' ); ?></option>
+                            <option value="summary"><?php esc_html_e( 'Summary', 'nuclear-engagement' ); ?></option>
+                        </select>
+                    </td>
+                </tr>
 
-				<tr id="nuclen-summary-settings" class="nuclen-form-group nuclen-hidden">
-					<th><label for="nuclen_summary_format" class="nuclen-label"><?php esc_html_e( 'Summary Format', 'nuclear-engagement' ); ?></label></th>
-					<td>
-						<select name="nuclen_summary_format" id="nuclen_summary_format" class="nuclen-input">
-							<option value="paragraph"><?php esc_html_e( 'Paragraph', 'nuclear-engagement' ); ?></option>
-							<option value="bullet_list"><?php esc_html_e( 'Bullet List', 'nuclear-engagement' ); ?></option>
-						</select>
-					</td>
-				</tr>
+                <tr id="nuclen-summary-settings" class="nuclen-form-group nuclen-hidden">
+                    <th><label for="nuclen_summary_format" class="nuclen-label"><?php esc_html_e( 'Summary Format', 'nuclear-engagement' ); ?></label></th>
+                    <td>
+                        <select name="nuclen_summary_format" id="nuclen_summary_format" class="nuclen-input">
+                            <option value="paragraph"><?php esc_html_e( 'Paragraph', 'nuclear-engagement' ); ?></option>
+                            <option value="bullet_list"><?php esc_html_e( 'Bullet List', 'nuclear-engagement' ); ?></option>
+                        </select>
+                    </td>
+                </tr>
 
-				<tr id="nuclen-summary-paragraph-options" class="nuclen-form-group nuclen-hidden">
-					<th><label for="nuclen_summary_length" class="nuclen-label"><?php esc_html_e( 'Paragraph length (words)', 'nuclear-engagement' ); ?></label></th>
-					<td>
-						<select name="nuclen_summary_length" id="nuclen_summary_length" class="nuclen-input">
-							<option value="20">20 <?php esc_html_e( 'words', 'nuclear-engagement' ); ?></option>
-							<option value="30">30 <?php esc_html_e( 'words', 'nuclear-engagement' ); ?></option>
-							<option value="40">40 <?php esc_html_e( 'words', 'nuclear-engagement' ); ?></option>
-							<option value="50">50 <?php esc_html_e( 'words', 'nuclear-engagement' ); ?></option>
-						</select>
-					</td>
-				</tr>
+                <tr id="nuclen-summary-paragraph-options" class="nuclen-form-group nuclen-hidden">
+                    <th><label for="nuclen_summary_length" class="nuclen-label"><?php esc_html_e( 'Paragraph length (words)', 'nuclear-engagement' ); ?></label></th>
+                    <td>
+                        <select name="nuclen_summary_length" id="nuclen_summary_length" class="nuclen-input">
+                            <option value="20">20 <?php esc_html_e( 'words', 'nuclear-engagement' ); ?></option>
+                            <option value="30">30 <?php esc_html_e( 'words', 'nuclear-engagement' ); ?></option>
+                            <option value="40">40 <?php esc_html_e( 'words', 'nuclear-engagement' ); ?></option>
+                            <option value="50">50 <?php esc_html_e( 'words', 'nuclear-engagement' ); ?></option>
+                        </select>
+                    </td>
+                </tr>
 
-				<tr id="nuclen-summary-bullet-options" class="nuclen-form-group nuclen-hidden">
-					<th><label for="nuclen_summary_number_of_items" class="nuclen-label"><?php esc_html_e( 'Number of bullet items', 'nuclear-engagement' ); ?></label></th>
-					<td>
-						<select name="nuclen_summary_number_of_items" id="nuclen_summary_number_of_items" class="nuclen-input">
-							<option value="3">3 <?php esc_html_e( 'items', 'nuclear-engagement' ); ?></option>
-							<option value="4">4 <?php esc_html_e( 'items', 'nuclear-engagement' ); ?></option>
-							<option value="5">5 <?php esc_html_e( 'items', 'nuclear-engagement' ); ?></option>
-							<option value="6">6 <?php esc_html_e( 'items', 'nuclear-engagement' ); ?></option>
-							<option value="7">7 <?php esc_html_e( 'items', 'nuclear-engagement' ); ?></option>
-						</select>
-					</td>
-				</tr>
+                <tr id="nuclen-summary-bullet-options" class="nuclen-form-group nuclen-hidden">
+                    <th><label for="nuclen_summary_number_of_items" class="nuclen-label"><?php esc_html_e( 'Number of bullet items', 'nuclear-engagement' ); ?></label></th>
+                    <td>
+                        <select name="nuclen_summary_number_of_items" id="nuclen_summary_number_of_items" class="nuclen-input">
+                            <option value="3">3 <?php esc_html_e( 'items', 'nuclear-engagement' ); ?></option>
+                            <option value="4">4 <?php esc_html_e( 'items', 'nuclear-engagement' ); ?></option>
+                            <option value="5">5 <?php esc_html_e( 'items', 'nuclear-engagement' ); ?></option>
+                            <option value="6">6 <?php esc_html_e( 'items', 'nuclear-engagement' ); ?></option>
+                            <option value="7">7 <?php esc_html_e( 'items', 'nuclear-engagement' ); ?></option>
+                        </select>
+                    </td>
+                </tr>
 
-			</table>
+            </table>
 
-			<div class="nuclen-form-row">
-				<div class="nuclen-form-field">
-					<input
-					type="checkbox"
-					class="nuclen-checkbox"
-					name="nuclen_allow_regenerate_data"
-					id="nuclen_allow_regenerate_data"
-					value="1"
-					/>
-					<label class="nuclen-checkbox-label" for="nuclen_allow_regenerate_data">
-					<?php esc_html_e( 'Allow bulk regeneration of existing data', 'nuclear-engagement' ); ?>
-					</label>
-					<span nuclen-tooltip="<?php esc_attr_e( 'By default, the plugin only generates content for posts lacking it. If checked, existing data is overwritten.', 'nuclear-engagement' ); ?>">🛈</span>
-				</div>
-			</div>
+            <div class="nuclen-form-row">
+                <div class="nuclen-form-field">
+                    <input
+                    type="checkbox"
+                    class="nuclen-checkbox"
+                    name="nuclen_allow_regenerate_data"
+                    id="nuclen_allow_regenerate_data"
+                    value="1"
+                    />
+                    <label class="nuclen-checkbox-label" for="nuclen_allow_regenerate_data">
+                    <?php esc_html_e( 'Allow bulk regeneration of existing data', 'nuclear-engagement' ); ?>
+                    </label>
+                    <span nuclen-tooltip="<?php esc_attr_e( 'By default, the plugin only generates content for posts lacking it. If checked, existing data is overwritten.', 'nuclear-engagement' ); ?>">🛈</span>
+                </div>
+            </div>
 
-			<div class="nuclen-form-row">
-				<div class="nuclen-form-field">
-					<input
-					type="checkbox"
-					class="nuclen-checkbox"
-					name="nuclen_regenerate_protected_data"
-					id="nuclen_regenerate_protected_data"
-					value="1"
-					/>
-					<label class="nuclen-checkbox-label" for="nuclen_regenerate_protected_data">
-					<?php esc_html_e( 'Allow bulk regeneration of protected data', 'nuclear-engagement' ); ?>
-					</label>
-					<span nuclen-tooltip="<?php esc_attr_e( 'By default, content marked protected is skipped. If checked, protected data can be overwritten too.', 'nuclear-engagement' ); ?>">🛈</span>
-				</div>
-			</div>
+            <div class="nuclen-form-row">
+                <div class="nuclen-form-field">
+                    <input
+                    type="checkbox"
+                    class="nuclen-checkbox"
+                    name="nuclen_regenerate_protected_data"
+                    id="nuclen_regenerate_protected_data"
+                    value="1"
+                    />
+                    <label class="nuclen-checkbox-label" for="nuclen_regenerate_protected_data">
+                    <?php esc_html_e( 'Allow bulk regeneration of protected data', 'nuclear-engagement' ); ?>
+                    </label>
+                    <span nuclen-tooltip="<?php esc_attr_e( 'By default, content marked protected is skipped. If checked, protected data can be overwritten too.', 'nuclear-engagement' ); ?>">🛈</span>
+                </div>
+            </div>
 
-			<button type="button" id="nuclen-get-posts-btn" class="button button-primary nuclen-button-primary">
-				<?php esc_html_e( 'Get Posts to Process', 'nuclear-engagement' ); ?>
-			</button>
-		</form>
-	</div>
+            <button type="button" id="nuclen-get-posts-btn" class="button button-primary nuclen-button-primary">
+                <?php esc_html_e( 'Get Posts to Process', 'nuclear-engagement' ); ?>
+            </button>
+        </form>
+    </div>

--- a/nuclear-engagement/templates/admin/generate/progress.php
+++ b/nuclear-engagement/templates/admin/generate/progress.php
@@ -1,7 +1,7 @@
-	<div id="nuclen-updates-section" class="nuclen-section nuclen-hidden" style="margin-top: 40px;">
-		<h2 class="nuclen-subheading"><?php esc_html_e( 'Progress', 'nuclear-engagement' ); ?></h2>
-		<div id="nuclen-updates-content" class="nuclen-progress"><?php esc_html_e( 'Processing posts...', 'nuclear-engagement' ); ?></div>
-		<button id="nuclen-restart-btn" class="button button-primary nuclen-button-primary nuclen-hidden" style="margin-top: 20px;">
-			<?php esc_html_e( 'Back to post selection', 'nuclear-engagement' ); ?>
-		</button>
-	</div>
+    <div id="nuclen-updates-section" class="nuclen-section nuclen-hidden" style="margin-top: 40px;">
+        <h2 class="nuclen-subheading"><?php esc_html_e( 'Progress', 'nuclear-engagement' ); ?></h2>
+        <div id="nuclen-updates-content" class="nuclen-progress"><?php esc_html_e( 'Processing posts...', 'nuclear-engagement' ); ?></div>
+        <button id="nuclen-restart-btn" class="button button-primary nuclen-button-primary nuclen-hidden" style="margin-top: 20px;">
+            <?php esc_html_e( 'Back to post selection', 'nuclear-engagement' ); ?>
+        </button>
+    </div>

--- a/nuclear-engagement/templates/admin/nuclen-admin-display.php
+++ b/nuclear-engagement/templates/admin/nuclen-admin-display.php
@@ -1,7 +1,7 @@
 <?php
 declare(strict_types=1);
 if ( ! defined( 'ABSPATH' ) ) {
-	exit;
+    exit;
 }
 
 /**

--- a/nuclear-engagement/templates/admin/nuclen-admin-generate.php
+++ b/nuclear-engagement/templates/admin/nuclen-admin-generate.php
@@ -1,7 +1,7 @@
 <?php
 declare(strict_types=1);
 if ( ! defined( 'ABSPATH' ) ) {
-	exit;
+    exit;
 }
 /**
  * File: admin/partials/nuclen-admin-generate.php
@@ -40,12 +40,12 @@ $utils->display_nuclen_page_header();
                 <div id="nuclen-step-bar-4" class="ne-step-bar__step ne-step-bar__step--todo"><?php esc_html_e( '4. Save', 'nuclear-engagement' ); ?></div>
         </div>
 
-	<h1 class="nuclen-heading"><?php esc_html_e( 'Generate Content', 'nuclear-engagement' ); ?></h1>
+    <h1 class="nuclen-heading"><?php esc_html_e( 'Generate Content', 'nuclear-engagement' ); ?></h1>
 <?php
-		$generate_dir = plugin_dir_path( __FILE__ ) . 'generate/';
-		require $generate_dir . 'filters.php';
-		require $generate_dir . 'confirm.php';
-		require $generate_dir . 'progress.php';
+        $generate_dir = plugin_dir_path( __FILE__ ) . 'generate/';
+        require $generate_dir . 'filters.php';
+        require $generate_dir . 'confirm.php';
+        require $generate_dir . 'progress.php';
 ?>
 
 </div>

--- a/nuclear-engagement/templates/admin/nuclen-admin-settings.php
+++ b/nuclear-engagement/templates/admin/nuclen-admin-settings.php
@@ -2,7 +2,7 @@
 declare(strict_types=1);
 // File: admin/partials/nuclen-admin-settings.php
 if ( ! defined( 'ABSPATH' ) ) {
-	exit;
+    exit;
 }
 /**
  * Settings-page wrapper – loads each tab from its own partial for readability.
@@ -11,41 +11,41 @@ if ( ! defined( 'ABSPATH' ) ) {
  */
 ?>
 <div class="wrap nuclen-container">
-	<h1><?php esc_html_e( 'Nuclear Engagement Settings', 'nuclear-engagement' ); ?></h1>
+    <h1><?php esc_html_e( 'Nuclear Engagement Settings', 'nuclear-engagement' ); ?></h1>
 
-	<form method="post">
-		<?php wp_nonce_field( 'nuclen_settings_nonce', 'nuclen_settings_nonce_field' ); ?>
+    <form method="post">
+        <?php wp_nonce_field( 'nuclen_settings_nonce', 'nuclen_settings_nonce_field' ); ?>
 
-		<!-- ───── Tabs nav ───── -->
-		<div class="nav-tab-wrapper">
-			<a id="placement-tab"   href="#placement"  class="nav-tab nav-tab-active"><?php esc_html_e( 'Placement', 'nuclear-engagement' ); ?></a>
-			<a id="theme-tab"       href="#theme"      class="nav-tab"><?php esc_html_e( 'Theme', 'nuclear-engagement' ); ?></a>
-			<a id="display-tab"     href="#display"    class="nav-tab"><?php esc_html_e( 'Display', 'nuclear-engagement' ); ?></a>
-			<a id="optin-tab"       href="#optin"      class="nav-tab"><?php esc_html_e( 'Opt-In', 'nuclear-engagement' ); ?></a>
-						<a id="generation-tab"  href="#generation" class="nav-tab"><?php esc_html_e( 'Generation', 'nuclear-engagement' ); ?></a>
-						<a id="uninstall-tab"   href="#uninstall"  class="nav-tab"><?php esc_html_e( 'Uninstall', 'nuclear-engagement' ); ?></a>
-		</div>
+        <!-- ───── Tabs nav ───── -->
+        <div class="nav-tab-wrapper">
+            <a id="placement-tab"   href="#placement"  class="nav-tab nav-tab-active"><?php esc_html_e( 'Placement', 'nuclear-engagement' ); ?></a>
+            <a id="theme-tab"       href="#theme"      class="nav-tab"><?php esc_html_e( 'Theme', 'nuclear-engagement' ); ?></a>
+            <a id="display-tab"     href="#display"    class="nav-tab"><?php esc_html_e( 'Display', 'nuclear-engagement' ); ?></a>
+            <a id="optin-tab"       href="#optin"      class="nav-tab"><?php esc_html_e( 'Opt-In', 'nuclear-engagement' ); ?></a>
+                        <a id="generation-tab"  href="#generation" class="nav-tab"><?php esc_html_e( 'Generation', 'nuclear-engagement' ); ?></a>
+                        <a id="uninstall-tab"   href="#uninstall"  class="nav-tab"><?php esc_html_e( 'Uninstall', 'nuclear-engagement' ); ?></a>
+        </div>
 
-		<?php
-		/* Load tab partials. */
-		$tabs_dir = plugin_dir_path( __FILE__ ) . 'settings/';
-		require $tabs_dir . 'placement.php';
-		require $tabs_dir . 'theme.php';
-		require $tabs_dir . 'display.php';
-		require $tabs_dir . 'optin.php';
-				require $tabs_dir . 'generation.php';
-				require $tabs_dir . 'uninstall.php';
-		?>
+        <?php
+        /* Load tab partials. */
+        $tabs_dir = plugin_dir_path( __FILE__ ) . 'settings/';
+        require $tabs_dir . 'placement.php';
+        require $tabs_dir . 'theme.php';
+        require $tabs_dir . 'display.php';
+        require $tabs_dir . 'optin.php';
+                require $tabs_dir . 'generation.php';
+                require $tabs_dir . 'uninstall.php';
+        ?>
 
-		<!-- ───── Save button ───── -->
-		<div>
-			<?php
-			submit_button(
-				esc_html__( 'Save Settings', 'nuclear-engagement' ),
-				'primary nuclen-button nuclen-button-primary',
-				'nuclen_save_settings'
-			);
-			?>
-		</div>
-	</form>
+        <!-- ───── Save button ───── -->
+        <div>
+            <?php
+            submit_button(
+                esc_html__( 'Save Settings', 'nuclear-engagement' ),
+                'primary nuclen-button nuclen-button-primary',
+                'nuclen_save_settings'
+            );
+            ?>
+        </div>
+    </form>
 </div>

--- a/nuclear-engagement/templates/admin/nuclen-dashboard-page.php
+++ b/nuclear-engagement/templates/admin/nuclen-dashboard-page.php
@@ -1,7 +1,7 @@
 <?php
 declare(strict_types=1);
 if ( ! defined( 'ABSPATH' ) ) {
-	exit;
+    exit;
 }
 /**
  * admin/partials/nuclen-dashboard-page.php
@@ -20,12 +20,12 @@ $utils = new \NuclearEngagement\Utils();
 $utils->display_nuclen_page_header();
 ?>
 <div class="wrap nuclen-container">
-	<h1 class="nuclen-heading"><?php esc_html_e( 'Dashboard', 'nuclear-engagement' ); ?></h1>
-	<?php
-		$dash_dir = plugin_dir_path( __FILE__ ) . 'dashboard/';
-		require $dash_dir . 'inventory.php';
-		require $dash_dir . 'analytics.php';
-		require $dash_dir . 'scheduled.php';
-		require $dash_dir . 'credits.php';
-	?>
+    <h1 class="nuclen-heading"><?php esc_html_e( 'Dashboard', 'nuclear-engagement' ); ?></h1>
+    <?php
+        $dash_dir = plugin_dir_path( __FILE__ ) . 'dashboard/';
+        require $dash_dir . 'inventory.php';
+        require $dash_dir . 'analytics.php';
+        require $dash_dir . 'scheduled.php';
+        require $dash_dir . 'credits.php';
+    ?>
 </div><!-- .wrap .nuclen-container -->

--- a/nuclear-engagement/templates/admin/settings/display.php
+++ b/nuclear-engagement/templates/admin/settings/display.php
@@ -2,7 +2,7 @@
 declare(strict_types=1);
 // File: admin/partials/settings/display.php
 if ( ! defined( 'ABSPATH' ) ) {
-	exit;
+    exit;
 }
 /**
  * Display tab
@@ -13,12 +13,12 @@ if ( ! defined( 'ABSPATH' ) ) {
 <!-- DISPLAY TAB -->
 <div id="display" class="nuclen-tab-content nuclen-section" style="display:none;">
 <?php
-	$display_dir = plugin_dir_path( __FILE__ ) . 'display/';
-	require $display_dir . 'counts.php';
-	require $display_dir . 'custom-quiz.php';
-	require $display_dir . 'labels.php';
-	require $display_dir . 'titles.php';
-	require $display_dir . 'attribution.php';
-	require $display_dir . 'toc.php';
+    $display_dir = plugin_dir_path( __FILE__ ) . 'display/';
+    require $display_dir . 'counts.php';
+    require $display_dir . 'custom-quiz.php';
+    require $display_dir . 'labels.php';
+    require $display_dir . 'titles.php';
+    require $display_dir . 'attribution.php';
+    require $display_dir . 'toc.php';
 ?>
 </div><!-- /#display -->

--- a/nuclear-engagement/templates/admin/settings/display/attribution.php
+++ b/nuclear-engagement/templates/admin/settings/display/attribution.php
@@ -2,17 +2,17 @@
 declare(strict_types=1);
 // File: admin/partials/settings/display/attribution.php
 if ( ! defined( 'ABSPATH' ) ) {
-	exit;
+    exit;
 }
 ?>
 <!-- Attribution -->
 <div class="nuclen-form-group nuclen-row">
-	<div class="nuclen-column nuclen-label-col">
-		<label for="nuclen_show_attribution" class="nuclen-label"><?php esc_html_e( 'Display Attribution Link', 'nuclear-engagement' ); ?>
-			<span nuclen-tooltip="<?php esc_attr_e( 'Help spread the word with a small link under the NE sections.', 'nuclear-engagement' ); ?>">🛈</span>
-		</label>
-	</div>
-	<div class="nuclen-column nuclen-input-col">
-		<input type="checkbox" name="show_attribution" id="nuclen_show_attribution" value="1" <?php checked( $settings['show_attribution'], true ); ?>>
-	</div>
+    <div class="nuclen-column nuclen-label-col">
+        <label for="nuclen_show_attribution" class="nuclen-label"><?php esc_html_e( 'Display Attribution Link', 'nuclear-engagement' ); ?>
+            <span nuclen-tooltip="<?php esc_attr_e( 'Help spread the word with a small link under the NE sections.', 'nuclear-engagement' ); ?>">🛈</span>
+        </label>
+    </div>
+    <div class="nuclen-column nuclen-input-col">
+        <input type="checkbox" name="show_attribution" id="nuclen_show_attribution" value="1" <?php checked( $settings['show_attribution'], true ); ?>>
+    </div>
 </div>

--- a/nuclear-engagement/templates/admin/settings/display/counts.php
+++ b/nuclear-engagement/templates/admin/settings/display/counts.php
@@ -2,27 +2,27 @@
 declare(strict_types=1);
 // File: admin/partials/settings/display/counts.php
 if ( ! defined( 'ABSPATH' ) ) {
-	exit;
+    exit;
 }
 ?>
 <h2 class="nuclen-subheading"><?php esc_html_e( 'Number of Quiz Questions, Answers', 'nuclear-engagement' ); ?></h2>
 <p>
-	<?php esc_html_e( 'Choose how many questions and answers to display per quiz.', 'nuclear-engagement' ); ?>
-	<span nuclen-tooltip="<?php esc_attr_e( 'NE always generates 10 questions and 4 answers. These settings only control how many you show. You can change them at any time.', 'nuclear-engagement' ); ?>">🛈</span>
+    <?php esc_html_e( 'Choose how many questions and answers to display per quiz.', 'nuclear-engagement' ); ?>
+    <span nuclen-tooltip="<?php esc_attr_e( 'NE always generates 10 questions and 4 answers. These settings only control how many you show. You can change them at any time.', 'nuclear-engagement' ); ?>">🛈</span>
 </p>
 <div class="nuclen-form-group nuclen-row">
-	<div class="nuclen-column nuclen-label-col">
-		<label for="nuclen_questions_per_quiz" class="nuclen-label"><?php esc_html_e( 'Number of Questions per Quiz', 'nuclear-engagement' ); ?></label>
-	</div>
-	<div class="nuclen-column nuclen-input-col">
-		<input type="number" class="nuclen-input" name="nuclen_questions_per_quiz" id="nuclen_questions_per_quiz" value="<?php echo esc_attr( $settings['questions_per_quiz'] ); ?>" min="3" max="10">
-	</div>
+    <div class="nuclen-column nuclen-label-col">
+        <label for="nuclen_questions_per_quiz" class="nuclen-label"><?php esc_html_e( 'Number of Questions per Quiz', 'nuclear-engagement' ); ?></label>
+    </div>
+    <div class="nuclen-column nuclen-input-col">
+        <input type="number" class="nuclen-input" name="nuclen_questions_per_quiz" id="nuclen_questions_per_quiz" value="<?php echo esc_attr( $settings['questions_per_quiz'] ); ?>" min="3" max="10">
+    </div>
 </div>
 <div class="nuclen-form-group nuclen-row">
-	<div class="nuclen-column nuclen-label-col">
-		<label for="nuclen_answers_per_question" class="nuclen-label"><?php esc_html_e( 'Number of Answers per Question', 'nuclear-engagement' ); ?></label>
-	</div>
-	<div class="nuclen-column nuclen-input-col">
-		<input type="number" class="nuclen-input" name="nuclen_answers_per_question" id="nuclen_answers_per_question" value="<?php echo esc_attr( $settings['answers_per_question'] ); ?>" min="2" max="4">
-	</div>
+    <div class="nuclen-column nuclen-label-col">
+        <label for="nuclen_answers_per_question" class="nuclen-label"><?php esc_html_e( 'Number of Answers per Question', 'nuclear-engagement' ); ?></label>
+    </div>
+    <div class="nuclen-column nuclen-input-col">
+        <input type="number" class="nuclen-input" name="nuclen_answers_per_question" id="nuclen_answers_per_question" value="<?php echo esc_attr( $settings['answers_per_question'] ); ?>" min="2" max="4">
+    </div>
 </div>

--- a/nuclear-engagement/templates/admin/settings/display/custom-quiz.php
+++ b/nuclear-engagement/templates/admin/settings/display/custom-quiz.php
@@ -2,43 +2,43 @@
 declare(strict_types=1);
 // File: admin/partials/settings/display/custom-quiz.php
 if ( ! defined( 'ABSPATH' ) ) {
-	exit;
+    exit;
 }
 ?>
 <h2 class="nuclen-subheading"><?php esc_html_e( 'Quiz Custom Text', 'nuclear-engagement' ); ?>
-	<span nuclen-tooltip="<?php esc_attr_e( 'Useful for coupons, disclaimers, etc.', 'nuclear-engagement' ); ?>">🛈</span>
+    <span nuclen-tooltip="<?php esc_attr_e( 'Useful for coupons, disclaimers, etc.', 'nuclear-engagement' ); ?>">🛈</span>
 </h2>
 <div class="nuclen-form-group nuclen-row">
-	<div class="nuclen-column nuclen-label-col">
-		<label for="custom_quiz_html_before" class="nuclen-label"><?php esc_html_e( 'Message before quiz start', 'nuclear-engagement' ); ?></label>
-	</div>
-	<div class="nuclen-column nuclen-input-col">
-		<?php
-		wp_editor(
-			$settings['custom_quiz_html_before'] ?? '',
-			'custom_quiz_html_before',
-			array(
-				'textarea_name' => 'custom_quiz_html_before',
-				'textarea_rows' => 5,
-			)
-		);
-		?>
-	</div>
+    <div class="nuclen-column nuclen-label-col">
+        <label for="custom_quiz_html_before" class="nuclen-label"><?php esc_html_e( 'Message before quiz start', 'nuclear-engagement' ); ?></label>
+    </div>
+    <div class="nuclen-column nuclen-input-col">
+        <?php
+        wp_editor(
+            $settings['custom_quiz_html_before'] ?? '',
+            'custom_quiz_html_before',
+            array(
+                'textarea_name' => 'custom_quiz_html_before',
+                'textarea_rows' => 5,
+            )
+        );
+        ?>
+    </div>
 </div>
 <div class="nuclen-form-group nuclen-row">
-	<div class="nuclen-column nuclen-label-col">
-		<label for="custom_quiz_html_after" class="nuclen-label"><?php esc_html_e( 'Message after quiz end', 'nuclear-engagement' ); ?></label>
-	</div>
-	<div class="nuclen-column nuclen-input-col">
-		<?php
-		wp_editor(
-			$settings['custom_quiz_html_after'] ?? '',
-			'custom_quiz_html_after',
-			array(
-				'textarea_name' => 'custom_quiz_html_after',
-				'textarea_rows' => 5,
-			)
-		);
-		?>
-	</div>
+    <div class="nuclen-column nuclen-label-col">
+        <label for="custom_quiz_html_after" class="nuclen-label"><?php esc_html_e( 'Message after quiz end', 'nuclear-engagement' ); ?></label>
+    </div>
+    <div class="nuclen-column nuclen-input-col">
+        <?php
+        wp_editor(
+            $settings['custom_quiz_html_after'] ?? '',
+            'custom_quiz_html_after',
+            array(
+                'textarea_name' => 'custom_quiz_html_after',
+                'textarea_rows' => 5,
+            )
+        );
+        ?>
+    </div>
 </div>

--- a/nuclear-engagement/templates/admin/settings/display/labels.php
+++ b/nuclear-engagement/templates/admin/settings/display/labels.php
@@ -2,63 +2,63 @@
 declare(strict_types=1);
 // File: admin/partials/settings/display/labels.php
 if ( ! defined( 'ABSPATH' ) ) {
-	exit;
+    exit;
 }
 ?>
 <h2 class="nuclen-subheading"><?php esc_html_e( 'Quiz Labels', 'nuclear-engagement' ); ?></h2>
 <div class="nuclen-form-group nuclen-row">
-	<div class="nuclen-column nuclen-label-col">
-		<label for="quiz_label_retake_test" class="nuclen-label"><?php esc_html_e( 'Retake Button', 'nuclear-engagement' ); ?></label>
-	</div>
-	<div class="nuclen-column nuclen-input-col">
-		<input type="text" class="nuclen-input" name="quiz_label_retake_test" id="quiz_label_retake_test" value="<?php echo esc_attr( $settings['quiz_label_retake_test'] ); ?>" />
-	</div>
+    <div class="nuclen-column nuclen-label-col">
+        <label for="quiz_label_retake_test" class="nuclen-label"><?php esc_html_e( 'Retake Button', 'nuclear-engagement' ); ?></label>
+    </div>
+    <div class="nuclen-column nuclen-input-col">
+        <input type="text" class="nuclen-input" name="quiz_label_retake_test" id="quiz_label_retake_test" value="<?php echo esc_attr( $settings['quiz_label_retake_test'] ); ?>" />
+    </div>
 </div>
 <div class="nuclen-form-group nuclen-row">
-	<div class="nuclen-column nuclen-label-col">
-		<label for="quiz_label_your_score" class="nuclen-label"><?php esc_html_e( 'Your Score Title', 'nuclear-engagement' ); ?></label>
-	</div>
-	<div class="nuclen-column nuclen-input-col">
-		<input type="text" class="nuclen-input" name="quiz_label_your_score" id="quiz_label_your_score" value="<?php echo esc_attr( $settings['quiz_label_your_score'] ); ?>" />
-	</div>
+    <div class="nuclen-column nuclen-label-col">
+        <label for="quiz_label_your_score" class="nuclen-label"><?php esc_html_e( 'Your Score Title', 'nuclear-engagement' ); ?></label>
+    </div>
+    <div class="nuclen-column nuclen-input-col">
+        <input type="text" class="nuclen-input" name="quiz_label_your_score" id="quiz_label_your_score" value="<?php echo esc_attr( $settings['quiz_label_your_score'] ); ?>" />
+    </div>
 </div>
 <div class="nuclen-form-group nuclen-row">
-	<div class="nuclen-column nuclen-label-col">
-		<label for="quiz_label_perfect" class="nuclen-label"><?php esc_html_e( 'Perfect Score Message', 'nuclear-engagement' ); ?></label>
-	</div>
-	<div class="nuclen-column nuclen-input-col">
-		<input type="text" class="nuclen-input" name="quiz_label_perfect" id="quiz_label_perfect" value="<?php echo esc_attr( $settings['quiz_label_perfect'] ); ?>" />
-	</div>
+    <div class="nuclen-column nuclen-label-col">
+        <label for="quiz_label_perfect" class="nuclen-label"><?php esc_html_e( 'Perfect Score Message', 'nuclear-engagement' ); ?></label>
+    </div>
+    <div class="nuclen-column nuclen-input-col">
+        <input type="text" class="nuclen-input" name="quiz_label_perfect" id="quiz_label_perfect" value="<?php echo esc_attr( $settings['quiz_label_perfect'] ); ?>" />
+    </div>
 </div>
 <div class="nuclen-form-group nuclen-row">
-	<div class="nuclen-column nuclen-label-col">
-		<label for="quiz_label_well_done" class="nuclen-label"><?php esc_html_e( 'Above Average Message', 'nuclear-engagement' ); ?></label>
-	</div>
-	<div class="nuclen-column nuclen-input-col">
-		<input type="text" class="nuclen-input" name="quiz_label_well_done" id="quiz_label_well_done" value="<?php echo esc_attr( $settings['quiz_label_well_done'] ); ?>" />
-	</div>
+    <div class="nuclen-column nuclen-label-col">
+        <label for="quiz_label_well_done" class="nuclen-label"><?php esc_html_e( 'Above Average Message', 'nuclear-engagement' ); ?></label>
+    </div>
+    <div class="nuclen-column nuclen-input-col">
+        <input type="text" class="nuclen-input" name="quiz_label_well_done" id="quiz_label_well_done" value="<?php echo esc_attr( $settings['quiz_label_well_done'] ); ?>" />
+    </div>
 </div>
 <div class="nuclen-form-group nuclen-row">
-	<div class="nuclen-column nuclen-label-col">
-		<label for="quiz_label_retake_prompt" class="nuclen-label"><?php esc_html_e( 'Try Again Message', 'nuclear-engagement' ); ?></label>
-	</div>
-	<div class="nuclen-column nuclen-input-col">
-		<input type="text" class="nuclen-input" name="quiz_label_retake_prompt" id="quiz_label_retake_prompt" value="<?php echo esc_attr( $settings['quiz_label_retake_prompt'] ); ?>" />
-	</div>
+    <div class="nuclen-column nuclen-label-col">
+        <label for="quiz_label_retake_prompt" class="nuclen-label"><?php esc_html_e( 'Try Again Message', 'nuclear-engagement' ); ?></label>
+    </div>
+    <div class="nuclen-column nuclen-input-col">
+        <input type="text" class="nuclen-input" name="quiz_label_retake_prompt" id="quiz_label_retake_prompt" value="<?php echo esc_attr( $settings['quiz_label_retake_prompt'] ); ?>" />
+    </div>
 </div>
 <div class="nuclen-form-group nuclen-row">
-	<div class="nuclen-column nuclen-label-col">
-		<label for="quiz_label_correct" class="nuclen-label"><?php esc_html_e( 'Correct Label', 'nuclear-engagement' ); ?></label>
-	</div>
-	<div class="nuclen-column nuclen-input-col">
-		<input type="text" class="nuclen-input" name="quiz_label_correct" id="quiz_label_correct" value="<?php echo esc_attr( $settings['quiz_label_correct'] ); ?>" />
-	</div>
+    <div class="nuclen-column nuclen-label-col">
+        <label for="quiz_label_correct" class="nuclen-label"><?php esc_html_e( 'Correct Label', 'nuclear-engagement' ); ?></label>
+    </div>
+    <div class="nuclen-column nuclen-input-col">
+        <input type="text" class="nuclen-input" name="quiz_label_correct" id="quiz_label_correct" value="<?php echo esc_attr( $settings['quiz_label_correct'] ); ?>" />
+    </div>
 </div>
 <div class="nuclen-form-group nuclen-row">
-	<div class="nuclen-column nuclen-label-col">
-		<label for="quiz_label_your_answer" class="nuclen-label"><?php esc_html_e( 'Your Answer Label', 'nuclear-engagement' ); ?></label>
-	</div>
-	<div class="nuclen-column nuclen-input-col">
-		<input type="text" class="nuclen-input" name="quiz_label_your_answer" id="quiz_label_your_answer" value="<?php echo esc_attr( $settings['quiz_label_your_answer'] ); ?>" />
-	</div>
+    <div class="nuclen-column nuclen-label-col">
+        <label for="quiz_label_your_answer" class="nuclen-label"><?php esc_html_e( 'Your Answer Label', 'nuclear-engagement' ); ?></label>
+    </div>
+    <div class="nuclen-column nuclen-input-col">
+        <input type="text" class="nuclen-input" name="quiz_label_your_answer" id="quiz_label_your_answer" value="<?php echo esc_attr( $settings['quiz_label_your_answer'] ); ?>" />
+    </div>
 </div>

--- a/nuclear-engagement/templates/admin/settings/display/titles.php
+++ b/nuclear-engagement/templates/admin/settings/display/titles.php
@@ -2,36 +2,36 @@
 declare(strict_types=1);
 // File: admin/partials/settings/display/titles.php
 if ( ! defined( 'ABSPATH' ) ) {
-	exit;
+    exit;
 }
 ?>
 <h2 class="nuclen-subheading"><?php esc_html_e( 'Section Titles', 'nuclear-engagement' ); ?></h2>
 <div class="nuclen-form-group nuclen-row">
-	<div class="nuclen-column nuclen-label-col">
-		<label for="quiz_title" class="nuclen-label"><?php esc_html_e( 'Quiz Title', 'nuclear-engagement' ); ?>
-			<span nuclen-tooltip="<?php esc_attr_e( 'Examples: \"Test your knowledge\", \"Can you pass this test?\"', 'nuclear-engagement' ); ?>">🛈</span>
-		</label>
-	</div>
-	<div class="nuclen-column nuclen-input-col">
-		<input type="text" class="nuclen-input" name="quiz_title" id="quiz_title" value="<?php echo esc_attr( $settings['quiz_title'] ); ?>">
-	</div>
+    <div class="nuclen-column nuclen-label-col">
+        <label for="quiz_title" class="nuclen-label"><?php esc_html_e( 'Quiz Title', 'nuclear-engagement' ); ?>
+            <span nuclen-tooltip="<?php esc_attr_e( 'Examples: \"Test your knowledge\", \"Can you pass this test?\"', 'nuclear-engagement' ); ?>">🛈</span>
+        </label>
+    </div>
+    <div class="nuclen-column nuclen-input-col">
+        <input type="text" class="nuclen-input" name="quiz_title" id="quiz_title" value="<?php echo esc_attr( $settings['quiz_title'] ); ?>">
+    </div>
 </div>
 <div class="nuclen-form-group nuclen-row">
-	<div class="nuclen-column nuclen-label-col">
-		<label for="summary_title" class="nuclen-label"><?php esc_html_e( 'Summary Title', 'nuclear-engagement' ); ?>
-			<span nuclen-tooltip="<?php esc_attr_e( 'Examples: \"Summary\", \"Key Concepts\".', 'nuclear-engagement' ); ?>">🛈</span>
-		</label>
-	</div>
-	<div class="nuclen-column nuclen-input-col">
-		<input type="text" class="nuclen-input" name="summary_title" id="summary_title" value="<?php echo esc_attr( $settings['summary_title'] ); ?>">
-	</div>
+    <div class="nuclen-column nuclen-label-col">
+        <label for="summary_title" class="nuclen-label"><?php esc_html_e( 'Summary Title', 'nuclear-engagement' ); ?>
+            <span nuclen-tooltip="<?php esc_attr_e( 'Examples: \"Summary\", \"Key Concepts\".', 'nuclear-engagement' ); ?>">🛈</span>
+        </label>
+    </div>
+    <div class="nuclen-column nuclen-input-col">
+        <input type="text" class="nuclen-input" name="summary_title" id="summary_title" value="<?php echo esc_attr( $settings['summary_title'] ); ?>">
+    </div>
 </div>
 <!-- **TOC title — name/id kept as nuclen_toc_title so it maps & persists** -->
 <div class="nuclen-form-group nuclen-row">
-	<div class="nuclen-column nuclen-label-col">
-		<label for="nuclen_toc_title" class="nuclen-label"><?php esc_html_e( 'TOC Title', 'nuclear-engagement' ); ?></label>
-	</div>
-	<div class="nuclen-column nuclen-input-col">
-		<input type="text" class="nuclen-input" name="nuclen_toc_title" id="nuclen_toc_title" value="<?php echo esc_attr( $settings['toc_title'] ); ?>">
-	</div>
+    <div class="nuclen-column nuclen-label-col">
+        <label for="nuclen_toc_title" class="nuclen-label"><?php esc_html_e( 'TOC Title', 'nuclear-engagement' ); ?></label>
+    </div>
+    <div class="nuclen-column nuclen-input-col">
+        <input type="text" class="nuclen-input" name="nuclen_toc_title" id="nuclen_toc_title" value="<?php echo esc_attr( $settings['toc_title'] ); ?>">
+    </div>
 </div>

--- a/nuclear-engagement/templates/admin/settings/display/toc.php
+++ b/nuclear-engagement/templates/admin/settings/display/toc.php
@@ -2,7 +2,7 @@
 declare(strict_types=1);
 // File: admin/partials/settings/display/toc.php
 if ( ! defined( 'ABSPATH' ) ) {
-	exit;
+    exit;
 }
 ?>
 <!-- ────────── Table of Contents settings ────────── -->
@@ -11,85 +11,85 @@ if ( ! defined( 'ABSPATH' ) ) {
 <!-- Heading levels -->
 <h4><?php esc_html_e( 'Heading Levels', 'nuclear-engagement' ); ?></h4>
 <div class="nuclen-form-group nuclen-row">
-	<div class="nuclen-column nuclen-label-col">
-		<label class="nuclen-label"><?php esc_html_e( 'Include in TOC', 'nuclear-engagement' ); ?></label>
-	</div>
-	<div class="nuclen-column nuclen-input-col">
-		<?php
-		$selected_levels = isset( $settings['toc_heading_levels'] ) ? (array) $settings['toc_heading_levels'] : range( 2, 6 );
-		$selected_levels = array_map( 'intval', $selected_levels );
-		$selected_levels = array_filter( $selected_levels, static fn ( $l ) => $l >= 2 && $l <= 6 );
-		if ( empty( $selected_levels ) ) {
-			$selected_levels = range( 2, 6 );
-		}
-		for ( $i = 2; $i <= 6; $i++ ) :
-			$checked = in_array( $i, $selected_levels, true ) ? 'checked="checked"' : '';
-			?>
-			<label style="display:inline-block;margin-right:15px;margin-bottom:5px;">
-				<input type="checkbox"
-						name="nuclear_engagement_settings[toc_heading_levels][]"
-						value="<?php echo esc_attr( $i ); ?>"
-						<?php echo $checked; ?>>
-				<?php printf( 'H%d', $i ); ?>
-			</label>
-		<?php endfor; ?>
-		<p class="description" style="margin-top:5px;">
-			<?php esc_html_e( 'Select which heading levels to include in the Table of Contents.', 'nuclear-engagement' ); ?>
-		</p>
-	</div>
+    <div class="nuclen-column nuclen-label-col">
+        <label class="nuclen-label"><?php esc_html_e( 'Include in TOC', 'nuclear-engagement' ); ?></label>
+    </div>
+    <div class="nuclen-column nuclen-input-col">
+        <?php
+        $selected_levels = isset( $settings['toc_heading_levels'] ) ? (array) $settings['toc_heading_levels'] : range( 2, 6 );
+        $selected_levels = array_map( 'intval', $selected_levels );
+        $selected_levels = array_filter( $selected_levels, static fn ( $l ) => $l >= 2 && $l <= 6 );
+        if ( empty( $selected_levels ) ) {
+            $selected_levels = range( 2, 6 );
+        }
+        for ( $i = 2; $i <= 6; $i++ ) :
+            $checked = in_array( $i, $selected_levels, true ) ? 'checked="checked"' : '';
+            ?>
+            <label style="display:inline-block;margin-right:15px;margin-bottom:5px;">
+                <input type="checkbox"
+                        name="nuclear_engagement_settings[toc_heading_levels][]"
+                        value="<?php echo esc_attr( $i ); ?>"
+                        <?php echo $checked; ?>>
+                <?php printf( 'H%d', $i ); ?>
+            </label>
+        <?php endfor; ?>
+        <p class="description" style="margin-top:5px;">
+            <?php esc_html_e( 'Select which heading levels to include in the Table of Contents.', 'nuclear-engagement' ); ?>
+        </p>
+    </div>
 </div>
 
 <!-- Toggle button -->
 <h4><?php esc_html_e( 'Display Options', 'nuclear-engagement' ); ?></h4>
 <div class="nuclen-form-group nuclen-row">
-	<div class="nuclen-column nuclen-label-col">
-		<label for="nuclen_toc_show_toggle" class="nuclen-label"><?php esc_html_e( 'Show Toggle Button', 'nuclear-engagement' ); ?></label>
-	</div>
-	<div class="nuclen-column nuclen-input-col">
-		<label class="nuclen-switch">
-			<input type="checkbox" name="nuclen_toc_show_toggle" id="nuclen_toc_show_toggle" value="1" <?php checked( ! empty( $settings['toc_show_toggle'] ) ); ?>>
-			<span class="nuclen-slider round"></span>
-		</label>
-		<p class="description"><?php esc_html_e( 'When enabled, a toggle button will be shown to show/hide the Table of Contents.', 'nuclear-engagement' ); ?></p>
-	</div>
+    <div class="nuclen-column nuclen-label-col">
+        <label for="nuclen_toc_show_toggle" class="nuclen-label"><?php esc_html_e( 'Show Toggle Button', 'nuclear-engagement' ); ?></label>
+    </div>
+    <div class="nuclen-column nuclen-input-col">
+        <label class="nuclen-switch">
+            <input type="checkbox" name="nuclen_toc_show_toggle" id="nuclen_toc_show_toggle" value="1" <?php checked( ! empty( $settings['toc_show_toggle'] ) ); ?>>
+            <span class="nuclen-slider round"></span>
+        </label>
+        <p class="description"><?php esc_html_e( 'When enabled, a toggle button will be shown to show/hide the Table of Contents.', 'nuclear-engagement' ); ?></p>
+    </div>
 </div>
 
 <!-- Show TOC content by default -->
 <div class="nuclen-form-group nuclen-row">
-	<div class="nuclen-column nuclen-label-col">
-		<label for="nuclen_toc_show_content" class="nuclen-label"><?php esc_html_e( 'Show TOC Content by Default', 'nuclear-engagement' ); ?></label>
-	</div>
-	<div class="nuclen-column nuclen-input-col">
-		<label class="nuclen-switch">
-			<input type="checkbox" name="nuclen_toc_show_content" id="nuclen_toc_show_content" value="1" <?php checked( empty( $settings['toc_show_toggle'] ) || ! empty( $settings['toc_show_content'] ) ); ?><?php echo empty( $settings['toc_show_toggle'] ) ? ' disabled' : ''; ?>>
-			<span class="nuclen-slider round"></span>
-		</label>
-		<p class="description">
-			<?php esc_html_e( 'When enabled, the Table of Contents content will be visible by default.', 'nuclear-engagement' ); ?>
-			<?php if ( empty( $settings['toc_show_toggle'] ) ) : ?>
-			<br><em><?php esc_html_e( 'This option is only available when the toggle button is enabled.', 'nuclear-engagement' ); ?></em>
-			<?php endif; ?>
-		</p>
-	</div>
+    <div class="nuclen-column nuclen-label-col">
+        <label for="nuclen_toc_show_content" class="nuclen-label"><?php esc_html_e( 'Show TOC Content by Default', 'nuclear-engagement' ); ?></label>
+    </div>
+    <div class="nuclen-column nuclen-input-col">
+        <label class="nuclen-switch">
+            <input type="checkbox" name="nuclen_toc_show_content" id="nuclen_toc_show_content" value="1" <?php checked( empty( $settings['toc_show_toggle'] ) || ! empty( $settings['toc_show_content'] ) ); ?><?php echo empty( $settings['toc_show_toggle'] ) ? ' disabled' : ''; ?>>
+            <span class="nuclen-slider round"></span>
+        </label>
+        <p class="description">
+            <?php esc_html_e( 'When enabled, the Table of Contents content will be visible by default.', 'nuclear-engagement' ); ?>
+            <?php if ( empty( $settings['toc_show_toggle'] ) ) : ?>
+            <br><em><?php esc_html_e( 'This option is only available when the toggle button is enabled.', 'nuclear-engagement' ); ?></em>
+            <?php endif; ?>
+        </p>
+    </div>
 </div>
 
 <script>
 document.addEventListener('DOMContentLoaded', () => {
-	const toggleEl = document.getElementById('nuclen_toc_show_toggle');
-	const showContentEl = document.getElementById('nuclen_toc_show_content');
-	if (!toggleEl || !showContentEl) {
-		return;
-	}
+    const toggleEl = document.getElementById('nuclen_toc_show_toggle');
+    const showContentEl = document.getElementById('nuclen_toc_show_content');
+    if (!toggleEl || !showContentEl) {
+        return;
+    }
 
-	const updateTocToggleState = () => {
-		const showToggle = toggleEl.checked;
-		showContentEl.disabled = !showToggle;
-		if (!showToggle) {
-			showContentEl.checked = true;
-		}
-	};
+    const updateTocToggleState = () => {
+        const showToggle = toggleEl.checked;
+        showContentEl.disabled = !showToggle;
+        if (!showToggle) {
+            showContentEl.checked = true;
+        }
+    };
 
-	toggleEl.addEventListener('change', updateTocToggleState);
-	updateTocToggleState();
+    toggleEl.addEventListener('change', updateTocToggleState);
+    updateTocToggleState();
 });
 </script>

--- a/nuclear-engagement/templates/admin/settings/generation.php
+++ b/nuclear-engagement/templates/admin/settings/generation.php
@@ -2,7 +2,7 @@
 declare(strict_types=1);
 // File: admin/partials/settings-tabs/generation.php
 if ( ! defined( 'ABSPATH' ) ) {
-	exit;
+    exit;
 }
 /**
  * Generation tab
@@ -12,74 +12,74 @@ if ( ! defined( 'ABSPATH' ) ) {
 ?>
 <!-- GENERATION TAB -->
 <div id="generation" class="nuclen-tab-content nuclen-section" style="display:none;">
-	<h2 class="nuclen-subheading"><?php esc_html_e( 'Generation', 'nuclear-engagement' ); ?></h2>
+    <h2 class="nuclen-subheading"><?php esc_html_e( 'Generation', 'nuclear-engagement' ); ?></h2>
 
-	<div class="nuclen-form-group nuclen-row">
-		<div class="nuclen-column nuclen-label-col">
-			<label for="update_last_modified" class="nuclen-label"><?php esc_html_e( 'Update "Last Modified" date', 'nuclear-engagement' ); ?>
-				<span nuclen-tooltip="<?php esc_attr_e( 'Check to update the post’s native "last modified" date whenever NE generation runs.', 'nuclear-engagement' ); ?>">🛈</span>
-			</label>
-		</div>
-		<div class="nuclen-column nuclen-input-col">
-			<input type="checkbox" class="nuclen-checkbox" name="update_last_modified" id="update_last_modified" value="1" <?php checked( $settings['update_last_modified'], 1 ); ?>>
-		</div>
-	</div>
+    <div class="nuclen-form-group nuclen-row">
+        <div class="nuclen-column nuclen-label-col">
+            <label for="update_last_modified" class="nuclen-label"><?php esc_html_e( 'Update "Last Modified" date', 'nuclear-engagement' ); ?>
+                <span nuclen-tooltip="<?php esc_attr_e( 'Check to update the post’s native "last modified" date whenever NE generation runs.', 'nuclear-engagement' ); ?>">🛈</span>
+            </label>
+        </div>
+        <div class="nuclen-column nuclen-input-col">
+            <input type="checkbox" class="nuclen-checkbox" name="update_last_modified" id="update_last_modified" value="1" <?php checked( $settings['update_last_modified'], 1 ); ?>>
+        </div>
+    </div>
 
-	<div class="nuclen-form-group nuclen-row">
-		<div class="nuclen-column nuclen-label-col">
-			<label for="auto_generate_quiz_on_publish" class="nuclen-label"><?php esc_html_e( 'Auto-generate Quiz on publish', 'nuclear-engagement' ); ?>
-				<span nuclen-tooltip="<?php esc_attr_e( 'If checked, a quiz is automatically generated or updated whenever the post is published or republished.', 'nuclear-engagement' ); ?>">🛈</span>
-			</label>
-		</div>
-		<div class="nuclen-column nuclen-input-col">
-			<input type="checkbox" class="nuclen-checkbox" name="auto_generate_quiz_on_publish" id="auto_generate_quiz_on_publish" value="1" <?php checked( $settings['auto_generate_quiz_on_publish'], 1 ); ?>>
-		</div>
-	</div>
+    <div class="nuclen-form-group nuclen-row">
+        <div class="nuclen-column nuclen-label-col">
+            <label for="auto_generate_quiz_on_publish" class="nuclen-label"><?php esc_html_e( 'Auto-generate Quiz on publish', 'nuclear-engagement' ); ?>
+                <span nuclen-tooltip="<?php esc_attr_e( 'If checked, a quiz is automatically generated or updated whenever the post is published or republished.', 'nuclear-engagement' ); ?>">🛈</span>
+            </label>
+        </div>
+        <div class="nuclen-column nuclen-input-col">
+            <input type="checkbox" class="nuclen-checkbox" name="auto_generate_quiz_on_publish" id="auto_generate_quiz_on_publish" value="1" <?php checked( $settings['auto_generate_quiz_on_publish'], 1 ); ?>>
+        </div>
+    </div>
 
-	<div class="nuclen-form-group nuclen-row">
-		<div class="nuclen-column nuclen-label-col">
-			<label for="auto_generate_summary_on_publish" class="nuclen-label"><?php esc_html_e( 'Auto-generate Summary on publish', 'nuclear-engagement' ); ?>
-				<span nuclen-tooltip="<?php esc_attr_e( 'If checked, a summary is automatically generated or updated whenever the post is published or republished.', 'nuclear-engagement' ); ?>">🛈</span>
-			</label>
-		</div>
-		<div class="nuclen-column nuclen-input-col">
-			<input type="checkbox" class="nuclen-checkbox" name="auto_generate_summary_on_publish" id="auto_generate_summary_on_publish" value="1" <?php checked( $settings['auto_generate_summary_on_publish'], 1 ); ?>>
-		</div>
-	</div>
+    <div class="nuclen-form-group nuclen-row">
+        <div class="nuclen-column nuclen-label-col">
+            <label for="auto_generate_summary_on_publish" class="nuclen-label"><?php esc_html_e( 'Auto-generate Summary on publish', 'nuclear-engagement' ); ?>
+                <span nuclen-tooltip="<?php esc_attr_e( 'If checked, a summary is automatically generated or updated whenever the post is published or republished.', 'nuclear-engagement' ); ?>">🛈</span>
+            </label>
+        </div>
+        <div class="nuclen-column nuclen-input-col">
+            <input type="checkbox" class="nuclen-checkbox" name="auto_generate_summary_on_publish" id="auto_generate_summary_on_publish" value="1" <?php checked( $settings['auto_generate_summary_on_publish'], 1 ); ?>>
+        </div>
+    </div>
 
-	<h2 class="nuclen-subheading"><?php esc_html_e( 'Allowed Post Types', 'nuclear-engagement' ); ?></h2>
-	<div class="nuclen-form-group nuclen-row">
-		<div class="nuclen-column nuclen-label-col">
-			<label for="nuclen_generation_post_types" class="nuclen-label"><?php esc_html_e( 'Select Post Types', 'nuclear-engagement' ); ?>
-				<span nuclen-tooltip="<?php esc_attr_e( 'By default, NE only processes posts. Select additional post types if you want quizzes/summaries for them as well. Use Ctrl/Cmd to select multiple.', 'nuclear-engagement' ); ?>">🛈</span>
-			</label>
-		</div>
-		<div class="nuclen-column nuclen-input-col">
-			<?php
-			$all_post_types   = get_post_types( array( 'public' => true ), 'objects' );
-			$excluded         = array(
-				'attachment',
-				'revision',
-				'nav_menu_item',
-				'custom_css',
-				'customize_changeset',
-				'oembed_cache',
-				'user_request',
-				'wp_block',
-				'wp_template',
-				'wp_template_part',
-			);
-			$saved_post_types = $settings['generation_post_types'] ?? array( 'post' );
-			echo '<select name="nuclen_generation_post_types[]" id="nuclen_generation_post_types" multiple style="height:6em;">';
-			foreach ( $all_post_types as $pt_key => $pt_obj ) {
-				if ( in_array( $pt_key, $excluded ) ) {
-					continue;
-				}
-				echo '<option value="' . esc_attr( $pt_key ) . '" ' . selected( in_array( $pt_key, $saved_post_types ), true, false ) . '>'
-					. esc_html( $pt_obj->labels->name ) . '</option>';
-			}
-			echo '</select>';
-			?>
-		</div>
-	</div>
+    <h2 class="nuclen-subheading"><?php esc_html_e( 'Allowed Post Types', 'nuclear-engagement' ); ?></h2>
+    <div class="nuclen-form-group nuclen-row">
+        <div class="nuclen-column nuclen-label-col">
+            <label for="nuclen_generation_post_types" class="nuclen-label"><?php esc_html_e( 'Select Post Types', 'nuclear-engagement' ); ?>
+                <span nuclen-tooltip="<?php esc_attr_e( 'By default, NE only processes posts. Select additional post types if you want quizzes/summaries for them as well. Use Ctrl/Cmd to select multiple.', 'nuclear-engagement' ); ?>">🛈</span>
+            </label>
+        </div>
+        <div class="nuclen-column nuclen-input-col">
+            <?php
+            $all_post_types   = get_post_types( array( 'public' => true ), 'objects' );
+            $excluded         = array(
+                'attachment',
+                'revision',
+                'nav_menu_item',
+                'custom_css',
+                'customize_changeset',
+                'oembed_cache',
+                'user_request',
+                'wp_block',
+                'wp_template',
+                'wp_template_part',
+            );
+            $saved_post_types = $settings['generation_post_types'] ?? array( 'post' );
+            echo '<select name="nuclen_generation_post_types[]" id="nuclen_generation_post_types" multiple style="height:6em;">';
+            foreach ( $all_post_types as $pt_key => $pt_obj ) {
+                if ( in_array( $pt_key, $excluded ) ) {
+                    continue;
+                }
+                echo '<option value="' . esc_attr( $pt_key ) . '" ' . selected( in_array( $pt_key, $saved_post_types ), true, false ) . '>'
+                    . esc_html( $pt_obj->labels->name ) . '</option>';
+            }
+            echo '</select>';
+            ?>
+        </div>
+    </div>
 </div><!-- /#generation -->

--- a/nuclear-engagement/templates/admin/settings/optin.php
+++ b/nuclear-engagement/templates/admin/settings/optin.php
@@ -2,7 +2,7 @@
 declare(strict_types=1);
 // File: admin/partials/settings/optin.php
 if ( ! defined( 'ABSPATH' ) ) {
-	exit;
+    exit;
 }
 /**
  * Opt-In tab
@@ -12,112 +12,112 @@ if ( ! defined( 'ABSPATH' ) ) {
 ?>
 <!-- OPT-IN TAB -->
 <div id="optin" class="nuclen-tab-content nuclen-section" style="display:none;">
-	<h2 class="nuclen-subheading"><?php esc_html_e( 'Email Opt-In Form', 'nuclear-engagement' ); ?> <span nuclen-tooltip="<?php esc_attr_e( 'You may need to clear page cache to see changes.', 'nuclear-engagement' ); ?>">🛈</span></h2>
-	<p><?php esc_html_e( 'To collect email addresses, display an opt-in form when the quiz is completed.', 'nuclear-engagement' ); ?></p>
+    <h2 class="nuclen-subheading"><?php esc_html_e( 'Email Opt-In Form', 'nuclear-engagement' ); ?> <span nuclen-tooltip="<?php esc_attr_e( 'You may need to clear page cache to see changes.', 'nuclear-engagement' ); ?>">🛈</span></h2>
+    <p><?php esc_html_e( 'To collect email addresses, display an opt-in form when the quiz is completed.', 'nuclear-engagement' ); ?></p>
 
-	<!-- Enable toggle -->
-	<div class="nuclen-form-group nuclen-row">
-		<label class="nuclen-label-col" for="enable_optin">
-			<?php esc_html_e( 'Enable Opt-In', 'nuclear-engagement' ); ?>
-			<span nuclen-tooltip="<?php esc_attr_e( 'Display an opt-in form at the end of the quiz to capture name + email.', 'nuclear-engagement' ); ?>">🛈</span>
-		</label>
-		<div class="nuclen-input-col">
-			<input type="checkbox" name="enable_optin" id="enable_optin" value="1" <?php checked( $settings['enable_optin'], true ); ?> />
-		</div>
-	</div>
+    <!-- Enable toggle -->
+    <div class="nuclen-form-group nuclen-row">
+        <label class="nuclen-label-col" for="enable_optin">
+            <?php esc_html_e( 'Enable Opt-In', 'nuclear-engagement' ); ?>
+            <span nuclen-tooltip="<?php esc_attr_e( 'Display an opt-in form at the end of the quiz to capture name + email.', 'nuclear-engagement' ); ?>">🛈</span>
+        </label>
+        <div class="nuclen-input-col">
+            <input type="checkbox" name="enable_optin" id="enable_optin" value="1" <?php checked( $settings['enable_optin'], true ); ?> />
+        </div>
+    </div>
 
-	<!-- Position -->
-	<div class="nuclen-form-group nuclen-row">
-		<label class="nuclen-label-col">
-			<?php esc_html_e( 'Display Position', 'nuclear-engagement' ); ?>
-		</label>
-		<div class="nuclen-input-col">
-			<label><input type="radio" name="nuclen_optin_position" value="with_results"  <?php checked( $settings['optin_position'], 'with_results' ); ?> /> <?php esc_html_e( 'With Results (results are displayed)', 'nuclear-engagement' ); ?></label><br/>
-			<label><input type="radio" name="nuclen_optin_position" value="before_results" <?php checked( $settings['optin_position'], 'before_results' ); ?> /> <?php esc_html_e( 'Before Results (results are hidden)', 'nuclear-engagement' ); ?></label>
-		</div>
-	</div>
+    <!-- Position -->
+    <div class="nuclen-form-group nuclen-row">
+        <label class="nuclen-label-col">
+            <?php esc_html_e( 'Display Position', 'nuclear-engagement' ); ?>
+        </label>
+        <div class="nuclen-input-col">
+            <label><input type="radio" name="nuclen_optin_position" value="with_results"  <?php checked( $settings['optin_position'], 'with_results' ); ?> /> <?php esc_html_e( 'With Results (results are displayed)', 'nuclear-engagement' ); ?></label><br/>
+            <label><input type="radio" name="nuclen_optin_position" value="before_results" <?php checked( $settings['optin_position'], 'before_results' ); ?> /> <?php esc_html_e( 'Before Results (results are hidden)', 'nuclear-engagement' ); ?></label>
+        </div>
+    </div>
 
-	<!-- Mandatory -->
-	<div class="nuclen-form-group nuclen-row">
-		<label class="nuclen-label-col" for="optin_mandatory">
-			<?php esc_html_e( 'Make Opt-In Mandatory', 'nuclear-engagement' ); ?>
-			<span nuclen-tooltip="<?php esc_attr_e( 'If unchecked, a “skip” link lets users view results without submitting.', 'nuclear-engagement' ); ?>">🛈</span>
-		</label>
-		<div class="nuclen-input-col">
-			<input type="checkbox" name="optin_mandatory" id="optin_mandatory" value="1" <?php checked( $settings['optin_mandatory'], true ); ?> />
-		</div>
-	</div>
+    <!-- Mandatory -->
+    <div class="nuclen-form-group nuclen-row">
+        <label class="nuclen-label-col" for="optin_mandatory">
+            <?php esc_html_e( 'Make Opt-In Mandatory', 'nuclear-engagement' ); ?>
+            <span nuclen-tooltip="<?php esc_attr_e( 'If unchecked, a “skip” link lets users view results without submitting.', 'nuclear-engagement' ); ?>">🛈</span>
+        </label>
+        <div class="nuclen-input-col">
+            <input type="checkbox" name="optin_mandatory" id="optin_mandatory" value="1" <?php checked( $settings['optin_mandatory'], true ); ?> />
+        </div>
+    </div>
 
-	<!-- Prompt text -->
-	<div class="nuclen-form-group nuclen-row">
-		<label class="nuclen-label-col" for="optin_prompt_text"><?php esc_html_e( 'Prompt Text Above Form', 'nuclear-engagement' ); ?></label>
-		<div class="nuclen-input-col">
-			<input type="text" class="nuclen-input" id="optin_prompt_text" name="optin_prompt_text" value="<?php echo esc_attr( $settings['optin_prompt_text'] ); ?>" />
-		</div>
-	</div>
+    <!-- Prompt text -->
+    <div class="nuclen-form-group nuclen-row">
+        <label class="nuclen-label-col" for="optin_prompt_text"><?php esc_html_e( 'Prompt Text Above Form', 'nuclear-engagement' ); ?></label>
+        <div class="nuclen-input-col">
+            <input type="text" class="nuclen-input" id="optin_prompt_text" name="optin_prompt_text" value="<?php echo esc_attr( $settings['optin_prompt_text'] ); ?>" />
+        </div>
+    </div>
 
-	<!-- Button text -->
-	<div class="nuclen-form-group nuclen-row">
-		<label class="nuclen-label-col" for="optin_button_text"><?php esc_html_e( 'Submit Button Text', 'nuclear-engagement' ); ?></label>
-		<div class="nuclen-input-col">
-			<input type="text" class="nuclen-input" id="optin_button_text" name="optin_button_text" value="<?php echo esc_attr( $settings['optin_button_text'] ); ?>" />
-		</div>
-	</div>
+    <!-- Button text -->
+    <div class="nuclen-form-group nuclen-row">
+        <label class="nuclen-label-col" for="optin_button_text"><?php esc_html_e( 'Submit Button Text', 'nuclear-engagement' ); ?></label>
+        <div class="nuclen-input-col">
+            <input type="text" class="nuclen-input" id="optin_button_text" name="optin_button_text" value="<?php echo esc_attr( $settings['optin_button_text'] ); ?>" />
+        </div>
+    </div>
 
-	<h2 class="nuclen-subheading"><?php esc_html_e( 'Data submission', 'nuclear-engagement' ); ?></h2>
-	<p><?php esc_html_e( 'Opt-in data is stored in database to be exported into a CSV file at any time. You can also send the data to your favorite ESP/CRM (ConvertKit, Mailchimp...) via a webhook (triggering an automation in Zapier, Make...).', 'nuclear-engagement' ); ?></p>
+    <h2 class="nuclen-subheading"><?php esc_html_e( 'Data submission', 'nuclear-engagement' ); ?></h2>
+    <p><?php esc_html_e( 'Opt-in data is stored in database to be exported into a CSV file at any time. You can also send the data to your favorite ESP/CRM (ConvertKit, Mailchimp...) via a webhook (triggering an automation in Zapier, Make...).', 'nuclear-engagement' ); ?></p>
 
-	<p>
-		<?php
-		printf(
-			wp_kses(
-				/* translators: 1: link to YouTube video */
-				__( 'Learn how to set up an automation: %1$s', 'nuclear-engagement' ),
-				array(
-					'a' => array(
-						'href'   => array(),
-						'target' => array(),
-						'rel'    => array(),
-					),
-				)
-			),
-			'<a href="https://www.youtube.com/watch?v=z39FJEFNKVM&pp=ygUebnVjbGVhciBlbmdhZ2VtZW50IG9wdGluIGVtYWls" target="_blank" rel="noopener noreferrer">'
-				. esc_html__( 'Tutorial', 'nuclear-engagement' )
-				. '</a>'
-		);
-		?>
-	</p>
+    <p>
+        <?php
+        printf(
+            wp_kses(
+                /* translators: 1: link to YouTube video */
+                __( 'Learn how to set up an automation: %1$s', 'nuclear-engagement' ),
+                array(
+                    'a' => array(
+                        'href'   => array(),
+                        'target' => array(),
+                        'rel'    => array(),
+                    ),
+                )
+            ),
+            '<a href="https://www.youtube.com/watch?v=z39FJEFNKVM&pp=ygUebnVjbGVhciBlbmdhZ2VtZW50IG9wdGluIGVtYWls" target="_blank" rel="noopener noreferrer">'
+                . esc_html__( 'Tutorial', 'nuclear-engagement' )
+                . '</a>'
+        );
+        ?>
+    </p>
 
-	<!-- Webhook URL -->
-	<div class="nuclen-form-group nuclen-row">
-		<label class="nuclen-label-col" for="optin_webhook">
-			<?php esc_html_e( 'Webhook URL', 'nuclear-engagement' ); ?>
-			<span nuclen-tooltip="<?php esc_attr_e( 'Paste the webhook from Make, Zapier, etc.', 'nuclear-engagement' ); ?>">🛈</span>
-		</label>
-		<div class="nuclen-input-col">
-			<input type="url" name="optin_webhook" id="optin_webhook" class="nuclen-input" value="<?php echo esc_attr( $settings['optin_webhook'] ); ?>" />
-		</div>
-	</div>
+    <!-- Webhook URL -->
+    <div class="nuclen-form-group nuclen-row">
+        <label class="nuclen-label-col" for="optin_webhook">
+            <?php esc_html_e( 'Webhook URL', 'nuclear-engagement' ); ?>
+            <span nuclen-tooltip="<?php esc_attr_e( 'Paste the webhook from Make, Zapier, etc.', 'nuclear-engagement' ); ?>">🛈</span>
+        </label>
+        <div class="nuclen-input-col">
+            <input type="url" name="optin_webhook" id="optin_webhook" class="nuclen-input" value="<?php echo esc_attr( $settings['optin_webhook'] ); ?>" />
+        </div>
+    </div>
 
-	<!-- Export to CSV -->
-	<div class="nuclen-form-group nuclen-row">
-		<label class="nuclen-label-col"><?php esc_html_e( 'Export Opt-In Data', 'nuclear-engagement' ); ?></label>
-		<div class="nuclen-input-col">
+    <!-- Export to CSV -->
+    <div class="nuclen-form-group nuclen-row">
+        <label class="nuclen-label-col"><?php esc_html_e( 'Export Opt-In Data', 'nuclear-engagement' ); ?></label>
+        <div class="nuclen-input-col">
 
-			<a href="
-			<?php
-				echo esc_url(
-					wp_nonce_url(
-						admin_url( 'admin-post.php?action=nuclen_export_optin' ),
-						'nuclen_export_optin'
-					)
-				);
-				?>
-				" class="button button-secondary" target="_blank" rel="noopener">
-				<?php esc_html_e( 'Download CSV', 'nuclear-engagement' ); ?>
-			</a>
+            <a href="
+            <?php
+                echo esc_url(
+                    wp_nonce_url(
+                        admin_url( 'admin-post.php?action=nuclen_export_optin' ),
+                        'nuclen_export_optin'
+                    )
+                );
+                ?>
+                " class="button button-secondary" target="_blank" rel="noopener">
+                <?php esc_html_e( 'Download CSV', 'nuclear-engagement' ); ?>
+            </a>
 
-		</div>
-	</div>
+        </div>
+    </div>
 
 </div><!-- /#optin -->

--- a/nuclear-engagement/templates/admin/settings/placement.php
+++ b/nuclear-engagement/templates/admin/settings/placement.php
@@ -2,7 +2,7 @@
 declare(strict_types=1);
 // File: admin/partials/settings/placement.php
 if ( ! defined( 'ABSPATH' ) ) {
-		exit;
+        exit;
 }
 /**
  * Placement tab
@@ -13,16 +13,16 @@ if ( ! defined( 'ABSPATH' ) ) {
 <!-- PLACEMENT TAB -->
 <div id="placement" class="nuclen-tab-content nuclen-section" style="display:block;">
 
-		<h2 class="nuclen-subheading"><?php esc_html_e( 'Placement', 'nuclear-engagement' ); ?></h2>
-		<p>
-				<?php esc_html_e( 'Choose how and where to display quizzes, summaries and the Table of Contents.', 'nuclear-engagement' ); ?>
-				<span nuclen-tooltip="<?php esc_attr_e( 'Shortcodes are the most versatile method. If your theme or page-builder lacks suitable slots you can append sections automatically.', 'nuclear-engagement' ); ?>">🛈</span>
-		</p>
+        <h2 class="nuclen-subheading"><?php esc_html_e( 'Placement', 'nuclear-engagement' ); ?></h2>
+        <p>
+                <?php esc_html_e( 'Choose how and where to display quizzes, summaries and the Table of Contents.', 'nuclear-engagement' ); ?>
+                <span nuclen-tooltip="<?php esc_attr_e( 'Shortcodes are the most versatile method. If your theme or page-builder lacks suitable slots you can append sections automatically.', 'nuclear-engagement' ); ?>">🛈</span>
+        </p>
 
-		<?php
-				$placement_dir = plugin_dir_path( __FILE__ ) . 'placement/';
-				require $placement_dir . 'positions.php';
-				require $placement_dir . 'sticky-toc.php';
-		?>
+        <?php
+                $placement_dir = plugin_dir_path( __FILE__ ) . 'placement/';
+                require $placement_dir . 'positions.php';
+                require $placement_dir . 'sticky-toc.php';
+        ?>
 
 </div><!-- /#placement -->

--- a/nuclear-engagement/templates/admin/settings/placement/positions.php
+++ b/nuclear-engagement/templates/admin/settings/placement/positions.php
@@ -1,45 +1,45 @@
 <!-- Display positions -->
 <!-- SUMMARY -->
 <div class="nuclen-form-group nuclen-row">
-		<div class="nuclen-column nuclen-label-col">
-				<label for="nuclen_display_summary" class="nuclen-label"><?php esc_html_e( 'Display Summary', 'nuclear-engagement' ); ?></label>
-		</div>
-		<div class="nuclen-column nuclen-input-col">
-				<select name="nuclen_display_summary" id="nuclen_display_summary" class="nuclen-input">
-						<option value="manual" <?php selected( $settings['display_summary'], 'manual' ); ?>><?php esc_html_e( 'Manually via shortcode', 'nuclear-engagement' ); ?></option>
-						<option value="before" <?php selected( $settings['display_summary'], 'before' ); ?>><?php esc_html_e( 'Before post content', 'nuclear-engagement' ); ?></option>
-						<option value="after"  <?php selected( $settings['display_summary'], 'after' ); ?>><?php esc_html_e( 'After post content', 'nuclear-engagement' ); ?></option>
-				</select>
-				<p class="description"><?php printf( wp_kses( __( 'Shortcode: <b>%s</b>.', 'nuclear-engagement' ), array( 'b' => array() ) ), '[nuclear_engagement_summary]' ); ?></p>
-		</div>
+        <div class="nuclen-column nuclen-label-col">
+                <label for="nuclen_display_summary" class="nuclen-label"><?php esc_html_e( 'Display Summary', 'nuclear-engagement' ); ?></label>
+        </div>
+        <div class="nuclen-column nuclen-input-col">
+                <select name="nuclen_display_summary" id="nuclen_display_summary" class="nuclen-input">
+                        <option value="manual" <?php selected( $settings['display_summary'], 'manual' ); ?>><?php esc_html_e( 'Manually via shortcode', 'nuclear-engagement' ); ?></option>
+                        <option value="before" <?php selected( $settings['display_summary'], 'before' ); ?>><?php esc_html_e( 'Before post content', 'nuclear-engagement' ); ?></option>
+                        <option value="after"  <?php selected( $settings['display_summary'], 'after' ); ?>><?php esc_html_e( 'After post content', 'nuclear-engagement' ); ?></option>
+                </select>
+                <p class="description"><?php printf( wp_kses( __( 'Shortcode: <b>%s</b>.', 'nuclear-engagement' ), array( 'b' => array() ) ), '[nuclear_engagement_summary]' ); ?></p>
+        </div>
 </div>
 
 <!-- QUIZ -->
 <div class="nuclen-form-group nuclen-row">
-		<div class="nuclen-column nuclen-label-col">
-				<label for="nuclen_display_quiz" class="nuclen-label"><?php esc_html_e( 'Display Quiz', 'nuclear-engagement' ); ?></label>
-		</div>
-		<div class="nuclen-column nuclen-input-col">
-				<select name="nuclen_display_quiz" id="nuclen_display_quiz" class="nuclen-input">
-						<option value="manual" <?php selected( $settings['display_quiz'], 'manual' ); ?>><?php esc_html_e( 'Manually via shortcode', 'nuclear-engagement' ); ?></option>
-						<option value="before" <?php selected( $settings['display_quiz'], 'before' ); ?>><?php esc_html_e( 'Before post content', 'nuclear-engagement' ); ?></option>
-						<option value="after"  <?php selected( $settings['display_quiz'], 'after' ); ?>><?php esc_html_e( 'After post content', 'nuclear-engagement' ); ?></option>
-				</select>
-				<p class="description"><?php printf( wp_kses( __( 'Shortcode: <b>%s</b>.', 'nuclear-engagement' ), array( 'b' => array() ) ), '[nuclear_engagement_quiz]' ); ?></p>
-		</div>
+        <div class="nuclen-column nuclen-label-col">
+                <label for="nuclen_display_quiz" class="nuclen-label"><?php esc_html_e( 'Display Quiz', 'nuclear-engagement' ); ?></label>
+        </div>
+        <div class="nuclen-column nuclen-input-col">
+                <select name="nuclen_display_quiz" id="nuclen_display_quiz" class="nuclen-input">
+                        <option value="manual" <?php selected( $settings['display_quiz'], 'manual' ); ?>><?php esc_html_e( 'Manually via shortcode', 'nuclear-engagement' ); ?></option>
+                        <option value="before" <?php selected( $settings['display_quiz'], 'before' ); ?>><?php esc_html_e( 'Before post content', 'nuclear-engagement' ); ?></option>
+                        <option value="after"  <?php selected( $settings['display_quiz'], 'after' ); ?>><?php esc_html_e( 'After post content', 'nuclear-engagement' ); ?></option>
+                </select>
+                <p class="description"><?php printf( wp_kses( __( 'Shortcode: <b>%s</b>.', 'nuclear-engagement' ), array( 'b' => array() ) ), '[nuclear_engagement_quiz]' ); ?></p>
+        </div>
 </div>
 
 <!-- TOC -->
 <div class="nuclen-form-group nuclen-row">
-		<div class="nuclen-column nuclen-label-col">
-				<label for="nuclen_display_toc" class="nuclen-label"><?php esc_html_e( 'Display Table of Contents', 'nuclear-engagement' ); ?></label>
-		</div>
-		<div class="nuclen-column nuclen-input-col">
-				<select name="nuclen_display_toc" id="nuclen_display_toc" class="nuclen-input">
-						<option value="manual" <?php selected( $settings['display_toc'] ?? 'manual', 'manual' ); ?>><?php esc_html_e( 'Manually via shortcode', 'nuclear-engagement' ); ?></option>
-						<option value="before" <?php selected( $settings['display_toc'] ?? 'manual', 'before' ); ?>><?php esc_html_e( 'Before post content', 'nuclear-engagement' ); ?></option>
-						<option value="after"  <?php selected( $settings['display_toc'] ?? 'manual', 'after' ); ?>><?php esc_html_e( 'After post content', 'nuclear-engagement' ); ?></option>
-				</select>
-				<p class="description"><?php printf( wp_kses( __( 'Shortcode: <b>%s</b>.', 'nuclear-engagement' ), array( 'b' => array() ) ), '[nuclear_engagement_toc]' ); ?></p>
-		</div>
+        <div class="nuclen-column nuclen-label-col">
+                <label for="nuclen_display_toc" class="nuclen-label"><?php esc_html_e( 'Display Table of Contents', 'nuclear-engagement' ); ?></label>
+        </div>
+        <div class="nuclen-column nuclen-input-col">
+                <select name="nuclen_display_toc" id="nuclen_display_toc" class="nuclen-input">
+                        <option value="manual" <?php selected( $settings['display_toc'] ?? 'manual', 'manual' ); ?>><?php esc_html_e( 'Manually via shortcode', 'nuclear-engagement' ); ?></option>
+                        <option value="before" <?php selected( $settings['display_toc'] ?? 'manual', 'before' ); ?>><?php esc_html_e( 'Before post content', 'nuclear-engagement' ); ?></option>
+                        <option value="after"  <?php selected( $settings['display_toc'] ?? 'manual', 'after' ); ?>><?php esc_html_e( 'After post content', 'nuclear-engagement' ); ?></option>
+                </select>
+                <p class="description"><?php printf( wp_kses( __( 'Shortcode: <b>%s</b>.', 'nuclear-engagement' ), array( 'b' => array() ) ), '[nuclear_engagement_toc]' ); ?></p>
+        </div>
 </div>

--- a/nuclear-engagement/templates/admin/settings/placement/sticky-toc.php
+++ b/nuclear-engagement/templates/admin/settings/placement/sticky-toc.php
@@ -1,78 +1,78 @@
 <!-- Sticky TOC settings -->
 <!-- Sticky toggle -->
 <div class="nuclen-form-group nuclen-row">
-		<div class="nuclen-column nuclen-label-col">
-				<label for="nuclen_toc_sticky" class="nuclen-label"><?php esc_html_e( 'Sticky TOC', 'nuclear-engagement' ); ?></label>
-		</div>
-		<div class="nuclen-column nuclen-input-col">
-				<label class="nuclen-checkbox-label">
-						<input type="checkbox" name="toc_sticky" id="nuclen_toc_sticky" value="1" <?php checked( '1', $settings['toc_sticky'] ?? '0' ); ?> />
-						<?php esc_html_e( 'Make Table of Contents sticky when scrolling', 'nuclear-engagement' ); ?>
-				</label>
-		</div>
+        <div class="nuclen-column nuclen-label-col">
+                <label for="nuclen_toc_sticky" class="nuclen-label"><?php esc_html_e( 'Sticky TOC', 'nuclear-engagement' ); ?></label>
+        </div>
+        <div class="nuclen-column nuclen-input-col">
+                <label class="nuclen-checkbox-label">
+                        <input type="checkbox" name="toc_sticky" id="nuclen_toc_sticky" value="1" <?php checked( '1', $settings['toc_sticky'] ?? '0' ); ?> />
+                        <?php esc_html_e( 'Make Table of Contents sticky when scrolling', 'nuclear-engagement' ); ?>
+                </label>
+        </div>
 </div>
 
 <!-- Z-index -->
 <div class="nuclen-form-group nuclen-row">
-		<div class="nuclen-column nuclen-label-col">
-				<label for="nuclen_toc_zindex" class="nuclen-label"><?php esc_html_e( 'TOC Z-Index', 'nuclear-engagement' ); ?></label>
-		</div>
-		<div class="nuclen-column nuclen-input-col">
-				<input type="number"
-						name="toc_zindex"
-						id="nuclen_toc_zindex"
-						class="small-text"
-						min="0"
-						step="1"
-						value="<?php echo esc_attr( $settings['toc_z_index'] ?? '100' ); ?>" />
-				<p class="description"><?php esc_html_e( 'Higher numbers keep the sticky TOC above other elements.', 'nuclear-engagement' ); ?></p>
-		</div>
+        <div class="nuclen-column nuclen-label-col">
+                <label for="nuclen_toc_zindex" class="nuclen-label"><?php esc_html_e( 'TOC Z-Index', 'nuclear-engagement' ); ?></label>
+        </div>
+        <div class="nuclen-column nuclen-input-col">
+                <input type="number"
+                        name="toc_zindex"
+                        id="nuclen_toc_zindex"
+                        class="small-text"
+                        min="0"
+                        step="1"
+                        value="<?php echo esc_attr( $settings['toc_z_index'] ?? '100' ); ?>" />
+                <p class="description"><?php esc_html_e( 'Higher numbers keep the sticky TOC above other elements.', 'nuclear-engagement' ); ?></p>
+        </div>
 </div>
 
 <!-- Offset X -->
 <div class="nuclen-form-group nuclen-row">
-		<div class="nuclen-column nuclen-label-col">
-				<label for="nuclen_toc_sticky_offset_x" class="nuclen-label"><?php esc_html_e( 'Sticky Offset X (px)', 'nuclear-engagement' ); ?></label>
-		</div>
-		<div class="nuclen-column nuclen-input-col">
-				<input type="number"
-						name="toc_sticky_offset_x"
-						id="nuclen_toc_sticky_offset_x"
-						class="small-text"
-						min="0"
-						step="1"
-						value="<?php echo esc_attr( $settings['toc_sticky_offset_x'] ?? '20' ); ?>" />
-		</div>
+        <div class="nuclen-column nuclen-label-col">
+                <label for="nuclen_toc_sticky_offset_x" class="nuclen-label"><?php esc_html_e( 'Sticky Offset X (px)', 'nuclear-engagement' ); ?></label>
+        </div>
+        <div class="nuclen-column nuclen-input-col">
+                <input type="number"
+                        name="toc_sticky_offset_x"
+                        id="nuclen_toc_sticky_offset_x"
+                        class="small-text"
+                        min="0"
+                        step="1"
+                        value="<?php echo esc_attr( $settings['toc_sticky_offset_x'] ?? '20' ); ?>" />
+        </div>
 </div>
 
 <!-- Offset Y -->
 <div class="nuclen-form-group nuclen-row">
-		<div class="nuclen-column nuclen-label-col">
-				<label for="nuclen_toc_sticky_offset_y" class="nuclen-label"><?php esc_html_e( 'Sticky Offset Y (px)', 'nuclear-engagement' ); ?></label>
-		</div>
-		<div class="nuclen-column nuclen-input-col">
-				<input type="number"
-						name="toc_sticky_offset_y"
-						id="nuclen_toc_sticky_offset_y"
-						class="small-text"
-						min="0"
-						step="1"
-						value="<?php echo esc_attr( $settings['toc_sticky_offset_y'] ?? '20' ); ?>" />
-		</div>
+        <div class="nuclen-column nuclen-label-col">
+                <label for="nuclen_toc_sticky_offset_y" class="nuclen-label"><?php esc_html_e( 'Sticky Offset Y (px)', 'nuclear-engagement' ); ?></label>
+        </div>
+        <div class="nuclen-column nuclen-input-col">
+                <input type="number"
+                        name="toc_sticky_offset_y"
+                        id="nuclen_toc_sticky_offset_y"
+                        class="small-text"
+                        min="0"
+                        step="1"
+                        value="<?php echo esc_attr( $settings['toc_sticky_offset_y'] ?? '20' ); ?>" />
+        </div>
 </div>
 
 <!-- Max width -->
 <div class="nuclen-form-group nuclen-row">
-		<div class="nuclen-column nuclen-label-col">
-				<label for="nuclen_toc_sticky_max_width" class="nuclen-label"><?php esc_html_e( 'Sticky Max-width (px)', 'nuclear-engagement' ); ?></label>
-		</div>
-		<div class="nuclen-column nuclen-input-col">
-				<input type="number"
-						name="toc_sticky_max_width"
-						id="nuclen_toc_sticky_max_width"
-						class="small-text"
-						min="200"
-						step="1"
-						value="<?php echo esc_attr( $settings['toc_sticky_max_width'] ?? '300' ); ?>" />
-		</div>
+        <div class="nuclen-column nuclen-label-col">
+                <label for="nuclen_toc_sticky_max_width" class="nuclen-label"><?php esc_html_e( 'Sticky Max-width (px)', 'nuclear-engagement' ); ?></label>
+        </div>
+        <div class="nuclen-column nuclen-input-col">
+                <input type="number"
+                        name="toc_sticky_max_width"
+                        id="nuclen_toc_sticky_max_width"
+                        class="small-text"
+                        min="200"
+                        step="1"
+                        value="<?php echo esc_attr( $settings['toc_sticky_max_width'] ?? '300' ); ?>" />
+        </div>
 </div>

--- a/nuclear-engagement/templates/admin/settings/theme.php
+++ b/nuclear-engagement/templates/admin/settings/theme.php
@@ -2,7 +2,7 @@
 declare(strict_types=1);
 // File: admin/partials/settings/theme.php
 if ( ! defined( 'ABSPATH' ) ) {
-		exit;
+        exit;
 }
 /**
  * Theme tab
@@ -12,26 +12,26 @@ if ( ! defined( 'ABSPATH' ) ) {
 ?>
 <!-- THEME TAB -->
 <div id="theme" class="nuclen-tab-content nuclen-section" style="display:none;">
-		<h2 class="nuclen-subheading"><?php esc_html_e( 'Theme', 'nuclear-engagement' ); ?></h2>
-		<p><?php esc_html_e( 'Select a theme preset, or choose custom to override individual settings.', 'nuclear-engagement' ); ?></p>
+        <h2 class="nuclen-subheading"><?php esc_html_e( 'Theme', 'nuclear-engagement' ); ?></h2>
+        <p><?php esc_html_e( 'Select a theme preset, or choose custom to override individual settings.', 'nuclear-engagement' ); ?></p>
 
-		<!-- Preset selector -->
-		<div class="nuclen-form-group">
-				<label><input type="radio" name="nuclen_theme" value="bright" <?php checked( $settings['theme'], 'bright' ); ?> /> <?php esc_html_e( 'Bright Theme (black on white)', 'nuclear-engagement' ); ?></label><br>
-				<label><input type="radio" name="nuclen_theme" value="dark"   <?php checked( $settings['theme'], 'dark' ); ?> /> <?php esc_html_e( 'Dark Theme (white on black)', 'nuclear-engagement' ); ?></label><br>
-				<label><input type="radio" name="nuclen_theme" value="custom" <?php checked( $settings['theme'], 'custom' ); ?> /> <?php esc_html_e( 'Custom', 'nuclear-engagement' ); ?></label><br>
-				<label><input type="radio" name="nuclen_theme" value="none"   <?php checked( $settings['theme'], 'none' ); ?> /> <?php esc_html_e( 'No Theme (only base CSS)', 'nuclear-engagement' ); ?></label>
-		</div>
+        <!-- Preset selector -->
+        <div class="nuclen-form-group">
+                <label><input type="radio" name="nuclen_theme" value="bright" <?php checked( $settings['theme'], 'bright' ); ?> /> <?php esc_html_e( 'Bright Theme (black on white)', 'nuclear-engagement' ); ?></label><br>
+                <label><input type="radio" name="nuclen_theme" value="dark"   <?php checked( $settings['theme'], 'dark' ); ?> /> <?php esc_html_e( 'Dark Theme (white on black)', 'nuclear-engagement' ); ?></label><br>
+                <label><input type="radio" name="nuclen_theme" value="custom" <?php checked( $settings['theme'], 'custom' ); ?> /> <?php esc_html_e( 'Custom', 'nuclear-engagement' ); ?></label><br>
+                <label><input type="radio" name="nuclen_theme" value="none"   <?php checked( $settings['theme'], 'none' ); ?> /> <?php esc_html_e( 'No Theme (only base CSS)', 'nuclear-engagement' ); ?></label>
+        </div>
 
-		<?php $custom_theme_class = ( $settings['theme'] === 'custom' ) ? '' : 'nuclen-hidden'; ?>
-		<div id="nuclen-custom-theme-section" class="nuclen-form-group <?php echo esc_attr( $custom_theme_class ); ?>" style="margin-top:20px;">
+        <?php $custom_theme_class = ( $settings['theme'] === 'custom' ) ? '' : 'nuclen-hidden'; ?>
+        <div id="nuclen-custom-theme-section" class="nuclen-form-group <?php echo esc_attr( $custom_theme_class ); ?>" style="margin-top:20px;">
 <?php
-				$theme_dir = plugin_dir_path( __FILE__ ) . 'theme/';
-				require $theme_dir . 'quiz-container.php';
-				require $theme_dir . 'quiz-buttons.php';
-				require $theme_dir . 'progress-bar.php';
-				require $theme_dir . 'summary-container.php';
-				require $theme_dir . 'toc-container.php';
+                $theme_dir = plugin_dir_path( __FILE__ ) . 'theme/';
+                require $theme_dir . 'quiz-container.php';
+                require $theme_dir . 'quiz-buttons.php';
+                require $theme_dir . 'progress-bar.php';
+                require $theme_dir . 'summary-container.php';
+                require $theme_dir . 'toc-container.php';
 ?>
-		</div><!-- /#nuclen-custom-theme-section -->
+        </div><!-- /#nuclen-custom-theme-section -->
 </div><!-- /#theme -->

--- a/nuclear-engagement/templates/admin/settings/theme/progress-bar.php
+++ b/nuclear-engagement/templates/admin/settings/theme/progress-bar.php
@@ -2,20 +2,20 @@
 declare(strict_types=1);
 // File: admin/partials/settings/theme/progress-bar.php
 if ( ! defined( 'ABSPATH' ) ) {
-	exit;
+    exit;
 }
 ?>
 <!-- ─────────── Progress bar ─────────── -->
 <h3 class="nuclen-subheading"><?php esc_html_e( 'Quiz Progress Bar', 'nuclear-engagement' ); ?></h3>
 <div class="nuclen-row">
-	<div class="nuclen-column nuclen-label-col"><label for="nuclen_quiz_progress_bar_fg_color" class="nuclen-label"><?php esc_html_e( 'Progress Foreground Color', 'nuclear-engagement' ); ?></label></div>
-	<div class="nuclen-column nuclen-input-col"><input type="color" class="nuclen-input" name="nuclen_quiz_progress_bar_fg_color" id="nuclen_quiz_progress_bar_fg_color" value="<?php echo esc_attr( $settings['quiz_progress_bar_fg_color'] ); ?>"></div>
+    <div class="nuclen-column nuclen-label-col"><label for="nuclen_quiz_progress_bar_fg_color" class="nuclen-label"><?php esc_html_e( 'Progress Foreground Color', 'nuclear-engagement' ); ?></label></div>
+    <div class="nuclen-column nuclen-input-col"><input type="color" class="nuclen-input" name="nuclen_quiz_progress_bar_fg_color" id="nuclen_quiz_progress_bar_fg_color" value="<?php echo esc_attr( $settings['quiz_progress_bar_fg_color'] ); ?>"></div>
 </div>
 <div class="nuclen-row">
-	<div class="nuclen-column nuclen-label-col"><label for="nuclen_quiz_progress_bar_bg_color" class="nuclen-label"><?php esc_html_e( 'Progress Background Color', 'nuclear-engagement' ); ?></label></div>
-	<div class="nuclen-column nuclen-input-col"><input type="color" class="nuclen-input" name="nuclen_quiz_progress_bar_bg_color" id="nuclen_quiz_progress_bar_bg_color" value="<?php echo esc_attr( $settings['quiz_progress_bar_bg_color'] ); ?>"></div>
+    <div class="nuclen-column nuclen-label-col"><label for="nuclen_quiz_progress_bar_bg_color" class="nuclen-label"><?php esc_html_e( 'Progress Background Color', 'nuclear-engagement' ); ?></label></div>
+    <div class="nuclen-column nuclen-input-col"><input type="color" class="nuclen-input" name="nuclen_quiz_progress_bar_bg_color" id="nuclen_quiz_progress_bar_bg_color" value="<?php echo esc_attr( $settings['quiz_progress_bar_bg_color'] ); ?>"></div>
 </div>
 <div class="nuclen-row">
-	<div class="nuclen-column nuclen-label-col"><label for="nuclen_quiz_progress_bar_height" class="nuclen-label"><?php esc_html_e( 'Progress Bar Height (px)', 'nuclear-engagement' ); ?></label></div>
-	<div class="nuclen-column nuclen-input-col"><input type="number" class="nuclen-input" name="nuclen_quiz_progress_bar_height" id="nuclen_quiz_progress_bar_height" value="<?php echo esc_attr( $settings['quiz_progress_bar_height'] ); ?>" min="1" max="50"></div>
+    <div class="nuclen-column nuclen-label-col"><label for="nuclen_quiz_progress_bar_height" class="nuclen-label"><?php esc_html_e( 'Progress Bar Height (px)', 'nuclear-engagement' ); ?></label></div>
+    <div class="nuclen-column nuclen-input-col"><input type="number" class="nuclen-input" name="nuclen_quiz_progress_bar_height" id="nuclen_quiz_progress_bar_height" value="<?php echo esc_attr( $settings['quiz_progress_bar_height'] ); ?>" min="1" max="50"></div>
 </div>

--- a/nuclear-engagement/templates/admin/settings/theme/quiz-buttons.php
+++ b/nuclear-engagement/templates/admin/settings/theme/quiz-buttons.php
@@ -2,24 +2,24 @@
 declare(strict_types=1);
 // File: admin/partials/settings/theme/quiz-buttons.php
 if ( ! defined( 'ABSPATH' ) ) {
-	exit;
+    exit;
 }
 ?>
 <!-- ─────────── Quiz answer buttons ─────────── -->
 <h3 class="nuclen-subheading"><?php esc_html_e( 'Quiz Answer Buttons', 'nuclear-engagement' ); ?></h3>
 <div class="nuclen-row">
-	<div class="nuclen-column nuclen-label-col"><label for="nuclen_quiz_answer_button_bg_color" class="nuclen-label"><?php esc_html_e( 'Button BG Color', 'nuclear-engagement' ); ?></label></div>
-	<div class="nuclen-column nuclen-input-col"><input type="color" class="nuclen-input" name="nuclen_quiz_answer_button_bg_color" id="nuclen_quiz_answer_button_bg_color" value="<?php echo esc_attr( $settings['quiz_answer_button_bg_color'] ); ?>"></div>
+    <div class="nuclen-column nuclen-label-col"><label for="nuclen_quiz_answer_button_bg_color" class="nuclen-label"><?php esc_html_e( 'Button BG Color', 'nuclear-engagement' ); ?></label></div>
+    <div class="nuclen-column nuclen-input-col"><input type="color" class="nuclen-input" name="nuclen_quiz_answer_button_bg_color" id="nuclen_quiz_answer_button_bg_color" value="<?php echo esc_attr( $settings['quiz_answer_button_bg_color'] ); ?>"></div>
 </div>
 <div class="nuclen-row">
-	<div class="nuclen-column nuclen-label-col"><label for="nuclen_quiz_answer_button_border_color" class="nuclen-label"><?php esc_html_e( 'Button Border Color', 'nuclear-engagement' ); ?></label></div>
-	<div class="nuclen-column nuclen-input-col"><input type="color" class="nuclen-input" name="nuclen_quiz_answer_button_border_color" id="nuclen_quiz_answer_button_border_color" value="<?php echo esc_attr( $settings['quiz_answer_button_border_color'] ); ?>"></div>
+    <div class="nuclen-column nuclen-label-col"><label for="nuclen_quiz_answer_button_border_color" class="nuclen-label"><?php esc_html_e( 'Button Border Color', 'nuclear-engagement' ); ?></label></div>
+    <div class="nuclen-column nuclen-input-col"><input type="color" class="nuclen-input" name="nuclen_quiz_answer_button_border_color" id="nuclen_quiz_answer_button_border_color" value="<?php echo esc_attr( $settings['quiz_answer_button_border_color'] ); ?>"></div>
 </div>
 <div class="nuclen-row">
-	<div class="nuclen-column nuclen-label-col"><label for="nuclen_quiz_answer_button_border_width" class="nuclen-label"><?php esc_html_e( 'Button Border Width (px)', 'nuclear-engagement' ); ?></label></div>
-	<div class="nuclen-column nuclen-input-col"><input type="number" class="nuclen-input" name="nuclen_quiz_answer_button_border_width" id="nuclen_quiz_answer_button_border_width" value="<?php echo esc_attr( $settings['quiz_answer_button_border_width'] ); ?>" min="0" max="10"></div>
+    <div class="nuclen-column nuclen-label-col"><label for="nuclen_quiz_answer_button_border_width" class="nuclen-label"><?php esc_html_e( 'Button Border Width (px)', 'nuclear-engagement' ); ?></label></div>
+    <div class="nuclen-column nuclen-input-col"><input type="number" class="nuclen-input" name="nuclen_quiz_answer_button_border_width" id="nuclen_quiz_answer_button_border_width" value="<?php echo esc_attr( $settings['quiz_answer_button_border_width'] ); ?>" min="0" max="10"></div>
 </div>
 <div class="nuclen-row">
-	<div class="nuclen-column nuclen-label-col"><label for="nuclen_quiz_answer_button_border_radius" class="nuclen-label"><?php esc_html_e( 'Button Border Radius (px)', 'nuclear-engagement' ); ?></label></div>
-	<div class="nuclen-column nuclen-input-col"><input type="number" class="nuclen-input" name="nuclen_quiz_answer_button_border_radius" id="nuclen_quiz_answer_button_border_radius" value="<?php echo esc_attr( $settings['quiz_answer_button_border_radius'] ); ?>" min="0" max="100"></div>
+    <div class="nuclen-column nuclen-label-col"><label for="nuclen_quiz_answer_button_border_radius" class="nuclen-label"><?php esc_html_e( 'Button Border Radius (px)', 'nuclear-engagement' ); ?></label></div>
+    <div class="nuclen-column nuclen-input-col"><input type="number" class="nuclen-input" name="nuclen_quiz_answer_button_border_radius" id="nuclen_quiz_answer_button_border_radius" value="<?php echo esc_attr( $settings['quiz_answer_button_border_radius'] ); ?>" min="0" max="100"></div>
 </div>

--- a/nuclear-engagement/templates/admin/settings/theme/quiz-container.php
+++ b/nuclear-engagement/templates/admin/settings/theme/quiz-container.php
@@ -2,7 +2,7 @@
 declare(strict_types=1);
 // File: admin/partials/settings/theme/quiz-container.php
 if ( ! defined( 'ABSPATH' ) ) {
-	exit;
+    exit;
 }
 ?>
 <!-- ─────────── Quiz container ─────────── -->
@@ -10,49 +10,49 @@ if ( ! defined( 'ABSPATH' ) ) {
 
 <h4><?php esc_html_e( 'Font & Background', 'nuclear-engagement' ); ?></h4>
 <div class="nuclen-row">
-	<div class="nuclen-column nuclen-label-col"><label for="nuclen_font_size" class="nuclen-label"><?php esc_html_e( 'Quiz Font Size (px)', 'nuclear-engagement' ); ?></label></div>
-	<div class="nuclen-column nuclen-input-col"><input type="number" class="nuclen-input" name="nuclen_font_size" id="nuclen_font_size" value="<?php echo esc_attr( $settings['font_size'] ); ?>" min="10" max="50"></div>
+    <div class="nuclen-column nuclen-label-col"><label for="nuclen_font_size" class="nuclen-label"><?php esc_html_e( 'Quiz Font Size (px)', 'nuclear-engagement' ); ?></label></div>
+    <div class="nuclen-column nuclen-input-col"><input type="number" class="nuclen-input" name="nuclen_font_size" id="nuclen_font_size" value="<?php echo esc_attr( $settings['font_size'] ); ?>" min="10" max="50"></div>
 </div>
 <div class="nuclen-row">
-	<div class="nuclen-column nuclen-label-col"><label for="nuclen_font_color" class="nuclen-label"><?php esc_html_e( 'Quiz Font Color', 'nuclear-engagement' ); ?></label></div>
-	<div class="nuclen-column nuclen-input-col"><input type="color" class="nuclen-input" name="nuclen_font_color" id="nuclen_font_color" value="<?php echo esc_attr( $settings['font_color'] ); ?>"></div>
+    <div class="nuclen-column nuclen-label-col"><label for="nuclen_font_color" class="nuclen-label"><?php esc_html_e( 'Quiz Font Color', 'nuclear-engagement' ); ?></label></div>
+    <div class="nuclen-column nuclen-input-col"><input type="color" class="nuclen-input" name="nuclen_font_color" id="nuclen_font_color" value="<?php echo esc_attr( $settings['font_color'] ); ?>"></div>
 </div>
 <div class="nuclen-row">
-	<div class="nuclen-column nuclen-label-col"><label for="nuclen_bg_color" class="nuclen-label"><?php esc_html_e( 'Quiz Background Color', 'nuclear-engagement' ); ?></label></div>
-	<div class="nuclen-column nuclen-input-col"><input type="color" class="nuclen-input" name="nuclen_bg_color" id="nuclen_bg_color" value="<?php echo esc_attr( $settings['bg_color'] ); ?>"></div>
+    <div class="nuclen-column nuclen-label-col"><label for="nuclen_bg_color" class="nuclen-label"><?php esc_html_e( 'Quiz Background Color', 'nuclear-engagement' ); ?></label></div>
+    <div class="nuclen-column nuclen-input-col"><input type="color" class="nuclen-input" name="nuclen_bg_color" id="nuclen_bg_color" value="<?php echo esc_attr( $settings['bg_color'] ); ?>"></div>
 </div>
 
 <h4><?php esc_html_e( 'Border Lines', 'nuclear-engagement' ); ?></h4>
 <div class="nuclen-row">
-	<div class="nuclen-column nuclen-label-col"><label for="nuclen_quiz_border_color" class="nuclen-label"><?php esc_html_e( 'Quiz Border Color', 'nuclear-engagement' ); ?></label></div>
-	<div class="nuclen-column nuclen-input-col"><input type="color" class="nuclen-input" name="nuclen_quiz_border_color" id="nuclen_quiz_border_color" value="<?php echo esc_attr( $settings['quiz_border_color'] ); ?>"></div>
+    <div class="nuclen-column nuclen-label-col"><label for="nuclen_quiz_border_color" class="nuclen-label"><?php esc_html_e( 'Quiz Border Color', 'nuclear-engagement' ); ?></label></div>
+    <div class="nuclen-column nuclen-input-col"><input type="color" class="nuclen-input" name="nuclen_quiz_border_color" id="nuclen_quiz_border_color" value="<?php echo esc_attr( $settings['quiz_border_color'] ); ?>"></div>
 </div>
 <div class="nuclen-row">
-	<div class="nuclen-column nuclen-label-col"><label for="nuclen_quiz_border_style" class="nuclen-label"><?php esc_html_e( 'Quiz Border Style', 'nuclear-engagement' ); ?></label></div>
-	<div class="nuclen-column nuclen-input-col">
-		<?php $styles = array( 'none', 'solid', 'dashed', 'dotted', 'double' ); ?>
-		<select name="nuclen_quiz_border_style" id="nuclen_quiz_border_style" class="nuclen-input">
-			<?php foreach ( $styles as $s ) : ?>
-				<option value="<?php echo esc_attr( $s ); ?>" <?php selected( $settings['quiz_border_style'], $s ); ?>><?php echo esc_html( ucfirst( $s ) ); ?></option>
-			<?php endforeach; ?>
-		</select>
-	</div>
+    <div class="nuclen-column nuclen-label-col"><label for="nuclen_quiz_border_style" class="nuclen-label"><?php esc_html_e( 'Quiz Border Style', 'nuclear-engagement' ); ?></label></div>
+    <div class="nuclen-column nuclen-input-col">
+        <?php $styles = array( 'none', 'solid', 'dashed', 'dotted', 'double' ); ?>
+        <select name="nuclen_quiz_border_style" id="nuclen_quiz_border_style" class="nuclen-input">
+            <?php foreach ( $styles as $s ) : ?>
+                <option value="<?php echo esc_attr( $s ); ?>" <?php selected( $settings['quiz_border_style'], $s ); ?>><?php echo esc_html( ucfirst( $s ) ); ?></option>
+            <?php endforeach; ?>
+        </select>
+    </div>
 </div>
 <div class="nuclen-row">
-	<div class="nuclen-column nuclen-label-col"><label for="nuclen_quiz_border_width" class="nuclen-label"><?php esc_html_e( 'Quiz Border Width (px)', 'nuclear-engagement' ); ?></label></div>
-	<div class="nuclen-column nuclen-input-col"><input type="number" class="nuclen-input" name="nuclen_quiz_border_width" id="nuclen_quiz_border_width" value="<?php echo esc_attr( $settings['quiz_border_width'] ); ?>" min="0" max="10"></div>
+    <div class="nuclen-column nuclen-label-col"><label for="nuclen_quiz_border_width" class="nuclen-label"><?php esc_html_e( 'Quiz Border Width (px)', 'nuclear-engagement' ); ?></label></div>
+    <div class="nuclen-column nuclen-input-col"><input type="number" class="nuclen-input" name="nuclen_quiz_border_width" id="nuclen_quiz_border_width" value="<?php echo esc_attr( $settings['quiz_border_width'] ); ?>" min="0" max="10"></div>
 </div>
 
 <h4><?php esc_html_e( 'Border Radius &amp; Shadow', 'nuclear-engagement' ); ?></h4>
 <div class="nuclen-row">
-	<div class="nuclen-column nuclen-label-col"><label for="nuclen_quiz_border_radius" class="nuclen-label"><?php esc_html_e( 'Quiz Border Radius (px)', 'nuclear-engagement' ); ?></label></div>
-	<div class="nuclen-column nuclen-input-col"><input type="number" class="nuclen-input" name="nuclen_quiz_border_radius" id="nuclen_quiz_border_radius" value="<?php echo esc_attr( $settings['quiz_border_radius'] ); ?>" min="0" max="100"></div>
+    <div class="nuclen-column nuclen-label-col"><label for="nuclen_quiz_border_radius" class="nuclen-label"><?php esc_html_e( 'Quiz Border Radius (px)', 'nuclear-engagement' ); ?></label></div>
+    <div class="nuclen-column nuclen-input-col"><input type="number" class="nuclen-input" name="nuclen_quiz_border_radius" id="nuclen_quiz_border_radius" value="<?php echo esc_attr( $settings['quiz_border_radius'] ); ?>" min="0" max="100"></div>
 </div>
 <div class="nuclen-row">
-	<div class="nuclen-column nuclen-label-col"><label for="nuclen_quiz_shadow_color" class="nuclen-label"><?php esc_html_e( 'Quiz Shadow Color', 'nuclear-engagement' ); ?></label></div>
-	<div class="nuclen-column nuclen-input-col"><input type="color" class="nuclen-input" name="nuclen_quiz_shadow_color" id="nuclen_quiz_shadow_color" value="<?php echo esc_attr( $settings['quiz_shadow_color'] ); ?>"></div>
+    <div class="nuclen-column nuclen-label-col"><label for="nuclen_quiz_shadow_color" class="nuclen-label"><?php esc_html_e( 'Quiz Shadow Color', 'nuclear-engagement' ); ?></label></div>
+    <div class="nuclen-column nuclen-input-col"><input type="color" class="nuclen-input" name="nuclen_quiz_shadow_color" id="nuclen_quiz_shadow_color" value="<?php echo esc_attr( $settings['quiz_shadow_color'] ); ?>"></div>
 </div>
 <div class="nuclen-row">
-	<div class="nuclen-column nuclen-label-col"><label for="nuclen_quiz_shadow_blur" class="nuclen-label"><?php esc_html_e( 'Quiz Shadow Blur (px)', 'nuclear-engagement' ); ?></label></div>
-	<div class="nuclen-column nuclen-input-col"><input type="number" class="nuclen-input" name="nuclen_quiz_shadow_blur" id="nuclen_quiz_shadow_blur" value="<?php echo esc_attr( $settings['quiz_shadow_blur'] ); ?>" min="0" max="100"></div>
+    <div class="nuclen-column nuclen-label-col"><label for="nuclen_quiz_shadow_blur" class="nuclen-label"><?php esc_html_e( 'Quiz Shadow Blur (px)', 'nuclear-engagement' ); ?></label></div>
+    <div class="nuclen-column nuclen-input-col"><input type="number" class="nuclen-input" name="nuclen_quiz_shadow_blur" id="nuclen_quiz_shadow_blur" value="<?php echo esc_attr( $settings['quiz_shadow_blur'] ); ?>" min="0" max="100"></div>
 </div>

--- a/nuclear-engagement/templates/admin/settings/theme/summary-container.php
+++ b/nuclear-engagement/templates/admin/settings/theme/summary-container.php
@@ -2,7 +2,7 @@
 declare(strict_types=1);
 // File: admin/partials/settings/theme/summary-container.php
 if ( ! defined( 'ABSPATH' ) ) {
-	exit;
+    exit;
 }
 ?>
 <!-- ─────────── Summary container ─────────── -->
@@ -10,49 +10,49 @@ if ( ! defined( 'ABSPATH' ) ) {
 
 <h4><?php esc_html_e( 'Font & Background', 'nuclear-engagement' ); ?></h4>
 <div class="nuclen-row">
-	<div class="nuclen-column nuclen-label-col"><label for="nuclen_summary_font_size" class="nuclen-label"><?php esc_html_e( 'Summary Font Size (px)', 'nuclear-engagement' ); ?></label></div>
-	<div class="nuclen-column nuclen-input-col"><input type="number" class="nuclen-input" name="nuclen_summary_font_size" id="nuclen_summary_font_size" value="<?php echo esc_attr( $settings['summary_font_size'] ); ?>" min="10" max="50"></div>
+    <div class="nuclen-column nuclen-label-col"><label for="nuclen_summary_font_size" class="nuclen-label"><?php esc_html_e( 'Summary Font Size (px)', 'nuclear-engagement' ); ?></label></div>
+    <div class="nuclen-column nuclen-input-col"><input type="number" class="nuclen-input" name="nuclen_summary_font_size" id="nuclen_summary_font_size" value="<?php echo esc_attr( $settings['summary_font_size'] ); ?>" min="10" max="50"></div>
 </div>
 <div class="nuclen-row">
-	<div class="nuclen-column nuclen-label-col"><label for="nuclen_summary_font_color" class="nuclen-label"><?php esc_html_e( 'Summary Font Color', 'nuclear-engagement' ); ?></label></div>
-	<div class="nuclen-column nuclen-input-col"><input type="color" class="nuclen-input" name="nuclen_summary_font_color" id="nuclen_summary_font_color" value="<?php echo esc_attr( $settings['summary_font_color'] ); ?>"></div>
+    <div class="nuclen-column nuclen-label-col"><label for="nuclen_summary_font_color" class="nuclen-label"><?php esc_html_e( 'Summary Font Color', 'nuclear-engagement' ); ?></label></div>
+    <div class="nuclen-column nuclen-input-col"><input type="color" class="nuclen-input" name="nuclen_summary_font_color" id="nuclen_summary_font_color" value="<?php echo esc_attr( $settings['summary_font_color'] ); ?>"></div>
 </div>
 <div class="nuclen-row">
-	<div class="nuclen-column nuclen-label-col"><label for="nuclen_summary_bg_color" class="nuclen-label"><?php esc_html_e( 'Summary Background Color', 'nuclear-engagement' ); ?></label></div>
-	<div class="nuclen-column nuclen-input-col"><input type="color" class="nuclen-input" name="nuclen_summary_bg_color" id="nuclen_summary_bg_color" value="<?php echo esc_attr( $settings['summary_bg_color'] ); ?>"></div>
+    <div class="nuclen-column nuclen-label-col"><label for="nuclen_summary_bg_color" class="nuclen-label"><?php esc_html_e( 'Summary Background Color', 'nuclear-engagement' ); ?></label></div>
+    <div class="nuclen-column nuclen-input-col"><input type="color" class="nuclen-input" name="nuclen_summary_bg_color" id="nuclen_summary_bg_color" value="<?php echo esc_attr( $settings['summary_bg_color'] ); ?>"></div>
 </div>
 
 <h4><?php esc_html_e( 'Border Lines', 'nuclear-engagement' ); ?></h4>
 <div class="nuclen-row">
-	<div class="nuclen-column nuclen-label-col"><label for="nuclen_summary_border_color" class="nuclen-label"><?php esc_html_e( 'Summary Border Color', 'nuclear-engagement' ); ?></label></div>
-	<div class="nuclen-column nuclen-input-col"><input type="color" class="nuclen-input" name="nuclen_summary_border_color" id="nuclen_summary_border_color" value="<?php echo esc_attr( $settings['summary_border_color'] ); ?>"></div>
+    <div class="nuclen-column nuclen-label-col"><label for="nuclen_summary_border_color" class="nuclen-label"><?php esc_html_e( 'Summary Border Color', 'nuclear-engagement' ); ?></label></div>
+    <div class="nuclen-column nuclen-input-col"><input type="color" class="nuclen-input" name="nuclen_summary_border_color" id="nuclen_summary_border_color" value="<?php echo esc_attr( $settings['summary_border_color'] ); ?>"></div>
 </div>
 <div class="nuclen-row">
-	<div class="nuclen-column nuclen-label-col"><label for="nuclen_summary_border_style" class="nuclen-label"><?php esc_html_e( 'Summary Border Style', 'nuclear-engagement' ); ?></label></div>
-	<div class="nuclen-column nuclen-input-col">
-		<?php $styles = array( 'none', 'solid', 'dashed', 'dotted', 'double' ); ?>
-		<select name="nuclen_summary_border_style" id="nuclen_summary_border_style" class="nuclen-input">
-			<?php foreach ( $styles as $s ) : ?>
-				<option value="<?php echo esc_attr( $s ); ?>" <?php selected( $settings['summary_border_style'], $s ); ?>><?php echo esc_html( ucfirst( $s ) ); ?></option>
-			<?php endforeach; ?>
-		</select>
-	</div>
+    <div class="nuclen-column nuclen-label-col"><label for="nuclen_summary_border_style" class="nuclen-label"><?php esc_html_e( 'Summary Border Style', 'nuclear-engagement' ); ?></label></div>
+    <div class="nuclen-column nuclen-input-col">
+        <?php $styles = array( 'none', 'solid', 'dashed', 'dotted', 'double' ); ?>
+        <select name="nuclen_summary_border_style" id="nuclen_summary_border_style" class="nuclen-input">
+            <?php foreach ( $styles as $s ) : ?>
+                <option value="<?php echo esc_attr( $s ); ?>" <?php selected( $settings['summary_border_style'], $s ); ?>><?php echo esc_html( ucfirst( $s ) ); ?></option>
+            <?php endforeach; ?>
+        </select>
+    </div>
 </div>
 <div class="nuclen-row">
-	<div class="nuclen-column nuclen-label-col"><label for="nuclen_summary_border_width" class="nuclen-label"><?php esc_html_e( 'Summary Border Width (px)', 'nuclear-engagement' ); ?></label></div>
-	<div class="nuclen-column nuclen-input-col"><input type="number" class="nuclen-input" name="nuclen_summary_border_width" id="nuclen_summary_border_width" value="<?php echo esc_attr( $settings['summary_border_width'] ); ?>" min="0" max="10"></div>
+    <div class="nuclen-column nuclen-label-col"><label for="nuclen_summary_border_width" class="nuclen-label"><?php esc_html_e( 'Summary Border Width (px)', 'nuclear-engagement' ); ?></label></div>
+    <div class="nuclen-column nuclen-input-col"><input type="number" class="nuclen-input" name="nuclen_summary_border_width" id="nuclen_summary_border_width" value="<?php echo esc_attr( $settings['summary_border_width'] ); ?>" min="0" max="10"></div>
 </div>
 
 <h4><?php esc_html_e( 'Border Radius &amp; Shadow', 'nuclear-engagement' ); ?></h4>
 <div class="nuclen-row">
-	<div class="nuclen-column nuclen-label-col"><label for="nuclen_summary_border_radius" class="nuclen-label"><?php esc_html_e( 'Summary Border Radius (px)', 'nuclear-engagement' ); ?></label></div>
-	<div class="nuclen-column nuclen-input-col"><input type="number" class="nuclen-input" name="nuclen_summary_border_radius" id="nuclen_summary_border_radius" value="<?php echo esc_attr( $settings['summary_border_radius'] ); ?>" min="0" max="100"></div>
+    <div class="nuclen-column nuclen-label-col"><label for="nuclen_summary_border_radius" class="nuclen-label"><?php esc_html_e( 'Summary Border Radius (px)', 'nuclear-engagement' ); ?></label></div>
+    <div class="nuclen-column nuclen-input-col"><input type="number" class="nuclen-input" name="nuclen_summary_border_radius" id="nuclen_summary_border_radius" value="<?php echo esc_attr( $settings['summary_border_radius'] ); ?>" min="0" max="100"></div>
 </div>
 <div class="nuclen-row">
-	<div class="nuclen-column nuclen-label-col"><label for="nuclen_summary_shadow_color" class="nuclen-label"><?php esc_html_e( 'Shadow Color', 'nuclear-engagement' ); ?></label></div>
-	<div class="nuclen-column nuclen-input-col"><input type="color" class="nuclen-input" name="nuclen_summary_shadow_color" id="nuclen_summary_shadow_color" value="<?php echo esc_attr( $settings['summary_shadow_color'] ); ?>"></div>
+    <div class="nuclen-column nuclen-label-col"><label for="nuclen_summary_shadow_color" class="nuclen-label"><?php esc_html_e( 'Shadow Color', 'nuclear-engagement' ); ?></label></div>
+    <div class="nuclen-column nuclen-input-col"><input type="color" class="nuclen-input" name="nuclen_summary_shadow_color" id="nuclen_summary_shadow_color" value="<?php echo esc_attr( $settings['summary_shadow_color'] ); ?>"></div>
 </div>
 <div class="nuclen-row">
-	<div class="nuclen-column nuclen-label-col"><label for="nuclen_summary_shadow_blur" class="nuclen-label"><?php esc_html_e( 'Shadow Blur (px)', 'nuclear-engagement' ); ?></label></div>
-	<div class="nuclen-column nuclen-input-col"><input type="number" class="nuclen-input" name="nuclen_summary_shadow_blur" id="nuclen_summary_shadow_blur" value="<?php echo esc_attr( $settings['summary_shadow_blur'] ); ?>" min="0" max="100"></div>
+    <div class="nuclen-column nuclen-label-col"><label for="nuclen_summary_shadow_blur" class="nuclen-label"><?php esc_html_e( 'Shadow Blur (px)', 'nuclear-engagement' ); ?></label></div>
+    <div class="nuclen-column nuclen-input-col"><input type="number" class="nuclen-input" name="nuclen_summary_shadow_blur" id="nuclen_summary_shadow_blur" value="<?php echo esc_attr( $settings['summary_shadow_blur'] ); ?>" min="0" max="100"></div>
 </div>

--- a/nuclear-engagement/templates/admin/settings/theme/toc-container.php
+++ b/nuclear-engagement/templates/admin/settings/theme/toc-container.php
@@ -2,7 +2,7 @@
 declare(strict_types=1);
 // File: admin/partials/settings/theme/toc-container.php
 if ( ! defined( 'ABSPATH' ) ) {
-	exit;
+    exit;
 }
 ?>
 <!-- ─────────── TOC container ─────────── -->
@@ -10,53 +10,53 @@ if ( ! defined( 'ABSPATH' ) ) {
 
 <h4><?php esc_html_e( 'Font & Background', 'nuclear-engagement' ); ?></h4>
 <div class="nuclen-row">
-	<div class="nuclen-column nuclen-label-col"><label for="nuclen_toc_font_size" class="nuclen-label"><?php esc_html_e( 'Font Size (px)', 'nuclear-engagement' ); ?></label></div>
-	<div class="nuclen-column nuclen-input-col"><input type="number" class="nuclen-input" name="nuclen_toc_font_size" id="nuclen_toc_font_size" value="<?php echo esc_attr( $settings['toc_font_size'] ); ?>" min="10" max="50"></div>
+    <div class="nuclen-column nuclen-label-col"><label for="nuclen_toc_font_size" class="nuclen-label"><?php esc_html_e( 'Font Size (px)', 'nuclear-engagement' ); ?></label></div>
+    <div class="nuclen-column nuclen-input-col"><input type="number" class="nuclen-input" name="nuclen_toc_font_size" id="nuclen_toc_font_size" value="<?php echo esc_attr( $settings['toc_font_size'] ); ?>" min="10" max="50"></div>
 </div>
 <div class="nuclen-row">
-	<div class="nuclen-column nuclen-label-col"><label for="nuclen_toc_font_color" class="nuclen-label"><?php esc_html_e( 'Font Color', 'nuclear-engagement' ); ?></label></div>
-	<div class="nuclen-column nuclen-input-col"><input type="color" class="nuclen-input" name="nuclen_toc_font_color" id="nuclen_toc_font_color" value="<?php echo esc_attr( $settings['toc_font_color'] ); ?>"></div>
+    <div class="nuclen-column nuclen-label-col"><label for="nuclen_toc_font_color" class="nuclen-label"><?php esc_html_e( 'Font Color', 'nuclear-engagement' ); ?></label></div>
+    <div class="nuclen-column nuclen-input-col"><input type="color" class="nuclen-input" name="nuclen_toc_font_color" id="nuclen_toc_font_color" value="<?php echo esc_attr( $settings['toc_font_color'] ); ?>"></div>
 </div>
 <div class="nuclen-row">
-	<div class="nuclen-column nuclen-label-col"><label for="nuclen_toc_bg_color" class="nuclen-label"><?php esc_html_e( 'TOC Background Color', 'nuclear-engagement' ); ?></label></div>
-	<div class="nuclen-column nuclen-input-col"><input type="color" class="nuclen-input" name="nuclen_toc_bg_color" id="nuclen_toc_bg_color" value="<?php echo esc_attr( $settings['toc_bg_color'] ); ?>"></div>
+    <div class="nuclen-column nuclen-label-col"><label for="nuclen_toc_bg_color" class="nuclen-label"><?php esc_html_e( 'TOC Background Color', 'nuclear-engagement' ); ?></label></div>
+    <div class="nuclen-column nuclen-input-col"><input type="color" class="nuclen-input" name="nuclen_toc_bg_color" id="nuclen_toc_bg_color" value="<?php echo esc_attr( $settings['toc_bg_color'] ); ?>"></div>
 </div>
 <div class="nuclen-row">
-	<div class="nuclen-column nuclen-label-col"><label for="nuclen_toc_link_color" class="nuclen-label"><?php esc_html_e( 'TOC Link Color', 'nuclear-engagement' ); ?></label></div>
-	<div class="nuclen-column nuclen-input-col"><input type="color" class="nuclen-input" name="nuclen_toc_link_color" id="nuclen_toc_link_color" value="<?php echo esc_attr( $settings['toc_link_color'] ); ?>"></div>
+    <div class="nuclen-column nuclen-label-col"><label for="nuclen_toc_link_color" class="nuclen-label"><?php esc_html_e( 'TOC Link Color', 'nuclear-engagement' ); ?></label></div>
+    <div class="nuclen-column nuclen-input-col"><input type="color" class="nuclen-input" name="nuclen_toc_link_color" id="nuclen_toc_link_color" value="<?php echo esc_attr( $settings['toc_link_color'] ); ?>"></div>
 </div>
 
 <h4><?php esc_html_e( 'Border Lines', 'nuclear-engagement' ); ?></h4>
 <div class="nuclen-row">
-	<div class="nuclen-column nuclen-label-col"><label for="nuclen_toc_border_color" class="nuclen-label"><?php esc_html_e( 'TOC Border Color', 'nuclear-engagement' ); ?></label></div>
-	<div class="nuclen-column nuclen-input-col"><input type="color" class="nuclen-input" name="nuclen_toc_border_color" id="nuclen_toc_border_color" value="<?php echo esc_attr( $settings['toc_border_color'] ); ?>"></div>
+    <div class="nuclen-column nuclen-label-col"><label for="nuclen_toc_border_color" class="nuclen-label"><?php esc_html_e( 'TOC Border Color', 'nuclear-engagement' ); ?></label></div>
+    <div class="nuclen-column nuclen-input-col"><input type="color" class="nuclen-input" name="nuclen_toc_border_color" id="nuclen_toc_border_color" value="<?php echo esc_attr( $settings['toc_border_color'] ); ?>"></div>
 </div>
 <div class="nuclen-row">
-	<div class="nuclen-column nuclen-label-col"><label for="nuclen_toc_border_style" class="nuclen-label"><?php esc_html_e( 'TOC Border Style', 'nuclear-engagement' ); ?></label></div>
-	<div class="nuclen-column nuclen-input-col">
-		<?php $styles = array( 'none', 'solid', 'dashed', 'dotted', 'double' ); ?>
-		<select name="nuclen_toc_border_style" id="nuclen_toc_border_style" class="nuclen-input">
-			<?php foreach ( $styles as $s ) : ?>
-				<option value="<?php echo esc_attr( $s ); ?>" <?php selected( $settings['toc_border_style'], $s ); ?>><?php echo esc_html( ucfirst( $s ) ); ?></option>
-			<?php endforeach; ?>
-		</select>
-	</div>
+    <div class="nuclen-column nuclen-label-col"><label for="nuclen_toc_border_style" class="nuclen-label"><?php esc_html_e( 'TOC Border Style', 'nuclear-engagement' ); ?></label></div>
+    <div class="nuclen-column nuclen-input-col">
+        <?php $styles = array( 'none', 'solid', 'dashed', 'dotted', 'double' ); ?>
+        <select name="nuclen_toc_border_style" id="nuclen_toc_border_style" class="nuclen-input">
+            <?php foreach ( $styles as $s ) : ?>
+                <option value="<?php echo esc_attr( $s ); ?>" <?php selected( $settings['toc_border_style'], $s ); ?>><?php echo esc_html( ucfirst( $s ) ); ?></option>
+            <?php endforeach; ?>
+        </select>
+    </div>
 </div>
 <div class="nuclen-row">
-	<div class="nuclen-column nuclen-label-col"><label for="nuclen_toc_border_width" class="nuclen-label"><?php esc_html_e( 'TOC Border Width (px)', 'nuclear-engagement' ); ?></label></div>
-	<div class="nuclen-column nuclen-input-col"><input type="number" class="nuclen-input" name="nuclen_toc_border_width" id="nuclen_toc_border_width" value="<?php echo esc_attr( $settings['toc_border_width'] ); ?>" min="0" max="10"></div>
+    <div class="nuclen-column nuclen-label-col"><label for="nuclen_toc_border_width" class="nuclen-label"><?php esc_html_e( 'TOC Border Width (px)', 'nuclear-engagement' ); ?></label></div>
+    <div class="nuclen-column nuclen-input-col"><input type="number" class="nuclen-input" name="nuclen_toc_border_width" id="nuclen_toc_border_width" value="<?php echo esc_attr( $settings['toc_border_width'] ); ?>" min="0" max="10"></div>
 </div>
 
 <h4><?php esc_html_e( 'Border Radius &amp; Shadow', 'nuclear-engagement' ); ?></h4>
 <div class="nuclen-row">
-	<div class="nuclen-column nuclen-label-col"><label for="nuclen_toc_border_radius" class="nuclen-label"><?php esc_html_e( 'TOC Border Radius (px)', 'nuclear-engagement' ); ?></label></div>
-	<div class="nuclen-column nuclen-input-col"><input type="number" class="nuclen-input" name="nuclen_toc_border_radius" id="nuclen_toc_border_radius" value="<?php echo esc_attr( $settings['toc_border_radius'] ); ?>" min="0" max="100"></div>
+    <div class="nuclen-column nuclen-label-col"><label for="nuclen_toc_border_radius" class="nuclen-label"><?php esc_html_e( 'TOC Border Radius (px)', 'nuclear-engagement' ); ?></label></div>
+    <div class="nuclen-column nuclen-input-col"><input type="number" class="nuclen-input" name="nuclen_toc_border_radius" id="nuclen_toc_border_radius" value="<?php echo esc_attr( $settings['toc_border_radius'] ); ?>" min="0" max="100"></div>
 </div>
 <div class="nuclen-row">
-	<div class="nuclen-column nuclen-label-col"><label for="nuclen_toc_shadow_color" class="nuclen-label"><?php esc_html_e( 'TOC Shadow Color', 'nuclear-engagement' ); ?></label></div>
-	<div class="nuclen-column nuclen-input-col"><input type="color" class="nuclen-input" name="nuclen_toc_shadow_color" id="nuclen_toc_shadow_color" value="<?php echo esc_attr( $settings['toc_shadow_color'] ); ?>"></div>
+    <div class="nuclen-column nuclen-label-col"><label for="nuclen_toc_shadow_color" class="nuclen-label"><?php esc_html_e( 'TOC Shadow Color', 'nuclear-engagement' ); ?></label></div>
+    <div class="nuclen-column nuclen-input-col"><input type="color" class="nuclen-input" name="nuclen_toc_shadow_color" id="nuclen_toc_shadow_color" value="<?php echo esc_attr( $settings['toc_shadow_color'] ); ?>"></div>
 </div>
 <div class="nuclen-row">
-	<div class="nuclen-column nuclen-label-col"><label for="nuclen_toc_shadow_blur" class="nuclen-label"><?php esc_html_e( 'TOC Shadow Blur (px)', 'nuclear-engagement' ); ?></label></div>
-	<div class="nuclen-column nuclen-input-col"><input type="number" class="nuclen-input" name="nuclen_toc_shadow_blur" id="nuclen_toc_shadow_blur" value="<?php echo esc_attr( $settings['toc_shadow_blur'] ); ?>" min="0" max="100"></div>
+    <div class="nuclen-column nuclen-label-col"><label for="nuclen_toc_shadow_blur" class="nuclen-label"><?php esc_html_e( 'TOC Shadow Blur (px)', 'nuclear-engagement' ); ?></label></div>
+    <div class="nuclen-column nuclen-input-col"><input type="number" class="nuclen-input" name="nuclen_toc_shadow_blur" id="nuclen_toc_shadow_blur" value="<?php echo esc_attr( $settings['toc_shadow_blur'] ); ?>" min="0" max="100"></div>
 </div>

--- a/nuclear-engagement/templates/admin/settings/uninstall.php
+++ b/nuclear-engagement/templates/admin/settings/uninstall.php
@@ -2,7 +2,7 @@
 declare(strict_types=1);
 // File: admin/partials/settings/uninstall.php
 if ( ! defined( 'ABSPATH' ) ) {
-		exit;
+        exit;
 }
 /**
  * Uninstall tab
@@ -12,51 +12,51 @@ if ( ! defined( 'ABSPATH' ) ) {
 ?>
 <!-- UNINSTALL TAB -->
 <div id="uninstall" class="nuclen-tab-content nuclen-section" style="display:none;">
-		<h2 class="nuclen-subheading"><?php esc_html_e( 'Uninstall Options', 'nuclear-engagement' ); ?></h2>
-		<p><?php esc_html_e( 'Choose what to remove when the plugin is deleted.', 'nuclear-engagement' ); ?></p>
+        <h2 class="nuclen-subheading"><?php esc_html_e( 'Uninstall Options', 'nuclear-engagement' ); ?></h2>
+        <p><?php esc_html_e( 'Choose what to remove when the plugin is deleted.', 'nuclear-engagement' ); ?></p>
 
-		<div class="nuclen-form-group nuclen-row">
-				<label class="nuclen-label-col" for="delete_settings_on_uninstall">
-						<?php esc_html_e( 'Delete plugin settings', 'nuclear-engagement' ); ?>
-				</label>
-				<div class="nuclen-input-col">
-						<input type="checkbox" name="delete_settings_on_uninstall" id="delete_settings_on_uninstall" value="1" <?php checked( $settings['delete_settings_on_uninstall'], true ); ?> />
-				</div>
-		</div>
+        <div class="nuclen-form-group nuclen-row">
+                <label class="nuclen-label-col" for="delete_settings_on_uninstall">
+                        <?php esc_html_e( 'Delete plugin settings', 'nuclear-engagement' ); ?>
+                </label>
+                <div class="nuclen-input-col">
+                        <input type="checkbox" name="delete_settings_on_uninstall" id="delete_settings_on_uninstall" value="1" <?php checked( $settings['delete_settings_on_uninstall'], true ); ?> />
+                </div>
+        </div>
 
-		<div class="nuclen-form-group nuclen-row">
-				<label class="nuclen-label-col" for="delete_generated_content_on_uninstall">
-						<?php esc_html_e( 'Delete generated post data', 'nuclear-engagement' ); ?>
-				</label>
-				<div class="nuclen-input-col">
-						<input type="checkbox" name="delete_generated_content_on_uninstall" id="delete_generated_content_on_uninstall" value="1" <?php checked( $settings['delete_generated_content_on_uninstall'], true ); ?> />
-				</div>
-		</div>
+        <div class="nuclen-form-group nuclen-row">
+                <label class="nuclen-label-col" for="delete_generated_content_on_uninstall">
+                        <?php esc_html_e( 'Delete generated post data', 'nuclear-engagement' ); ?>
+                </label>
+                <div class="nuclen-input-col">
+                        <input type="checkbox" name="delete_generated_content_on_uninstall" id="delete_generated_content_on_uninstall" value="1" <?php checked( $settings['delete_generated_content_on_uninstall'], true ); ?> />
+                </div>
+        </div>
 
-		<div class="nuclen-form-group nuclen-row">
-				<label class="nuclen-label-col" for="delete_optin_data_on_uninstall">
-						<?php esc_html_e( 'Delete email opt-in data', 'nuclear-engagement' ); ?>
-				</label>
-				<div class="nuclen-input-col">
-						<input type="checkbox" name="delete_optin_data_on_uninstall" id="delete_optin_data_on_uninstall" value="1" <?php checked( $settings['delete_optin_data_on_uninstall'], true ); ?> />
-				</div>
-		</div>
+        <div class="nuclen-form-group nuclen-row">
+                <label class="nuclen-label-col" for="delete_optin_data_on_uninstall">
+                        <?php esc_html_e( 'Delete email opt-in data', 'nuclear-engagement' ); ?>
+                </label>
+                <div class="nuclen-input-col">
+                        <input type="checkbox" name="delete_optin_data_on_uninstall" id="delete_optin_data_on_uninstall" value="1" <?php checked( $settings['delete_optin_data_on_uninstall'], true ); ?> />
+                </div>
+        </div>
 
-		<div class="nuclen-form-group nuclen-row">
-				<label class="nuclen-label-col" for="delete_log_file_on_uninstall">
-						<?php esc_html_e( 'Delete log file', 'nuclear-engagement' ); ?>
-				</label>
-				<div class="nuclen-input-col">
-						<input type="checkbox" name="delete_log_file_on_uninstall" id="delete_log_file_on_uninstall" value="1" <?php checked( $settings['delete_log_file_on_uninstall'], true ); ?> />
-				</div>
-		</div>
+        <div class="nuclen-form-group nuclen-row">
+                <label class="nuclen-label-col" for="delete_log_file_on_uninstall">
+                        <?php esc_html_e( 'Delete log file', 'nuclear-engagement' ); ?>
+                </label>
+                <div class="nuclen-input-col">
+                        <input type="checkbox" name="delete_log_file_on_uninstall" id="delete_log_file_on_uninstall" value="1" <?php checked( $settings['delete_log_file_on_uninstall'], true ); ?> />
+                </div>
+        </div>
 
-		<div class="nuclen-form-group nuclen-row">
-				<label class="nuclen-label-col" for="delete_custom_css_on_uninstall">
-						<?php esc_html_e( 'Delete custom theme file', 'nuclear-engagement' ); ?>
-				</label>
-				<div class="nuclen-input-col">
-						<input type="checkbox" name="delete_custom_css_on_uninstall" id="delete_custom_css_on_uninstall" value="1" <?php checked( $settings['delete_custom_css_on_uninstall'], true ); ?> />
-				</div>
-		</div>
+        <div class="nuclen-form-group nuclen-row">
+                <label class="nuclen-label-col" for="delete_custom_css_on_uninstall">
+                        <?php esc_html_e( 'Delete custom theme file', 'nuclear-engagement' ); ?>
+                </label>
+                <div class="nuclen-input-col">
+                        <input type="checkbox" name="delete_custom_css_on_uninstall" id="delete_custom_css_on_uninstall" value="1" <?php checked( $settings['delete_custom_css_on_uninstall'], true ); ?> />
+                </div>
+        </div>
 </div><!-- /#uninstall -->

--- a/nuclear-engagement/templates/admin/setup/credits.php
+++ b/nuclear-engagement/templates/admin/setup/credits.php
@@ -1,7 +1,7 @@
 <?php
 declare(strict_types=1);
 if ( ! defined( 'ABSPATH' ) ) {
-	exit;
+    exit;
 }
 /**
  * Setup - Credits section (only when fully set up)
@@ -14,33 +14,33 @@ if ( ! defined( 'ABSPATH' ) ) {
  */
 ?>
 <?php if ( $fully_setup ) : ?>
-	<h2 style="margin-top:30px;"><?php esc_html_e( 'Your Credits', 'nuclear-engagement' ); ?></h2>
-	<p id="nuclen-setup-credits-msg"><?php esc_html_e( 'Loading credits…', 'nuclear-engagement' ); ?></p>
-	<script>
-	document.addEventListener('DOMContentLoaded', async () => {
-		const msgEl = document.getElementById('nuclen-setup-credits-msg');
-		if (!msgEl) return;
+    <h2 style="margin-top:30px;"><?php esc_html_e( 'Your Credits', 'nuclear-engagement' ); ?></h2>
+    <p id="nuclen-setup-credits-msg"><?php esc_html_e( 'Loading credits…', 'nuclear-engagement' ); ?></p>
+    <script>
+    document.addEventListener('DOMContentLoaded', async () => {
+        const msgEl = document.getElementById('nuclen-setup-credits-msg');
+        if (!msgEl) return;
 
-		try {
-			const formData = new FormData();
-			formData.append('action', 'nuclen_fetch_app_updates');
-			formData.append('security', '<?php echo esc_js( wp_create_nonce( 'nuclen_admin_ajax_nonce' ) ); ?>');
+        try {
+            const formData = new FormData();
+            formData.append('action', 'nuclen_fetch_app_updates');
+            formData.append('security', '<?php echo esc_js( wp_create_nonce( 'nuclen_admin_ajax_nonce' ) ); ?>');
 
-			const resp = await fetch("<?php echo esc_url( admin_url( 'admin-ajax.php' ) ); ?>", { method:'POST', body:formData });
-			const data = await resp.json();
-			if (!data.success) throw new Error(data.data?.message || 'Failed');
+            const resp = await fetch("<?php echo esc_url( admin_url( 'admin-ajax.php' ) ); ?>", { method:'POST', body:formData });
+            const data = await resp.json();
+            if (!data.success) throw new Error(data.data?.message || 'Failed');
 
-			const remote = data.data;
-			if (typeof remote.remaining_credits !== 'undefined') {
-				msgEl.textContent = '<?php echo esc_js( __( 'You have', 'nuclear-engagement' ) ); ?> '
-					+ remote.remaining_credits
-					+ ' <?php echo esc_js( __( 'credits left.', 'nuclear-engagement' ) ); ?>';
-			} else {
-				msgEl.textContent = '<?php echo esc_js( __( 'No credits info returned.', 'nuclear-engagement' ) ); ?>';
-			}
-		} catch (err) {
-			msgEl.textContent = 'Error: ' + err;
-		}
-	});
-	</script>
+            const remote = data.data;
+            if (typeof remote.remaining_credits !== 'undefined') {
+                msgEl.textContent = '<?php echo esc_js( __( 'You have', 'nuclear-engagement' ) ); ?> '
+                    + remote.remaining_credits
+                    + ' <?php echo esc_js( __( 'credits left.', 'nuclear-engagement' ) ); ?>';
+            } else {
+                msgEl.textContent = '<?php echo esc_js( __( 'No credits info returned.', 'nuclear-engagement' ) ); ?>';
+            }
+        } catch (err) {
+            msgEl.textContent = 'Error: ' + err;
+        }
+    });
+    </script>
 <?php endif; ?>

--- a/nuclear-engagement/templates/admin/setup/header.php
+++ b/nuclear-engagement/templates/admin/setup/header.php
@@ -1,7 +1,7 @@
 <?php
 declare(strict_types=1);
 if ( ! defined( 'ABSPATH' ) ) {
-	exit;
+    exit;
 }
 /**
  * Setup - Main heading & intro paragraph

--- a/nuclear-engagement/templates/admin/setup/step1.php
+++ b/nuclear-engagement/templates/admin/setup/step1.php
@@ -1,7 +1,7 @@
 <?php
 declare(strict_types=1);
 if ( ! defined( 'ABSPATH' ) ) {
-	exit;
+    exit;
 }
 /**
  * Setup - Step 1 (Gold Code) – both states
@@ -14,63 +14,63 @@ if ( ! defined( 'ABSPATH' ) ) {
 ?>
 <!-- ───── STEP 1 – Gold Code ───── -->
 <?php if ( empty( $app_setup['connected'] ) ) : ?>
-	<div id="nuclen-setup-step-1" class="nuclen-section">
-		<span class="dashicons dashicons-admin-plugins"></span>
-		<h2 class="nuclen-subheading"><?php esc_html_e( 'Step 1 – Authorise your site', 'nuclear-engagement' ); ?></h2>
-		<p class="nuclen-paragraph">
-			<?php esc_html_e( 'Enter your Gold Code (API key) to connect this site to Nuclear Engagement.', 'nuclear-engagement' ); ?>
-		</p>
-		<p class="nuclen-paragraph">
-			<?php
-			printf(
-				wp_kses(
-					/* translators: %s: link */
-					__( 'Need a Gold Code? Create a free account %s.', 'nuclear-engagement' ),
-					array(
-						'a' => array(
-							'href'   => array(),
-							'target' => array(),
-						),
-					)
-				),
-				'<a href="https://app.nuclearengagement.com/api-keys" target="_blank"> '
-				. esc_html__( 'here', 'nuclear-engagement' )
-				. '</a>'
-			);
-			?>
-		</p>
+    <div id="nuclen-setup-step-1" class="nuclen-section">
+        <span class="dashicons dashicons-admin-plugins"></span>
+        <h2 class="nuclen-subheading"><?php esc_html_e( 'Step 1 – Authorise your site', 'nuclear-engagement' ); ?></h2>
+        <p class="nuclen-paragraph">
+            <?php esc_html_e( 'Enter your Gold Code (API key) to connect this site to Nuclear Engagement.', 'nuclear-engagement' ); ?>
+        </p>
+        <p class="nuclen-paragraph">
+            <?php
+            printf(
+                wp_kses(
+                    /* translators: %s: link */
+                    __( 'Need a Gold Code? Create a free account %s.', 'nuclear-engagement' ),
+                    array(
+                        'a' => array(
+                            'href'   => array(),
+                            'target' => array(),
+                        ),
+                    )
+                ),
+                '<a href="https://app.nuclearengagement.com/api-keys" target="_blank"> '
+                . esc_html__( 'here', 'nuclear-engagement' )
+                . '</a>'
+            );
+            ?>
+        </p>
 
-		<form method="post" action="<?php echo esc_url( admin_url( 'admin-post.php' ) ); ?>">
-			<?php wp_nonce_field( 'nuclen_connect_app_action', 'nuclen_connect_app_nonce' ); ?>
-			<input type="hidden" name="action" value="nuclen_connect_app">
+        <form method="post" action="<?php echo esc_url( admin_url( 'admin-post.php' ) ); ?>">
+            <?php wp_nonce_field( 'nuclen_connect_app_action', 'nuclen_connect_app_nonce' ); ?>
+            <input type="hidden" name="action" value="nuclen_connect_app">
 
-			<label for="nuclen_api_key" class="nuclen-label"><?php esc_html_e( 'Gold Code', 'nuclear-engagement' ); ?></label><br>
-			<input type="text" id="nuclen_api_key" name="nuclen_api_key" style="width:350px;"><br><br>
+            <label for="nuclen_api_key" class="nuclen-label"><?php esc_html_e( 'Gold Code', 'nuclear-engagement' ); ?></label><br>
+            <input type="text" id="nuclen_api_key" name="nuclen_api_key" style="width:350px;"><br><br>
 
-			<button type="submit" class="button button-primary nuclen-button nuclen-button-primary">
-				<?php esc_html_e( 'Authorise Site', 'nuclear-engagement' ); ?>
-			</button>
-		</form>
-	</div>
+            <button type="submit" class="button button-primary nuclen-button nuclen-button-primary">
+                <?php esc_html_e( 'Authorise Site', 'nuclear-engagement' ); ?>
+            </button>
+        </form>
+    </div>
 <?php else : ?>
-	<div id="nuclen-setup-step-1" class="nuclen-section">
-		<span class="dashicons dashicons-plugins-checked"></span>
-		<h2 class="nuclen-subheading"><?php esc_html_e( 'Step 1 complete – Site authorised', 'nuclear-engagement' ); ?></h2>
-		<p class="nuclen-paragraph" style="color:green;"><?php esc_html_e( 'Your site is connected.', 'nuclear-engagement' ); ?></p>
-				<?php $short_key = isset( $app_setup['api_key'] ) ? substr( $app_setup['api_key'], 0, 6 ) : ''; ?>
-		<p class="nuclen-paragraph">
-			<?php esc_html_e( 'Current Gold Code:', 'nuclear-engagement' ); ?>
-			<input type="text" readonly style="width:80px;color:#888;" value="<?php echo esc_attr( $short_key ); ?>">
-		</p>
-		<?php if ( current_user_can( 'manage_options' ) ) : ?>
-			<form method="post"
-					action="<?php echo esc_url( admin_url( 'admin-post.php' ) ); ?>"
-					onsubmit="return confirm('<?php echo esc_js( __( 'Reset Gold Code?', 'nuclear-engagement' ) ); ?>');"
-					style="margin-top:10px;">
-				<?php wp_nonce_field( 'nuclen_reset_api_key_action', 'nuclen_reset_api_key_nonce' ); ?>
-				<input type="hidden" name="action" value="nuclen_reset_api_key">
-				<button type="submit" class="button button-secondary"><?php esc_html_e( 'Reset Gold Code', 'nuclear-engagement' ); ?></button>
-			</form>
-		<?php endif; ?>
-	</div>
+    <div id="nuclen-setup-step-1" class="nuclen-section">
+        <span class="dashicons dashicons-plugins-checked"></span>
+        <h2 class="nuclen-subheading"><?php esc_html_e( 'Step 1 complete – Site authorised', 'nuclear-engagement' ); ?></h2>
+        <p class="nuclen-paragraph" style="color:green;"><?php esc_html_e( 'Your site is connected.', 'nuclear-engagement' ); ?></p>
+                <?php $short_key = isset( $app_setup['api_key'] ) ? substr( $app_setup['api_key'], 0, 6 ) : ''; ?>
+        <p class="nuclen-paragraph">
+            <?php esc_html_e( 'Current Gold Code:', 'nuclear-engagement' ); ?>
+            <input type="text" readonly style="width:80px;color:#888;" value="<?php echo esc_attr( $short_key ); ?>">
+        </p>
+        <?php if ( current_user_can( 'manage_options' ) ) : ?>
+            <form method="post"
+                    action="<?php echo esc_url( admin_url( 'admin-post.php' ) ); ?>"
+                    onsubmit="return confirm('<?php echo esc_js( __( 'Reset Gold Code?', 'nuclear-engagement' ) ); ?>');"
+                    style="margin-top:10px;">
+                <?php wp_nonce_field( 'nuclen_reset_api_key_action', 'nuclen_reset_api_key_nonce' ); ?>
+                <input type="hidden" name="action" value="nuclen_reset_api_key">
+                <button type="submit" class="button button-secondary"><?php esc_html_e( 'Reset Gold Code', 'nuclear-engagement' ); ?></button>
+            </form>
+        <?php endif; ?>
+    </div>
 <?php endif; ?>

--- a/nuclear-engagement/templates/admin/setup/step2.php
+++ b/nuclear-engagement/templates/admin/setup/step2.php
@@ -1,7 +1,7 @@
 <?php
 declare(strict_types=1);
 if ( ! defined( 'ABSPATH' ) ) {
-	exit;
+    exit;
 }
 /**
  * Setup - Step 2 (App Password) – both states
@@ -14,40 +14,40 @@ if ( ! defined( 'ABSPATH' ) ) {
 ?>
 <!-- ───── STEP 2 – Plugin App Password ───── -->
 <?php if ( ! empty( $app_setup['connected'] ) ) : ?>
-	<div id="nuclen-setup-step-2" class="nuclen-section" style="margin-top:30px;">
-		<?php if ( empty( $app_setup['wp_app_pass_created'] ) ) : ?>
-			<span class="dashicons dashicons-admin-plugins"></span>
-			<h2 class="nuclen-subheading"><?php esc_html_e( 'Step 2 – Allow data-push', 'nuclear-engagement' ); ?></h2>
-			<p class="nuclen-paragraph">
-				<?php esc_html_e( 'Click the button below to let Nuclear Engagement push generated content into WordPress. A secure password will be created automatically – you don’t have to copy or store it anywhere.', 'nuclear-engagement' ); ?>
-			</p>
+    <div id="nuclen-setup-step-2" class="nuclen-section" style="margin-top:30px;">
+        <?php if ( empty( $app_setup['wp_app_pass_created'] ) ) : ?>
+            <span class="dashicons dashicons-admin-plugins"></span>
+            <h2 class="nuclen-subheading"><?php esc_html_e( 'Step 2 – Allow data-push', 'nuclear-engagement' ); ?></h2>
+            <p class="nuclen-paragraph">
+                <?php esc_html_e( 'Click the button below to let Nuclear Engagement push generated content into WordPress. A secure password will be created automatically – you don’t have to copy or store it anywhere.', 'nuclear-engagement' ); ?>
+            </p>
 
-			<form method="post"
-					action="<?php echo esc_url( admin_url( 'admin-post.php' ) ); ?>"
-					onsubmit="this.querySelector('button').disabled = true;">
-				<?php wp_nonce_field( 'nuclen_generate_app_password_action', 'nuclen_generate_app_password_nonce' ); ?>
-				<input type="hidden" name="action" value="nuclen_generate_app_password">
-				<button type="submit" class="button button-primary nuclen-button nuclen-button-primary">
-					<?php esc_html_e( 'Allow', 'nuclear-engagement' ); ?>
-				</button>
-			</form>
-		<?php else : ?>
-			<span class="dashicons dashicons-plugins-checked"></span>
-			<h2 class="nuclen-subheading"><?php esc_html_e( 'Step 2 complete – Access granted', 'nuclear-engagement' ); ?></h2>
-			<p class="nuclen-paragraph" style="color:green;">
-				<?php esc_html_e( 'Nuclear Engagement can now push content into this site.', 'nuclear-engagement' ); ?>
-			</p>
+            <form method="post"
+                    action="<?php echo esc_url( admin_url( 'admin-post.php' ) ); ?>"
+                    onsubmit="this.querySelector('button').disabled = true;">
+                <?php wp_nonce_field( 'nuclen_generate_app_password_action', 'nuclen_generate_app_password_nonce' ); ?>
+                <input type="hidden" name="action" value="nuclen_generate_app_password">
+                <button type="submit" class="button button-primary nuclen-button nuclen-button-primary">
+                    <?php esc_html_e( 'Allow', 'nuclear-engagement' ); ?>
+                </button>
+            </form>
+        <?php else : ?>
+            <span class="dashicons dashicons-plugins-checked"></span>
+            <h2 class="nuclen-subheading"><?php esc_html_e( 'Step 2 complete – Access granted', 'nuclear-engagement' ); ?></h2>
+            <p class="nuclen-paragraph" style="color:green;">
+                <?php esc_html_e( 'Nuclear Engagement can now push content into this site.', 'nuclear-engagement' ); ?>
+            </p>
 
-			<?php if ( current_user_can( 'manage_options' ) ) : ?>
-				<form method="post"
-						action="<?php echo esc_url( admin_url( 'admin-post.php' ) ); ?>"
-						onsubmit="return confirm('<?php echo esc_js( __( 'Revoke access?', 'nuclear-engagement' ) ); ?>');"
-						style="margin-top:10px;">
-					<?php wp_nonce_field( 'nuclen_reset_wp_app_action', 'nuclen_reset_wp_app_nonce' ); ?>
-					<input type="hidden" name="action" value="nuclen_reset_wp_app_connection">
-					<button type="submit" class="button button-secondary"><?php esc_html_e( 'Revoke Access', 'nuclear-engagement' ); ?></button>
-				</form>
-			<?php endif; ?>
-		<?php endif; ?>
-	</div>
+            <?php if ( current_user_can( 'manage_options' ) ) : ?>
+                <form method="post"
+                        action="<?php echo esc_url( admin_url( 'admin-post.php' ) ); ?>"
+                        onsubmit="return confirm('<?php echo esc_js( __( 'Revoke access?', 'nuclear-engagement' ) ); ?>');"
+                        style="margin-top:10px;">
+                    <?php wp_nonce_field( 'nuclen_reset_wp_app_action', 'nuclen_reset_wp_app_nonce' ); ?>
+                    <input type="hidden" name="action" value="nuclen_reset_wp_app_connection">
+                    <button type="submit" class="button button-secondary"><?php esc_html_e( 'Revoke Access', 'nuclear-engagement' ); ?></button>
+                </form>
+            <?php endif; ?>
+        <?php endif; ?>
+    </div>
 <?php endif; ?>

--- a/nuclear-engagement/templates/admin/setup/support.php
+++ b/nuclear-engagement/templates/admin/setup/support.php
@@ -1,7 +1,7 @@
 <?php
 declare(strict_types=1);
 if ( ! defined( 'ABSPATH' ) ) {
-	exit;
+    exit;
 }
 /**
  * Setup - Support & review links
@@ -12,88 +12,88 @@ if ( ! defined( 'ABSPATH' ) ) {
 <!-- ───── Support ───── -->
 <h2><?php esc_html_e( 'Support', 'nuclear-engagement' ); ?></h2>
 <p>
-	<?php esc_html_e( 'This is an early version. Some details might have been overlooked, functionalities might be missing or broken, or there might be plugin conflicts on some websites.', 'nuclear-engagement' ); ?>
+    <?php esc_html_e( 'This is an early version. Some details might have been overlooked, functionalities might be missing or broken, or there might be plugin conflicts on some websites.', 'nuclear-engagement' ); ?>
 </p>
 <p>
-	<?php
-	printf(
-		wp_kses(
-			/* translators: 1: link to contact form, 2: mailto link */
-			__(
-				'To report bugs, suggest features, or just any question or comment, please %1$s or drop Stefano an email at %2$s. I\'m constantly developing this service and will respond within 24 hours.',
-				'nuclear-engagement'
-			),
-			array(
-				'a' => array(
-					'href'   => array(),
-					'target' => array(),
-					'rel'    => array(),
-				),
-			)
-		),
-		'<a href="https://www.nuclearengagement.com/contact" target="_blank" rel="noopener noreferrer">'
-			. esc_html__( 'submit the contact form', 'nuclear-engagement' )
-			. '</a>',
-		'<a href="mailto:stefano@nuclearengagement.com">stefano@nuclearengagement.com</a>'
-	);
-	?>
+    <?php
+    printf(
+        wp_kses(
+            /* translators: 1: link to contact form, 2: mailto link */
+            __(
+                'To report bugs, suggest features, or just any question or comment, please %1$s or drop Stefano an email at %2$s. I\'m constantly developing this service and will respond within 24 hours.',
+                'nuclear-engagement'
+            ),
+            array(
+                'a' => array(
+                    'href'   => array(),
+                    'target' => array(),
+                    'rel'    => array(),
+                ),
+            )
+        ),
+        '<a href="https://www.nuclearengagement.com/contact" target="_blank" rel="noopener noreferrer">'
+            . esc_html__( 'submit the contact form', 'nuclear-engagement' )
+            . '</a>',
+        '<a href="mailto:stefano@nuclearengagement.com">stefano@nuclearengagement.com</a>'
+    );
+    ?>
 </p>
 
 <?php
-		$info = \NuclearEngagement\Services\LoggingService::get_log_file_info();
-	$log_file = $info['path'];
-	$log_url  = $info['url'];
+        $info = \NuclearEngagement\Services\LoggingService::get_log_file_info();
+    $log_file = $info['path'];
+    $log_url  = $info['url'];
 
 if ( file_exists( $log_file ) ) :
-	?>
+    ?>
 <p style="margin-top: 20px;">
-	<?php
-	printf(
-		esc_html__( 'For faster results, attach this %1$slog file%2$s to your support request.', 'nuclear-engagement' ),
-		'<a href="' . esc_url( $log_url ) . '" target="_blank" rel="noopener noreferrer">',
-		'</a>'
-	);
-	?>
+    <?php
+    printf(
+        esc_html__( 'For faster results, attach this %1$slog file%2$s to your support request.', 'nuclear-engagement' ),
+        '<a href="' . esc_url( $log_url ) . '" target="_blank" rel="noopener noreferrer">',
+        '</a>'
+    );
+    ?>
 </p>
 <?php endif; ?>
 
 <p>
 <?php
 printf(
-	wp_kses(
-		/* translators: review links */
-		__(
-			'If you like what I\'m doing, please leave me a review on %1$s, %2$s, %3$s, %4$s, or %5$s. It takes 1 minute to drop a 1-line review and it helps me immensely.',
-			'nuclear-engagement'
-		),
-		array(
-			'a' => array(
-				'href'   => array(),
-				'target' => array(),
-				'rel'    => array(),
-			),
-		)
-	),
-	// Google
-	'<a href="https://www.google.com/search?q=Nuclear+Engagement" target="_blank" rel="noopener noreferrer">'
-		. esc_html__( 'Google', 'nuclear-engagement' )
-		. '</a>',
-	// TrustPilot
-	'<a href="https://www.trustpilot.com/evaluate/nuclearengagement.com?stars=5" target="_blank" rel="noopener noreferrer">'
-		. esc_html__( 'TrustPilot', 'nuclear-engagement' )
-		. '</a>',
-	// Facebook
-	'<a href="https://www.facebook.com/nuclearengagement/reviews" target="_blank" rel="noopener noreferrer">'
-		. esc_html__( 'Facebook', 'nuclear-engagement' )
-		. '</a>',
-	// TrustIndex
-	'<a href="https://public.trustindex.io/review/write/slug/www.nuclearengagement.com" target="_blank" rel="noopener noreferrer">'
-		. esc_html__( 'TrustIndex', 'nuclear-engagement' )
-		. '</a>',
-	// WordPress.org
-	'<a href="https://wordpress.org/support/plugin/nuclear-engagement/reviews/#new-post" target="_blank" rel="noopener noreferrer">'
-		. esc_html__( 'WordPress.org', 'nuclear-engagement' )
-		. '</a>'
+    wp_kses(
+        /* translators: review links */
+        __(
+            'If you like what I\'m doing, please leave me a review on %1$s, %2$s, %3$s, %4$s, or %5$s. It takes 1 minute to drop a 1-line review and it helps me immensely.',
+            'nuclear-engagement'
+        ),
+        array(
+            'a' => array(
+                'href'   => array(),
+                'target' => array(),
+                'rel'    => array(),
+            ),
+        )
+    ),
+    // Google
+    '<a href="https://www.google.com/search?q=Nuclear+Engagement" target="_blank" rel="noopener noreferrer">'
+        . esc_html__( 'Google', 'nuclear-engagement' )
+        . '</a>',
+    // TrustPilot
+    '<a href="https://www.trustpilot.com/evaluate/nuclearengagement.com?stars=5" target="_blank" rel="noopener noreferrer">'
+        . esc_html__( 'TrustPilot', 'nuclear-engagement' )
+        . '</a>',
+    // Facebook
+    '<a href="https://www.facebook.com/nuclearengagement/reviews" target="_blank" rel="noopener noreferrer">'
+        . esc_html__( 'Facebook', 'nuclear-engagement' )
+        . '</a>',
+    // TrustIndex
+    '<a href="https://public.trustindex.io/review/write/slug/www.nuclearengagement.com" target="_blank" rel="noopener noreferrer">'
+        . esc_html__( 'TrustIndex', 'nuclear-engagement' )
+        . '</a>',
+    // WordPress.org
+    '<a href="https://wordpress.org/support/plugin/nuclear-engagement/reviews/#new-post" target="_blank" rel="noopener noreferrer">'
+        . esc_html__( 'WordPress.org', 'nuclear-engagement' )
+        . '</a>'
 );
 ?>
 </p>

--- a/nuclear-engagement/templates/front/nuclear-engagement-public-display.php
+++ b/nuclear-engagement/templates/front/nuclear-engagement-public-display.php
@@ -1,7 +1,7 @@
 <?php
 declare(strict_types=1);
 if ( ! defined( 'ABSPATH' ) ) {
-	exit;
+    exit;
 }
 
 /**
@@ -33,11 +33,11 @@ $border_width = $settings->get_int( 'border_width', 1 );
 
 // For backward compatibility, create an options array
 $options = array(
-	'theme'        => $theme,
-	'font_size'    => $font_size,
-	'font_color'   => $font_color,
-	'bg_color'     => $bg_color,
-	'border_color' => $border_color,
-	'border_style' => $border_style,
-	'border_width' => $border_width,
+    'theme'        => $theme,
+    'font_size'    => $font_size,
+    'font_color'   => $font_color,
+    'bg_color'     => $bg_color,
+    'border_color' => $border_color,
+    'border_style' => $border_style,
+    'border_width' => $border_width,
 );

--- a/nuclear-engagement/uninstall.php
+++ b/nuclear-engagement/uninstall.php
@@ -27,7 +27,7 @@
 declare(strict_types=1);
 
 if ( ! defined( 'ABSPATH' ) ) {
-		exit;
+        exit;
 }
 
 // If uninstall not called from WordPress, then exit.
@@ -64,30 +64,30 @@ $delete_css       = ! empty( $settings['delete_custom_css_on_uninstall'] );
 
 // Delete generated content from post meta if requested.
 if ( $delete_generated ) {
-				$meta_keys = array(
-					'nuclen-quiz-data',
-					'nuclen-summary-data',
-					'nuclen_quiz_protected',
-					'nuclen_summary_protected',
-				);
-				foreach ( $meta_keys as $mk ) {
-						delete_post_meta_by_key( $mk );
-				}
+                $meta_keys = array(
+                    'nuclen-quiz-data',
+                    'nuclen-summary-data',
+                    'nuclen_quiz_protected',
+                    'nuclen_summary_protected',
+                );
+                foreach ( $meta_keys as $mk ) {
+                        delete_post_meta_by_key( $mk );
+                }
 }
 
 // Delete plugin settings if requested.
 if ( $delete_settings ) {
-		delete_option( 'nuclear_engagement_settings' );
-		delete_option( 'nuclear_engagement_setup' );
-		delete_option( 'nuclen_custom_css_version' );
+        delete_option( 'nuclear_engagement_settings' );
+        delete_option( 'nuclear_engagement_setup' );
+        delete_option( 'nuclen_custom_css_version' );
 }
 
 // Remove log file if requested.
 if ( $delete_log ) {
-		$info = \NuclearEngagement\Services\LoggingService::get_log_file_info();
-	if ( file_exists( $info['path'] ) ) {
-			wp_delete_file( $info['path'] );
-	}
+        $info = \NuclearEngagement\Services\LoggingService::get_log_file_info();
+    if ( file_exists( $info['path'] ) ) {
+            wp_delete_file( $info['path'] );
+    }
 }
 
 // Remove custom theme file if requested.
@@ -102,8 +102,8 @@ if ( $delete_css ) {
 // Drop opt-in table only when the user opts to delete settings or generated
 // content. This avoids data loss unless a full cleanup was requested.
 if ( $delete_settings || $delete_generated ) {
-		global $wpdb;
-				$table = $wpdb->prefix . 'nuclen_optins';
-				// Remove stored email opt-in submissions on uninstall.
-				$wpdb->query( 'DROP TABLE IF EXISTS ' . esc_sql( $table ) );
+        global $wpdb;
+                $table = $wpdb->prefix . 'nuclen_optins';
+                // Remove stored email opt-in submissions on uninstall.
+                $wpdb->query( 'DROP TABLE IF EXISTS ' . esc_sql( $table ) );
 }


### PR DESCRIPTION
## Summary
- use four spaces for indentation throughout `nuclear-engagement` PHP files

## Testing
- `composer lint` *(fails: command not found)*
- `composer test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685c17ee7d388327a2c73c9b0e00caa3

<!-- Korbit AI PR Description Start -->
## Description by Korbit AI

### What change is being made?

Replace all occurrences of tabs with spaces in plugin PHP files to ensure consistent code formatting.

### Why are these changes being made?

This change enhances code readability and maintainability by adhering to a common whitespace standard across the codebase. Tabs and spaces can render differently depending on editor settings, so using spaces ensures uniform appearance for all collaborators and contributors.

> Is this description stale? Ask me to generate a new description by commenting `/korbit-generate-pr-description`
<!-- Korbit AI PR Description End -->