### PR TITLE
Improve post fetch batching

### DIFF
--- a/nuclear-engagement/inc/Core/constants.php
+++ b/nuclear-engagement/inc/Core/constants.php
@@ -37,6 +37,9 @@ define( 'NUCLEN_POLL_RETRY_DELAY', MINUTE_IN_SECONDS );
 /** Delay for manual generation polling in seconds. */
 define( 'NUCLEN_GENERATION_POLL_DELAY', 30 );
 
+/** Number of post IDs fetched per database query when generating. */
+define( 'NUCLEN_POST_FETCH_CHUNK', 200 );
+
 /** Default summary length when generating posts. */
 define( 'NUCLEN_SUMMARY_LENGTH_DEFAULT', 30 );
 

--- a/nuclear-engagement/inc/Services/GenerationService.php
+++ b/nuclear-engagement/inc/Services/GenerationService.php
@@ -198,7 +198,10 @@ class GenerationService {
         $data      = array();
         $postsById = array();
 
-        foreach ( array_chunk( $postIds, 50 ) as $chunk ) {
+        $chunkSize = defined( 'NUCLEN_POST_FETCH_CHUNK' ) ? (int) constant( 'NUCLEN_POST_FETCH_CHUNK' ) : 200;
+        $chunks    = count( $postIds ) <= $chunkSize ? array( $postIds ) : array_chunk( $postIds, $chunkSize );
+
+        foreach ( $chunks as $chunk ) {
             $placeholders = implode( ',', array_fill( 0, count( $chunk ), '%d' ) );
             $sql          = $wpdb->prepare(
                 "SELECT ID, post_title, post_content


### PR DESCRIPTION
## Summary
- make post fetch batch size configurable
- optimize `getPostsData()` to use large chunks or a single query
- test large ID lists are chunked properly

## Testing
- `composer lint --working-dir=nuclear-engagement` *(fails: command not found)*
- `composer test --working-dir=nuclear-engagement` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685cd97d060c8327b77211b1be28f799

<!-- Korbit AI PR Description Start -->
## Description by Korbit AI

### What change is being made?

Increase the number of post IDs fetched per database query in batch processing from 50 to a configurable chunk size, which is now set at 200, and add tests to verify behavior for larger ID lists.

### Why are these changes being made?

This change aims to improve the efficiency of database queries during the post generation process by allowing larger chunks of data to be fetched at once, reducing the number of queries necessary. By defining a constant `NUCLEN_POST_FETCH_CHUNK` to manage chunk size, it provides flexibility for future adjustments without altering the core logic. Adding unit tests ensures that the new configuration behaves as expected, enhancing the reliability of the generation service.

> Is this description stale? Ask me to generate a new description by commenting `/korbit-generate-pr-description`
<!-- Korbit AI PR Description End -->