### PR TITLE
Fix vitest peer dependency mismatch

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -22,8 +22,8 @@
         "eslint": "^8.57.1",
         "typescript": "~5.6.2",
         "vite": "^6.0.6",
-        "vitest": "^1.5.0",
-        "@vitest/browser": "^0.34.6"
+        "vitest": "^1.6.1",
+        "@vitest/browser": "^1.6.1"
       }
     },
     "node_modules/@esbuild/aix-ppc64": {

--- a/package.json
+++ b/package.json
@@ -17,8 +17,8 @@
     "eslint": "^8.57.1",
     "typescript": "~5.6.2",
     "vite": "^6.0.6",
-    "vitest": "^1.5.0",
-    "@vitest/browser": "^0.34.6"
+    "vitest": "^1.6.1",
+    "@vitest/browser": "^1.6.1"
   },
   "main": "index.js",
   "dependencies": {


### PR DESCRIPTION
## Summary
- update @vitest/browser to match vitest version

## Testing
- `composer lint --working-dir=nuclear-engagement` *(fails: command not found)*
- `composer test --working-dir=nuclear-engagement` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685cf5d31bec8327b3534b0eafe9f797

<!-- Korbit AI PR Description Start -->
## Description by Korbit AI

### What change is being made?

Update the `vitest` and `@vitest/browser` packages to version `^1.6.1` in the `package.json`.

### Why are these changes being made?

To fix a peer dependency mismatch issue in the project, ensuring compatibility and stability when using the latest features or fixes associated with those libraries. This will help in maintaining seamless development and testing workflows.

> Is this description stale? Ask me to generate a new description by commenting `/korbit-generate-pr-description`
<!-- Korbit AI PR Description End -->