### PR TITLE
Log and notify admin on custom CSS dir failure

### DIFF
--- a/nuclear-engagement/inc/Utils/Utils.php
+++ b/nuclear-engagement/inc/Utils/Utils.php
@@ -58,6 +58,7 @@ class Utils {
         if ( ! file_exists( $custom_dir ) ) {
             if ( ! wp_mkdir_p( $custom_dir ) ) {
                 \NuclearEngagement\Services\LoggingService::log( 'Failed creating custom CSS directory: ' . $custom_dir );
+                \NuclearEngagement\Services\LoggingService::notify_admin( 'Failed creating custom CSS directory.' );
                 return array();
             }
         }


### PR DESCRIPTION
## Summary
- notify admin when the plugin fails to create the custom CSS directory

## Testing
- `composer lint` *(fails: command not found)*
- `composer test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685c2ed131808327b332e30fc7b2105e