### PR TITLE
Add IntersectionObserver tests

### DIFF
--- a/tests/frontend/nuclen-front-lazy.test.ts
+++ b/tests/frontend/nuclen-front-lazy.test.ts
@@ -1,0 +1,72 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+
+let originalIO: typeof IntersectionObserver;
+let originalMO: typeof MutationObserver;
+const ioInstances: any[] = [];
+let moInstance: any;
+
+beforeEach(() => {
+  vi.resetModules();
+  ioInstances.length = 0;
+  originalIO = global.IntersectionObserver;
+  originalMO = global.MutationObserver;
+
+  global.IntersectionObserver = vi.fn(function (this: any, cb: any, options: any) {
+    this.callback = cb;
+    this.options = options;
+    this.observe = vi.fn();
+    this.unobserve = vi.fn();
+    this.disconnect = vi.fn();
+    ioInstances.push(this);
+  }) as unknown as typeof IntersectionObserver;
+
+  global.MutationObserver = vi.fn(function (this: any, cb: any) {
+    this.cb = cb;
+    this.observe = vi.fn();
+    this.disconnect = vi.fn();
+    moInstance = this;
+  }) as unknown as typeof MutationObserver;
+
+  (global as any).gtag = vi.fn();
+})
+
+afterEach(() => {
+  global.IntersectionObserver = originalIO;
+  global.MutationObserver = originalMO;
+  vi.restoreAllMocks();
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  delete (global as any).NuclenLazyLoadComponent;
+});
+
+describe('nuclen-front-lazy', () => {
+  it('lazy loads component and calls init on intersection', async () => {
+    await import('../../src/front/ts/nuclen-front-lazy');
+    document.body.innerHTML = '<div id="lazy-el"></div>';
+    const initFn = vi.fn();
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    (window as any).testInit = initFn;
+    window.NuclenLazyLoadComponent!('lazy-el', 'testInit');
+
+    expect(ioInstances).toHaveLength(1);
+    const inst = ioInstances[0];
+    expect(inst.options).toEqual({ rootMargin: '0px 0px -200px 0px', threshold: 0.1 });
+    expect(inst.observe).toHaveBeenCalledWith(document.getElementById('lazy-el'));
+
+    inst.callback([{ isIntersecting: true }]);
+    expect(initFn).toHaveBeenCalled();
+    expect(inst.disconnect).toHaveBeenCalled();
+  });
+
+  it('dispatches GA event when element fully visible', async () => {
+    await import('../../src/front/ts/nuclen-front-lazy');
+    document.body.innerHTML = '<div id="nuclen-quiz-container"></div><div id="nuclen-summary-container"></div>';
+    moInstance.cb([], moInstance);
+
+    expect(ioInstances).toHaveLength(2);
+    const summaryIO = ioInstances[0];
+    const summaryEl = document.getElementById('nuclen-summary-container');
+    summaryIO.callback([{ isIntersecting: true, intersectionRatio: 1, target: summaryEl }], summaryIO);
+    expect((global as any).gtag).toHaveBeenCalledWith('event', 'nuclen_summary_view');
+    expect(summaryIO.unobserve).toHaveBeenCalledWith(summaryEl);
+  });
+});


### PR DESCRIPTION
## Summary
- add vitest coverage for lazy loading and GA IntersectionObserver logic

## Testing
- `composer lint` *(fails: command not found)*
- `composer test` *(fails: command not found)*
- `npm run test` *(fails: vitest not installed)*

------
https://chatgpt.com/codex/tasks/task_e_685cf1c3b7e48327b31459e49bdfff72

<!-- Korbit AI PR Description Start -->
## Description by Korbit AI

### What change is being made?

Add tests for the `IntersectionObserver` and related functionality in the `nuclen-front-lazy` component.

### Why are these changes being made?

These tests are being added to ensure the `nuclen-front-lazy` component's lazy loading behavior works correctly when elements come into the viewport and to verify that Google Analytics events are dispatched correctly when the elements become fully visible. By mocking the `IntersectionObserver` and `MutationObserver`, we can validate the component's interaction with these APIs without relying on actual browser environment behavior, improving test reliability.

> Is this description stale? Ask me to generate a new description by commenting `/korbit-generate-pr-description`
<!-- Korbit AI PR Description End -->