### PR TITLE
Add lint step to CI and document dev checks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,6 +39,9 @@ jobs:
       - name: Install Node dependencies
         run: npm ci
 
+      - name: Run Node lint
+        run: npm run lint
+
       - name: Build assets
         run: npm run build
 

--- a/docs/DEV_WORKFLOW.md
+++ b/docs/DEV_WORKFLOW.md
@@ -17,6 +17,13 @@ This guide shows how to run and debug the plugin locally using `wp-env` and Dock
    composer dump-autoload --working-dir=nuclear-engagement
    ```
 
+   Run quality checks before committing:
+   ```bash
+   composer lint --working-dir=nuclear-engagement
+   composer test --working-dir=nuclear-engagement
+   npm run lint
+   ```
+
 2. Start WordPress with the plugin:
    ```bash
    npx wp-env start --xdebug
@@ -57,6 +64,7 @@ After starting the environment, run PHPUnit and PHPStan from the repository root
 ```bash
 composer test --working-dir=nuclear-engagement
 composer phpstan --working-dir=nuclear-engagement
+npm run lint
 ```
 
 ## Typical workflow


### PR DESCRIPTION
## Summary
- install node deps and run `npm run lint` in CI
- document running composer/Node quality checks in DEV_WORKFLOW

## Testing
- `composer lint --working-dir=nuclear-engagement` *(fails: command not found)*
- `composer test --working-dir=nuclear-engagement` *(fails: command not found)*
- `npm run lint` *(fails: missing @typescript-eslint/eslint-plugin)*

------
https://chatgpt.com/codex/tasks/task_e_685c17f8bf908327992955ae92359e9b