### PR TITLE
Add PointerService tests

### DIFF
--- a/tests/PointerServiceTest.php
+++ b/tests/PointerServiceTest.php
@@ -1,0 +1,29 @@
+<?php
+use PHPUnit\Framework\TestCase;
+use NuclearEngagement\Services\PointerService;
+
+class PointerServiceTest extends TestCase {
+    protected function setUp(): void {
+        $GLOBALS['wp_user_meta'] = [];
+    }
+
+    public function test_dismiss_pointer_sets_meta(): void {
+        $service = new PointerService();
+        $service->dismissPointer('intro', 10);
+        $this->assertTrue(
+            $GLOBALS['wp_user_meta'][10]['nuclen_pointer_dismissed_intro'] ?? false
+        );
+    }
+
+    public function test_get_undismissed_filters_dismissed(): void {
+        $GLOBALS['wp_user_meta'][5]['nuclen_pointer_dismissed_a'] = true;
+        $pointers = [
+            ['id' => 'a', 'title' => 'A'],
+            ['id' => 'b', 'title' => 'B'],
+        ];
+        $service = new PointerService();
+        $undismissed = $service->getUndismissedPointers($pointers, 5);
+        $this->assertCount(1, $undismissed);
+        $this->assertSame('b', $undismissed[0]['id']);
+    }
+}

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -35,6 +35,7 @@ $GLOBALS['update_option_calls'] = [];
 $GLOBALS['wp_posts'] = [];
 $GLOBALS['wp_meta'] = [];
 $GLOBALS['wp_events'] = [];
+$GLOBALS['wp_user_meta'] = [];
 
 if (!function_exists('update_option')) {
     function update_option($name, $value, $autoload = 'yes') {
@@ -56,6 +57,19 @@ if (!function_exists('delete_option')) {
     function delete_option($name) {
         unset($GLOBALS['wp_options'][$name], $GLOBALS['wp_autoload'][$name]);
         return true;
+    }
+}
+
+if (!function_exists('update_user_meta')) {
+    function update_user_meta($user_id, $meta_key, $meta_value) {
+        $GLOBALS['wp_user_meta'][$user_id][$meta_key] = $meta_value;
+        return true;
+    }
+}
+
+if (!function_exists('get_user_meta')) {
+    function get_user_meta($user_id, $meta_key, $single = false) {
+        return $GLOBALS['wp_user_meta'][$user_id][$meta_key] ?? '';
     }
 }
 


### PR DESCRIPTION
## Summary
- add stubs for `update_user_meta` and `get_user_meta`
- add unit tests for `PointerService`

## Testing
- `composer lint --working-dir=nuclear-engagement` *(fails: composer not found)*
- `composer test --working-dir=nuclear-engagement` *(fails: composer not found)*

------
https://chatgpt.com/codex/tasks/task_e_685ce7dc84208327b1d130bf6337b882

<!-- Korbit AI PR Description Start -->
## Description by Korbit AI

### What change is being made?

Add unit tests for the `PointerService` class to verify the pointer dismissal functionality and filter mechanism, extend the test bootstrap with user meta global variables and functions for user meta operations.

### Why are these changes being made?

These changes introduce comprehensive tests to enhance the reliability and maintainability of the `PointerService` by ensuring its key functionalities are tested. Adding global variables and functions for user meta operations in the test bootstrap is necessary to mimic WordPress function behavior for testing purposes.

> Is this description stale? Ask me to generate a new description by commenting `/korbit-generate-pr-description`
<!-- Korbit AI PR Description End -->