### PR TITLE
Fix missing namespaced helper functions

### DIFF
--- a/nuclear-engagement/inc/Core/helpers.php
+++ b/nuclear-engagement/inc/Core/helpers.php
@@ -6,6 +6,8 @@ declare(strict_types=1);
  * @package NuclearEngagement
  */
 
+namespace NuclearEngagement;
+
 use NuclearEngagement\SettingsRepository;
 
 if ( ! function_exists( 'nuclen_settings' ) ) {
@@ -104,5 +106,43 @@ if ( ! function_exists( 'nuclen_settings_array' ) ) {
         }
 
         return $repo->get_array( $key, $default );
+    }
+}
+
+namespace {
+    use function NuclearEngagement\nuclen_settings as ns_settings;
+    use function NuclearEngagement\nuclen_settings_bool as ns_settings_bool;
+    use function NuclearEngagement\nuclen_settings_int as ns_settings_int;
+    use function NuclearEngagement\nuclen_settings_string as ns_settings_string;
+    use function NuclearEngagement\nuclen_settings_array as ns_settings_array;
+
+    if ( ! function_exists( 'nuclen_settings' ) ) {
+        function nuclen_settings( ?string $key = null, $default = null ) {
+            return ns_settings( $key, $default );
+        }
+    }
+
+    if ( ! function_exists( 'nuclen_settings_bool' ) ) {
+        function nuclen_settings_bool( string $key, bool $default = false ): bool {
+            return ns_settings_bool( $key, $default );
+        }
+    }
+
+    if ( ! function_exists( 'nuclen_settings_int' ) ) {
+        function nuclen_settings_int( string $key, int $default = 0 ): int {
+            return ns_settings_int( $key, $default );
+        }
+    }
+
+    if ( ! function_exists( 'nuclen_settings_string' ) ) {
+        function nuclen_settings_string( string $key, string $default = '' ): string {
+            return ns_settings_string( $key, $default );
+        }
+    }
+
+    if ( ! function_exists( 'nuclen_settings_array' ) ) {
+        function nuclen_settings_array( string $key, array $default = array() ): array {
+            return ns_settings_array( $key, $default );
+        }
     }
 }


### PR DESCRIPTION
## Summary
- namespace helper functions to match `use function` declarations
- provide global wrappers for backward compatibility

## Testing
- `composer lint` *(fails: command not found)*
- `composer test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685cd5e962dc8327a4d3a404e570762f

<!-- Korbit AI PR Description Start -->
## Description by Korbit AI

### What change is being made?

Introduce namespace `NuclearEngagement` in `helpers.php` file and provide alternative non-namespaced versions of helper functions if they do not already exist.

### Why are these changes being made?

This change ensures that the helper functions within the `NuclearEngagement` namespace are properly namespaced, reducing potential conflicts with other functions in the global namespace. By aliasing these functions and providing a fallback, we maintain backward compatibility with existing code that relies on the non-namespaced function names.

> Is this description stale? Ask me to generate a new description by commenting `/korbit-generate-pr-description`
<!-- Korbit AI PR Description End -->