### PR TITLE
Optimize active generations update

### DIFF
--- a/nuclear-engagement/inc/Services/AutoGenerationQueue.php
+++ b/nuclear-engagement/inc/Services/AutoGenerationQueue.php
@@ -135,7 +135,6 @@ class AutoGenerationQueue {
                     'workflow_type' => $workflow_type,
                 );
 
-                update_option( 'nuclen_active_generations', $generations, 'no' );
                 $scheduled = wp_schedule_single_event( $next_poll, 'nuclen_poll_generation', array( $generation_id, $workflow_type, $batch, 1 ) );
                 if ( false === $scheduled ) {
                     \NuclearEngagement\Services\LoggingService::log( 'Failed to schedule event nuclen_poll_generation for generation ' . $generation_id );
@@ -144,9 +143,10 @@ class AutoGenerationQueue {
                     );
                 }
             }
-
             $queue[ $workflow_type ] = $ids;
         }
+
+        update_option( 'nuclen_active_generations', $generations, 'no' );
 
         foreach ( $queue as $type => $ids ) {
             if ( empty( $ids ) ) {

--- a/tests/AutoGenerationQueueTest.php
+++ b/tests/AutoGenerationQueueTest.php
@@ -47,4 +47,22 @@ class AutoGenerationQueueTest extends TestCase {
         $q->process_queue();
         $this->assertNotEmpty($wp_events);
     }
+
+    public function test_process_queue_updates_option_once(): void {
+        global $wp_posts, $update_option_calls;
+
+        for ($i = 1; $i <= 6; $i++) {
+            $wp_posts[$i] = (object) [ 'ID' => $i, 'post_title' => 'T' . $i, 'post_content' => 'C' . $i ];
+        }
+
+        $q = $this->makeQueue();
+        for ($i = 1; $i <= 6; $i++) {
+            $q->queue_post($i, 'quiz');
+        }
+
+        $update_option_calls = [];
+        $q->process_queue();
+
+        $this->assertSame(1, $update_option_calls['nuclen_active_generations'] ?? 0);
+    }
 }

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -31,12 +31,15 @@ if (!function_exists('register_deactivation_hook')) {
 // Simple in-memory storage for options and related autoload flags
 $GLOBALS['wp_options'] = [];
 $GLOBALS['wp_autoload'] = [];
+$GLOBALS['update_option_calls'] = [];
 $GLOBALS['wp_posts'] = [];
 $GLOBALS['wp_meta'] = [];
 $GLOBALS['wp_events'] = [];
 
 if (!function_exists('update_option')) {
     function update_option($name, $value, $autoload = 'yes') {
+        global $update_option_calls;
+        $update_option_calls[$name] = ($update_option_calls[$name] ?? 0) + 1;
         $GLOBALS['wp_options'][$name] = $value;
         $GLOBALS['wp_autoload'][$name] = $autoload;
         return true;


### PR DESCRIPTION
## Summary
- store queued generations in memory during processing
- write `nuclen_active_generations` option once per run
- track `update_option` calls in tests
- ensure queue only writes active generations once

## Testing
- `composer lint` *(fails: command not found)*
- `composer test` *(fails: command not found)*
- `vendor/bin/phpunit -c ../phpunit.xml` *(fails: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_685c2f28c5d08327a9f452b67a2e7971

<!-- Korbit AI PR Description Start -->
## Description by Korbit AI

### What change is being made?
Update the location of the `update_option` call for `nuclen_active_generations` to occur once after queue processing, and add a test to ensure it's only updated once per queue processing.

### Why are these changes being made?
This change reduces unnecessary repeated updates to the `nuclen_active_generations` option, optimizing performance by minimizing database writes. A new test case is added to verify the optimization, thus ensuring that `update_option` is invoked exactly once during the queue processing function, preventing excess database transactions.

> Is this description stale? Ask me to generate a new description by commenting `/korbit-generate-pr-description`
<!-- Korbit AI PR Description End -->