### PR TITLE
Fix autoloader for core classes

### DIFF
--- a/nuclear-engagement/bootstrap.php
+++ b/nuclear-engagement/bootstrap.php
@@ -79,6 +79,9 @@ spl_autoload_register(
         // Module classes under inc/.
         $paths[] = NUCLEN_PLUGIN_DIR . 'inc/' . $relative . '.php';
 
+        // Core classes reside under inc/Core when no subnamespace is used.
+        $paths[] = NUCLEN_PLUGIN_DIR . 'inc/Core/' . $relative . '.php';
+
         foreach ( $paths as $file ) {
             if ( file_exists( $file ) ) {
                 require_once $file;


### PR DESCRIPTION
## Summary
- ensure bootstrap autoloads classes in `inc/Core`

## Testing
- `composer lint` *(fails: command not found)*
- `composer test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685ccf004f1c83279794bc7ff31d9e68

<!-- Korbit AI PR Description Start -->
## Description by Korbit AI

### What change is being made?

Add a new path to the autoloader configuration to correctly load core classes from the `inc/Core` directory.

### Why are these changes being made?

The autoloader currently fails to locate core classes without a specified subnamespace, causing runtime errors. The added path ensures that core classes are correctly loaded from the `inc/Core` directory, preventing these errors and making the plugin more reliable.

> Is this description stale? Ask me to generate a new description by commenting `/korbit-generate-pr-description`
<!-- Korbit AI PR Description End -->