### PR TITLE
Add translation update script

### DIFF
--- a/docs/TRANSLATION.md
+++ b/docs/TRANSLATION.md
@@ -23,4 +23,10 @@ After adding new translatable strings in the plugin code, regenerate the templat
 wp i18n make-pot nuclear-engagement nuclear-engagement/languages/nuclear-engagement.pot
 ```
 
+You can also use the helper script defined in `package.json`:
+
+```bash
+npm run i18n
+```
+
 Then refresh your `.po` files in Poedit ("Update from POT") and recompile the `.mo` files.

--- a/package.json
+++ b/package.json
@@ -7,7 +7,8 @@
     "dev": "vite",
     "build": "tsc && vite build",
     "preview": "vite preview",
-    "lint": "eslint \"src/**/*.ts\""
+    "lint": "eslint \"src/**/*.ts\"",
+    "i18n": "bash scripts/update-translations.sh"
   },
   "devDependencies": {
     "@typescript-eslint/eslint-plugin": "^7.0.0",

--- a/scripts/update-translations.sh
+++ b/scripts/update-translations.sh
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+cd "$ROOT"
+
+wp i18n make-pot nuclear-engagement nuclear-engagement/languages/nuclear-engagement.pot


### PR DESCRIPTION
## Summary
- add `scripts/update-translations.sh` to generate the POT file
- expose it as `npm run i18n`
- document usage in `docs/TRANSLATION.md`

## Testing
- `composer lint` *(fails: command not found)*
- `composer test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685cd63e6978832789632b068473e09c


> [!NOTE]
> I'm currently writing a description for your pull request. I should be done shortly (<1 minute). Please don't edit the description field until I'm finished, or we may overwrite each other. If I find nothing to write about, I'll delete this message.
