### PR TITLE
Fix SummaryShortcode final class error

### DIFF
--- a/nuclear-engagement/front/SummaryShortcode.php
+++ b/nuclear-engagement/front/SummaryShortcode.php
@@ -9,4 +9,7 @@ namespace NuclearEngagement\Front;
 
 use NuclearEngagement\Modules\Summary\Nuclen_Summary_Shortcode as ModuleSummaryShortcode;
 
-class SummaryShortcode extends ModuleSummaryShortcode {}
+class_alias(
+    ModuleSummaryShortcode::class,
+    __NAMESPACE__ . '\\SummaryShortcode'
+);


### PR DESCRIPTION
## Summary
- avoid extending a final class in `SummaryShortcode`

## Testing
- `composer lint` *(fails: command not found)*
- `composer test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685ce45094e48327acda886d9ca3bb7a

<!-- Korbit AI PR Description Start -->
## Description by Korbit AI

### What change is being made?

Replace the `SummaryShortcode` class extension with a class alias for `ModuleSummaryShortcode`.

### Why are these changes being made?

The `final class` error occurred because `SummaryShortcode` was incorrectly attempting to extend a final class, `ModuleSummaryShortcode`. Using a class alias resolves the issue without altering the existing final class behavior, maintaining code integrity while fixing the error.

> Is this description stale? Ask me to generate a new description by commenting `/korbit-generate-pr-description`
<!-- Korbit AI PR Description End -->