### PR TITLE
Add admin utility tests

### DIFF
--- a/tests/frontend/admin-fetch.test.ts
+++ b/tests/frontend/admin-fetch.test.ts
@@ -1,0 +1,92 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { nuclenFetchWithRetry, nuclenFetchUpdates, NuclenStartGeneration } from '../../src/admin/ts/generation/api';
+import * as logger from '../../src/admin/ts/utils/logger';
+
+// helper to build a mock Response-like object
+function mockResponse(body: string, ok = true, status = 200) {
+  return {
+    ok,
+    status,
+    text: vi.fn().mockResolvedValue(body)
+  } as unknown as Response;
+}
+
+afterEach(() => {
+  vi.restoreAllMocks();
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  delete (global as any).fetch;
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  delete (window as any).nuclenAjax;
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  delete (window as any).nuclenAdminVars;
+});
+
+describe('nuclenFetchWithRetry', () => {
+  it('returns parsed data when successful', async () => {
+    const fetchMock = vi.fn().mockResolvedValue(mockResponse('{"a":1}'));
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    (global as any).fetch = fetchMock;
+    const result = await nuclenFetchWithRetry<any>('u', { method: 'GET' }, 0);
+    expect(result).toEqual({ ok: true, status: 200, data: { a: 1 } });
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+
+  it('retries on failure then succeeds', async () => {
+    vi.useFakeTimers();
+    const err = new Error('net');
+    const fetchMock = vi
+      .fn()
+      .mockRejectedValueOnce(err)
+      .mockResolvedValueOnce(mockResponse(''));
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    (global as any).fetch = fetchMock;
+    vi.spyOn(logger, 'warn').mockImplementation(() => {});
+    vi.spyOn(logger, 'error').mockImplementation(() => {});
+    const promise = nuclenFetchWithRetry('u', {}, 1, 10);
+    await vi.runAllTimersAsync();
+    const result = await promise;
+    expect(result.ok).toBe(true);
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+    vi.useRealTimers();
+  });
+});
+
+describe('nuclenFetchUpdates', () => {
+  beforeEach(() => {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    (window as any).nuclenAjax = { ajax_url: 'a', fetch_action: 'f', nonce: 'n' };
+  });
+
+  it('returns response data when ok', async () => {
+    const data = { success: true };
+    const fetchMock = vi.fn().mockResolvedValue(mockResponse(JSON.stringify(data)));
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    (global as any).fetch = fetchMock;
+    const res = await nuclenFetchUpdates('id');
+    expect(res).toEqual(data);
+  });
+
+  it('throws on error response', async () => {
+    const fetchMock = vi.fn().mockResolvedValue(mockResponse('bad', false, 500));
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    (global as any).fetch = fetchMock;
+    await expect(nuclenFetchUpdates()).rejects.toThrow('bad');
+  });
+});
+
+describe('NuclenStartGeneration', () => {
+  beforeEach(() => {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    (window as any).nuclenAdminVars = { ajax_url: 'a' };
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    (window as any).nuclenAjax = { nonce: 'n' };
+  });
+
+  it('throws message from response when generation fails', async () => {
+    const body = { success: false, data: { message: 'nope' } };
+    const fetchMock = vi.fn().mockResolvedValue(mockResponse(JSON.stringify(body)));
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    (global as any).fetch = fetchMock;
+    await expect(NuclenStartGeneration({})).rejects.toThrow('nope');
+  });
+});

--- a/tests/frontend/admin-polling.test.ts
+++ b/tests/frontend/admin-polling.test.ts
@@ -1,0 +1,60 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { NuclenPollAndPullUpdates } from '../../src/admin/ts/generation/polling';
+import * as api from '../../src/admin/ts/generation/api';
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe('NuclenPollAndPullUpdates', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('polls until processed >= total', async () => {
+    const fetchMock = vi
+      .spyOn(api, 'nuclenFetchUpdates')
+      .mockResolvedValueOnce({ success: true, data: { processed: 1, total: 2 } })
+      .mockResolvedValueOnce({ success: true, data: { processed: 2, total: 2, finalReport: 'r' } });
+
+    const progress = vi.fn();
+    const complete = vi.fn();
+
+    NuclenPollAndPullUpdates({ intervalMs: 1000, generationId: 'g', onProgress: progress, onComplete: complete });
+
+    await vi.runOnlyPendingTimersAsync();
+    await Promise.resolve();
+    expect(progress).toHaveBeenCalledWith(1, 2);
+    expect(complete).not.toHaveBeenCalled();
+
+    await vi.runOnlyPendingTimersAsync();
+    await Promise.resolve();
+    expect(progress).toHaveBeenCalledWith(2, 2);
+    expect(complete).toHaveBeenCalledWith({
+      processed: 2,
+      total: 2,
+      successCount: 2,
+      failCount: undefined,
+      finalReport: 'r',
+      results: undefined,
+      workflow: undefined,
+    });
+
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+  });
+
+  it('calls onError when request fails', async () => {
+    vi.spyOn(api, 'nuclenFetchUpdates').mockRejectedValue(new Error('boom'));
+    const onError = vi.fn();
+
+    NuclenPollAndPullUpdates({ intervalMs: 1000, generationId: 'g', onError });
+
+    await vi.runOnlyPendingTimersAsync();
+    await Promise.resolve();
+    expect(onError).toHaveBeenCalledWith('boom');
+  });
+});

--- a/tests/frontend/admin-utils.test.ts
+++ b/tests/frontend/admin-utils.test.ts
@@ -1,0 +1,55 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import { nuclenShowElement, nuclenHideElement, nuclenUpdateProgressBarStep, nuclenToggleSummaryFields } from '../../src/admin/ts/generate/generate-page-utils';
+
+describe('nuclenShowElement & nuclenHideElement', () => {
+  it('toggles nuclen-hidden class', () => {
+    document.body.innerHTML = '<div id="el" class="nuclen-hidden"></div>';
+    const el = document.getElementById('el') as HTMLElement;
+    nuclenShowElement(el);
+    expect(el.classList.contains('nuclen-hidden')).toBe(false);
+    nuclenHideElement(el);
+    expect(el.classList.contains('nuclen-hidden')).toBe(true);
+  });
+});
+
+describe('nuclenUpdateProgressBarStep', () => {
+  it('applies state class', () => {
+    document.body.innerHTML = '<div id="step" class="ne-step-bar__step--todo"></div>';
+    const el = document.getElementById('step') as HTMLElement;
+    nuclenUpdateProgressBarStep(el, 'done');
+    expect(el.className).toBe('ne-step-bar__step--done');
+  });
+});
+
+describe('nuclenToggleSummaryFields', () => {
+  beforeEach(() => {
+    document.body.innerHTML = `
+      <select id="nuclen_generate_workflow">
+        <option value="posts">Posts</option>
+        <option value="summary">Summary</option>
+      </select>
+      <div id="nuclen-summary-settings" class="nuclen-hidden"></div>
+      <div id="nuclen-summary-paragraph-options" class="nuclen-hidden"></div>
+      <div id="nuclen-summary-bullet-options" class="nuclen-hidden"></div>
+      <select id="nuclen_summary_format">
+        <option value="paragraph">Paragraph</option>
+        <option value="bullet">Bullet</option>
+      </select>
+    `;
+  });
+
+  it('shows paragraph options when workflow is summary and format paragraph', () => {
+    (document.getElementById('nuclen_generate_workflow') as HTMLSelectElement).value = 'summary';
+    (document.getElementById('nuclen_summary_format') as HTMLSelectElement).value = 'paragraph';
+    nuclenToggleSummaryFields();
+    expect(document.getElementById('nuclen-summary-settings')!.classList.contains('nuclen-hidden')).toBe(false);
+    expect(document.getElementById('nuclen-summary-paragraph-options')!.classList.contains('nuclen-hidden')).toBe(false);
+    expect(document.getElementById('nuclen-summary-bullet-options')!.classList.contains('nuclen-hidden')).toBe(true);
+  });
+
+  it('hides settings when workflow is posts', () => {
+    (document.getElementById('nuclen_generate_workflow') as HTMLSelectElement).value = 'posts';
+    nuclenToggleSummaryFields();
+    expect(document.getElementById('nuclen-summary-settings')!.classList.contains('nuclen-hidden')).toBe(true);
+  });
+});

--- a/tests/frontend/display-error.test.ts
+++ b/tests/frontend/display-error.test.ts
@@ -1,0 +1,25 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { displayError } from '../../src/admin/ts/utils/displayError';
+
+describe('displayError', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    vi.restoreAllMocks();
+    document.body.innerHTML = '';
+  });
+
+  it('adds and removes toast and logs to console', async () => {
+    const log = vi.spyOn(console, 'error').mockImplementation(() => {});
+    displayError('boom');
+    const toast = document.querySelector('.nuclen-error-toast');
+    expect(toast).not.toBeNull();
+    expect(log).toHaveBeenCalledWith('boom');
+    vi.advanceTimersByTime(5000);
+    await Promise.resolve();
+    expect(document.querySelector('.nuclen-error-toast')).toBeNull();
+  });
+});


### PR DESCRIPTION
## Summary
- add tests for admin fetch utilities
- add polling tests with mocked timers
- cover admin UI helpers
- test error display behavior

## Testing
- `npm run test` *(fails: vitest not found)*
- `composer lint` *(fails: command not found)*
- `composer test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685cff15014c8327a362ff21dfeea485

<!-- Korbit AI PR Description Start -->
## Description by Korbit AI

### What change is being made?

Add comprehensive unit tests for various admin utilities, including API fetch methods, polling, utility functions, and error display functionalities.

### Why are these changes being made?

These changes are made to ensure the robustness and reliability of the admin utilities, improving their test coverage and facilitating early detection of bugs. By verifying the behavior of critical functionalities such as fetching data, handling UI elements, and error management through automated tests, future modifications to the codebase can be made with greater confidence.

> Is this description stale? Ask me to generate a new description by commenting `/korbit-generate-pr-description`
<!-- Korbit AI PR Description End -->