### PR TITLE
Add node test stage to CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,11 +36,22 @@ jobs:
           node-version: '20'
           cache: 'npm'
 
+      # Cache node_modules to speed up repeated installs
+      - name: Cache node modules
+        uses: actions/cache@v3
+        with:
+          path: node_modules
+          key: ${{ runner.os }}-node-${{ hashFiles('package-lock.json') }}
+          restore-keys: ${{ runner.os }}-node-
+
       - name: Install Node dependencies
         run: npm ci
 
       - name: Run Node lint
         run: npm run lint
+
+      - name: Run Node tests
+        run: npm run test
 
       - name: Build assets
         run: npm run build

--- a/package.json
+++ b/package.json
@@ -8,7 +8,8 @@
     "build": "tsc && vite build",
     "preview": "vite preview",
     "lint": "eslint \"src/**/*.ts\"",
-    "i18n": "bash scripts/update-translations.sh"
+    "i18n": "bash scripts/update-translations.sh",
+    "test": "echo \"No JavaScript tests configured\""
   },
   "devDependencies": {
     "@typescript-eslint/eslint-plugin": "^7.0.0",


### PR DESCRIPTION
## Summary
- cache `node_modules` and run JS tests in CI
- provide placeholder `npm run test` command

## Testing
- `npm run test`
- `npm ci` *(fails: unable to reach registry)*
- `composer lint --working-dir=nuclear-engagement` *(fails: command not found)*


------
https://chatgpt.com/codex/tasks/task_e_685ce7f7c898832781e501d342b6003a

<!-- Korbit AI PR Description Start -->
## Description by Korbit AI

### What change is being made?

Add a node test stage to the continuous integration (CI) workflow along with caching of `node_modules` to improve performance.

### Why are these changes being made?

These changes are implemented to automate the testing of Node.js projects as part of the CI process, ensuring that code changes are consistently verified. Caching `node_modules` will speed up the install process for repeated CI runs and the addition of a test script placeholder in `package.json` prepares the configuration for future JavaScript tests.

> Is this description stale? Ask me to generate a new description by commenting `/korbit-generate-pr-description`
<!-- Korbit AI PR Description End -->