### PR TITLE
Use typed closures in ContainerRegistrar

### DIFF
--- a/nuclear-engagement/inc/Core/ContainerRegistrar.php
+++ b/nuclear-engagement/inc/Core/ContainerRegistrar.php
@@ -8,6 +8,7 @@ declare(strict_types=1);
 
 namespace NuclearEngagement;
 
+use NuclearEngagement\Container;
 use NuclearEngagement\Services\{GenerationService, RemoteApiService, ContentStorageService, PointerService, PostsQueryService, AutoGenerationService, AutoGenerationQueue, AutoGenerationScheduler, GenerationPoller, PublishGenerationHandler, VersionService, DashboardDataService};
 use NuclearEngagement\Services\Remote\{RemoteRequest, ApiResponseHandler};
 use NuclearEngagement\Admin\Controller\Ajax\{GenerateController, UpdatesController, PointerController, PostsCountController};
@@ -24,12 +25,12 @@ final class ContainerRegistrar {
 
         $container->register( 'remote_request', static fn() => new Services\Remote\RemoteRequest() );
         $container->register( 'api_response_handler', static fn() => new Services\Remote\ApiResponseHandler() );
-        $container->register( 'remote_api', static fn( $c ) => new RemoteApiService( $c->get( 'settings' ), $c->get( 'remote_request' ), $c->get( 'api_response_handler' ) ) );
-        $container->register( 'content_storage', static fn( $c ) => new ContentStorageService( $c->get( 'settings' ) ) );
+        $container->register( 'remote_api', static fn( Container $c ) => new RemoteApiService( $c->get( 'settings' ), $c->get( 'remote_request' ), $c->get( 'api_response_handler' ) ) );
+        $container->register( 'content_storage', static fn( Container $c ) => new ContentStorageService( $c->get( 'settings' ) ) );
 
                 $container->register(
                         'generation_poller',
-                        static fn( $c ) => new GenerationPoller(
+                        static fn( Container $c ) => new GenerationPoller(
                                 $c->get( 'settings' ),
                                 $c->get( 'remote_api' ),
                                 $c->get( 'content_storage' )
@@ -38,7 +39,7 @@ final class ContainerRegistrar {
 
                 $container->register(
                         'auto_generation_queue',
-                        static fn( $c ) => new AutoGenerationQueue(
+                        static fn( Container $c ) => new AutoGenerationQueue(
                                 $c->get( 'remote_api' ),
                                 $c->get( 'content_storage' ),
                                 new PostDataFetcher()
@@ -47,21 +48,21 @@ final class ContainerRegistrar {
 
                 $container->register(
                         'auto_generation_scheduler',
-                        static fn( $c ) => new AutoGenerationScheduler(
+                        static fn( Container $c ) => new AutoGenerationScheduler(
                                 $c->get( 'generation_poller' )
                         )
                 );
 
         $container->register(
             'publish_generation_handler',
-            static fn( $c ) => new PublishGenerationHandler(
+            static fn( Container $c ) => new PublishGenerationHandler(
                 $c->get( 'settings' )
             )
         );
 
                 $container->register(
                         'auto_generation_service',
-                        static fn( $c ) => new AutoGenerationService(
+                        static fn( Container $c ) => new AutoGenerationService(
                                 $c->get( 'settings' ),
                                 $c->get( 'auto_generation_queue' ),
                                 $c->get( 'auto_generation_scheduler' ),
@@ -71,7 +72,7 @@ final class ContainerRegistrar {
 
         $container->register(
             'generation_service',
-            static fn( $c ) => new GenerationService(
+            static fn( Container $c ) => new GenerationService(
                 $c->get( 'settings' ),
                 $c->get( 'remote_api' ),
                 $c->get( 'content_storage' )
@@ -83,13 +84,13 @@ final class ContainerRegistrar {
                 $container->register( 'dashboard_data_service', static fn() => new DashboardDataService() );
                 $container->register( 'version_service', static fn() => new VersionService() );
 
-        $container->register( 'generate_controller', static fn( $c ) => new GenerateController( $c->get( 'generation_service' ) ) );
-        $container->register( 'updates_controller', static fn( $c ) => new UpdatesController( $c->get( 'remote_api' ), $c->get( 'content_storage' ) ) );
-        $container->register( 'pointer_controller', static fn( $c ) => new PointerController( $c->get( 'pointer_service' ) ) );
-        $container->register( 'posts_count_controller', static fn( $c ) => new PostsCountController( $c->get( 'posts_query_service' ) ) );
+        $container->register( 'generate_controller', static fn( Container $c ) => new GenerateController( $c->get( 'generation_service' ) ) );
+        $container->register( 'updates_controller', static fn( Container $c ) => new UpdatesController( $c->get( 'remote_api' ), $c->get( 'content_storage' ) ) );
+        $container->register( 'pointer_controller', static fn( Container $c ) => new PointerController( $c->get( 'pointer_service' ) ) );
+        $container->register( 'posts_count_controller', static fn( Container $c ) => new PostsCountController( $c->get( 'posts_query_service' ) ) );
                 $container->register(
                         'content_controller',
-                        static fn( $c ) => new ContentController(
+                        static fn( Container $c ) => new ContentController(
                                 $c->get( 'content_storage' ),
                                 $c->get( 'settings' )
                         )


### PR DESCRIPTION
## Summary
- import the `Container` class
- typehint each DI closure

## Testing
- `composer lint` *(fails: command not found)*
- `composer test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685c39afe278832794450a80c7d10fb4

<!-- Korbit AI PR Description Start -->
## Description by Korbit AI

### What change is being made?

Add typed closures to the `ContainerRegistrar` to specify `Container` as the parameter type in closure declarations.

### Why are these changes being made?

These changes improve code clarity and type safety by explicitly specifying `Container` as the expected parameter type for closures, reducing potential runtime errors and enhancing the developer experience with explicit type information. This aligns with modern PHP practices and ensures consistency throughout the codebase.

> Is this description stale? Ask me to generate a new description by commenting `/korbit-generate-pr-description`
<!-- Korbit AI PR Description End -->