### PR TITLE
Fix failing opt-in test

### DIFF
--- a/tests/frontend/nuclen-quiz-optin.test.ts
+++ b/tests/frontend/nuclen-quiz-optin.test.ts
@@ -81,11 +81,14 @@ describe('mountOptinBeforeResults', () => {
     const alertMock = vi.fn();
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     (global as any).alert = alertMock;
+    vi.spyOn(utils, 'storeOptinLocally').mockResolvedValue();
+    vi.spyOn(utils, 'submitToWebhook').mockResolvedValue();
     vi.spyOn(utils, 'isValidEmail').mockReturnValue(false);
     mountOptinBeforeResults(container, baseCtx, vi.fn(), vi.fn());
     (document.getElementById('nuclen-optin-submit') as HTMLElement).click();
     expect(alertMock).toHaveBeenCalled();
     expect(utils.storeOptinLocally).not.toHaveBeenCalled();
+    expect(utils.submitToWebhook).not.toHaveBeenCalled();
   });
 
   it('calls skip callback', () => {


### PR DESCRIPTION
## Summary
- spy on `storeOptinLocally` and `submitToWebhook` so that invalid email check works

## Testing
- `composer lint` *(fails: composer not found)*
- `composer test` *(fails: composer not found)*
- `npm install` *(fails: network access blocked)*
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_685d05bfc63c83279750a75a4778deec

<!-- Korbit AI PR Description Start -->
## Description by Korbit AI

### What change is being made?

Add mock implementations for `storeOptinLocally` and `submitToWebhook` functions in the `nuclen-quiz-optin.test.ts` test suite to ensure the test does not fail due to unmocked external dependencies.

### Why are these changes being made?

The opt-in test was failing because the `storeOptinLocally` and `submitToWebhook` functions were not mocked, leading to unexpected errors during test execution. By mocking these functions, the test can focus on its intended functionality without interference from dependencies, ensuring it passes consistently.

> Is this description stale? Ask me to generate a new description by commenting `/korbit-generate-pr-description`
<!-- Korbit AI PR Description End -->