### PR TITLE
Add typed window globals

### DIFF
--- a/src/admin/ts/generate/generate-page-utils.ts
+++ b/src/admin/ts/generate/generate-page-utils.ts
@@ -23,18 +23,18 @@ export function nuclenUpdateProgressBarStep(stepEl: HTMLElement | null, state: s
  * Fetch remaining credits from the SaaS.
  */
 export async function nuclenCheckCreditsAjax(): Promise<number> {
-  if (!(window as any).nuclenAjax || !(window as any).nuclenAjax.ajax_url) {
+  if (!window.nuclenAjax || !window.nuclenAjax.ajax_url) {
     throw new Error('Missing nuclenAjax configuration (ajax_url).');
   }
-  if (!(window as any).nuclenAjax.fetch_action) {
+  if (!window.nuclenAjax.fetch_action) {
     throw new Error('Missing fetch_action in nuclenAjax configuration.');
   }
   const formData = new FormData();
-  formData.append('action', (window as any).nuclenAjax.fetch_action);
-  if ((window as any).nuclenAjax.nonce) {
-    formData.append('security', (window as any).nuclenAjax.nonce);
+  formData.append('action', window.nuclenAjax.fetch_action);
+  if (window.nuclenAjax.nonce) {
+    formData.append('security', window.nuclenAjax.nonce);
   }
-  const result = await nuclenFetchWithRetry<any>((window as any).nuclenAjax.ajax_url, {
+  const result = await nuclenFetchWithRetry<any>(window.nuclenAjax.ajax_url, {
     method: 'POST',
     body: formData,
     credentials: 'same-origin',

--- a/src/admin/ts/generate/step1.ts
+++ b/src/admin/ts/generate/step1.ts
@@ -17,7 +17,7 @@ import * as logger from '../utils/logger';
 
 export function initStep1(elements: GeneratePageElements): void {
   elements.getPostsBtn?.addEventListener('click', async () => {
-    if (!(window as any).nuclenAjax || !(window as any).nuclenAjax.ajax_url) {
+    if (!window.nuclenAjax || !window.nuclenAjax.ajax_url) {
       displayError('Error: Ajax is not configured properly. Please check the plugin settings.');
       return;
     }
@@ -27,13 +27,13 @@ export function initStep1(elements: GeneratePageElements): void {
 
     const formData = new FormData();
     formData.append('action', 'nuclen_get_posts_count');
-    if ((window as any).nuclenAjax?.nonce) {
-      formData.append('security', (window as any).nuclenAjax.nonce);
+    if (window.nuclenAjax?.nonce) {
+      formData.append('security', window.nuclenAjax.nonce);
     }
     const filters: NuclenFilterValues = nuclenCollectFilters();
     nuclenAppendFilters(formData, filters);
 
-    const result = await nuclenFetchWithRetry<any>((window as any).nuclenAjax.ajax_url || '', {
+    const result = await nuclenFetchWithRetry<any>(window.nuclenAjax.ajax_url || '', {
       method: 'POST',
       body: formData,
       credentials: 'same-origin',

--- a/src/admin/ts/generate/step2.ts
+++ b/src/admin/ts/generate/step2.ts
@@ -15,7 +15,7 @@ import * as logger from '../utils/logger';
 export function initStep2(elements: GeneratePageElements): void {
   elements.generateForm?.addEventListener('submit', async (event) => {
     event.preventDefault();
-    if (!(window as any).nuclenAdminVars || !(window as any).nuclenAdminVars.ajax_url) {
+    if (!window.nuclenAdminVars || !window.nuclenAdminVars.ajax_url) {
       displayError('Error: WP Ajax config not found. Please check the plugin settings.');
       return;
     }

--- a/src/admin/ts/generation/results.ts
+++ b/src/admin/ts/generation/results.ts
@@ -1,8 +1,8 @@
 export const REST_ENDPOINT =
-  (window as any).nuclenAdminVars?.rest_receive_content ||
+  window.nuclenAdminVars?.rest_receive_content ||
   '/wp-json/nuclear-engagement/v1/receive-content';
 
-export const REST_NONCE = (window as any).nuclenAdminVars?.rest_nonce || '';
+export const REST_NONCE = window.nuclenAdminVars?.rest_nonce || '';
 import { displayError } from '../utils/displayError';
 import * as logger from '../utils/logger';
 

--- a/src/admin/ts/nuclen-globals.d.ts
+++ b/src/admin/ts/nuclen-globals.d.ts
@@ -12,7 +12,10 @@ declare global {
     nuclenAdminVars?: {
       ajax_url?: string;
       security?: string;
+      rest_receive_content?: string;
+      rest_nonce?: string;
     };
+    tinymce?: any;
     wp?: any;
   }
 }

--- a/src/admin/ts/single/single-generation-utils.ts
+++ b/src/admin/ts/single/single-generation-utils.ts
@@ -50,8 +50,8 @@ export function populateSummaryMetaBox(postResult: any, finalDate?: string): voi
     dateField.readOnly = true;
   }
 
-  if (typeof (window as any).tinymce !== 'undefined') {
-    const editor = (window as any).tinymce.get('nuclen_summary_data_summary');
+  if (typeof window.tinymce !== 'undefined') {
+    const editor = window.tinymce.get('nuclen_summary_data_summary');
     if (editor && typeof editor.setContent === 'function') {
       editor.setContent(summary || '');
       editor.save();

--- a/src/front/ts/nuclen-front-global.ts
+++ b/src/front/ts/nuclen-front-global.ts
@@ -33,21 +33,6 @@ declare global {
   };
 
   function gtag(...args: any[]): void;
-
-  interface Window {
-    NuclenOptinEnabled: boolean;
-    NuclenOptinWebhook: string;
-    NuclenOptinSuccessMessage: string;
-
-    NuclenLazyLoadComponent?: (
-      containerId: string,
-      initFunctionName?: string | null
-    ) => void;
-
-    nuclearEngagementInitQuiz?: () => void;
-    nuclearEngagementShowQuizQuestionDetails?: (index: number) => void;
-    nuclearEngagementRetakeQuiz?: () => void;
-  }
 }
 
 export {};

--- a/src/front/ts/nuclen-front-lazy.ts
+++ b/src/front/ts/nuclen-front-lazy.ts
@@ -11,7 +11,10 @@
 /**
  * 2a) Lazy-load container. Observes 'containerId' and triggers `initFunctionName` once visible.
  */
-window.NuclenLazyLoadComponent = function (containerId: string, initFunctionName: string | null = null) {
+window.NuclenLazyLoadComponent = function (
+  containerId: string,
+  initFunctionName: string | null = null,
+) {
     const component = document.getElementById(containerId);
     if (!component) return;
 
@@ -19,8 +22,9 @@ window.NuclenLazyLoadComponent = function (containerId: string, initFunctionName
       (entries) => {
         entries.forEach((entry) => {
           if (entry.isIntersecting) {
-            if (initFunctionName && typeof (window as any)[initFunctionName] === 'function') {
-              (window as any)[initFunctionName]();
+            const win = window as unknown as Record<string, unknown>;
+            if (initFunctionName && typeof win[initFunctionName] === 'function') {
+              (win[initFunctionName] as () => void)();
             }
             observer.disconnect();
           }

--- a/src/front/ts/nuclen-front-quiz.ts
+++ b/src/front/ts/nuclen-front-quiz.ts
@@ -5,4 +5,4 @@
 import { initQuiz } from './nuclen-quiz-main';
 
 /* Expose for lazy loader / global inline calls */
-(window as any).nuclearEngagementInitQuiz = initQuiz;
+window.nuclearEngagementInitQuiz = initQuiz;

--- a/src/front/ts/nuclen-globals.d.ts
+++ b/src/front/ts/nuclen-globals.d.ts
@@ -1,0 +1,16 @@
+export {};
+
+declare global {
+  interface Window {
+    NuclenOptinEnabled?: boolean;
+    NuclenOptinWebhook?: string;
+    NuclenOptinSuccessMessage?: string;
+    NuclenLazyLoadComponent?: (
+      containerId: string,
+      initFunctionName?: string | null
+    ) => void;
+    nuclearEngagementInitQuiz?: () => void;
+    nuclearEngagementShowQuizQuestionDetails?: (index: number) => void;
+    nuclearEngagementRetakeQuiz?: () => void;
+  }
+}

--- a/src/front/ts/nuclen-quiz-main.ts
+++ b/src/front/ts/nuclen-quiz-main.ts
@@ -77,8 +77,8 @@ import * as logger from './logger';
       mandatory: Boolean(NuclenOptinMandatory),
       promptText: NuclenOptinPromptText,
       submitLabel: NuclenOptinButtonText,
-      enabled: Boolean((window as any).NuclenOptinEnabled),
-      webhook: (window as any).NuclenOptinWebhook,
+      enabled: Boolean(window.NuclenOptinEnabled),
+      webhook: window.NuclenOptinWebhook ?? '',
       ajaxUrl: NuclenOptinAjax?.url ?? '',
       ajaxNonce: NuclenOptinAjax?.nonce ?? '',
     };

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -33,6 +33,7 @@
   "include": [
     "src/admin/ts/**/*",
     "src/front/ts/**/*",
+    "src/front/ts/nuclen-globals.d.ts",
     "src/modules/toc/ts/**/*"
   ]
 }


### PR DESCRIPTION
## Summary
- add `nuclen-globals.d.ts` for front-end globals and include in `tsconfig.json`
- augment admin globals with REST fields and TinyMCE
- expose globals without `any`
- use typed window references in admin modules

## Testing
- `npm run lint` *(fails: Cannot find package '@typescript-eslint/eslint-plugin')*
- `composer lint` *(fails: command not found)*
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_685cd6344a288327b1fde6c02b0faae3

<!-- Korbit AI PR Description Start -->
## Description by Korbit AI

### What change is being made?
Refactor code to replace unsafe `any` typecasting with explicit type declarations for global `window` variables.

### Why are these changes being made?
This change improves TypeScript type safety and code maintainability by using explicit types for window globals, reducing the risk of runtime errors due to incorrect assumptions about object structures. This approach enhances developer experience and clarifies the expected properties of `window` objects across the codebase.

> Is this description stale? Ask me to generate a new description by commenting `/korbit-generate-pr-description`
<!-- Korbit AI PR Description End -->