### PR TITLE
Fix namespace syntax in helpers.php

### DIFF
--- a/nuclear-engagement/inc/Core/helpers.php
+++ b/nuclear-engagement/inc/Core/helpers.php
@@ -109,7 +109,7 @@ if ( ! function_exists( 'nuclen_settings_array' ) ) {
     }
 }
 
-namespace {
+namespace;
 
 use function NuclearEngagement\nuclen_settings as ns_settings;
 use function NuclearEngagement\nuclen_settings_bool as ns_settings_bool;
@@ -145,6 +145,4 @@ if ( ! function_exists( 'nuclen_settings_array' ) ) {
     function nuclen_settings_array( string $key, array $default = array() ): array {
         return ns_settings_array( $key, $default );
     }
-}
-
 }


### PR DESCRIPTION
## Summary
- fix `helpers.php` to use unbracketed namespace syntax consistently

## Testing
- `composer lint` *(fails: composer not found)*
- `composer test` *(fails: composer not found)*

------
https://chatgpt.com/codex/tasks/task_e_685cdf61a8548327949a54c85e8588ef

<!-- Korbit AI PR Description Start -->
## Description by Korbit AI

### What change is being made?

Correct the namespace syntax in `helpers.php` from `namespace {}` to `namespace;` and remove unnecessary trailing lines. 

### Why are these changes being made?

This change addresses a syntax issue to ensure consistency and avoid potential parsing errors caused by incorrect namespace declaration, improving adherence to PHP standards. Moreover, the removal of trailing lines enhances code neatness and maintains cleaner file structure.

> Is this description stale? Ask me to generate a new description by commenting `/korbit-generate-pr-description`
<!-- Korbit AI PR Description End -->