### PR TITLE
Add unit tests for Blocks registration

### DIFF
--- a/tests/BlocksTest.php
+++ b/tests/BlocksTest.php
@@ -1,0 +1,77 @@
+<?php
+use PHPUnit\Framework\TestCase;
+use NuclearEngagement\Blocks;
+
+namespace NuclearEngagement\Services {
+    class LoggingService {
+        public static array $logs = [];
+        public static function log(string $msg): void {
+            self::$logs[] = $msg;
+        }
+    }
+}
+
+namespace {
+    function register_block_type(string $name, array $args): void {
+        $GLOBALS['block_regs'][$name] = $args;
+    }
+    function wp_script_is(string $handle, string $list = ''): bool {
+        return $GLOBALS['script_is'] ?? false;
+    }
+    if (!function_exists('__')) {
+        function __($t, $d = null) { return $t; }
+    }
+    if (!function_exists('esc_html__')) {
+        function esc_html__($t, $d = null) { return $t; }
+    }
+    function do_shortcode(string $code) {
+        $GLOBALS['shortcode_calls'][] = $code;
+        return 'OUT:' . $code;
+    }
+
+    require_once dirname(__DIR__) . '/nuclear-engagement/inc/Core/Blocks.php';
+
+    class BlocksTest extends TestCase {
+        protected function setUp(): void {
+            $GLOBALS['block_regs'] = [];
+            $GLOBALS['script_is'] = true;
+            $GLOBALS['shortcode_calls'] = [];
+            \NuclearEngagement\Services\LoggingService::$logs = [];
+        }
+
+        public function test_missing_script_triggers_logging(): void {
+            $GLOBALS['script_is'] = false;
+            Blocks::register();
+            $this->assertSame(
+                ['Nuclear Engagement: nuclen-admin script missing.'],
+                \NuclearEngagement\Services\LoggingService::$logs
+            );
+            $this->assertSame([], $GLOBALS['block_regs']);
+        }
+
+        public function test_registers_two_blocks_and_callbacks_use_shortcodes(): void {
+            Blocks::register();
+            $this->assertCount(2, $GLOBALS['block_regs']);
+            $this->assertArrayHasKey('nuclear-engagement/quiz', $GLOBALS['block_regs']);
+            $this->assertArrayHasKey('nuclear-engagement/summary', $GLOBALS['block_regs']);
+
+            $quiz_cb = $GLOBALS['block_regs']['nuclear-engagement/quiz']['render_callback'];
+            $summary_cb = $GLOBALS['block_regs']['nuclear-engagement/summary']['render_callback'];
+
+            $this->assertIsCallable($quiz_cb);
+            $this->assertIsCallable($summary_cb);
+
+            $quiz_html = $quiz_cb();
+            $summary_html = $summary_cb();
+
+            $this->assertSame('OUT:[nuclear_engagement_quiz]', $quiz_html);
+            $this->assertSame('OUT:[nuclear_engagement_summary]', $summary_html);
+
+            $this->assertSame([
+                '[nuclear_engagement_quiz]',
+                '[nuclear_engagement_summary]'
+            ], $GLOBALS['shortcode_calls']);
+            $this->assertSame([], \NuclearEngagement\Services\LoggingService::$logs);
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- cover block registration in BlocksTest
- stub `register_block_type`, `wp_script_is`, and `LoggingService` calls
- verify logging occurs when scripts are missing
- ensure valid conditions register both blocks and render callbacks use shortcodes

## Testing
- `composer lint` *(fails: command not found)*
- `composer test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685ce7e053608327bb025cb01a9bc574

<!-- Korbit AI PR Description Start -->
## Description by Korbit AI

### What change is being made?

Add unit tests for the Blocks registration process in the Nuclear Engagement plugin to ensure proper script handling, block registration, and shortcode execution.

### Why are these changes being made?

These changes provide automated testing to verify that the Blocks registration feature behaves as expected, including logging events when scripts are missing and confirming that shortcode callbacks render correctly. This increases code reliability and helps prevent future regressions.

> Is this description stale? Ask me to generate a new description by commenting `/korbit-generate-pr-description`
<!-- Korbit AI PR Description End -->