### PR TITLE
Remove redundant API_BASE constant

### DIFF
--- a/nuclear-engagement/inc/Services/Remote/RemoteRequest.php
+++ b/nuclear-engagement/inc/Services/Remote/RemoteRequest.php
@@ -11,8 +11,8 @@ if ( ! defined( 'ABSPATH' ) ) {
  * Helper for sending HTTP requests to the Nuclear Engagement API.
  */
 class RemoteRequest {
-    /** Base API URL. */
-    private const API_BASE = 'https://app.nuclearengagement.com/api';
+    /** Base API URL accessible to other services. */
+    public const API_BASE = 'https://app.nuclearengagement.com/api';
 
     /**
      * Send a POST request to the given API endpoint.

--- a/nuclear-engagement/inc/Services/RemoteApiService.php
+++ b/nuclear-engagement/inc/Services/RemoteApiService.php
@@ -27,10 +27,6 @@ if ( ! defined( 'ABSPATH' ) ) {
  * Service for communicating with Nuclear Engagement remote API
  */
 class RemoteApiService {
-    /**
-     * @var string Base API URL
-     */
-    private const API_BASE = 'https://app.nuclearengagement.com/api';
 
     /** Cache group for API responses. */
     private const CACHE_GROUP = 'nuclen_remote';

--- a/nuclear-engagement/inc/Services/SetupService.php
+++ b/nuclear-engagement/inc/Services/SetupService.php
@@ -14,6 +14,7 @@ declare( strict_types = 1 );
 namespace NuclearEngagement\Services;
 
 use NuclearEngagement\Utils;
+use NuclearEngagement\Services\Remote\RemoteRequest;
 
 // If this file is called directly, abort.
 if ( ! defined( 'ABSPATH' ) ) {
@@ -29,14 +30,6 @@ if ( ! defined( 'ABSPATH' ) ) {
  * @since 1.0.0
  */
 class SetupService {
-
-    /**
-     * Base URL for remote API.
-     *
-     * @since 1.0.0
-     * @var string
-     */
-    private const API_BASE = 'https://app.nuclearengagement.com/api';
 
     /**
      * Default timeout for API requests in seconds.
@@ -79,7 +72,7 @@ class SetupService {
         $timeout = defined( 'NUCLEN_API_TIMEOUT' ) ? NUCLEN_API_TIMEOUT : self::DEFAULT_TIMEOUT;
 
         $response = wp_remote_post(
-            self::API_BASE . '/check-api-key',
+            RemoteRequest::API_BASE . '/check-api-key',
             array(
                 'method'             => 'POST',
                 'headers'            => array( 'Content-Type' => 'application/json' ),
@@ -123,7 +116,7 @@ class SetupService {
         }
 
         $response = wp_remote_post(
-            self::API_BASE . '/store-wp-creds',
+            RemoteRequest::API_BASE . '/store-wp-creds',
             array(
                 'method'             => 'POST',
                 'headers'            => array( 'Content-Type' => 'application/json' ),


### PR DESCRIPTION
## Summary
- drop unused API_BASE from RemoteApiService
- expose RemoteRequest::API_BASE for reuse
- use RemoteRequest::API_BASE within SetupService

## Testing
- `composer install --working-dir=nuclear-engagement` *(fails: composer not found)*

------
https://chatgpt.com/codex/tasks/task_e_685c39ac77448327b4406dcf845bbd01

<!-- Korbit AI PR Description Start -->
## Description by Korbit AI

### What change is being made?

Standardize the API base URL access by removing redundant `API_BASE` constants and exposing it as a public constant in `RemoteRequest` class.

### Why are these changes being made?

Previously, multiple duplicate constants defined the same API base URL across different service classes, which created a risk of discrepancies and made updates cumbersome. By consolidating the `API_BASE` constant in the `RemoteRequest` class as a public constant, we maintain a single source of truth, ensuring consistency and simplifying maintenance across the codebase.

> Is this description stale? Ask me to generate a new description by commenting `/korbit-generate-pr-description`
<!-- Korbit AI PR Description End -->