### PR TITLE
Add admin notices for setup errors

### DIFF
--- a/nuclear-engagement/inc/Services/SetupService.php
+++ b/nuclear-engagement/inc/Services/SetupService.php
@@ -92,11 +92,21 @@ class SetupService {
 
         if ( is_wp_error( $response ) ) {
             LoggingService::log( 'API-key validation error: ' . $response->get_error_message() );
+            LoggingService::notify_admin( 'Failed to validate API key.' );
             return false;
         }
 
-        LoggingService::debug( 'API key validation response: ' . wp_remote_retrieve_body( $response ) );
-        return 200 === wp_remote_retrieve_response_code( $response );
+        $code = wp_remote_retrieve_response_code( $response );
+        $body = wp_remote_retrieve_body( $response );
+        LoggingService::debug( 'API key validation response: ' . $body );
+
+        if ( 200 !== $code ) {
+            LoggingService::log( 'Unexpected API-key validation response code: ' . $code . ', body: ' . $body );
+            LoggingService::notify_admin( 'Failed to validate API key.' );
+            return false;
+        }
+
+        return true;
     }
 
     /**
@@ -126,6 +136,7 @@ class SetupService {
 
                 if ( is_wp_error( $response ) ) {
                         \NuclearEngagement\Services\LoggingService::log( 'Error sending creds: ' . $response->get_error_message() );
+                        \NuclearEngagement\Services\LoggingService::notify_admin( 'Failed to send WordPress credentials.' );
                         return false;
                 }
 
@@ -135,6 +146,7 @@ class SetupService {
 
                 if ( 200 !== $code ) {
                         \NuclearEngagement\Services\LoggingService::log( 'Unexpected creds response code: ' . $code . ', body: ' . $body );
+                        \NuclearEngagement\Services\LoggingService::notify_admin( 'Failed to send WordPress credentials.' );
                         return false;
                 }
 

--- a/tests/SetupServiceTest.php
+++ b/tests/SetupServiceTest.php
@@ -6,7 +6,9 @@ use NuclearEngagement\Services\LoggingService;
 namespace NuclearEngagement\Services {
     class LoggingService {
         public static array $logs = [];
+        public static array $notices = [];
         public static function log(string $msg): void { self::$logs[] = $msg; }
+        public static function notify_admin(string $msg): void { self::$notices[] = $msg; }
     }
     function wp_json_encode($data) { return json_encode($data); }
 }
@@ -22,6 +24,7 @@ namespace {
         protected function setUp(): void {
             $GLOBALS['test_http_response'] = null;
             LoggingService::$logs = [];
+            LoggingService::$notices = [];
         }
 
         public function test_validate_api_key_success(): void {
@@ -29,6 +32,7 @@ namespace {
             $svc = new SetupService();
             $this->assertTrue($svc->validate_api_key('key'));
             $this->assertEmpty(LoggingService::$logs);
+            $this->assertEmpty(LoggingService::$notices);
         }
 
         public function test_validate_api_key_failure_logs_error(): void {
@@ -36,6 +40,7 @@ namespace {
             $svc = new SetupService();
             $this->assertFalse($svc->validate_api_key('key'));
             $this->assertSame(['API-key validation error: error'], LoggingService::$logs);
+            $this->assertSame(['Failed to validate API key.'], LoggingService::$notices);
         }
 
         public function test_send_app_password_success(): void {
@@ -44,6 +49,7 @@ namespace {
             $data = ['appApiKey' => 'key', 'user' => 'u'];
             $this->assertTrue($svc->send_app_password($data));
             $this->assertEmpty(LoggingService::$logs);
+            $this->assertEmpty(LoggingService::$notices);
         }
 
         public function test_send_app_password_failure_logs_error(): void {
@@ -52,6 +58,7 @@ namespace {
             $data = ['appApiKey' => 'key', 'user' => 'u'];
             $this->assertFalse($svc->send_app_password($data));
             $this->assertSame(['Error sending creds: error'], LoggingService::$logs);
+            $this->assertSame(['Failed to send WordPress credentials.'], LoggingService::$notices);
         }
 
         public function test_send_app_password_http_error_logs_error(): void {
@@ -62,6 +69,7 @@ namespace {
             $this->assertSame([
                 'Unexpected creds response code: 400, body: bad'
             ], LoggingService::$logs);
+            $this->assertSame(['Failed to send WordPress credentials.'], LoggingService::$notices);
         }
     }
 }


### PR DESCRIPTION
## Summary
- notify admin when API validation or credential submission fails
- update SetupService tests for notifications

## Testing
- `composer lint` *(fails: command not found)*
- `composer test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685c2ecfc9d88327820fed14df82841a

<!-- Korbit AI PR Description Start -->
## Description by Korbit AI

### What change is being made?
Add admin notifications for failed API key and WordPress credentials setup attempts in the `SetupService` class and update tests to include assertions for these admin notices.

### Why are these changes being made?
The change ensures administrators are promptly informed of any setup errors, which helps quickly identify and resolve configuration issues, thus improving the usability and reliability of the system. This approach is optimal as it enhances error visibility without altering the core logic of error handling.

> Is this description stale? Ask me to generate a new description by commenting `/korbit-generate-pr-description`
<!-- Korbit AI PR Description End -->