### PR TITLE
Localize admin metabox strings

### DIFF
--- a/nuclear-engagement/templates/admin/quiz-metabox.php
+++ b/nuclear-engagement/templates/admin/quiz-metabox.php
@@ -7,7 +7,8 @@ wp_nonce_field( 'nuclen_quiz_data_nonce', 'nuclen_quiz_data_nonce' );
 ?>
 <div><label>
     <input type="checkbox" name="nuclen_quiz_protected" value="1" <?php checked( $quiz_protected, 1 ); ?> />
-    Protected? <span nuclen-tooltip="Tick this box and save post to prevent overwriting during bulk generation.">🛈</span>
+    <?php esc_html_e( 'Protected?', 'nuclear-engagement' ); ?>
+    <span nuclen-tooltip="<?php esc_attr_e( 'Tick this box and save post to prevent overwriting during bulk generation.', 'nuclear-engagement' ); ?>">🛈</span>
 </label></div>
 <div>
     <button type="button"
@@ -15,11 +16,11 @@ wp_nonce_field( 'nuclen_quiz_data_nonce', 'nuclen_quiz_data_nonce' );
             class="button nuclen-generate-single"
             data-post-id="<?php echo esc_attr( $post->ID ); ?>"
             data-workflow="quiz">
-        Generate Quiz with AI
+        <?php esc_html_e( 'Generate Quiz with AI', 'nuclear-engagement' ); ?>
     </button>
-    <span nuclen-tooltip="(re)Generate. Data will be stored automatically (no need to save post).">🛈</span>
+    <span nuclen-tooltip="<?php esc_attr_e( '(re)Generate. Data will be stored automatically (no need to save post).', 'nuclear-engagement' ); ?>">🛈</span>
 </div>
-<p><strong>Date</strong><br>
+<p><strong><?php esc_html_e( 'Date', 'nuclear-engagement' ); ?></strong><br>
     <input type="text" name="nuclen_quiz_data[date]" value="<?php echo esc_attr( $date ); ?>" readonly class="nuclen-meta-date-input" />
 </p>
 <?php for ( $q_index = 0; $q_index < 10; $q_index++ ) :
@@ -32,17 +33,17 @@ wp_nonce_field( 'nuclen_quiz_data_nonce', 'nuclen_quiz_data_nonce' );
     $answers = array_pad( $answers, 4, '' );
     ?>
     <div class="nuclen-quiz-metabox-question">
-        <h4><?php echo esc_html( 'Question ' . ( $q_index + 1 ) ); ?></h4>
+        <h4><?php printf( esc_html__( 'Question %d', 'nuclear-engagement' ), $q_index + 1 ); ?></h4>
         <input type="text" name="nuclen_quiz_data[questions][<?php echo esc_attr( $q_index ); ?>][question]" value="<?php echo esc_attr( $q_text ); ?>" class="nuclen-width-full" />
-        <p><strong>Answers</strong></p>
+        <p><strong><?php esc_html_e( 'Answers', 'nuclear-engagement' ); ?></strong></p>
         <?php foreach ( $answers as $a_index => $answer ) :
             $class = $a_index === 0 ? 'nuclen-answer-correct' : '';
             ?>
-            <p class="nuclen-answer-label <?php echo esc_attr( $class ); ?>">Answer <?php echo esc_html( $a_index + 1 ); ?><br>
+            <p class="nuclen-answer-label <?php echo esc_attr( $class ); ?>"><?php printf( esc_html__( 'Answer %d', 'nuclear-engagement' ), $a_index + 1 ); ?><br>
                 <input type="text" name="nuclen_quiz_data[questions][<?php echo esc_attr( $q_index ); ?>][answers][<?php echo esc_attr( $a_index ); ?>]" value="<?php echo esc_attr( $answer ); ?>" class="nuclen-width-full" />
             </p>
         <?php endforeach; ?>
-        <p><strong>Explanation</strong><br>
+        <p><strong><?php esc_html_e( 'Explanation', 'nuclear-engagement' ); ?></strong><br>
             <textarea name="nuclen_quiz_data[questions][<?php echo esc_attr( $q_index ); ?>][explanation]" rows="3" class="nuclen-width-full"><?php echo esc_textarea( $explan ); ?></textarea>
         </p>
     </div>

--- a/nuclear-engagement/templates/admin/summary-metabox.php
+++ b/nuclear-engagement/templates/admin/summary-metabox.php
@@ -7,7 +7,8 @@ wp_nonce_field( 'nuclen_summary_data_nonce', 'nuclen_summary_data_nonce' );
 ?>
 <div><label>
     <input type="checkbox" name="nuclen_summary_protected" value="1" <?php checked( $summary_protected, 1 ); ?> />
-    Protected? <span nuclen-tooltip="Tick this box and save post to prevent overwriting during bulk generation.">🛈</span>
+    <?php esc_html_e( 'Protected?', 'nuclear-engagement' ); ?>
+    <span nuclen-tooltip="<?php esc_attr_e( 'Tick this box and save post to prevent overwriting during bulk generation.', 'nuclear-engagement' ); ?>">🛈</span>
 </label></div>
 <div>
     <button type="button"
@@ -15,14 +16,14 @@ wp_nonce_field( 'nuclen_summary_data_nonce', 'nuclen_summary_data_nonce' );
             class="button nuclen-generate-single"
             data-post-id="<?php echo esc_attr( $post->ID ); ?>"
             data-workflow="summary">
-        Generate Summary with AI
+        <?php esc_html_e( 'Generate Summary with AI', 'nuclear-engagement' ); ?>
     </button>
-    <span nuclen-tooltip="(re)Generate. Data will be stored automatically (no need to save post).">🛈</span>
+    <span nuclen-tooltip="<?php esc_attr_e( '(re)Generate. Data will be stored automatically (no need to save post).', 'nuclear-engagement' ); ?>">🛈</span>
 </div>
-<p><strong>Date</strong><br>
+<p><strong><?php esc_html_e( 'Date', 'nuclear-engagement' ); ?></strong><br>
     <input type="text" name="nuclen_summary_data[date]" value="<?php echo esc_attr( $date ); ?>" readonly class="nuclen-meta-date-input" />
 </p>
-<p><strong>Summary</strong><br>
+<p><strong><?php esc_html_e( 'Summary', 'nuclear-engagement' ); ?></strong><br>
 <?php
 wp_editor(
     $summary,


### PR DESCRIPTION
## Summary
- localize quiz metabox UI labels
- localize summary metabox UI labels

## Testing
- `composer lint` *(fails: command not found)*
- `composer test` *(fails: command not found)*
- `wp i18n make-pot nuclear-engagement nuclear-engagement/languages/nuclear-engagement.pot` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685c474253a483278f386b2e8f98a111

<!-- Korbit AI PR Description Start -->
## Description by Korbit AI

### What change is being made?

Localize strings in the admin metabox templates for quizzes and summaries within the 'nuclear-engagement' plugin.

### Why are these changes being made?

This change ensures the strings are fully translatable, improving the internationalization (i18n) support of the plugin by using WordPress localization functions like `esc_html_e()` and `esc_attr_e()`. This enables users to provide translations for the plugin strings, catering to a wider audience.

> Is this description stale? Ask me to generate a new description by commenting `/korbit-generate-pr-description`
<!-- Korbit AI PR Description End -->