### PR TITLE
Add typed properties to SettingsRepository

### DIFF
--- a/nuclear-engagement/inc/Core/SettingsRepository.php
+++ b/nuclear-engagement/inc/Core/SettingsRepository.php
@@ -54,7 +54,7 @@ final class SettingsRepository {
      * @since 1.0.0
      * @var SettingsRepository|null
      */
-    private static $instance = null;
+    private static ?self $instance = null;
 
     /**
      * Default settings values.
@@ -62,7 +62,7 @@ final class SettingsRepository {
      * @since 1.0.0
      * @var array
      */
-    private $defaults = array();
+    private array $defaults = array();
 
     /**
      * Pending changes not yet saved.
@@ -70,7 +70,7 @@ final class SettingsRepository {
      * @since 1.0.0
      * @var array
      */
-    private $pending = array();
+    private array $pending = array();
 
     /**
      * Cache handler.


### PR DESCRIPTION
## Summary
- make SettingsRepository instance nullable self
- type `$defaults` and `$pending` properties

## Testing
- `composer lint` *(fails: command not found)*
- `composer test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685c39b4a854832781b29cded1cf9696

<!-- Korbit AI PR Description Start -->
## Description by Korbit AI

### What change is being made?

Add typed properties to the `SettingsRepository` class to ensure proper type definitions for class properties.

### Why are these changes being made?

These changes enhance type safety within the `SettingsRepository` class, making the codebase more robust and easier to maintain by clearly defining the expected property types (`?self` for the singleton instance and `array` for `defaults` and `pending`). This reduces the potential for runtime errors related to incorrect property initialization.

> Is this description stale? Ask me to generate a new description by commenting `/korbit-generate-pr-description`
<!-- Korbit AI PR Description End -->