### PR TITLE
Cache TOC headings in post meta

### DIFF
--- a/nuclear-engagement/inc/Modules/TOC/includes/class-nuclen-toc-render.php
+++ b/nuclear-engagement/inc/Modules/TOC/includes/class-nuclen-toc-render.php
@@ -182,7 +182,7 @@ final class Nuclen_TOC_Render {
         $atts     = $this->prepare_shortcode_attributes( $atts, $settings );
 
         $list  = ( strtolower( $atts['list'] ) === 'ol' ) ? 'ol' : 'ul';
-        $heads = Nuclen_TOC_Utils::extract( $post->post_content, $atts['heading_levels'] );
+        $heads = Nuclen_TOC_Utils::extract( $post->post_content, $atts['heading_levels'], $post->ID );
         if ( ! $heads ) {
             return '';
         }

--- a/tests/NuclenTOCHeadingsTest.php
+++ b/tests/NuclenTOCHeadingsTest.php
@@ -34,6 +34,7 @@ if (!function_exists('esc_attr')) { function esc_attr($t){ return htmlspecialcha
 if (!function_exists('__')) { function __($t, $d = null) { return $t; } }
 if (!function_exists('apply_filters')) { function apply_filters($hook, $value) { return $value; } }
 if (!function_exists('wp_strip_all_tags')) { function wp_strip_all_tags($t){ return strip_tags($t); } }
+if (!function_exists('get_the_ID')) { function get_the_ID() { return $GLOBALS['current_post_id'] ?? 0; } }
 
 namespace NuclearEngagement\Modules\TOC {
     if (!function_exists('apply_filters')) {

--- a/tests/NuclenTOCMetaCacheTest.php
+++ b/tests/NuclenTOCMetaCacheTest.php
@@ -1,0 +1,47 @@
+<?php
+use PHPUnit\Framework\TestCase;
+use NuclearEngagement\Modules\TOC\Nuclen_TOC_Utils;
+use NuclearEngagement\Modules\TOC\Nuclen_TOC_Headings;
+
+namespace NuclearEngagement\Modules\TOC {
+    function update_post_meta($postId, $key, $value){
+        $GLOBALS['wp_meta'][$postId][$key] = $value; return true;
+    }
+    function delete_post_meta($postId, $key){ unset($GLOBALS['wp_meta'][$postId][$key]); }
+}
+
+namespace {
+    if (!defined('HOUR_IN_SECONDS')) { define('HOUR_IN_SECONDS', 3600); }
+    if (!defined('NUCLEN_TOC_DIR')) { define('NUCLEN_TOC_DIR', dirname(__DIR__).'/nuclear-engagement/inc/Modules/TOC/'); }
+    if (!defined('NUCLEN_TOC_URL')) { define('NUCLEN_TOC_URL', 'http://example.com/'); }
+    require_once NUCLEN_TOC_DIR.'includes/polyfills.php';
+    require_once NUCLEN_TOC_DIR.'includes/class-nuclen-toc-utils.php';
+    require_once NUCLEN_TOC_DIR.'includes/class-nuclen-toc-headings.php';
+
+    class NuclenTOCMetaCacheTest extends TestCase {
+        protected function setUp(): void {
+            $GLOBALS['wp_posts'] = [];
+            $GLOBALS['wp_meta'] = [];
+            $GLOBALS['wp_cache'] = [];
+            $GLOBALS['transients'] = [];
+        }
+
+        public function test_extract_returns_meta_when_available(): void {
+            $post = (object)[ 'ID' => 1, 'post_content' => '<h2>One</h2>' ];
+            $stored = [ [ 'tag'=>'h2','level'=>2,'text'=>'One','inner'=>'One','id'=>'one' ] ];
+            $GLOBALS['wp_posts'][1] = $post;
+            $GLOBALS['wp_meta'][1][Nuclen_TOC_Headings::META_KEY] = $stored;
+            $result = Nuclen_TOC_Utils::extract($post->post_content, [2], 1);
+            $this->assertSame($stored, $result);
+        }
+
+        public function test_cache_saved_on_save_post(): void {
+            $post = (object)[ 'ID' => 2, 'post_content' => '<h2>Two</h2>' ];
+            $handler = new Nuclen_TOC_Headings();
+            $handler->cache_headings_on_save(2, $post, true);
+            $this->assertArrayHasKey(Nuclen_TOC_Headings::META_KEY, $GLOBALS['wp_meta'][2]);
+            $saved = $GLOBALS['wp_meta'][2][Nuclen_TOC_Headings::META_KEY];
+            $this->assertSame('two', $saved[0]['id']);
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- store extracted TOC headings in new `nuclen_toc_headings` meta key
- save/update/delete cached headings when posts are saved or removed
- allow `Nuclen_TOC_Utils::extract()` to read cached headings first
- add unit tests for new caching behaviour
- update existing tests for new helper requirements

## Testing
- `composer lint` *(fails: command not found)*
- `composer test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685cd979e6a083278e59fa574c45ebe6

<!-- Korbit AI PR Description Start -->
## Description by Korbit AI

### What change is being made?

Cache Table of Contents (TOC) headings in post metadata to improve content rendering efficiency and update related functionality in existing classes and tests.

### Why are these changes being made?

These changes are made to enhance the performance by caching TOC headings in the post meta, allowing for faster retrieval during content rendering. This approach reduces overhead by avoiding repetitive extraction processes, especially on frequently accessed posts. The decision to store cache upon saving and remove it upon deletion ensures data consistency and aligns with post lifecycle events.

> Is this description stale? Ask me to generate a new description by commenting `/korbit-generate-pr-description`
<!-- Korbit AI PR Description End -->