### PR TITLE
Introduce PostDataFetcher helper

### DIFF
--- a/nuclear-engagement/inc/Services/PostDataFetcher.php
+++ b/nuclear-engagement/inc/Services/PostDataFetcher.php
@@ -1,0 +1,55 @@
+<?php
+declare(strict_types=1);
+/**
+ * Helper for fetching post data via $wpdb
+ */
+namespace NuclearEngagement\Services;
+
+if ( ! defined( 'ABSPATH' ) ) {
+    exit;
+}
+
+class PostDataFetcher {
+    /**
+     * Fetch posts excluding protected ones.
+     *
+     * @param array $postIds
+     * @return array
+     */
+    public function fetch_without_protection( array $postIds ): array {
+        global $wpdb;
+
+        if ( empty( $postIds ) ) {
+            return array();
+        }
+
+        $placeholders = implode( ',', array_fill( 0, count( $postIds ), '%d' ) );
+
+        $sql = "SELECT p.ID, p.post_title, p.post_content
+                FROM {$wpdb->posts} p
+                LEFT JOIN {$wpdb->postmeta} pm_q
+                    ON pm_q.post_id = p.ID AND pm_q.meta_key = %s
+                LEFT JOIN {$wpdb->postmeta} pm_s
+                    ON pm_s.post_id = p.ID AND pm_s.meta_key = %s
+                WHERE p.ID IN ($placeholders)
+                  AND pm_q.meta_id IS NULL
+                  AND pm_s.meta_id IS NULL";
+
+        $query = $wpdb->prepare( $sql, array_merge( array( 'nuclen_quiz_protected', 'nuclen_summary_protected' ), $postIds ) );
+        $rows  = $wpdb->get_results( $query );
+
+        $byId = array();
+        foreach ( $rows as $row ) {
+            $byId[ (int) $row->ID ] = $row;
+        }
+
+        $ordered = array();
+        foreach ( $postIds as $id ) {
+            if ( isset( $byId[ $id ] ) ) {
+                $ordered[] = $byId[ $id ];
+            }
+        }
+
+        return $ordered;
+    }
+}

--- a/tests/AutoGenerationQueueTest.php
+++ b/tests/AutoGenerationQueueTest.php
@@ -20,10 +20,36 @@ class DummyContentStorageService {
     }
 }
 
+class Q_WPDB {
+    public $posts = 'wp_posts';
+    public $postmeta = 'wp_postmeta';
+    public array $args = [];
+    public function prepare($sql, ...$args) { $this->args = $args; return $sql; }
+    public function get_results($sql) {
+        $ids = array_slice($this->args, 2);
+        $rows = [];
+        foreach ($ids as $id) {
+            if (!isset($GLOBALS['wp_posts'][$id])) { continue; }
+            $meta = $GLOBALS['wp_meta'][$id] ?? [];
+            if (!empty($meta['nuclen_quiz_protected']) || !empty($meta['nuclen_summary_protected'])) {
+                continue;
+            }
+            $p = $GLOBALS['wp_posts'][$id];
+            $rows[] = (object)[
+                'ID' => $p->ID,
+                'post_title' => $p->post_title,
+                'post_content' => $p->post_content,
+            ];
+        }
+        return $rows;
+    }
+}
+
 class AutoGenerationQueueTest extends TestCase {
     protected function setUp(): void {
-        global $wp_options, $wp_autoload, $wp_posts, $wp_meta, $wp_events;
+        global $wp_options, $wp_autoload, $wp_posts, $wp_meta, $wp_events, $wpdb;
         $wp_options = $wp_autoload = $wp_posts = $wp_meta = $wp_events = [];
+        $wpdb = new Q_WPDB();
         SettingsRepository::reset_for_tests();
     }
 
@@ -46,5 +72,25 @@ class AutoGenerationQueueTest extends TestCase {
         $q->queue_post(1, 'quiz');
         $q->process_queue();
         $this->assertNotEmpty($wp_events);
+    }
+
+    public function test_process_queue_sends_unprotected_posts(): void {
+        global $wp_posts, $wp_meta;
+
+        $wp_posts[1] = (object) [ 'ID' => 1, 'post_title' => 'A', 'post_content' => '<b>C1</b>' ];
+        $wp_posts[2] = (object) [ 'ID' => 2, 'post_title' => 'B', 'post_content' => '<i>C2</i>' ];
+        $wp_meta[1]  = [ 'nuclen_quiz_protected' => 1 ];
+
+        $api = new DummyRemoteApiService();
+        $q = new AutoGenerationQueue($api, new DummyContentStorageService());
+        $q->queue_post(1, 'quiz');
+        $q->queue_post(2, 'quiz');
+        $q->process_queue();
+
+        $this->assertCount(1, $api->lastData['posts']);
+        $sent = $api->lastData['posts'][0];
+        $this->assertSame(2, $sent['id']);
+        $this->assertSame('B', $sent['title']);
+        $this->assertSame('C2', $sent['content']);
     }
 }


### PR DESCRIPTION
## Summary
- create `PostDataFetcher` for fetching post data with `$wpdb`
- inject helper into `AutoGenerationQueue`
- use direct post titles when queuing
- test queue behaviour via new helper

## Testing
- `composer lint`
- `composer test`

------
https://chatgpt.com/codex/tasks/task_e_685c2f262aac83279290eddbece6b136

<!-- Korbit AI PR Description Start -->
## Description by Korbit AI

### What change is being made?

Introduce a new helper class, `PostDataFetcher`, to fetch post data, streamlining the process in the `AutoGenerationQueue` and simplifying data fetching by excluding protected posts.

### Why are these changes being made?

The changes improve the modularity and maintainability of the codebase by isolating the post data fetching logic into a dedicated class, `PostDataFetcher`. This reduces duplication, enhances readability, and allows easier testing and future modifications. The approach also optimizes performance by utilizing direct SQL queries instead of multiple WordPress functions.

> Is this description stale? Ask me to generate a new description by commenting `/korbit-generate-pr-description`
<!-- Korbit AI PR Description End -->