### PR TITLE
Fix trait loading for SettingsRepository

### DIFF
--- a/nuclear-engagement/inc/Core/SettingsRepository.php
+++ b/nuclear-engagement/inc/Core/SettingsRepository.php
@@ -84,7 +84,7 @@ final class SettingsRepository {
     use \NuclearEngagement\Traits\SettingsPersistenceTrait;
     use \NuclearEngagement\Traits\SettingsCacheTrait;
     use \NuclearEngagement\Traits\SettingsAccessTrait;
-    use PendingSettingsTrait;
+    use \NuclearEngagement\PendingSettingsTrait;
 
 
     /**


### PR DESCRIPTION
## Summary
- reference PendingSettingsTrait with full namespace

## Testing
- `composer lint` *(fails: command not found)*
- `composer test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685d0e29301c8327951da063c921d903