### PR TITLE
Log exceptions in TOC cache clearing

### DIFF
--- a/nuclear-engagement/inc/Modules/TOC/includes/class-nuclen-toc-utils.php
+++ b/nuclear-engagement/inc/Modules/TOC/includes/class-nuclen-toc-utils.php
@@ -210,9 +210,10 @@ final class Nuclen_TOC_Utils {
                        try {
                                $settings = \NuclearEngagement\Container::getInstance()->get( 'settings' );
                                $levels   = $settings->get_array( 'toc_heading_levels', $levels );
-                       } catch ( \Throwable $e ) {
-                               // Use default levels if settings unavailable.
-                       }
+                        } catch ( \Throwable $e ) {
+                                \NuclearEngagement\Services\LoggingService::log_exception( $e );
+                                // Use default levels if settings unavailable.
+                        }
                }
 
                $levels = array_unique( array_map( 'intval', $levels ) );


### PR DESCRIPTION
## Summary
- log thrown errors when clearing the TOC cache so that issues aren't silent

## Testing
- `composer lint` *(fails: command not found)*
- `composer test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685c2ed451e08327808d1c0b21172b7f