### PR TITLE
Fix namespace syntax in helpers

### DIFF
--- a/nuclear-engagement/inc/Core/helpers.php
+++ b/nuclear-engagement/inc/Core/helpers.php
@@ -109,7 +109,7 @@ if ( ! function_exists( 'nuclen_settings_array' ) ) {
     }
 }
 
-namespace {
+namespace;
 
 use function NuclearEngagement\nuclen_settings as ns_settings;
 use function NuclearEngagement\nuclen_settings_bool as ns_settings_bool;
@@ -117,33 +117,32 @@ use function NuclearEngagement\nuclen_settings_int as ns_settings_int;
 use function NuclearEngagement\nuclen_settings_string as ns_settings_string;
 use function NuclearEngagement\nuclen_settings_array as ns_settings_array;
 
-    if ( ! function_exists( 'nuclen_settings' ) ) {
-        function nuclen_settings( ?string $key = null, $default = null ) {
-            return ns_settings( $key, $default );
-        }
+if ( ! function_exists( 'nuclen_settings' ) ) {
+    function nuclen_settings( ?string $key = null, $default = null ) {
+        return ns_settings( $key, $default );
     }
+}
 
-    if ( ! function_exists( 'nuclen_settings_bool' ) ) {
-        function nuclen_settings_bool( string $key, bool $default = false ): bool {
-            return ns_settings_bool( $key, $default );
-        }
+if ( ! function_exists( 'nuclen_settings_bool' ) ) {
+    function nuclen_settings_bool( string $key, bool $default = false ): bool {
+        return ns_settings_bool( $key, $default );
     }
+}
 
-    if ( ! function_exists( 'nuclen_settings_int' ) ) {
-        function nuclen_settings_int( string $key, int $default = 0 ): int {
-            return ns_settings_int( $key, $default );
-        }
+if ( ! function_exists( 'nuclen_settings_int' ) ) {
+    function nuclen_settings_int( string $key, int $default = 0 ): int {
+        return ns_settings_int( $key, $default );
     }
+}
 
-    if ( ! function_exists( 'nuclen_settings_string' ) ) {
-        function nuclen_settings_string( string $key, string $default = '' ): string {
-            return ns_settings_string( $key, $default );
-        }
+if ( ! function_exists( 'nuclen_settings_string' ) ) {
+    function nuclen_settings_string( string $key, string $default = '' ): string {
+        return ns_settings_string( $key, $default );
     }
+}
 
-    if ( ! function_exists( 'nuclen_settings_array' ) ) {
-        function nuclen_settings_array( string $key, array $default = array() ): array {
-            return ns_settings_array( $key, $default );
-        }
+if ( ! function_exists( 'nuclen_settings_array' ) ) {
+    function nuclen_settings_array( string $key, array $default = array() ): array {
+        return ns_settings_array( $key, $default );
     }
 }


### PR DESCRIPTION
## Summary
- stop mixing bracketed and unbracketed namespaces
- ensure global helper functions are in unbracketed namespace

## Testing
- `composer lint` *(fails: command not found)*
- `composer test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685cdd8398d08327bac657ee77de8b3f

<!-- Korbit AI PR Description Start -->
## Description by Korbit AI

### What change is being made?

Correct the namespace syntax by removing the curly braces and simplifying function definitions in `helpers.php`.

### Why are these changes being made?

The existing namespace syntax using curly braces was incorrect for this context, leading to potential confusion or errors. Simplifying the syntax by using namespace without braces and removing unnecessary indentation improves code readability and adherence to proper PHP standards. This approach aligns with best practices and makes the code more maintainable.

> Is this description stale? Ask me to generate a new description by commenting `/korbit-generate-pr-description`
<!-- Korbit AI PR Description End -->