### PR TITLE
Fix autoload and lint setup

### DIFF
--- a/nuclear-engagement/composer.json
+++ b/nuclear-engagement/composer.json
@@ -8,7 +8,9 @@
       "NuclearEngagement\\Responses\\": "inc/Responses/",
       "NuclearEngagement\\Modules\\": "inc/Modules/",
       "NuclearEngagement\\Core\\": "inc/Core/",
-      "NuclearEngagement\\Utils\\": "inc/Utils/"
+      "NuclearEngagement\\Utils\\": "inc/Utils/",
+      "NuclearEngagement\\Traits\\": "inc/Traits/",
+      "NuclearEngagement\\": "inc/"
     }
   },
   "config": {
@@ -19,10 +21,11 @@
   "require-dev": {
     "wp-coding-standards/wpcs": "3.0",
     "phpunit/phpunit": "^9.6",
-    "phpstan/phpstan-deprecation-rules": "^1.0"
+    "phpstan/phpstan-deprecation-rules": "^1.0",
+    "php-stubs/wordpress-stubs": "^6.0"
   },
   "scripts": {
-    "lint": "phpcs",
+    "lint": "phpcs -q --standard=../phpcs.xml .",
     "phpstan": "phpstan analyse -c ../phpstan.neon.dist",
     "test": "phpunit --configuration ../phpunit.xml"
   }

--- a/nuclear-engagement/inc/Core/SettingsRepository.php
+++ b/nuclear-engagement/inc/Core/SettingsRepository.php
@@ -80,6 +80,12 @@ final class SettingsRepository {
      */
     private SettingsCache $cache;
 
+    use \NuclearEngagement\Traits\SettingsGettersTrait;
+    use \NuclearEngagement\Traits\SettingsPersistenceTrait;
+    use \NuclearEngagement\Traits\SettingsCacheTrait;
+    use \NuclearEngagement\Traits\SettingsAccessTrait;
+    use PendingSettingsTrait;
+
 
     /**
      * Get the singleton instance.
@@ -110,20 +116,7 @@ final class SettingsRepository {
         $this->cache->register_hooks();
     }
 
-
-        /*
-        ===================================================================
-        * GETTERS
-        * ===================================================================
-        */
-
-use \NuclearEngagement\Traits\SettingsGettersTrait;
-use \NuclearEngagement\Traits\SettingsPersistenceTrait;
-use \NuclearEngagement\Traits\SettingsCacheTrait;
-use \NuclearEngagement\Traits\SettingsAccessTrait;
-use PendingSettingsTrait;
-
-        /**
+    /**
          * Get the default values.
          *
          * @since 1.0.0

--- a/nuclear-engagement/phpcs.xml
+++ b/nuclear-engagement/phpcs.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0"?>
+<ruleset name="Nuclear Engagement">
+    <rule ref="WordPress">
+        <exclude name="WordPress.Files.FileName" />
+    </rule>
+
+    <exclude-pattern>vendor/*</exclude-pattern>
+    <exclude-pattern>node_modules/*</exclude-pattern>
+    <exclude-pattern>tests/*</exclude-pattern>
+</ruleset>


### PR DESCRIPTION
## Summary
- add missing PSR-4 autoload rules
- require WordPress stubs for phpstan
- configure phpcs paths and add plugin-level phpcs.xml
- reorganize trait usage in `SettingsRepository`

## Testing
- `composer install` *(fails: command not found)*
- `composer lint` *(fails: command not found)*
- `composer test` *(fails: command not found)*
- `composer phpstan` *(fails: command not found)*


------
https://chatgpt.com/codex/tasks/task_e_685d0b94a8e083278139db8ed4977799

<!-- Korbit AI PR Description Start -->
## Description by Korbit AI

### What change is being made?

Enhance autoload and lint setup by adding new autoload namespaces, refining lint scripts, and including a `phpcs.xml` configuration file for code styling rules.

### Why are these changes being made?

The changes address the need for better organization and modularization of the codebase by introducing autoload for traits, ensuring code quality with improved linting setup, and specifying coding standards through the new `phpcs.xml` file. The updates ensure the code adheres to WordPress standards while avoiding unnecessary directories during the linting process.

> Is this description stale? Ask me to generate a new description by commenting `/korbit-generate-pr-description`
<!-- Korbit AI PR Description End -->