### PR TITLE
Fix PHP tool configs

### DIFF
--- a/nuclear-engagement/composer.json
+++ b/nuclear-engagement/composer.json
@@ -23,7 +23,7 @@
   },
   "scripts": {
     "lint": "phpcs",
-    "phpstan": "vendor/bin/phpstan analyse",
-    "test": "phpunit"
+    "phpstan": "phpstan analyse -c ../phpstan.neon.dist",
+    "test": "phpunit --configuration ../phpunit.xml"
   }
 }

--- a/phpcs.xml
+++ b/phpcs.xml
@@ -3,7 +3,6 @@
     <rule ref="WordPress">
         <exclude name="WordPress.Files.FileName" />
     </rule>
-    <rule ref="Generic.Metrics.MagicNumbers" />
 
     <exclude-pattern>vendor/*</exclude-pattern>
     <exclude-pattern>node_modules/*</exclude-pattern>


### PR DESCRIPTION
## Summary
- remove invalid Generic.Metrics.MagicNumbers sniff
- provide paths for phpunit and phpstan in composer.json

## Testing
- `composer lint --working-dir=nuclear-engagement` *(fails: composer not found)*
- `composer test --working-dir=nuclear-engagement` *(fails: composer not found)*
- `composer phpstan --working-dir=nuclear-engagement` *(fails: composer not found)*


------
https://chatgpt.com/codex/tasks/task_e_685d0645ca8083278cc4fb6f8fd87089


> [!NOTE]
> I'm currently writing a description for your pull request. I should be done shortly (<1 minute). Please don't edit the description field until I'm finished, or we may overwrite each other. If I find nothing to write about, I'll delete this message.
