### PR TITLE
Add AdminNoticeService tests

### DIFF
--- a/tests/AdminNoticeServiceTest.php
+++ b/tests/AdminNoticeServiceTest.php
@@ -1,0 +1,45 @@
+<?php
+use PHPUnit\Framework\TestCase;
+use NuclearEngagement\Services\AdminNoticeService;
+
+namespace NuclearEngagement\Services {
+    function add_action(...$args) {
+        $GLOBALS['ans_actions'][] = $args;
+    }
+    if (!function_exists('esc_html')) {
+        function esc_html($text) { return $text; }
+    }
+}
+
+namespace {
+    class AdminNoticeServiceTest extends TestCase {
+        protected function setUp(): void {
+            $GLOBALS['ans_actions'] = [];
+        }
+
+        public function test_add_hooks_into_admin_notices_once(): void {
+            $service = new AdminNoticeService();
+            $service->add('First');
+            $service->add('Second');
+            $this->assertCount(1, $GLOBALS['ans_actions']);
+            $this->assertSame('admin_notices', $GLOBALS['ans_actions'][0][0]);
+            $this->assertSame([$service, 'render'], $GLOBALS['ans_actions'][0][1]);
+        }
+
+        public function test_render_outputs_notices_and_clears(): void {
+            $service = new AdminNoticeService();
+            $service->add('Hello');
+            ob_start();
+            $service->render();
+            $output = ob_get_clean();
+            $this->assertSame('<div class="notice notice-error"><p>Hello</p></div>', trim($output));
+
+            $service->add('Again');
+            $this->assertCount(2, $GLOBALS['ans_actions']);
+            ob_start();
+            $service->render();
+            $second = ob_get_clean();
+            $this->assertSame('<div class="notice notice-error"><p>Again</p></div>', trim($second));
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- add a new test suite for `AdminNoticeService`
- verify that notices hook into `admin_notices`
- ensure `render()` outputs notices correctly

## Testing
- `composer lint` *(fails: command not found)*
- `composer test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685cf1bfe4c48327a865cd5552a18561


> [!NOTE]
> I'm currently writing a description for your pull request. I should be done shortly (<1 minute). Please don't edit the description field until I'm finished, or we may overwrite each other. If I find nothing to write about, I'll delete this message.
