### PR TITLE
Handle update_post_meta failures

### DIFF
--- a/nuclear-engagement/inc/Modules/Quiz/class-quiz-service.php
+++ b/nuclear-engagement/inc/Modules/Quiz/class-quiz-service.php
@@ -60,7 +60,11 @@ final class Quiz_Service {
             }
         }
 
-        update_post_meta( $post_id, self::META_KEY, $formatted );
+        $updated = update_post_meta( $post_id, self::META_KEY, $formatted );
+        if ( false === $updated ) {
+            LoggingService::log( 'Failed to update quiz data for post ' . $post_id );
+            LoggingService::notify_admin( 'Failed to update quiz data for post ' . $post_id );
+        }
         clean_post_cache( $post_id );
     }
 
@@ -76,7 +80,11 @@ final class Quiz_Service {
      */
     public function set_protected( int $post_id, bool $protected ): void {
         if ( $protected ) {
-            update_post_meta( $post_id, self::PROTECTED_KEY, 1 );
+            $updated = update_post_meta( $post_id, self::PROTECTED_KEY, 1 );
+            if ( false === $updated ) {
+                LoggingService::log( 'Failed to update quiz protected flag for post ' . $post_id );
+                LoggingService::notify_admin( 'Failed to update quiz protected flag for post ' . $post_id );
+            }
         } else {
             delete_post_meta( $post_id, self::PROTECTED_KEY );
         }

--- a/nuclear-engagement/inc/Modules/Summary/includes/class-nuclen-summary-metabox.php
+++ b/nuclear-engagement/inc/Modules/Summary/includes/class-nuclen-summary-metabox.php
@@ -108,7 +108,11 @@ final class Nuclen_Summary_Metabox {
         );
 
         /* ---- Save to DB --------------------------------------------------- */
-        update_post_meta( $post_id, 'nuclen-summary-data', $formatted );
+        $updated = update_post_meta( $post_id, 'nuclen-summary-data', $formatted );
+        if ( false === $updated ) {
+            \NuclearEngagement\Services\LoggingService::log( 'Failed to update summary data for post ' . $post_id );
+            \NuclearEngagement\Services\LoggingService::notify_admin( 'Failed to update summary data for post ' . $post_id );
+        }
         clean_post_cache( $post_id );
 
         /* ---- Update post_modified if enabled ----------------------------- */
@@ -137,7 +141,11 @@ final class Nuclen_Summary_Metabox {
 
         /* ---- Protected flag ---------------------------------------------- */
         if ( isset( $_POST['nuclen_summary_protected'] ) && $_POST['nuclen_summary_protected'] === '1' ) {
-            update_post_meta( $post_id, 'nuclen_summary_protected', 1 );
+            $updated_prot = update_post_meta( $post_id, 'nuclen_summary_protected', 1 );
+            if ( false === $updated_prot ) {
+                \NuclearEngagement\Services\LoggingService::log( 'Failed to update summary protected flag for post ' . $post_id );
+                \NuclearEngagement\Services\LoggingService::notify_admin( 'Failed to update summary protected flag for post ' . $post_id );
+            }
         } else {
             delete_post_meta( $post_id, 'nuclen_summary_protected' );
         }

--- a/tests/QuizServiceFailureTest.php
+++ b/tests/QuizServiceFailureTest.php
@@ -1,0 +1,45 @@
+<?php
+use PHPUnit\Framework\TestCase;
+use NuclearEngagement\Modules\Quiz\Quiz_Service;
+
+namespace NuclearEngagement\Modules\Quiz {
+    function update_post_meta($postId, $key, $value) { return false; }
+    function delete_post_meta($postId, $key) {}
+    function clean_post_cache($id) {}
+    function sanitize_text_field($val) { return $val; }
+    function wp_kses_post($val) { return $val; }
+}
+
+namespace NuclearEngagement\Services {
+    class LoggingService {
+        public static array $logs = [];
+        public static array $notices = [];
+        public static function log(string $msg): void { self::$logs[] = $msg; }
+        public static function notify_admin(string $msg): void { self::$notices[] = $msg; }
+    }
+}
+
+namespace {
+    class QuizServiceFailureTest extends TestCase {
+        protected function setUp(): void {
+            \NuclearEngagement\Services\LoggingService::$logs = [];
+            \NuclearEngagement\Services\LoggingService::$notices = [];
+        }
+
+        public function test_save_quiz_data_logs_on_failure(): void {
+            $service = new Quiz_Service();
+            $service->save_quiz_data(1, [ 'questions' => [ [ 'question' => 'Q', 'answers' => ['A'] ] ] ]);
+            $expected = ['Failed to update quiz data for post 1'];
+            $this->assertSame($expected, \NuclearEngagement\Services\LoggingService::$logs);
+            $this->assertSame($expected, \NuclearEngagement\Services\LoggingService::$notices);
+        }
+
+        public function test_set_protected_logs_on_failure(): void {
+            $service = new Quiz_Service();
+            $service->set_protected(2, true);
+            $expected = ['Failed to update quiz protected flag for post 2'];
+            $this->assertSame($expected, \NuclearEngagement\Services\LoggingService::$logs);
+            $this->assertSame($expected, \NuclearEngagement\Services\LoggingService::$notices);
+        }
+    }
+}

--- a/tests/SummaryMetaboxFailureTest.php
+++ b/tests/SummaryMetaboxFailureTest.php
@@ -1,0 +1,64 @@
+<?php
+use PHPUnit\Framework\TestCase;
+use NuclearEngagement\Modules\Summary\Nuclen_Summary_Metabox;
+
+namespace NuclearEngagement\Modules\Summary {
+    function current_user_can($cap, $id) { return true; }
+    function wp_unslash($val) { return $val; }
+    function sanitize_text_field($val) { return $val; }
+    function wp_kses_post($val) { return $val; }
+    function update_post_meta($id, $key, $value) { return false; }
+    function delete_post_meta($id, $key) {}
+    function clean_post_cache($id) {}
+}
+
+namespace NuclearEngagement\Services {
+    class LoggingService {
+        public static array $logs = [];
+        public static array $notices = [];
+        public static function log(string $msg): void { self::$logs[] = $msg; }
+        public static function notify_admin(string $msg): void { self::$notices[] = $msg; }
+    }
+}
+
+namespace {
+    class DummyRepo {
+        public function get($key, $default = 0) { return 0; }
+    }
+
+    class SummaryMetaboxFailureTest extends TestCase {
+        protected function setUp(): void {
+            $_POST = [
+                'nuclen_summary_data_nonce' => 'n',
+                'nuclen_summary_data' => [],
+            ];
+            \NuclearEngagement\Services\LoggingService::$logs = [];
+            \NuclearEngagement\Services\LoggingService::$notices = [];
+            $GLOBALS['test_verify_nonce'] = true;
+        }
+
+        protected function tearDown(): void {
+            unset($GLOBALS['test_verify_nonce']);
+        }
+
+        public function test_save_meta_logs_on_failure(): void {
+            $box = new Nuclen_Summary_Metabox(new DummyRepo());
+            $box->nuclen_save_summary_data_meta(1);
+            $expected = ['Failed to update summary data for post 1'];
+            $this->assertSame($expected, \NuclearEngagement\Services\LoggingService::$logs);
+            $this->assertSame($expected, \NuclearEngagement\Services\LoggingService::$notices);
+        }
+
+        public function test_protected_flag_logs_on_failure(): void {
+            $_POST['nuclen_summary_protected'] = '1';
+            $box = new Nuclen_Summary_Metabox(new DummyRepo());
+            $box->nuclen_save_summary_data_meta(2);
+            $expected = [
+                'Failed to update summary data for post 2',
+                'Failed to update summary protected flag for post 2'
+            ];
+            $this->assertSame($expected, \NuclearEngagement\Services\LoggingService::$logs);
+            $this->assertSame($expected, \NuclearEngagement\Services\LoggingService::$notices);
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- log failures when saving quiz meta or protected flag
- log failures when saving summary meta or protected flag
- test failure handling for quiz and summary services

## Testing
- `composer lint` *(fails: command not found)*
- `composer test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685cdb820210832788125e1c1adb9639