### PR TITLE
Fix composer scripts and remove unsupported sniff

### DIFF
--- a/nuclear-engagement/composer.json
+++ b/nuclear-engagement/composer.json
@@ -22,8 +22,8 @@
     "phpstan/phpstan-deprecation-rules": "^1.0"
   },
   "scripts": {
-    "lint": "phpcs",
-    "phpstan": "vendor/bin/phpstan analyse",
-    "test": "phpunit"
+    "lint": "phpcs -q --standard=../phpcs.xml",
+    "phpstan": "vendor/bin/phpstan analyse --configuration=../phpstan.neon.dist",
+    "test": "phpunit --configuration=../phpunit.xml"
   }
 }

--- a/phpcs.xml
+++ b/phpcs.xml
@@ -3,7 +3,6 @@
     <rule ref="WordPress">
         <exclude name="WordPress.Files.FileName" />
     </rule>
-    <rule ref="Generic.Metrics.MagicNumbers" />
 
     <exclude-pattern>vendor/*</exclude-pattern>
     <exclude-pattern>node_modules/*</exclude-pattern>


### PR DESCRIPTION
## Summary
- remove nonexistent sniff from `phpcs.xml`
- update composer scripts to point to root configuration files

## Testing
- `composer lint --working-dir=nuclear-engagement` *(fails: `composer` not found)*
- `composer test --working-dir=nuclear-engagement` *(fails: `composer` not found)*
- `composer phpstan --working-dir=nuclear-engagement` *(fails: `composer` not found)*
- `npm install` *(fails: network access required)*
- `npm run test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_685d068a6ee88327822ad19025ebe178