### PR TITLE
Add onboarding and controller tests

### DIFF
--- a/tests/GenerateControllerTest.php
+++ b/tests/GenerateControllerTest.php
@@ -1,0 +1,67 @@
+<?php
+use PHPUnit\Framework\TestCase;
+use NuclearEngagement\Admin\Controller\Ajax\GenerateController;
+use NuclearEngagement\Requests\GenerateRequest;
+
+namespace NuclearEngagement\Services {
+    class GenerationService {
+        public array $received = [];
+        public function generateContent(GenerateRequest $r) { $this->received[] = $r; return new \NuclearEngagement\Responses\GenerateResponse(); }
+    }
+    class LoggingService {
+        public static array $errors = [];
+        public static function log_exception(\Throwable $e): void { self::$errors[] = $e->getMessage(); }
+        public static function log(string $m): void { self::$errors[] = $m; }
+    }
+}
+
+namespace NuclearEngagement\Responses {
+    class GenerateResponse {
+        public function toArray(): array { return ['ok'=>1]; }
+    }
+}
+
+namespace {
+    if (!function_exists('check_ajax_referer')) { function check_ajax_referer($a,$f,$d=false){ return true; } }
+    if (!function_exists('current_user_can')) { function current_user_can($c){ return true; } }
+    if (!function_exists('wp_send_json_success')) { function wp_send_json_success($d){ $GLOBALS['json_response']=['success',$d]; } }
+    if (!function_exists('wp_send_json_error')) { function wp_send_json_error($d,$c=0){ $GLOBALS['json_response']=['error',$d,$c]; } }
+    if (!function_exists('status_header')) { function status_header($c){ $GLOBALS['status_header']=$c; } }
+    if (!function_exists('sanitize_text_field')) { function sanitize_text_field($t){ return $t; } }
+    if (!function_exists('wp_unslash')) { function wp_unslash($d){ return $d; } }
+    if (!function_exists('__')) { function __($t,$d=null){ return $t; } }
+
+    require_once __DIR__ . '/../nuclear-engagement/admin/Controller/Ajax/BaseController.php';
+    require_once __DIR__ . '/../nuclear-engagement/admin/Controller/Ajax/GenerateController.php';
+    require_once __DIR__ . '/../nuclear-engagement/inc/Requests/GenerateRequest.php';
+    
+    class GenerateControllerTest extends TestCase {
+        protected function setUp(): void {
+            $_POST = [];
+            $GLOBALS['json_response'] = null;
+            $GLOBALS['status_header'] = null;
+        }
+
+        public function test_valid_request_calls_service(): void {
+            $service = new \NuclearEngagement\Services\GenerationService();
+            $controller = new GenerateController($service);
+            $_POST['payload'] = json_encode([
+                'nuclen_selected_post_ids' => json_encode([1]),
+                'nuclen_selected_generate_workflow' => 'quiz'
+            ]);
+            $_POST['security'] = 'valid';
+            $controller->handle();
+            $this->assertSame(['success',['ok'=>1]], $GLOBALS['json_response']);
+            $this->assertInstanceOf(GenerateRequest::class, $service->received[0]);
+        }
+
+        public function test_missing_payload_returns_400(): void {
+            $service = new \NuclearEngagement\Services\GenerationService();
+            $controller = new GenerateController($service);
+            $_POST['security'] = 'valid';
+            $controller->handle();
+            $this->assertSame(400, $GLOBALS['status_header']);
+            $this->assertSame('Missing payload in request', $GLOBALS['json_response'][1]['message']);
+        }
+    }
+}

--- a/tests/OnboardingPointersTest.php
+++ b/tests/OnboardingPointersTest.php
@@ -1,0 +1,18 @@
+<?php
+use PHPUnit\Framework\TestCase;
+use NuclearEngagement\Admin\OnboardingPointers;
+
+require_once __DIR__ . '/../nuclear-engagement/admin/OnboardingPointers.php';
+
+class OnboardingPointersTest extends TestCase {
+    public function test_get_pointers_returns_expected_structure(): void {
+        $pointers = OnboardingPointers::get_pointers();
+        $this->assertIsArray($pointers);
+        $this->assertArrayHasKey('post.php', $pointers);
+        $first = $pointers['post.php'][0];
+        $this->assertArrayHasKey('id', $first);
+        $this->assertArrayHasKey('target', $first);
+        $this->assertArrayHasKey('title', $first);
+        $this->assertArrayHasKey('content', $first);
+    }
+}

--- a/tests/OnboardingTest.php
+++ b/tests/OnboardingTest.php
@@ -1,0 +1,84 @@
+<?php
+use PHPUnit\Framework\TestCase;
+use NuclearEngagement\Admin\Onboarding;
+
+namespace {
+    if (!function_exists('wp_enqueue_style')) {
+        function wp_enqueue_style($handle) { $GLOBALS['enqueued_styles'][] = $handle; }
+    }
+    if (!function_exists('wp_enqueue_script')) {
+        function wp_enqueue_script($handle, $src='', $deps=array(), $ver='', $in_footer=false) { $GLOBALS['enqueued_scripts'][] = $handle; }
+    }
+    if (!function_exists('wp_add_inline_script')) {
+        function wp_add_inline_script($handle, $code, $pos='after') { $GLOBALS['inline_script'][$handle] = $code; }
+    }
+    if (!function_exists('admin_url')) {
+        function admin_url($path='') { return 'admin-ajax.php'; }
+    }
+    if (!function_exists('wp_create_nonce')) {
+        function wp_create_nonce($a) { return 'nonce123'; }
+    }
+    if (!function_exists('plugin_dir_url')) {
+        function plugin_dir_url($file) { return ''; }
+    }
+    if (!function_exists('current_user_can')) {
+        function current_user_can($cap) { return $GLOBALS['can_manage'] ?? true; }
+    }
+    if (!function_exists('check_ajax_referer')) {
+        function check_ajax_referer($a,$f) { return true; }
+    }
+    if (!function_exists('wp_send_json_success')) {
+        function wp_send_json_success($data) { $GLOBALS['json_response'] = ['success',$data]; }
+    }
+    if (!function_exists('wp_send_json_error')) {
+        function wp_send_json_error($data,$code=0) { $GLOBALS['json_response'] = ['error',$data,$code]; }
+    }
+    if (!function_exists('sanitize_text_field')) { function sanitize_text_field($t){ return $t; } }
+    if (!function_exists('wp_unslash')) { function wp_unslash($d){ return $d; } }
+}
+
+namespace {
+    require_once __DIR__ . '/../nuclear-engagement/admin/OnboardingPointers.php';
+    require_once __DIR__ . '/../nuclear-engagement/admin/Onboarding.php';
+
+    class OnboardingTest extends TestCase {
+        protected function setUp(): void {
+            global $enqueued_scripts, $inline_script, $wp_user_meta, $json_response, $can_manage;
+            $enqueued_scripts = $inline_script = [];
+            $wp_user_meta = [];
+            $json_response = null;
+            $can_manage = true;
+        }
+
+        public function test_enqueue_pointers_enqueues_and_injects(): void {
+            global $enqueued_scripts, $inline_script, $wp_user_meta;
+            $wp_user_meta[1]['nuclen_pointer_dismissed_nuclen_postedit_step1'] = true;
+            $onb = new Onboarding();
+            $onb->enqueue_nuclen_onboarding_pointers('post.php');
+            $this->assertContains('nuclen-onboarding', $enqueued_scripts);
+            $this->assertArrayHasKey('nuclen-onboarding', $inline_script);
+            $json = str_replace('window.nePointerData = ', '', rtrim($inline_script['nuclen-onboarding'], ';'));
+            $data = json_decode($json, true);
+            $ids = array_column($data['pointers'], 'id');
+            $this->assertNotContains('nuclen_postedit_step1', $ids);
+        }
+
+        public function test_ajax_dismiss_pointer_permission_failure(): void {
+            global $json_response, $can_manage;
+            $can_manage = false;
+            $onb = new Onboarding();
+            $_POST = ['pointer' => 'x', 'nonce' => 'n'];
+            $onb->nuclen_ajax_dismiss_pointer();
+            $this->assertSame(['error',['message'=>'No permission'],0], $json_response);
+        }
+
+        public function test_ajax_dismiss_pointer_updates_meta(): void {
+            global $json_response, $wp_user_meta;
+            $onb = new Onboarding();
+            $_POST = ['pointer' => 'abc', 'nonce' => 'n'];
+            $onb->nuclen_ajax_dismiss_pointer();
+            $this->assertTrue($wp_user_meta[1]['nuclen_pointer_dismissed_abc']);
+            $this->assertSame(['success',['message'=>'Pointer dismissed.']], $json_response);
+        }
+    }
+}

--- a/tests/OptinExportControllerTest.php
+++ b/tests/OptinExportControllerTest.php
@@ -1,0 +1,26 @@
+<?php
+use PHPUnit\Framework\TestCase;
+use NuclearEngagement\Admin\Controller\OptinExportController;
+
+namespace NuclearEngagement {
+    class OptinData {
+        public static int $calls = 0;
+        public static function handle_export(): void { self::$calls++; }
+    }
+}
+
+namespace {
+    require_once __DIR__ . '/../nuclear-engagement/admin/Controller/OptinExportController.php';
+
+    class OptinExportControllerTest extends TestCase {
+        protected function setUp(): void {
+            \NuclearEngagement\OptinData::$calls = 0;
+        }
+
+        public function test_handle_invokes_export(): void {
+            $c = new OptinExportController();
+            $c->handle();
+            $this->assertSame(1, \NuclearEngagement\OptinData::$calls);
+        }
+    }
+}

--- a/tests/frontend/onboarding.test.ts
+++ b/tests/frontend/onboarding.test.ts
@@ -1,0 +1,45 @@
+import { describe, it, beforeEach, afterEach, expect, vi } from 'vitest';
+
+vi.mock('../../src/admin/ts/nuclen-admin-generate', () => ({
+  nuclenFetchWithRetry: vi.fn().mockResolvedValue({ ok: true })
+}));
+vi.mock('../../src/admin/ts/utils/displayError', () => ({
+  displayError: vi.fn()
+}));
+vi.mock('../../src/admin/ts/utils/logger', () => ({
+  error: vi.fn()
+}));
+
+const { nuclenFetchWithRetry } = await import('../../src/admin/ts/nuclen-admin-generate');
+
+beforeEach(() => {
+  vi.resetModules();
+  document.body.innerHTML = '<div id="target"></div>';
+  (window as any).nePointerData = {
+    pointers: [{ id: 'p1', target: '#target', title: 'T', content: 'C', position: { edge: 'top', align: 'center' } }],
+    ajaxurl: 'ajax.php',
+    nonce: 'n'
+  };
+});
+
+afterEach(() => {
+  delete (window as any).nePointerData;
+  document.body.innerHTML = '';
+});
+
+describe('nuclen-admin-onboarding', () => {
+  it('renders pointer from window data', async () => {
+    await import('../../src/admin/ts/nuclen-admin-onboarding');
+    document.dispatchEvent(new Event('DOMContentLoaded'));
+    expect(document.querySelector('.wp-pointer')).not.toBeNull();
+  });
+
+  it('sends AJAX dismissal request', async () => {
+    await import('../../src/admin/ts/nuclen-admin-onboarding');
+    document.dispatchEvent(new Event('DOMContentLoaded'));
+    const close = document.querySelector<HTMLAnchorElement>('.wp-pointer .close')!;
+    close.click();
+    await Promise.resolve();
+    expect(nuclenFetchWithRetry).toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## Summary
- add unit tests for onboarding and pointer dismissal
- add unit tests for onboarding pointers definition
- cover generate ajax controller and optin export
- add vitest suite for onboarding TS

## Testing
- `composer lint` *(fails: command not found)*
- `composer test` *(fails: command not found)*
- `npm run test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_685d077f512883279fe414b0b758accc

<!-- Korbit AI PR Description Start -->
## Description by Korbit AI

### What change is being made?

Add unit tests for GenerateController, OnboardingPointers, Onboarding, OptinExportController, and a frontend onboarding test in TypeScript.

### Why are these changes being made?

These changes are being made to ensure the integrity and reliability of the new features by verifying their expected behavior through unit tests. By adding comprehensive test coverage, we are aiming to catch potential issues early and maintain code quality as the project evolves.

> Is this description stale? Ask me to generate a new description by commenting `/korbit-generate-pr-description`
<!-- Korbit AI PR Description End -->