### PR TITLE
Remove redundant cleanup loop

### DIFF
--- a/nuclear-engagement/inc/Services/GenerationPoller.php
+++ b/nuclear-engagement/inc/Services/GenerationPoller.php
@@ -141,18 +141,16 @@ class GenerationPoller {
      * @param string $generation_id Generation ID to remove
      */
     private function cleanup_generation( string $generation_id ): void {
-        for ( $i = 0; $i < 3; $i++ ) {
-            $generations = get_option( 'nuclen_active_generations', array() );
-            if ( ! isset( $generations[ $generation_id ] ) ) {
-                return;
-            }
-            unset( $generations[ $generation_id ] );
-            $updated = empty( $generations )
-                ? delete_option( 'nuclen_active_generations' )
-                : update_option( 'nuclen_active_generations', $generations, 'no' );
-            if ( $updated ) {
-                break;
-            }
+        $generations = get_option( 'nuclen_active_generations', array() );
+
+        if ( ! isset( $generations[ $generation_id ] ) ) {
+            return;
         }
+
+        unset( $generations[ $generation_id ] );
+
+        empty( $generations )
+            ? delete_option( 'nuclen_active_generations' )
+            : update_option( 'nuclen_active_generations', $generations, 'no' );
     }
 }


### PR DESCRIPTION
## Summary
- simplify `GenerationPoller::cleanup_generation` to fetch & update option once

## Testing
- `composer lint` *(fails: composer not found)*
- `composer test` *(fails: composer not found)*

------
https://chatgpt.com/codex/tasks/task_e_685c49d6d8908327b03d9ea4c0cd06d6

<!-- Korbit AI PR Description Start -->
## Description by Korbit AI

### What change is being made?

Remove the redundant loop from the `cleanup_generation` method in `GenerationPoller.php`.

### Why are these changes being made?

The loop was unnecessary as there is no need to attempt multiple updates; if the option update fails, it is not retried elsewhere, and making a single attempt aligns with other patterns in the code. This simplifies the code and reduces complexity without impacting functionality.

> Is this description stale? Ask me to generate a new description by commenting `/korbit-generate-pr-description`
<!-- Korbit AI PR Description End -->