### PR TITLE
Add vitest and tests for quiz utils

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,12 @@ Run the PHPUnit test suite with:
 composer test --working-dir=nuclear-engagement
 ```
 
+Run the front-end unit tests with:
+
+```bash
+npm run test
+```
+
 Run static analysis using PHPStan:
 
 ```bash

--- a/package.json
+++ b/package.json
@@ -8,14 +8,17 @@
     "build": "tsc && vite build",
     "preview": "vite preview",
     "lint": "eslint \"src/**/*.ts\"",
-    "i18n": "bash scripts/update-translations.sh"
+    "i18n": "bash scripts/update-translations.sh",
+    "test": "vitest"
   },
   "devDependencies": {
     "@typescript-eslint/eslint-plugin": "^7.0.0",
     "@typescript-eslint/parser": "^7.0.0",
     "eslint": "^8.57.1",
     "typescript": "~5.6.2",
-    "vite": "^6.0.6"
+    "vite": "^6.0.6",
+    "vitest": "^1.5.1",
+    "@vitest/browser": "^0.34.6"
   },
   "main": "index.js",
   "dependencies": {

--- a/src/front/ts/__tests__/nuclen-quiz-utils.test.ts
+++ b/src/front/ts/__tests__/nuclen-quiz-utils.test.ts
@@ -1,0 +1,125 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import {
+  shuffle,
+  isValidEmail,
+  escapeHtml,
+  storeOptinLocally,
+  submitToWebhook,
+} from '../nuclen-quiz-utils';
+import * as logger from '../logger';
+
+const baseCtx = {
+  position: 'with_results',
+  mandatory: false,
+  promptText: '',
+  submitLabel: '',
+  enabled: true,
+  webhook: '',
+  ajaxUrl: '',
+  ajaxNonce: '',
+};
+
+beforeEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe('shuffle', () => {
+  it('shuffles array without mutating original', () => {
+    const arr = [1, 2, 3];
+    const spy = vi.spyOn(Math, 'random');
+    spy.mockReturnValueOnce(0.1).mockReturnValueOnce(0.9);
+    const result = shuffle(arr);
+    expect(result).toEqual([3, 2, 1]);
+    expect(arr).toEqual([1, 2, 3]);
+  });
+});
+
+describe('isValidEmail', () => {
+  it('validates simple email addresses', () => {
+    expect(isValidEmail('test@example.com')).toBe(true);
+    expect(isValidEmail('bad-email')).toBe(false);
+  });
+});
+
+describe('escapeHtml', () => {
+  it('escapes special characters', () => {
+    expect(escapeHtml("<div>&\"'")).toBe('&lt;div&gt;&amp;&quot;&#039;');
+  });
+});
+
+describe('storeOptinLocally', () => {
+  it('posts optin data and logs server error', async () => {
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValueOnce({ ok: false, status: 500 });
+    // @ts-ignore
+    global.fetch = fetchMock;
+    const errorSpy = vi.spyOn(logger, 'error');
+    await storeOptinLocally(
+      'name',
+      'email',
+      'https://example.com',
+      {
+        ...baseCtx,
+        ajaxUrl: 'api',
+        ajaxNonce: 'nonce',
+      },
+    );
+    expect(fetchMock).toHaveBeenCalled();
+    expect(errorSpy).toHaveBeenCalledWith('[NE] Local opt-in failed', 500);
+  });
+
+  it('logs network error', async () => {
+    const fetchMock = vi.fn().mockRejectedValueOnce('oops');
+    // @ts-ignore
+    global.fetch = fetchMock;
+    const errorSpy = vi.spyOn(logger, 'error');
+    await storeOptinLocally(
+      'name',
+      'email',
+      'https://example.com',
+      {
+        ...baseCtx,
+        ajaxUrl: 'api',
+        ajaxNonce: 'nonce',
+      },
+    );
+    expect(errorSpy).toHaveBeenCalledWith('[NE] Local opt-in network error', 'oops');
+  });
+});
+
+describe('submitToWebhook', () => {
+  it('posts to webhook', async () => {
+    const fetchMock = vi.fn().mockResolvedValueOnce({ ok: true });
+    // @ts-ignore
+    global.fetch = fetchMock;
+    await submitToWebhook('n', 'e', { ...baseCtx, webhook: 'w' });
+    expect(fetchMock).toHaveBeenCalledWith('w', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ name: 'n', email: 'e' }),
+    });
+  });
+
+  it('throws and logs on http error', async () => {
+    const fetchMock = vi.fn().mockResolvedValueOnce({ ok: false, status: 400 });
+    // @ts-ignore
+    global.fetch = fetchMock;
+    const errorSpy = vi.spyOn(logger, 'error');
+    await expect(
+      submitToWebhook('n', 'e', { ...baseCtx, webhook: 'w' }),
+    ).rejects.toThrow('400');
+    expect(errorSpy).toHaveBeenCalledWith('[NE] Webhook responded with', 400);
+  });
+
+  it('throws and logs on network error', async () => {
+    const fetchMock = vi.fn().mockRejectedValueOnce('fail');
+    // @ts-ignore
+    global.fetch = fetchMock;
+    const errorSpy = vi.spyOn(logger, 'error');
+    await expect(
+      submitToWebhook('n', 'e', { ...baseCtx, webhook: 'w' }),
+    ).rejects.toBe('fail');
+    expect(errorSpy).toHaveBeenCalledWith('[NE] Webhook request error', 'fail');
+  });
+});

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,0 +1,7 @@
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+  test: {
+    environment: 'jsdom',
+  },
+});


### PR DESCRIPTION
## Summary
- add Vitest configuration and dependencies
- document how to run JS tests
- implement unit tests for quiz utilities

## Testing
- `npm install` *(fails: 403 Forbidden)*
- `npm run test` *(fails: vitest not found)*
- `composer lint --working-dir=nuclear-engagement` *(fails: command not found)*
- `composer test --working-dir=nuclear-engagement` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685ce7e6c62c832785e9b986ab7c09e0

<!-- Korbit AI PR Description Start -->
## Description by Korbit AI

### What change is being made?

Add Vitest testing framework to the codebase and implement unit tests for quiz utility functions.

### Why are these changes being made?

These changes provide a robust testing environment using Vitest, ensuring that the quiz utility functions perform as expected. By adding unit tests, we can verify function correctness, enhance code reliability, and log errors effectively in case of failures. This approach is necessary to maintain high code quality and facilitate future code refactoring with confidence.

> Is this description stale? Ask me to generate a new description by commenting `/korbit-generate-pr-description`
<!-- Korbit AI PR Description End -->