### PR TITLE
Fix PostDataFetcher autoload in ContainerRegistrar

### DIFF
--- a/nuclear-engagement/inc/Core/ContainerRegistrar.php
+++ b/nuclear-engagement/inc/Core/ContainerRegistrar.php
@@ -11,6 +11,7 @@ namespace NuclearEngagement;
 use NuclearEngagement\Container;
 use NuclearEngagement\Services\{GenerationService, RemoteApiService, ContentStorageService, PointerService, PostsQueryService, AutoGenerationService, AutoGenerationQueue, AutoGenerationScheduler, GenerationPoller, PublishGenerationHandler, VersionService, DashboardDataService};
 use NuclearEngagement\Services\{AdminNoticeService, LoggingService};
+use NuclearEngagement\Services\PostDataFetcher;
 use NuclearEngagement\Services\Remote\{RemoteRequest, ApiResponseHandler};
 use NuclearEngagement\Admin\Controller\Ajax\{GenerateController, UpdatesController, PointerController, PostsCountController};
 use NuclearEngagement\Admin\Controller\OptinExportController;


### PR DESCRIPTION
## Summary
- import `PostDataFetcher` in `ContainerRegistrar`

## Testing
- `composer lint` *(fails: command not found)*
- `composer test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685cd50c6ce08327a03ed31dbdbe47bc


> [!NOTE]
> I'm currently writing a description for your pull request. I should be done shortly (<1 minute). Please don't edit the description field until I'm finished, or we may overwrite each other. If I find nothing to write about, I'll delete this message.
