### PR TITLE
Add PostDataFetcher helper and update queue

### DIFF
--- a/nuclear-engagement/inc/Core/ContainerRegistrar.php
+++ b/nuclear-engagement/inc/Core/ContainerRegistrar.php
@@ -37,7 +37,8 @@ final class ContainerRegistrar {
                         'auto_generation_queue',
                         static fn( $c ) => new AutoGenerationQueue(
                                 $c->get( 'remote_api' ),
-                                $c->get( 'content_storage' )
+                                $c->get( 'content_storage' ),
+                                new PostDataFetcher()
                         )
                 );
 

--- a/nuclear-engagement/inc/Services/AutoGenerationQueue.php
+++ b/nuclear-engagement/inc/Services/AutoGenerationQueue.php
@@ -22,10 +22,12 @@ class AutoGenerationQueue {
 
     private RemoteApiService $remote_api;
     private ContentStorageService $content_storage;
+    private PostDataFetcher $fetcher;
 
-    public function __construct( RemoteApiService $remote_api, ContentStorageService $content_storage ) {
+    public function __construct( RemoteApiService $remote_api, ContentStorageService $content_storage, ?PostDataFetcher $fetcher = null ) {
         $this->remote_api      = $remote_api;
         $this->content_storage = $content_storage;
+        $this->fetcher         = $fetcher ?: new PostDataFetcher();
     }
 
     /**
@@ -68,33 +70,13 @@ class AutoGenerationQueue {
                 $batch     = array_splice( $ids, 0, self::BATCH_SIZE );
                 $post_data = array();
 
-                $posts = get_posts(
-                    array(
-                        'post__in'               => $batch,
-                        'posts_per_page'         => count( $batch ),
-                        'post_type'              => 'any',
-                        'orderby'                => 'post__in',
-                        'update_post_meta_cache' => false,
-                        'update_post_term_cache' => false,
-                        'meta_query'             => array(
-                            'relation' => 'AND',
-                            array(
-                                'key'     => 'nuclen_quiz_protected',
-                                'compare' => 'NOT EXISTS',
-                            ),
-                            array(
-                                'key'     => 'nuclen_summary_protected',
-                                'compare' => 'NOT EXISTS',
-                            ),
-                        ),
-                    )
-                );
+                $posts = $this->fetcher->fetch( $batch );
 
                 foreach ( $posts as $post ) {
                     $pid        = (int) $post->ID;
                     $post_data[] = array(
                         'id'      => $pid,
-                        'title'   => get_the_title( $pid ),
+                        'title'   => $post->post_title,
                         'content' => wp_strip_all_tags( $post->post_content ),
                     );
                 }

--- a/nuclear-engagement/inc/Services/PostDataFetcher.php
+++ b/nuclear-engagement/inc/Services/PostDataFetcher.php
@@ -1,0 +1,60 @@
+<?php
+declare(strict_types=1);
+/**
+ * File: includes/Services/PostDataFetcher.php
+ *
+ * Helper for retrieving post data via direct SQL.
+ *
+ * @package NuclearEngagement\Services
+ */
+
+namespace NuclearEngagement\Services;
+
+if ( ! defined( 'ABSPATH' ) ) {
+    exit;
+}
+
+/**
+ * Fetches post data for batches using $wpdb.
+ */
+class PostDataFetcher {
+    /**
+     * Retrieve post rows for the given IDs.
+     *
+     * Posts are filtered to published status and exclude those
+     * with quiz or summary protection meta set.
+     *
+     * @param array $ids Post IDs.
+     * @return array Rows from the posts table.
+     */
+    public function fetch( array $ids ): array {
+        global $wpdb;
+
+        if ( empty( $ids ) ) {
+            return array();
+        }
+
+        $ids         = array_map( 'absint', $ids );
+        $placeholders = implode( ',', array_fill( 0, count( $ids ), '%d' ) );
+        $order_ids    = implode( ',', $ids );
+
+        $sql = $wpdb->prepare(
+            "SELECT p.ID, p.post_title, p.post_content
+             FROM {$wpdb->posts} p
+             LEFT JOIN {$wpdb->postmeta} pmq
+               ON pmq.post_id = p.ID
+              AND pmq.meta_key = %s
+             LEFT JOIN {$wpdb->postmeta} pms
+               ON pms.post_id = p.ID
+              AND pms.meta_key = %s
+             WHERE p.ID IN ($placeholders)
+               AND p.post_status = 'publish'
+               AND pmq.meta_id IS NULL
+               AND pms.meta_id IS NULL
+             ORDER BY FIELD(p.ID, $order_ids)",
+            array_merge( array( 'nuclen_quiz_protected', 'nuclen_summary_protected' ), $ids )
+        );
+
+        return $wpdb->get_results( $sql );
+    }
+}

--- a/tests/AutoGenerationServiceTest.php
+++ b/tests/AutoGenerationServiceTest.php
@@ -25,10 +25,32 @@ class DummyContentStorageService {
     }
 }
 
+class AQ_WPDB {
+    public $posts = 'wp_posts';
+    public $postmeta = 'wp_postmeta';
+    public array $args = [];
+    public function prepare($sql, ...$args) { $this->args = $args; return $sql; }
+    public function get_results($sql) {
+        $ids = array_slice($this->args, 2);
+        $rows = [];
+        foreach ($ids as $id) {
+            if (!isset($GLOBALS['wp_posts'][$id])) { continue; }
+            $p = $GLOBALS['wp_posts'][$id];
+            if ($p->post_status !== 'publish') { continue; }
+            if (!empty($GLOBALS['wp_meta'][$id]['nuclen_quiz_protected']) || !empty($GLOBALS['wp_meta'][$id]['nuclen_summary_protected'])) {
+                continue;
+            }
+            $rows[] = (object) [ 'ID' => $p->ID, 'post_title' => $p->post_title, 'post_content' => $p->post_content ];
+        }
+        return $rows;
+    }
+}
+
 class AutoGenerationServiceTest extends TestCase {
     protected function setUp(): void {
-        global $wp_options, $wp_autoload, $wp_posts, $wp_meta, $wp_events;
+        global $wp_options, $wp_autoload, $wp_posts, $wp_meta, $wp_events, $wpdb;
         $wp_options = $wp_autoload = $wp_posts = $wp_meta = $wp_events = [];
+        $wpdb = new AQ_WPDB();
         SettingsRepository::reset_for_tests();
     }
 
@@ -39,7 +61,7 @@ class AutoGenerationServiceTest extends TestCase {
 
         $poller    = new \NuclearEngagement\Services\GenerationPoller($settings, $api, $storage);
         $scheduler = new \NuclearEngagement\Services\AutoGenerationScheduler($poller);
-        $queue     = new \NuclearEngagement\Services\AutoGenerationQueue($api, $storage);
+        $queue     = new \NuclearEngagement\Services\AutoGenerationQueue($api, $storage, new \NuclearEngagement\Services\PostDataFetcher());
         $handler   = new \NuclearEngagement\Services\PublishGenerationHandler($settings);
 
         return new AutoGenerationService($settings, $queue, $scheduler, $handler);


### PR DESCRIPTION
## Summary
- implement `PostDataFetcher` for retrieving post data via `$wpdb`
- update `AutoGenerationQueue` to use the new helper
- wire helper in `ContainerRegistrar`
- extend unit tests for queue and adjust dependent tests

## Testing
- `composer lint` *(fails: command not found)*
- `composer test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685c30cfcf048327acbda755951da0b3

<!-- Korbit AI PR Description Start -->
## Description by Korbit AI

### What change is being made?

Add a `PostDataFetcher` helper to streamline post retrieval logic in the `AutoGenerationQueue` and update the queue handling mechanism accordingly.

### Why are these changes being made?

This change improves maintainability and performance by moving post fetching logic to a dedicated `PostDataFetcher` class, which reduces dependency on global functions and enhances testability. Additionally, this allows for exclusion of posts with specific meta protections during fetching, hence refining the data processing workflow within the queue.

> Is this description stale? Ask me to generate a new description by commenting `/korbit-generate-pr-description`
<!-- Korbit AI PR Description End -->