### PR TITLE
Add AdminNoticeService and integrate with LoggingService

### DIFF
--- a/nuclear-engagement/inc/Core/ContainerRegistrar.php
+++ b/nuclear-engagement/inc/Core/ContainerRegistrar.php
@@ -10,6 +10,7 @@ namespace NuclearEngagement;
 
 use NuclearEngagement\Container;
 use NuclearEngagement\Services\{GenerationService, RemoteApiService, ContentStorageService, PointerService, PostsQueryService, AutoGenerationService, AutoGenerationQueue, AutoGenerationScheduler, GenerationPoller, PublishGenerationHandler, VersionService, DashboardDataService};
+use NuclearEngagement\Services\{AdminNoticeService, LoggingService};
 use NuclearEngagement\Services\Remote\{RemoteRequest, ApiResponseHandler};
 use NuclearEngagement\Admin\Controller\Ajax\{GenerateController, UpdatesController, PointerController, PostsCountController};
 use NuclearEngagement\Admin\Controller\OptinExportController;
@@ -22,6 +23,9 @@ if ( ! defined( 'ABSPATH' ) ) {
 final class ContainerRegistrar {
     public static function register( Container $container, SettingsRepository $settings ): void {
         $container->register( 'settings', static fn() => $settings );
+
+        $container->register( 'admin_notice_service', static fn() => new AdminNoticeService() );
+        $container->register( 'logging_service', static fn( Container $c ) => new LoggingService( $c->get( 'admin_notice_service' ) ) );
 
         $container->register( 'remote_request', static fn() => new Services\Remote\RemoteRequest() );
         $container->register( 'api_response_handler', static fn() => new Services\Remote\ApiResponseHandler() );

--- a/nuclear-engagement/inc/Services/AdminNoticeService.php
+++ b/nuclear-engagement/inc/Services/AdminNoticeService.php
@@ -1,0 +1,32 @@
+<?php
+declare(strict_types=1);
+/**
+ * Handles admin notices for the plugin.
+ */
+
+namespace NuclearEngagement\Services;
+
+if ( ! defined( 'ABSPATH' ) ) {
+    exit;
+}
+
+class AdminNoticeService {
+    /**
+     * @var array<string>
+     */
+    private array $messages = array();
+
+    public function add( string $message ): void {
+        $this->messages[] = $message;
+        if ( count( $this->messages ) === 1 ) {
+            add_action( 'admin_notices', array( $this, 'render' ) );
+        }
+    }
+
+    public function render(): void {
+        foreach ( $this->messages as $msg ) {
+            echo '<div class="notice notice-error"><p>' . esc_html( $msg ) . '</p></div>';
+        }
+        $this->messages = array();
+    }
+}

--- a/nuclear-engagement/inc/Services/LoggingService.php
+++ b/nuclear-engagement/inc/Services/LoggingService.php
@@ -16,9 +16,13 @@ if ( ! defined( 'ABSPATH' ) ) {
 
 class LoggingService {
     /**
-     * @var array<string>
+     * Admin notice service instance.
      */
-        private static array $admin_notices = array();
+    private static ?AdminNoticeService $notices = null;
+
+    public function __construct( AdminNoticeService $notices ) {
+        self::$notices = $notices;
+    }
 
         /**
          * @var array<string> Buffered log messages.
@@ -62,10 +66,11 @@ class LoggingService {
      * Store an admin notice and ensure the hook is registered.
      */
     private static function add_admin_notice( string $message ): void {
-        self::$admin_notices[] = $message;
-        if ( count( self::$admin_notices ) === 1 ) {
-            add_action( 'admin_notices', array( self::class, 'render_admin_notices' ) );
+        if ( null === self::$notices ) {
+            return;
         }
+
+        self::$notices->add( $message );
     }
 
     /**
@@ -98,14 +103,7 @@ class LoggingService {
                self::log( $msg );
        }
 
-    /**
-     * Output stored admin notices.
-     */
-    public static function render_admin_notices(): void {
-        foreach ( self::$admin_notices as $notice ) {
-            echo '<div class="notice notice-error"><p>' . esc_html( $notice ) . '</p></div>';
-        }
-    }
+
 
     /**
      * Fallback when writing to the log fails.

--- a/tests/LoggingServiceTest.php
+++ b/tests/LoggingServiceTest.php
@@ -1,6 +1,7 @@
 <?php
 use PHPUnit\Framework\TestCase;
 use NuclearEngagement\Services\LoggingService;
+use NuclearEngagement\Services\AdminNoticeService;
 
 namespace NuclearEngagement\Services {
     function add_action(...$args) {
@@ -33,6 +34,15 @@ namespace NuclearEngagement\Services {
     if (!function_exists('esc_html')) {
         function esc_html($text) { return $text; }
     }
+
+    class AdminNoticeService {
+        public array $messages = [];
+        public function add(string $msg): void {
+            $this->messages[] = $msg;
+            add_action('admin_notices', [$this, 'render']);
+        }
+        public function render(): void {}
+    }
 }
 
 namespace {
@@ -57,6 +67,8 @@ namespace {
             if (!is_dir(self::$plugin_dir)) {
                 mkdir(self::$plugin_dir, 0777, true);
             }
+
+            new LoggingService(new AdminNoticeService());
         }
 
         protected function tearDown(): void {


### PR DESCRIPTION
## Summary
- introduce `AdminNoticeService` for managing admin notices
- inject `AdminNoticeService` into `LoggingService`
- register both services through the container
- update `LoggingServiceTest` to initialize with the notice service

## Testing
- `composer lint` *(fails: command not found)*
- `composer test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685c487f532c8327a491e4b8850115ad

<!-- Korbit AI PR Description Start -->
## Description by Korbit AI

### What change is being made?

Add `AdminNoticeService` to manage admin notices and integrate it with `LoggingService` for improved admin notification handling.

### Why are these changes being made?

These changes aim to enhance the way admin notices are managed by decoupling this responsibility from `LoggingService`, thereby promoting better code organization and maintainability. The integration of `AdminNoticeService` allows for better centralization of notice management and simplifies the `LoggingService` by offloading the rendering and message storage responsibilities.

> Is this description stale? Ask me to generate a new description by commenting `/korbit-generate-pr-description`
<!-- Korbit AI PR Description End -->