### PR TITLE
Add PHPStan config and docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,12 @@ Run the PHPUnit test suite with:
 composer test --working-dir=nuclear-engagement
 ```
 
+Run static analysis using PHPStan:
+
+```bash
+composer phpstan --working-dir=nuclear-engagement
+```
+
 ### Building assets
 
 TypeScript source files live in `src/` and need to be compiled before the plugin can run. Install Node dependencies and build the JavaScript with:

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -1,0 +1,5 @@
+includes:
+    - vendor/php-stubs/wordpress-stubs/wordpress-stubs.php
+
+parameters:
+    level: 6


### PR DESCRIPTION
## Summary
- add a phpstan.neon.dist config
- document running `composer phpstan`

## Testing
- `composer lint --working-dir=nuclear-engagement` *(fails: composer not found)*
- `composer test --working-dir=nuclear-engagement` *(fails: composer not found)*

------
https://chatgpt.com/codex/tasks/task_e_685c475a3b0483279facb5a77bdebcf8

<!-- Korbit AI PR Description Start -->
## Description by Korbit AI

### What change is being made?

Add PHPStan configuration file and update documentation to include instructions for running static analysis.

### Why are these changes being made?

To integrate PHPStan for static analysis within the project, enhancing code quality by detecting potential issues early in development. This addition helps maintain high coding standards and ensures reliability by providing developers a clear guideline for analysis with PHPStan.

> Is this description stale? Ask me to generate a new description by commenting `/korbit-generate-pr-description`
<!-- Korbit AI PR Description End -->