### PR TITLE
Add TOC module unit tests

### DIFF
--- a/tests/NuclenTOCHeadingsTest.php
+++ b/tests/NuclenTOCHeadingsTest.php
@@ -1,0 +1,77 @@
+<?php
+use PHPUnit\Framework\TestCase;
+use NuclearEngagement\Modules\TOC\Nuclen_TOC_Headings;
+
+// ------------------------------------------------------
+// Constants and WordPress function stubs
+// ------------------------------------------------------
+if (!defined('HOUR_IN_SECONDS')) { define('HOUR_IN_SECONDS', 3600); }
+if (!defined('NUCLEN_TOC_SCROLL_OFFSET_DEFAULT')) { define('NUCLEN_TOC_SCROLL_OFFSET_DEFAULT', 72); }
+if (!defined('NUCLEN_TOC_DIR')) { define('NUCLEN_TOC_DIR', dirname(__DIR__) . '/nuclear-engagement/inc/Modules/TOC/'); }
+if (!defined('NUCLEN_TOC_URL')) { define('NUCLEN_TOC_URL', 'http://example.com/'); }
+
+$GLOBALS['wp_cache'] = $GLOBALS['transients'] = [];
+
+if (!function_exists('wp_cache_get')) {
+    function wp_cache_get($key, $group = '') { return $GLOBALS['wp_cache'][$group][$key] ?? false; }
+}
+if (!function_exists('wp_cache_set')) {
+    function wp_cache_set($key, $value, $group = '', $ttl = 0) { $GLOBALS['wp_cache'][$group][$key] = $value; }
+}
+if (!function_exists('get_transient')) {
+    function get_transient($key) { return $GLOBALS['transients'][$key] ?? false; }
+}
+if (!function_exists('set_transient')) {
+    function set_transient($key, $value, $ttl = 0) { $GLOBALS['transients'][$key] = $value; }
+}
+if (!function_exists('sanitize_title')) {
+    function sanitize_title($text) { $text = strtolower(trim($text)); $text = preg_replace('/[^a-z0-9_-]+/','-',$text); return trim($text,'-'); }
+}
+if (!function_exists('sanitize_html_class')) {
+    function sanitize_html_class($text) { $text = strtolower(trim($text)); $text = preg_replace('/[^a-z0-9_-]+/','-',$text); return trim($text,'-'); }
+}
+if (!function_exists('esc_attr')) { function esc_attr($t){ return htmlspecialchars($t, ENT_QUOTES); } }
+if (!function_exists('__')) { function __($t, $d = null) { return $t; } }
+if (!function_exists('apply_filters')) { function apply_filters($hook, $value) { return $value; } }
+if (!function_exists('wp_strip_all_tags')) { function wp_strip_all_tags($t){ return strip_tags($t); } }
+
+namespace NuclearEngagement\Modules\TOC {
+    if (!function_exists('apply_filters')) {
+        function apply_filters($hook, $value) {
+            if ($hook === 'nuclen_toc_enable_heading_ids' && array_key_exists('toc_enable_heading_ids', $GLOBALS)) {
+                return $GLOBALS['toc_enable_heading_ids'];
+            }
+            return \apply_filters($hook, $value);
+        }
+    }
+}
+
+namespace {
+    require_once NUCLEN_TOC_DIR . 'includes/polyfills.php';
+    require_once NUCLEN_TOC_DIR . 'includes/class-nuclen-toc-utils.php';
+    require_once NUCLEN_TOC_DIR . 'includes/class-nuclen-toc-headings.php';
+
+    class NuclenTOCHeadingsTest extends TestCase {
+        protected function setUp(): void {
+            $GLOBALS['toc_enable_heading_ids'] = true;
+            $GLOBALS['wp_cache'] = [];
+            $GLOBALS['transients'] = [];
+        }
+
+        public function test_injects_unique_ids(): void {
+            $headings = new \NuclearEngagement\Modules\TOC\Nuclen_TOC_Headings();
+            $html = '<h2>Intro</h2><h2>Intro</h2><h2 id="custom">X</h2>';
+            $out = $headings->add_heading_ids($html);
+            $this->assertStringContainsString('<h2 id="intro">Intro</h2>', $out);
+            $this->assertStringContainsString('<h2 id="intro-2">Intro</h2>', $out);
+            $this->assertStringContainsString('<h2 id="custom">X</h2>', $out);
+        }
+
+        public function test_filter_disables_injection(): void {
+            $GLOBALS['toc_enable_heading_ids'] = false;
+            $headings = new \NuclearEngagement\Modules\TOC\Nuclen_TOC_Headings();
+            $html = '<h2>Intro</h2>';
+            $this->assertSame($html, $headings->add_heading_ids($html));
+        }
+    }
+}

--- a/tests/NuclenTOCRenderTest.php
+++ b/tests/NuclenTOCRenderTest.php
@@ -1,0 +1,114 @@
+<?php
+use PHPUnit\Framework\TestCase;
+use NuclearEngagement\Modules\TOC\Nuclen_TOC_Render;
+use NuclearEngagement\SettingsRepository;
+use NuclearEngagement\Container;
+
+// ------------------------------------------------------
+// Constants and WordPress function stubs
+// ------------------------------------------------------
+if (!defined('HOUR_IN_SECONDS')) { define('HOUR_IN_SECONDS', 3600); }
+if (!defined('NUCLEN_TOC_SCROLL_OFFSET_DEFAULT')) { define('NUCLEN_TOC_SCROLL_OFFSET_DEFAULT', 72); }
+if (!defined('NUCLEN_TOC_DIR')) { define('NUCLEN_TOC_DIR', dirname(__DIR__) . '/nuclear-engagement/inc/Modules/TOC/'); }
+if (!defined('NUCLEN_TOC_URL')) { define('NUCLEN_TOC_URL', 'http://example.com/'); }
+
+$GLOBALS['wp_cache'] = $GLOBALS['transients'] = [];
+
+if (!function_exists('wp_cache_get')) {
+    function wp_cache_get($key, $group = '') { return $GLOBALS['wp_cache'][$group][$key] ?? false; }
+}
+if (!function_exists('wp_cache_set')) {
+    function wp_cache_set($key, $value, $group = '', $ttl = 0) { $GLOBALS['wp_cache'][$group][$key] = $value; }
+}
+if (!function_exists('get_transient')) {
+    function get_transient($key) { return $GLOBALS['transients'][$key] ?? false; }
+}
+if (!function_exists('set_transient')) {
+    function set_transient($key, $value, $ttl = 0) { $GLOBALS['transients'][$key] = $value; }
+}
+if (!function_exists('sanitize_title')) { function sanitize_title($t){ $t=strtolower(trim($t)); $t=preg_replace('/[^a-z0-9_-]+/','-',$t); return trim($t,'-'); } }
+if (!function_exists('sanitize_html_class')) { function sanitize_html_class($t){ $t=strtolower(trim($t)); $t=preg_replace('/[^a-z0-9_-]+/','-',$t); return trim($t,'-'); } }
+if (!function_exists('sanitize_text_field')) { function sanitize_text_field($t){ return trim($t); } }
+if (!function_exists('esc_html')) { function esc_html($t){ return htmlspecialchars($t,ENT_QUOTES); } }
+if (!function_exists('esc_attr')) { function esc_attr($t){ return htmlspecialchars($t,ENT_QUOTES); } }
+if (!function_exists('__')) { function __($t,$d=null){ return $t; } }
+if (!function_exists('esc_html__')) { function esc_html__($t,$d=null){ return esc_html($t); } }
+if (!function_exists('esc_attr__')) { function esc_attr__($t,$d=null){ return esc_attr($t); } }
+if (!function_exists('apply_filters')) { function apply_filters($hook,$value){ return $value; } }
+if (!function_exists('add_filter')) { function add_filter(...$a) {} }
+if (!function_exists('add_shortcode')) { function add_shortcode(...$a) {} }
+if (!function_exists('shortcode_atts')) {
+    function shortcode_atts($pairs,$atts,$shortcode='') {
+        $out=$pairs; foreach($pairs as $name=>$default){ if(isset($atts[$name])) $out[$name]=$atts[$name]; }
+        foreach($atts as $name=>$value){ if(!isset($out[$name])) $out[$name]=$value; }
+        return $out;
+    }
+}
+if (!function_exists('wp_unique_id')) { function wp_unique_id($p=''){ static $i=1; return $p.$i++; } }
+if (!function_exists('wp_script_is')) { function wp_script_is($h,$l='enqueued'){ return false; } }
+if (!function_exists('wp_enqueue_script')) { function wp_enqueue_script($h) {} }
+if (!function_exists('wp_enqueue_style')) { function wp_enqueue_style($h) {} }
+if (!function_exists('wp_add_inline_style')) { function wp_add_inline_style($h,$c) {} }
+if (!function_exists('wp_register_style')) { function wp_register_style($h,$s,$d=[],$v='') {} }
+if (!function_exists('wp_register_script')) { function wp_register_script($h,$s,$d=[],$v='',$f=false) {} }
+if (!function_exists('wp_localize_script')) { function wp_localize_script($h,$o,$l) {} }
+if (!function_exists('is_singular')) { function is_singular(){ return true; } }
+if (!function_exists('get_the_ID')) { function get_the_ID(){ return $GLOBALS['current_post_id'] ?? 0; } }
+
+namespace {
+    require_once NUCLEN_TOC_DIR . 'includes/polyfills.php';
+    require_once NUCLEN_TOC_DIR . 'includes/class-nuclen-toc-utils.php';
+    require_once NUCLEN_TOC_DIR . 'includes/class-nuclen-toc-view.php';
+    require_once NUCLEN_TOC_DIR . 'includes/class-nuclen-toc-assets.php';
+    require_once NUCLEN_TOC_DIR . 'includes/class-nuclen-toc-headings.php';
+    require_once NUCLEN_TOC_DIR . 'includes/class-nuclen-toc-render.php';
+    require_once dirname(__DIR__) . '/nuclear-engagement/inc/Core/SettingsCache.php';
+    require_once dirname(__DIR__) . '/nuclear-engagement/inc/Core/SettingsRepository.php';
+    require_once dirname(__DIR__) . '/nuclear-engagement/inc/Core/Defaults.php';
+    require_once dirname(__DIR__) . '/nuclear-engagement/inc/Core/Container.php';
+
+    class NuclenTOCRenderTest extends TestCase {
+        protected function setUp(): void {
+            global $wp_posts, $current_post_id, $wp_cache, $transients;
+            $wp_posts = [];
+            $current_post_id = 0;
+            $wp_cache = [];
+            $transients = [];
+            SettingsRepository::reset_for_tests();
+            Container::getInstance()->reset();
+        }
+
+        private function registerSettings(): SettingsRepository {
+            $settings = SettingsRepository::get_instance([
+                'toc_heading_levels' => [2,3],
+                'toc_show_toggle'    => true,
+                'toc_show_content'   => true,
+            ]);
+            Container::getInstance()->register('settings', static function () use ($settings) {
+                return $settings;
+            });
+            return $settings;
+        }
+
+        public function test_shortcode_outputs_markup(): void {
+            global $wp_posts, $current_post_id;
+            $current_post_id = 1;
+            $wp_posts[1] = (object)[
+                'ID' => 1,
+                'post_content' => '<h2>One</h2><h3>Sub</h3>',
+            ];
+            $this->registerSettings();
+            $render = new \NuclearEngagement\Modules\TOC\Nuclen_TOC_Render();
+            $out = $render->nuclen_toc_shortcode([]);
+            $this->assertStringContainsString('<nav id="', $out);
+            $this->assertStringContainsString('<a href="#one">One</a>', $out);
+            $this->assertStringContainsString('<a href="#sub">Sub</a>', $out);
+        }
+
+        public function test_shortcode_returns_empty_when_no_post(): void {
+            $this->registerSettings();
+            $render = new \NuclearEngagement\Modules\TOC\Nuclen_TOC_Render();
+            $this->assertSame('', $render->nuclen_toc_shortcode([]));
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- add tests for `Nuclen_TOC_Render`
- add tests for `Nuclen_TOC_Headings`

## Testing
- `composer install -n` *(fails: command not found)*
- `composer lint` *(fails: command not found)*
- `composer test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685c35c031c88327b1807298357a9b90

<!-- Korbit AI PR Description Start -->
## Description by Korbit AI

### What change is being made?
Add unit tests for the TOC module, specifically focusing on `Nuclen_TOC_Headings` and `Nuclen_TOC_Render` classes.

### Why are these changes being made?
These unit tests ensure that the TOC module functions as expected, particularly with regard to injecting heading IDs and rendering shortcodes. This helps prevent regressions and facilitates future development by providing a testing framework to verify the integrity and performance of the TOC functionalities.

> Is this description stale? Ask me to generate a new description by commenting `/korbit-generate-pr-description`
<!-- Korbit AI PR Description End -->