### PR TITLE
Cache date/time format in DashboardDataService

### DIFF
--- a/nuclear-engagement/inc/Services/DashboardDataService.php
+++ b/nuclear-engagement/inc/Services/DashboardDataService.php
@@ -159,12 +159,14 @@ class DashboardDataService {
     public function get_scheduled_generations(): array {
         $active_generations = get_option( 'nuclen_active_generations', array() );
         $scheduled_tasks    = array();
+        $date_format        = get_option( 'date_format' );
+        $time_format        = get_option( 'time_format' );
 
         foreach ( $active_generations as $gen_id => $info ) {
             $post_id   = (int) ( $info['post_ids'][0] ?? 0 );
             $title     = $post_id ? get_the_title( $post_id ) : $gen_id;
             $next_poll = isset( $info['next_poll'] )
-                ? date_i18n( get_option( 'date_format' ) . ' ' . get_option( 'time_format' ), (int) $info['next_poll'] )
+                ? date_i18n( $date_format . ' ' . $time_format, (int) $info['next_poll'] )
                 : '';
 
             $scheduled_tasks[] = array(


### PR DESCRIPTION
## Summary
- avoid calling `get_option()` repeatedly in DashboardDataService

## Testing
- `composer lint` *(fails: command not found)*
- `composer test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685c49d50920832787b77a0e4ffe8e1e