### PR TITLE
Fix namespace syntax in helper functions

### DIFF
--- a/nuclear-engagement/inc/Core/helpers.php
+++ b/nuclear-engagement/inc/Core/helpers.php
@@ -109,7 +109,7 @@ if ( ! function_exists( 'nuclen_settings_array' ) ) {
     }
 }
 
-namespace;
+namespace {
 
 use function NuclearEngagement\nuclen_settings as ns_settings;
 use function NuclearEngagement\nuclen_settings_bool as ns_settings_bool;
@@ -146,3 +146,4 @@ use function NuclearEngagement\nuclen_settings_array as ns_settings_array;
             return ns_settings_array( $key, $default );
         }
     }
+}


### PR DESCRIPTION
## Summary
- correct global namespace syntax in `helpers.php`

## Testing
- `composer lint` *(fails: command not found)*
- `composer test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685cdc2cae1c8327b1819211fe330b25


> [!NOTE]
> I'm currently writing a description for your pull request. I should be done shortly (<1 minute). Please don't edit the description field until I'm finished, or we may overwrite each other. If I find nothing to write about, I'll delete this message.
