### PR TITLE
Add DB error checks

### DIFF
--- a/nuclear-engagement/admin/Dashboard.php
+++ b/nuclear-engagement/admin/Dashboard.php
@@ -148,7 +148,12 @@ if ( null === $inventory_cache ) {
                 GROUP BY t.term_id",
             array_merge( $sanitized_pt, $sanitized_st )
         );
-            $cat_rows = $wpdb->get_results( $sql_cat, ARRAY_A );
+        $cat_rows = $wpdb->get_results( $sql_cat, ARRAY_A );
+
+        if ( ! empty( $wpdb->last_error ) ) {
+            \NuclearEngagement\Services\LoggingService::log( 'Category stats query error: ' . $wpdb->last_error );
+            $cat_rows = array();
+        }
 
         foreach ( $cat_rows as $r ) {
             $by_category_quiz[ $r['cat_name'] ]['with']       = (int) $r['quiz_with'];

--- a/nuclear-engagement/inc/Services/DashboardDataService.php
+++ b/nuclear-engagement/inc/Services/DashboardDataService.php
@@ -93,6 +93,11 @@ class DashboardDataService {
 
         $rows = $wpdb->get_results( $sql, ARRAY_A );
 
+        if ( ! empty( $wpdb->last_error ) ) {
+            LoggingService::log( 'Dashboard query error: ' . $wpdb->last_error );
+            return array();
+        }
+
         wp_cache_set( $cache_key, $rows, self::CACHE_GROUP, self::CACHE_TTL );
         set_transient( $transient, $rows, self::CACHE_TTL );
 
@@ -144,6 +149,11 @@ class DashboardDataService {
         );
 
         $rows = $wpdb->get_results( $sql, ARRAY_A );
+
+        if ( ! empty( $wpdb->last_error ) ) {
+            LoggingService::log( 'Dashboard query error: ' . $wpdb->last_error );
+            return array();
+        }
 
         wp_cache_set( $cache_key, $rows, self::CACHE_GROUP, self::CACHE_TTL );
         set_transient( $transient, $rows, self::CACHE_TTL );

--- a/nuclear-engagement/inc/Services/PostDataFetcher.php
+++ b/nuclear-engagement/inc/Services/PostDataFetcher.php
@@ -55,6 +55,13 @@ class PostDataFetcher {
             array_merge( array( 'nuclen_quiz_protected', 'nuclen_summary_protected' ), $ids )
         );
 
-        return $wpdb->get_results( $sql );
+        $rows = $wpdb->get_results( $sql );
+
+        if ( ! empty( $wpdb->last_error ) ) {
+            LoggingService::log( 'Post fetch error: ' . $wpdb->last_error );
+            return array();
+        }
+
+        return $rows;
     }
 }

--- a/tests/PostDataFetcherTest.php
+++ b/tests/PostDataFetcherTest.php
@@ -1,0 +1,38 @@
+<?php
+use PHPUnit\Framework\TestCase;
+use NuclearEngagement\Services\PostDataFetcher;
+
+namespace NuclearEngagement\Services {
+    class LoggingService {
+        public static array $logs = [];
+        public static function log(string $msg): void { self::$logs[] = $msg; }
+    }
+}
+
+namespace {
+    class PDF_WPDB {
+        public $posts = 'wp_posts';
+        public $postmeta = 'wp_postmeta';
+        public string $last_error = '';
+        public array $args = [];
+        public function prepare($sql, ...$args) { $this->args = $args; return 'SQL'; }
+        public function get_results($sql) { $this->last_error = 'fail'; return []; }
+    }
+
+    require_once __DIR__ . '/../nuclear-engagement/inc/Services/PostDataFetcher.php';
+
+    class PostDataFetcherTest extends TestCase {
+        protected function setUp(): void {
+            global $wpdb;
+            $wpdb = new PDF_WPDB();
+            \NuclearEngagement\Services\LoggingService::$logs = [];
+        }
+
+        public function test_fetch_logs_error_and_returns_empty_array(): void {
+            $fetcher = new PostDataFetcher();
+            $rows = $fetcher->fetch([1]);
+            $this->assertSame([], $rows);
+            $this->assertSame(['Post fetch error: fail'], \NuclearEngagement\Services\LoggingService::$logs);
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- add DB error checking to PostDataFetcher
- add DB error checking to DashboardDataService
- surface query errors on dashboard category stats
- test new failure handling

## Testing
- `composer lint`
- `composer test`


------
https://chatgpt.com/codex/tasks/task_e_685cdb803828832795090ef42ceeda70

<!-- Korbit AI PR Description Start -->
## Description by Korbit AI

### What change is being made?

Add error checking for database queries and corresponding logging in the `Dashboard.php`, `DashboardDataService.php`, and `PostDataFetcher.php` files, and augment test files to assert behavior when errors occur.

### Why are these changes being made?

These changes enhance the robustness of the application by capturing and logging database query errors to aid in debugging and prevent the application from failing silently. By returning empty arrays upon error detection, the functionality degrades gracefully, ensuring reliability even in the face of database issues. The accompanying tests ensure that the error handling performs as expected and helps maintain code quality.

> Is this description stale? Ask me to generate a new description by commenting `/korbit-generate-pr-description`
<!-- Korbit AI PR Description End -->