### PR TITLE
Refactor RemoteApiService to use helper classes

### DIFF
--- a/nuclear-engagement/inc/Core/ContainerRegistrar.php
+++ b/nuclear-engagement/inc/Core/ContainerRegistrar.php
@@ -9,6 +9,7 @@ declare(strict_types=1);
 namespace NuclearEngagement;
 
 use NuclearEngagement\Services\{GenerationService, RemoteApiService, ContentStorageService, PointerService, PostsQueryService, AutoGenerationService, AutoGenerationQueue, AutoGenerationScheduler, GenerationPoller, PublishGenerationHandler, VersionService, DashboardDataService};
+use NuclearEngagement\Services\Remote\{RemoteRequest, ApiResponseHandler};
 use NuclearEngagement\Admin\Controller\Ajax\{GenerateController, UpdatesController, PointerController, PostsCountController};
 use NuclearEngagement\Admin\Controller\OptinExportController;
 use NuclearEngagement\Front\Controller\Rest\ContentController;
@@ -21,7 +22,9 @@ final class ContainerRegistrar {
     public static function register( Container $container, SettingsRepository $settings ): void {
         $container->register( 'settings', static fn() => $settings );
 
-        $container->register( 'remote_api', static fn( $c ) => new RemoteApiService( $c->get( 'settings' ) ) );
+        $container->register( 'remote_request', static fn() => new Services\Remote\RemoteRequest() );
+        $container->register( 'api_response_handler', static fn() => new Services\Remote\ApiResponseHandler() );
+        $container->register( 'remote_api', static fn( $c ) => new RemoteApiService( $c->get( 'settings' ), $c->get( 'remote_request' ), $c->get( 'api_response_handler' ) ) );
         $container->register( 'content_storage', static fn( $c ) => new ContentStorageService( $c->get( 'settings' ) ) );
 
                 $container->register(

--- a/nuclear-engagement/inc/Services/Remote/ApiResponseHandler.php
+++ b/nuclear-engagement/inc/Services/Remote/ApiResponseHandler.php
@@ -1,0 +1,131 @@
+<?php
+declare(strict_types=1);
+
+namespace NuclearEngagement\Services\Remote;
+
+use NuclearEngagement\Services\ApiException;
+use NuclearEngagement\Services\LoggingService;
+
+if ( ! defined( 'ABSPATH' ) ) {
+    exit;
+}
+
+/**
+ * Handles parsing and validation of remote API responses.
+ */
+class ApiResponseHandler {
+    /**
+     * Validate and decode the HTTP response.
+     *
+     * @param mixed $response Response from wp_remote_post.
+     * @return array Parsed response data.
+     * @throws ApiException When the response indicates an error.
+     */
+    public function handle( $response ): array {
+        if ( is_wp_error( $response ) ) {
+            $error = 'API request failed: ' . $response->get_error_message();
+            LoggingService::log( $error );
+            LoggingService::notify_admin( __( 'Failed to contact the Nuclear Engagement API.', 'nuclear-engagement' ) );
+            throw new ApiException( $error );
+        }
+
+        $code = wp_remote_retrieve_response_code( $response );
+        $body = wp_remote_retrieve_body( $response );
+        LoggingService::debug( "API response body: {$body}" );
+        LoggingService::log( "API response code: {$code}" );
+
+        if ( 401 === $code || 403 === $code ) {
+            $auth = $this->handle_auth_error( $body, $code );
+            throw new ApiException( $auth['error'], $auth['status_code'], $auth['error_code'] ?? null );
+        }
+
+        if ( 200 !== $code ) {
+            LoggingService::log( "Unexpected response code: {$code}, body: {$body}" );
+            $parsed = $this->parse_error_response( $body );
+            $msg    = $parsed['message'] ?? "Failed request, code: {$code}";
+            throw new ApiException( $msg, $code, $parsed['error_code'] );
+        }
+
+        $data = json_decode( $body, true );
+        if ( ! is_array( $data ) ) {
+            LoggingService::log( "Invalid JSON response: {$body}" );
+            throw new ApiException( 'Invalid data received from API', $code );
+        }
+        if ( isset( $data['success'] ) && false === $data['success'] ) {
+            $msg = $data['error'] ?? 'API error';
+            throw new ApiException( $msg, $code, $data['error_code'] ?? null );
+        }
+
+        return $data;
+    }
+
+    /**
+     * Parse an error response body.
+     */
+    private function parse_error_response( string $body ): array {
+        $data = json_decode( $body, true );
+        $msg  = null;
+        $code = null;
+        if ( is_array( $data ) ) {
+            if ( isset( $data['error'] ) ) {
+                $msg = (string) $data['error'];
+            } elseif ( isset( $data['message'] ) ) {
+                $msg = (string) $data['message'];
+            }
+            if ( isset( $data['error_code'] ) ) {
+                $code = (string) $data['error_code'];
+            }
+        }
+        return array(
+            'message'    => $msg,
+            'error_code' => $code,
+        );
+    }
+
+    /**
+     * Build an error array for authentication failures.
+     */
+    private function handle_auth_error( string $body, int $code ): array {
+        $data = json_decode( $body, true );
+
+        if ( is_array( $data ) && isset( $data['error_code'] ) ) {
+            $error_code = $data['error_code'];
+            if ( 'invalid_api_key' === $error_code ) {
+                return array(
+                    'error'       => 'Invalid API key. Please update it on the Setup page.',
+                    'error_code'  => 'invalid_api_key',
+                    'status_code' => $code,
+                );
+            }
+
+            if ( 'invalid_wp_app_pass' === $error_code ) {
+                return array(
+                    'error'       => 'Invalid plugin password. Please re-generate on the Setup page.',
+                    'error_code'  => 'invalid_wp_app_pass',
+                    'status_code' => $code,
+                );
+            }
+        }
+
+        if ( false !== strpos( $body, 'invalid_api_key' ) ) {
+            return array(
+                'error'       => 'Invalid API key. Please update it on the Setup page.',
+                'error_code'  => 'invalid_api_key',
+                'status_code' => $code,
+            );
+        }
+
+        if ( false !== strpos( $body, 'invalid_wp_app_pass' ) ) {
+            return array(
+                'error'       => 'Invalid plugin password. Please re-generate on the Setup page.',
+                'error_code'  => 'invalid_wp_app_pass',
+                'status_code' => $code,
+            );
+        }
+
+        return array(
+            'error'       => 'Authentication error (API key or plugin password may be invalid).',
+            'status_code' => $code,
+        );
+    }
+}

--- a/nuclear-engagement/inc/Services/Remote/RemoteRequest.php
+++ b/nuclear-engagement/inc/Services/Remote/RemoteRequest.php
@@ -1,0 +1,41 @@
+<?php
+declare(strict_types=1);
+
+namespace NuclearEngagement\Services\Remote;
+
+if ( ! defined( 'ABSPATH' ) ) {
+    exit;
+}
+
+/**
+ * Helper for sending HTTP requests to the Nuclear Engagement API.
+ */
+class RemoteRequest {
+    /** Base API URL. */
+    private const API_BASE = 'https://app.nuclearengagement.com/api';
+
+    /**
+     * Send a POST request to the given API endpoint.
+     *
+     * @param string $path API path beginning with '/'.
+     * @param array  $payload Request payload.
+     * @param string $api_key API key header.
+     * @return mixed Array response or WP_Error on failure.
+     */
+    public function post( string $path, array $payload, string $api_key ) {
+        return wp_remote_post(
+            self::API_BASE . $path,
+            array(
+                'method'             => 'POST',
+                'headers'            => array(
+                    'Content-Type' => 'application/json',
+                    'X-API-Key'    => $api_key,
+                ),
+                'body'               => wp_json_encode( $payload ),
+                'timeout'            => NUCLEN_API_TIMEOUT,
+                'reject_unsafe_urls' => true,
+                'user-agent'         => 'NuclearEngagement/' . NUCLEN_PLUGIN_VERSION,
+            )
+        );
+    }
+}

--- a/nuclear-engagement/inc/Services/RemoteApiService.php
+++ b/nuclear-engagement/inc/Services/RemoteApiService.php
@@ -15,8 +15,9 @@ declare(strict_types=1);
 namespace NuclearEngagement\Services;
 
 use NuclearEngagement\SettingsRepository;
-use NuclearEngagement\Utils;
 use NuclearEngagement\Services\ApiException;
+use NuclearEngagement\Services\Remote\RemoteRequest;
+use NuclearEngagement\Services\Remote\ApiResponseHandler;
 
 if ( ! defined( 'ABSPATH' ) ) {
     exit;
@@ -42,45 +43,20 @@ class RemoteApiService {
      */
     private SettingsRepository $settings;
 
-    /**
-     * @var Utils
-     */
-    private Utils $utils;
+
+    private RemoteRequest $request;
+
+    private ApiResponseHandler $handler;
 
     /**
      * Constructor
      *
      * @param SettingsRepository $settings
      */
-    public function __construct( SettingsRepository $settings ) {
+    public function __construct( SettingsRepository $settings, RemoteRequest $request, ApiResponseHandler $handler ) {
         $this->settings = $settings;
-        $this->utils    = new Utils();
-    }
-
-    /**
-     * Parse an error response body.
-     *
-     * @param string $body HTTP response body.
-     * @return array{message:string|null,error_code:?string}
-     */
-    private function parse_error_response( string $body ): array {
-        $data = json_decode( $body, true );
-        $msg  = null;
-        $code = null;
-        if ( is_array( $data ) ) {
-            if ( isset( $data['error'] ) ) {
-                $msg = (string) $data['error'];
-            } elseif ( isset( $data['message'] ) ) {
-                $msg = (string) $data['message'];
-            }
-            if ( isset( $data['error_code'] ) ) {
-                $code = (string) $data['error_code'];
-            }
-        }
-        return array(
-            'message'    => $msg,
-            'error_code' => $code,
-        );
+        $this->request  = $request;
+        $this->handler  = $handler;
     }
 
     /**
@@ -126,58 +102,9 @@ class RemoteApiService {
 
         \NuclearEngagement\Services\LoggingService::log( 'Sending generation request: ' . $generation_id ); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
 
-        $response = wp_remote_post(
-            self::API_BASE . '/process-posts',
-            array(
-                'method'             => 'POST',
-                'headers'            => array(
-                    'Content-Type' => 'application/json',
-                    'X-API-Key'    => $api_key,
-                ),
-                'body'               => wp_json_encode( $payload ),
-                'timeout'            => NUCLEN_API_TIMEOUT,
-                'reject_unsafe_urls' => true,
-                'user-agent'         => 'NuclearEngagement/' . NUCLEN_PLUGIN_VERSION,
-            )
-        );
+        $response = $this->request->post( '/process-posts', $payload, $api_key );
 
-                if ( is_wp_error( $response ) ) {
-                        $error = 'API request failed: ' . $response->get_error_message();
-                        \NuclearEngagement\Services\LoggingService::log( $error ); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
-                        \NuclearEngagement\Services\LoggingService::notify_admin( __( 'Failed to contact the Nuclear Engagement API.', 'nuclear-engagement' ) );
-                        throw new ApiException( $error );
-                }
-
-        $code = wp_remote_retrieve_response_code( $response );
-        $body = wp_remote_retrieve_body( $response );
-        \NuclearEngagement\Services\LoggingService::debug( "API response body: {$body}" );
-
-        \NuclearEngagement\Services\LoggingService::log( "API response code: {$code}" ); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
-
-        // Check for auth errors
-        if ( 401 === $code || 403 === $code ) {
-            $auth_result = $this->handle_auth_error( $body, $code );
-            throw new ApiException( $auth_result['error'], $auth_result['status_code'], $auth_result['error_code'] ?? null );
-        }
-
-        if ( 200 !== $code ) {
-                        \NuclearEngagement\Services\LoggingService::log( "Unexpected response code: {$code}, body: {$body}" ); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
-                    $parsed = $this->parse_error_response( $body );
-            $msg            = $parsed['message'] ?? "Failed to fetch updates, code: {$code}";
-            throw new ApiException( $msg, $code, $parsed['error_code'] );
-        }
-
-        $data = json_decode( $body, true );
-        if ( ! is_array( $data ) ) {
-                        \NuclearEngagement\Services\LoggingService::log( "Invalid JSON response: {$body}" ); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
-            throw new ApiException( 'Invalid data received from API', $code );
-        }
-        if ( isset( $data['success'] ) && false === $data['success'] ) {
-            $msg = $data['error'] ?? 'API error';
-            throw new ApiException( $msg, $code, $data['error_code'] ?? null );
-        }
-
-        return $data;
+        return $this->handler->handle( $response );
     }
 
     /**
@@ -205,53 +132,9 @@ class RemoteApiService {
             \NuclearEngagement\Services\LoggingService::log( "Fetching updates for generation: {$generation_id}" ); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
         }
 
-        $response = wp_remote_post(
-            self::API_BASE . '/updates',
-            array(
-                'method'             => 'POST',
-                'headers'            => array(
-                    'Content-Type' => 'application/json',
-                    'X-API-Key'    => $api_key,
-                ),
-                'body'               => wp_json_encode( $payload ),
-                'timeout'            => NUCLEN_API_TIMEOUT,
-                'reject_unsafe_urls' => true,
-                'user-agent'         => 'NuclearEngagement/' . NUCLEN_PLUGIN_VERSION,
-            )
-        );
+        $response = $this->request->post( '/updates', $payload, $api_key );
 
-                if ( is_wp_error( $response ) ) {
-                        $error = 'API request failed: ' . $response->get_error_message();
-                                        \NuclearEngagement\Services\LoggingService::log( $error ); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
-                        \NuclearEngagement\Services\LoggingService::notify_admin( __( 'Failed to contact the Nuclear Engagement API.', 'nuclear-engagement' ) );
-                        throw new ApiException( $error );
-                }
-
-        $code = wp_remote_retrieve_response_code( $response );
-        $body = wp_remote_retrieve_body( $response );
-
-        // Check for auth errors
-        if ( 401 === $code || 403 === $code ) {
-            $auth_result = $this->handle_auth_error( $body, $code );
-            throw new ApiException( $auth_result['error'], $auth_result['status_code'], $auth_result['error_code'] ?? null );
-        }
-
-        if ( 200 !== $code ) {
-                        \NuclearEngagement\Services\LoggingService::log( "Unexpected response code: {$code}, body: {$body}" ); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
-                    $parsed = $this->parse_error_response( $body );
-            $msg            = $parsed['message'] ?? "Failed to fetch updates, code: {$code}";
-            throw new ApiException( $msg, $code, $parsed['error_code'] );
-        }
-
-        $data = json_decode( $body, true );
-        if ( ! is_array( $data ) ) {
-                        \NuclearEngagement\Services\LoggingService::log( "Invalid JSON response: {$body}" ); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
-            throw new ApiException( 'Invalid data received from API', $code );
-        }
-        if ( isset( $data['success'] ) && false === $data['success'] ) {
-            $msg = $data['error'] ?? 'API error';
-            throw new ApiException( $msg, $code, $data['error_code'] ?? null );
-        }
+        $data = $this->handler->handle( $response );
 
         $cache_key = 'nuclen_update_' . $generation_id;
         wp_cache_set( $cache_key, $data, self::CACHE_GROUP, self::CACHE_TTL );
@@ -260,54 +143,4 @@ class RemoteApiService {
         return $data;
     }
 
-    /**
-     * Handle authentication errors from API
-     *
-     * @param string $body Response body.
-     * @param int    $code HTTP status code.
-     * @return array Error data.
-     */
-    private function handle_auth_error( string $body, int $code ): array {
-        $data = json_decode( $body, true );
-
-        if ( is_array( $data ) && isset( $data['error_code'] ) ) {
-            $error_code = $data['error_code'];
-            if ( 'invalid_api_key' === $error_code ) {
-                return array(
-                    'error'       => 'Invalid API key. Please update it on the Setup page.',
-                    'error_code'  => 'invalid_api_key',
-                    'status_code' => $code,
-                );
-            }
-
-            if ( 'invalid_wp_app_pass' === $error_code ) {
-                               return array(
-                                       'error'       => 'Invalid plugin password. Please re-generate on the Setup page.',
-                                       'error_code'  => 'invalid_wp_app_pass',
-                                       'status_code' => $code,
-                               );
-            }
-        }
-
-        if ( false !== strpos( $body, 'invalid_api_key' ) ) {
-            return array(
-                'error'       => 'Invalid API key. Please update it on the Setup page.',
-                'error_code'  => 'invalid_api_key',
-                'status_code' => $code,
-            );
-        }
-
-                if ( false !== strpos( $body, 'invalid_wp_app_pass' ) ) {
-                        return array(
-                                'error'       => 'Invalid plugin password. Please re-generate on the Setup page.',
-                                'error_code'  => 'invalid_wp_app_pass',
-                                'status_code' => $code,
-                        );
-                }
-
-                return array(
-                        'error'       => 'Authentication error (API key or plugin password may be invalid).',
-                        'status_code' => $code,
-                );
-    }
 }

--- a/tests/RemoteApiServiceTest.php
+++ b/tests/RemoteApiServiceTest.php
@@ -47,7 +47,9 @@ class RemoteApiServiceTest extends TestCase {
     }
 
     private function makeService(): RemoteApiService {
-        return new RemoteApiService(SettingsRepository::get_instance());
+        $req = new \NuclearEngagement\Services\Remote\RemoteRequest();
+        $handler = new \NuclearEngagement\Services\Remote\ApiResponseHandler();
+        return new RemoteApiService(SettingsRepository::get_instance(), $req, $handler);
     }
 
     public function test_parses_json_message(): void {


### PR DESCRIPTION
## Summary
- refactor RemoteApiService to use RemoteRequest and ApiResponseHandler
- register new helper classes in ContainerRegistrar
- adjust RemoteApiService tests for new structure

## Testing
- `composer lint` *(fails: command not found)*
- `composer test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685c35be308c8327b7cce8d277b7067b