### PR TITLE
Fix optin invalid email test

### DIFF
--- a/tests/frontend/nuclen-quiz-optin.test.ts
+++ b/tests/frontend/nuclen-quiz-optin.test.ts
@@ -82,6 +82,8 @@ describe('mountOptinBeforeResults', () => {
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     (global as any).alert = alertMock;
     vi.spyOn(utils, 'isValidEmail').mockReturnValue(false);
+    vi.spyOn(utils, 'storeOptinLocally');
+    vi.spyOn(utils, 'submitToWebhook');
     mountOptinBeforeResults(container, baseCtx, vi.fn(), vi.fn());
     (document.getElementById('nuclen-optin-submit') as HTMLElement).click();
     expect(alertMock).toHaveBeenCalled();


### PR DESCRIPTION
## Summary
- ensure `storeOptinLocally` and `submitToWebhook` are spied in the invalid email test

## Testing
- `composer lint` *(fails: command not found)*
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_685d05b7d6088327b682787751a2c6c8

<!-- Korbit AI PR Description Start -->
## Description by Korbit AI

### What change is being made?

Add spies for `storeOptinLocally` and `submitToWebhook` in the `nuclen-quiz-optin` test.

### Why are these changes being made?

The additional spies ensure that the functions `storeOptinLocally` and `submitToWebhook` are monitored during the test execution to verify that they are called appropriately, enabling more comprehensive testing of the email opt-in invalidation scenario.

> Is this description stale? Ask me to generate a new description by commenting `/korbit-generate-pr-description`
<!-- Korbit AI PR Description End -->