### PR TITLE
Add tests to PHPStan analysis

### DIFF
--- a/docs/DEV_WORKFLOW.md
+++ b/docs/DEV_WORKFLOW.md
@@ -64,6 +64,7 @@ After starting the environment, run PHPUnit and PHPStan from the repository root
 ```bash
 composer test --working-dir=nuclear-engagement
 composer phpstan --working-dir=nuclear-engagement
+# PHPStan analyzes both plugin source and test code
 npm run lint
 ```
 

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -3,3 +3,6 @@ includes:
 
 parameters:
     level: 6
+    paths:
+        - nuclear-engagement
+        - tests


### PR DESCRIPTION
## Summary
- include plugin and tests paths in `phpstan.neon.dist`
- document that PHPStan checks both source and tests

## Testing
- `composer lint --working-dir=nuclear-engagement` *(fails: composer not found)*
- `composer test --working-dir=nuclear-engagement` *(fails: composer not found)*
- `composer phpstan --working-dir=nuclear-engagement` *(fails: composer not found)*

------
https://chatgpt.com/codex/tasks/task_e_685ce7e9e3148327b5cd7c8b890afdab


> [!NOTE]
> I'm currently writing a description for your pull request. I should be done shortly (<1 minute). Please don't edit the description field until I'm finished, or we may overwrite each other. If I find nothing to write about, I'll delete this message.
