### PR TITLE
Use Throwable catches and log exceptions

### DIFF
--- a/nuclear-engagement/admin/Controller/Ajax/GenerateController.php
+++ b/nuclear-engagement/admin/Controller/Ajax/GenerateController.php
@@ -67,11 +67,8 @@ class GenerateController extends BaseController {
                 'Nuclear Engagement validation error: ' . $e->getMessage()
             );
             $this->sendError( $e->getMessage(), 400 );
-        } catch ( \Exception $e ) {
-            \NuclearEngagement\Services\LoggingService::log(
-                'Nuclear Engagement generation error: ' . $e->getMessage() . ' in ' . $e->getFile() . ':' . $e->getLine()
-            );
-            \NuclearEngagement\Services\LoggingService::log( 'Stack trace: ' . $e->getTraceAsString() );
+        } catch ( \Throwable $e ) {
+            \NuclearEngagement\Services\LoggingService::log_exception( $e );
             $this->sendError(
                 __( 'An unexpected error occurred. Please check your error logs.', 'nuclear-engagement' ),
                 500

--- a/nuclear-engagement/admin/Controller/Ajax/PointerController.php
+++ b/nuclear-engagement/admin/Controller/Ajax/PointerController.php
@@ -52,7 +52,8 @@ class PointerController extends BaseController {
 
         } catch ( \InvalidArgumentException $e ) {
             $this->sendError( $e->getMessage() );
-        } catch ( \Exception $e ) {
+        } catch ( \Throwable $e ) {
+            \NuclearEngagement\Services\LoggingService::log_exception( $e );
             $this->sendError( __( 'An error occurred', 'nuclear-engagement' ) );
         }
     }

--- a/nuclear-engagement/admin/Controller/Ajax/PostsCountController.php
+++ b/nuclear-engagement/admin/Controller/Ajax/PostsCountController.php
@@ -53,7 +53,7 @@ class PostsCountController extends BaseController {
 
             wp_send_json_success( $result );
 
-        } catch ( \Exception $e ) {
+        } catch ( \Throwable $e ) {
             LoggingService::log_exception( $e );
             $this->sendError( $e->getMessage() );
         }

--- a/nuclear-engagement/admin/Traits/AdminAutoGenerate.php
+++ b/nuclear-engagement/admin/Traits/AdminAutoGenerate.php
@@ -81,7 +81,7 @@ trait AdminAutoGenerate {
             $container = $this->get_container();
             $service   = $container->get( 'generation_service' );
             $service->generateSingle( $post_id, $workflow_type );
-               } catch ( \Exception $e ) {
+               } catch ( \Throwable $e ) {
                        \NuclearEngagement\Services\LoggingService::log_exception( $e );
                }
        }
@@ -125,7 +125,7 @@ trait AdminAutoGenerate {
                     "Still processing post {$post_id} ({$workflow_type}), attempt {$attempt}/{$max_attempts}"
                 );
             }
-               } catch ( \Exception $e ) {
+               } catch ( \Throwable $e ) {
                        \NuclearEngagement\Services\LoggingService::log_exception( $e );
                }
 

--- a/nuclear-engagement/front/Controller/Rest/ContentController.php
+++ b/nuclear-engagement/front/Controller/Rest/ContentController.php
@@ -111,7 +111,7 @@ class ContentController {
                } catch ( \InvalidArgumentException $e ) {
                        \NuclearEngagement\Services\LoggingService::log_exception( $e );
                        return new \WP_Error( 'ne_invalid', $e->getMessage(), array( 'status' => 400 ) );
-               } catch ( \Exception $e ) {
+               } catch ( \Throwable $e ) {
                        \NuclearEngagement\Services\LoggingService::log_exception( $e );
                        return new \WP_Error( 'ne_error', __( 'An error occurred', 'nuclear-engagement' ), array( 'status' => 500 ) );
                }

--- a/nuclear-engagement/front/traits/RestTrait.php
+++ b/nuclear-engagement/front/traits/RestTrait.php
@@ -39,7 +39,7 @@ trait RestTrait {
                         $storage   = $container->get( 'content_storage' );
             $storage->storeQuizData( $post_id, $quiz_data );
             return true;
-               } catch ( \Exception $e ) {
+               } catch ( \Throwable $e ) {
                        \NuclearEngagement\Services\LoggingService::log_exception( $e );
                        return false;
                }

--- a/nuclear-engagement/inc/Services/ContentStorageService.php
+++ b/nuclear-engagement/inc/Services/ContentStorageService.php
@@ -75,8 +75,8 @@ class ContentStorageService {
 
                 \NuclearEngagement\Services\LoggingService::log( "Stored {$workflowType} data for post {$postId}" );
 
-            } catch ( \Exception $e ) {
-                \NuclearEngagement\Services\LoggingService::log( "Error storing {$workflowType} for post {$postId}: " . $e->getMessage() );
+            } catch ( \Throwable $e ) {
+                \NuclearEngagement\Services\LoggingService::log_exception( $e );
             }
         }
     }

--- a/nuclear-engagement/inc/Services/GenerationService.php
+++ b/nuclear-engagement/inc/Services/GenerationService.php
@@ -178,8 +178,8 @@ class GenerationService {
                                 }
                                 \NuclearEngagement\Services\LoggingService::log( "Scheduled polling for post {$postId}, generation {$response->generationId}" );
                         }
-        } catch ( \Exception $e ) {
-            \NuclearEngagement\Services\LoggingService::log( "Error generating {$workflowType} for post {$postId}: " . $e->getMessage() );
+        } catch ( \Throwable $e ) {
+            \NuclearEngagement\Services\LoggingService::log_exception( $e );
             throw $e;
         }
     }

--- a/tests/ContentControllerTest.php
+++ b/tests/ContentControllerTest.php
@@ -10,6 +10,9 @@ namespace NuclearEngagement\Services {
         public static function log(string $msg): void {
             self::$logs[] = $msg;
         }
+        public static function log_exception(\Throwable $e): void {
+            self::$logs[] = $e->getMessage();
+        }
     }
 }
 

--- a/tests/GenerationServiceSingleTest.php
+++ b/tests/GenerationServiceSingleTest.php
@@ -11,6 +11,9 @@ namespace NuclearEngagement\Services {
         public static function log(string $msg): void {
             self::$logs[] = $msg;
         }
+        public static function log_exception(\Throwable $e): void {
+            self::$logs[] = $e->getMessage();
+        }
     }
 }
 


### PR DESCRIPTION
## Summary
- broaden catch blocks to `\Throwable`
- log caught errors with `LoggingService::log_exception`
- update test stubs for `log_exception`

## Testing
- `composer lint` *(fails: command not found)*
- `composer test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685cdb83a7008327bd71cb0b12748951

<!-- Korbit AI PR Description Start -->
## Description by Korbit AI

### What change is being made?

Replace `\Exception` catches with `\Throwable` in various controllers and services, and utilize a new `log_exception` method for logging exceptions across the nuclear-engagement codebase.

### Why are these changes being made?

The change to catching `\Throwable` instead of `\Exception` allows for a broader range of error types to be caught, including both exceptions and errors. This is important for robust error handling, ensuring that any type of throwable error can be processed. The consolidation of exception logging through `log_exception` simplifies the code and standardizes how detailed logging is performed, improving maintainability and clarity.

> Is this description stale? Ask me to generate a new description by commenting `/korbit-generate-pr-description`
<!-- Korbit AI PR Description End -->