### PR TITLE
Add opt-in UI tests

### DIFF
--- a/tests/frontend/nuclen-quiz-optin.test.ts
+++ b/tests/frontend/nuclen-quiz-optin.test.ts
@@ -1,0 +1,98 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { buildOptinInlineHTML, mountOptinBeforeResults } from '../../src/front/ts/nuclen-quiz-optin';
+import * as utils from '../../src/front/ts/nuclen-quiz-utils';
+import type { OptinContext } from '../../src/front/ts/nuclen-quiz-types';
+
+const baseCtx: OptinContext = {
+  position: 'before_results',
+  mandatory: false,
+  promptText: 'Join us',
+  submitLabel: 'Submit',
+  enabled: true,
+  webhook: '',
+  ajaxUrl: '',
+  ajaxNonce: '',
+};
+
+function createContainer() {
+  document.body.innerHTML = '<div id="target"></div>';
+  return document.getElementById('target') as HTMLElement;
+}
+
+afterEach(() => {
+  vi.restoreAllMocks();
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  delete (global as any).alert;
+});
+
+describe('buildOptinInlineHTML', () => {
+  it('returns expected HTML', () => {
+    const html = buildOptinInlineHTML({
+      ...baseCtx,
+      position: 'with_results',
+    });
+    const expected = `
+  <div id="nuclen-optin-container" class="nuclen-optin-with-results">
+    <p class="nuclen-fg"><strong>Join us</strong></p>
+    <label for="nuclen-optin-name"  class="nuclen-fg">Name</label>
+    <input  type="text"  id="nuclen-optin-name">
+    <label for="nuclen-optin-email" class="nuclen-fg">Email</label>
+    <input  type="email" id="nuclen-optin-email" required>
+    <button type="button" id="nuclen-optin-submit">Submit</button>
+  </div>`;
+    expect(html).toBe(expected);
+  });
+});
+
+describe('mountOptinBeforeResults', () => {
+  it('renders opt-in with skip link when not mandatory', () => {
+    const container = createContainer();
+    mountOptinBeforeResults(container, baseCtx, vi.fn(), vi.fn());
+    expect(container.innerHTML).toContain('nuclen-optin-skip');
+  });
+
+  it('omits skip link when mandatory', () => {
+    const container = createContainer();
+    mountOptinBeforeResults(container, { ...baseCtx, mandatory: true }, vi.fn(), vi.fn());
+    expect(container.innerHTML).not.toContain('nuclen-optin-skip');
+  });
+
+  it('handles submit success', async () => {
+    const container = createContainer();
+    const complete = vi.fn();
+    const skip = vi.fn();
+    vi.spyOn(utils, 'isValidEmail').mockReturnValue(true);
+    vi.spyOn(utils, 'storeOptinLocally').mockResolvedValue();
+    vi.spyOn(utils, 'submitToWebhook').mockResolvedValue();
+    mountOptinBeforeResults(container, baseCtx, complete, skip);
+    (document.getElementById('nuclen-optin-name') as HTMLInputElement).value = 'n';
+    (document.getElementById('nuclen-optin-email') as HTMLInputElement).value = 'e@b.com';
+    (document.getElementById('nuclen-optin-submit') as HTMLElement).click();
+    await Promise.resolve();
+    await Promise.resolve();
+    expect(utils.storeOptinLocally).toHaveBeenCalled();
+    expect(utils.submitToWebhook).toHaveBeenCalled();
+    expect(complete).toHaveBeenCalled();
+    expect(skip).not.toHaveBeenCalled();
+  });
+
+  it('alerts on invalid email', () => {
+    const container = createContainer();
+    const alertMock = vi.fn();
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    (global as any).alert = alertMock;
+    vi.spyOn(utils, 'isValidEmail').mockReturnValue(false);
+    mountOptinBeforeResults(container, baseCtx, vi.fn(), vi.fn());
+    (document.getElementById('nuclen-optin-submit') as HTMLElement).click();
+    expect(alertMock).toHaveBeenCalled();
+    expect(utils.storeOptinLocally).not.toHaveBeenCalled();
+  });
+
+  it('calls skip callback', () => {
+    const container = createContainer();
+    const skip = vi.fn();
+    mountOptinBeforeResults(container, baseCtx, vi.fn(), skip);
+    (document.getElementById('nuclen-optin-skip') as HTMLElement).dispatchEvent(new Event('click', { bubbles: true }));
+    expect(skip).toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## Summary
- add frontend tests for the opt-in HTML builder and mount logic

## Testing
- `npm run test` *(fails: vitest not found)*
- `composer --working-dir=nuclear-engagement lint` *(fails: composer not found)*
- `composer --working-dir=nuclear-engagement test` *(fails: composer not found)*

------
https://chatgpt.com/codex/tasks/task_e_685cf1c2f9c48327b1f05f34e108f712

<!-- Korbit AI PR Description Start -->
## Description by Korbit AI

### What change is being made?

Add opt-in UI tests to ensure HTML rendering and interaction logic work as expected.

### Why are these changes being made?

To verify that the opt-in user interface functions correctly, enhancing reliability by testing various scenarios including rendering, submission success, mandatory settings, and error handling. These tests improve code coverage and help prevent future regressions.



> Is this description stale? Ask me to generate a new description by commenting `/korbit-generate-pr-description`
<!-- Korbit AI PR Description End -->