### PR TITLE
Add MetaRegistration sanitizer tests

### DIFF
--- a/tests/MetaRegistrationTest.php
+++ b/tests/MetaRegistrationTest.php
@@ -1,0 +1,76 @@
+<?php
+use PHPUnit\Framework\TestCase;
+use NuclearEngagement\MetaRegistration;
+
+namespace NuclearEngagement {
+    if (!function_exists('sanitize_text_field')) {
+        function sanitize_text_field($text) { return trim($text); }
+    }
+    if (!function_exists('wp_kses_post')) {
+        function wp_kses_post($text) { return $text; }
+    }
+    if (!function_exists('wp_kses')) {
+        function wp_kses($text, $allowed_html) {
+            $allowed = '<' . implode('><', array_keys($allowed_html)) . '>';
+            return strip_tags($text, $allowed);
+        }
+    }
+}
+
+namespace {
+    require_once dirname(__DIR__) . '/nuclear-engagement/inc/Core/MetaRegistration.php';
+
+    class MetaRegistrationTest extends TestCase {
+        public function test_invalid_input_returns_empty_string(): void {
+            $this->assertSame('', MetaRegistration::sanitize_quiz_data('bad'));
+            $this->assertSame('', MetaRegistration::sanitize_summary_data(false));
+        }
+
+        public function test_quiz_data_sanitizes_structure(): void {
+            $input = [
+                'date' => ' 2024-05-01 ',
+                'questions' => [
+                    [
+                        'question' => '<i>Q1</i>',
+                        'answers' => ['A1', '<b>A2</b>'],
+                        'explanation' => '<p>E1</p>'
+                    ],
+                    'ignore',
+                    [
+                        'question' => 'Q2'
+                    ]
+                ]
+            ];
+
+            $expected = [
+                'date' => '2024-05-01',
+                'questions' => [
+                    [
+                        'question' => '<i>Q1</i>',
+                        'answers' => ['A1', '<b>A2</b>'],
+                        'explanation' => '<p>E1</p>'
+                    ],
+                    [
+                        'question' => 'Q2',
+                        'answers' => [],
+                        'explanation' => ''
+                    ]
+                ]
+            ];
+
+            $this->assertSame($expected, MetaRegistration::sanitize_quiz_data($input));
+        }
+
+        public function test_summary_data_sanitizes_structure(): void {
+            $input = [
+                'date' => ' 2024 ',
+                'summary' => '<p>hello <script>alert("x")</script> <a href="/">Link</a></p>'
+            ];
+            $expected = [
+                'date' => '2024',
+                'summary' => '<p>hello alert("x") <a href="/">Link</a></p>'
+            ];
+            $this->assertSame($expected, MetaRegistration::sanitize_summary_data($input));
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- test quiz/summary sanitizers for handling invalid values
- verify quiz questions and summary fields are sanitized

## Testing
- `composer lint` *(fails: command not found)*
- `composer test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685cf1bcccbc83279102a6d27e552a6c

<!-- Korbit AI PR Description Start -->
## Description by Korbit AI

### What change is being made?

Add unit tests for the `MetaRegistration` sanitizer functions to ensure data is sanitized correctly and consistently with expected output formats.

### Why are these changes being made?

These changes ensure the `MetaRegistration` class's sanitization methods are robust and produce expected results when dealing with various input data. By mocking WordPress functions and testing different data scenarios, we can better maintain data integrity and security within the application.

> Is this description stale? Ask me to generate a new description by commenting `/korbit-generate-pr-description`
<!-- Korbit AI PR Description End -->