### PR TITLE
Fix namespace syntax in helpers.php

### DIFF
--- a/nuclear-engagement/inc/Core/helpers.php
+++ b/nuclear-engagement/inc/Core/helpers.php
@@ -6,7 +6,7 @@ declare(strict_types=1);
  * @package NuclearEngagement
  */
 
-namespace NuclearEngagement;
+namespace NuclearEngagement {
 
 use NuclearEngagement\SettingsRepository;
 
@@ -107,6 +107,8 @@ if ( ! function_exists( 'nuclen_settings_array' ) ) {
 
         return $repo->get_array( $key, $default );
     }
+}
+
 }
 
 namespace {


### PR DESCRIPTION
## Summary
- ensure consistent bracketed namespace declarations in `helpers.php`

## Testing
- `composer lint` *(fails: composer not found)*
- `composer test` *(fails: composer not found)*

------
https://chatgpt.com/codex/tasks/task_e_685cdf61a8548327949a54c85e8588ef

<!-- Korbit AI PR Description Start -->
## Description by Korbit AI

### What change is being made?
Correct the namespace syntax in `helpers.php` to use braces and close the namespace block properly.

### Why are these changes being made?
The previous syntax error caused the namespace to not be properly defined, which could lead to issues with function and class resolution. This adjustment ensures the namespace block is correctly closed, maintaining the intended encapsulation and organization within the file.

> Is this description stale? Ask me to generate a new description by commenting `/korbit-generate-pr-description`
<!-- Korbit AI PR Description End -->