### PR TITLE
Fix helper functions not loaded

### DIFF
--- a/nuclear-engagement/bootstrap.php
+++ b/nuclear-engagement/bootstrap.php
@@ -49,6 +49,9 @@ if ( file_exists( $autoload ) ) {
         return;
 }
 
+// Load helper functions used across the plugin.
+require_once NUCLEN_PLUGIN_DIR . 'inc/Core/helpers.php';
+
 // Register a minimal PSR-4 autoloader for plugin classes when Composer
 // autoload rules are incomplete.
 spl_autoload_register(


### PR DESCRIPTION
## Summary
- load `helpers.php` from `bootstrap.php`

## Testing
- `composer lint` *(fails: command not found)*
- `composer test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685cd7418ef88327aa20f999e286ac99


> [!NOTE]
> I'm currently writing a description for your pull request. I should be done shortly (<1 minute). Please don't edit the description field until I'm finished, or we may overwrite each other. If I find nothing to write about, I'll delete this message.
