### PR TITLE
Add Vitest setup and tests for quiz utils

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,12 @@ Run the PHPUnit test suite with:
 composer test --working-dir=nuclear-engagement
 ```
 
+Run the JavaScript tests with:
+
+```bash
+npm run test
+```
+
 Run static analysis using PHPStan:
 
 ```bash

--- a/package-lock.json
+++ b/package-lock.json
@@ -21,7 +21,9 @@
         "@typescript-eslint/parser": "^7.0.0",
         "eslint": "^8.57.1",
         "typescript": "~5.6.2",
-        "vite": "^6.0.6"
+        "vite": "^6.0.6",
+        "vitest": "^1.5.0",
+        "@vitest/browser": "^0.34.6"
       }
     },
     "node_modules/@esbuild/aix-ppc64": {

--- a/package.json
+++ b/package.json
@@ -9,14 +9,16 @@
     "preview": "vite preview",
     "lint": "eslint \"src/**/*.ts\"",
     "i18n": "bash scripts/update-translations.sh",
-    "test": "echo \"No JavaScript tests configured\""
+    "test": "vitest"
   },
   "devDependencies": {
     "@typescript-eslint/eslint-plugin": "^7.0.0",
     "@typescript-eslint/parser": "^7.0.0",
     "eslint": "^8.57.1",
     "typescript": "~5.6.2",
-    "vite": "^6.0.6"
+    "vite": "^6.0.6",
+    "vitest": "^1.5.0",
+    "@vitest/browser": "^0.34.6"
   },
   "main": "index.js",
   "dependencies": {

--- a/tests/frontend/nuclen-quiz-utils.test.ts
+++ b/tests/frontend/nuclen-quiz-utils.test.ts
@@ -1,0 +1,137 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { shuffle, isValidEmail, escapeHtml, storeOptinLocally, submitToWebhook } from '../../src/front/ts/nuclen-quiz-utils';
+import * as logger from '../../src/front/ts/logger';
+import type { OptinContext } from '../../src/front/ts/nuclen-quiz-types';
+
+describe('shuffle', () => {
+  it('shuffles deterministically', () => {
+    const arr = [1, 2, 3];
+    const rand = vi.spyOn(Math, 'random')
+      .mockReturnValueOnce(0.5) // j=1
+      .mockReturnValueOnce(0);  // j=0
+    const res = shuffle(arr);
+    expect(res).toEqual([3, 1, 2]);
+    expect(res).not.toBe(arr);
+    rand.mockRestore();
+  });
+});
+
+describe('isValidEmail', () => {
+  it('validates basic email format', () => {
+    expect(isValidEmail('a@b.com')).toBe(true);
+    expect(isValidEmail('invalid')).toBe(false);
+  });
+});
+
+describe('escapeHtml', () => {
+  it('escapes HTML characters', () => {
+    const res = escapeHtml('<div>"O\'H&"</div>');
+    expect(res).toBe('&lt;div&gt;&quot;O&#039;H&amp;&quot;&lt;/div&gt;');
+  });
+});
+
+describe('storeOptinLocally', () => {
+  const baseCtx: OptinContext = {
+    position: 'with_results',
+    mandatory: false,
+    promptText: '',
+    submitLabel: '',
+    enabled: true,
+    webhook: '',
+    ajaxUrl: 'https://example.com',
+    ajaxNonce: '123'
+  };
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    delete (global as any).fetch;
+  });
+
+  it('posts to ajax url', async () => {
+    const fetchMock = vi.fn().mockResolvedValue({ ok: true });
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    (global as any).fetch = fetchMock;
+    const log = vi.spyOn(logger, 'error').mockImplementation(() => {});
+    await storeOptinLocally('n', 'e', 'u', baseCtx);
+    expect(fetchMock).toHaveBeenCalled();
+    expect(log).not.toHaveBeenCalled();
+  });
+
+  it('logs when response not ok', async () => {
+    const fetchMock = vi.fn().mockResolvedValue({ ok: false, status: 500 });
+    (global as any).fetch = fetchMock;
+    const log = vi.spyOn(logger, 'error').mockImplementation(() => {});
+    await storeOptinLocally('n', 'e', 'u', baseCtx);
+    expect(log).toHaveBeenCalledWith('[NE] Local opt-in failed', 500);
+  });
+
+  it('logs network error', async () => {
+    const err = new Error('fail');
+    const fetchMock = vi.fn().mockRejectedValue(err);
+    (global as any).fetch = fetchMock;
+    const log = vi.spyOn(logger, 'error').mockImplementation(() => {});
+    await storeOptinLocally('n', 'e', 'u', baseCtx);
+    expect(log).toHaveBeenCalledWith('[NE] Local opt-in network error', err);
+  });
+
+  it('skips when ajax info missing', async () => {
+    const fetchMock = vi.fn();
+    (global as any).fetch = fetchMock;
+    const ctx = { ...baseCtx, ajaxUrl: '', ajaxNonce: '' };
+    await storeOptinLocally('n', 'e', 'u', ctx);
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+});
+
+describe('submitToWebhook', () => {
+  const baseCtx: OptinContext = {
+    position: 'with_results',
+    mandatory: false,
+    promptText: '',
+    submitLabel: '',
+    enabled: true,
+    webhook: 'https://example.com',
+    ajaxUrl: '',
+    ajaxNonce: ''
+  };
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    delete (global as any).fetch;
+  });
+
+  it('posts to webhook', async () => {
+    const fetchMock = vi.fn().mockResolvedValue({ ok: true });
+    (global as any).fetch = fetchMock;
+    const log = vi.spyOn(logger, 'error').mockImplementation(() => {});
+    await submitToWebhook('n', 'e', baseCtx);
+    expect(fetchMock).toHaveBeenCalledWith('https://example.com', expect.objectContaining({ method: 'POST' }));
+    expect(log).not.toHaveBeenCalled();
+  });
+
+  it('skips when webhook missing', async () => {
+    const fetchMock = vi.fn();
+    (global as any).fetch = fetchMock;
+    await submitToWebhook('n', 'e', { ...baseCtx, webhook: '' });
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it('throws on non ok response', async () => {
+    const fetchMock = vi.fn().mockResolvedValue({ ok: false, status: 400 });
+    (global as any).fetch = fetchMock;
+    const log = vi.spyOn(logger, 'error').mockImplementation(() => {});
+    await expect(submitToWebhook('n', 'e', baseCtx)).rejects.toBeTruthy();
+    expect(log).toHaveBeenCalledWith('[NE] Webhook responded with', 400);
+  });
+
+  it('throws on fetch error', async () => {
+    const err = new Error('net');
+    const fetchMock = vi.fn().mockRejectedValue(err);
+    (global as any).fetch = fetchMock;
+    const log = vi.spyOn(logger, 'error').mockImplementation(() => {});
+    await expect(submitToWebhook('n', 'e', baseCtx)).rejects.toBe(err);
+    expect(log).toHaveBeenCalledWith('[NE] Webhook request error', err);
+  });
+});

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,0 +1,8 @@
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+  test: {
+    environment: 'jsdom',
+    include: ['tests/**/*.test.ts']
+  }
+});


### PR DESCRIPTION
## Summary
- configure Vitest with jsdom
- add Vitest dev dependencies and test npm script
- document running `npm run test`
- add unit tests for quiz utility helpers

## Testing
- `npm run lint` *(fails: Cannot find package '@typescript-eslint/eslint-plugin')*
- `npm run test` *(fails: vitest not found)*
- `composer lint --working-dir=nuclear-engagement` *(fails: composer not found)*
- `composer test --working-dir=nuclear-engagement` *(fails: composer not found)*

------
https://chatgpt.com/codex/tasks/task_e_685ceca7704883278848eaf257d127c1