### PR TITLE
Fix phpstan deprecation package

### DIFF
--- a/nuclear-engagement/composer.json
+++ b/nuclear-engagement/composer.json
@@ -19,7 +19,7 @@
   "require-dev": {
     "wp-coding-standards/wpcs": "3.0",
     "phpunit/phpunit": "^9.6",
-    "phpstan/phpstan-deprecation": "^1.0"
+    "phpstan/phpstan-deprecation-rules": "^1.0"
   },
   "scripts": {
     "lint": "phpcs",


### PR DESCRIPTION
## Summary
- correct phpstan package name

## Testing
- `composer lint --working-dir=nuclear-engagement` *(fails: command not found)*
- `composer test --working-dir=nuclear-engagement` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685cf276d9748327b66a243c67531e9e