### PR TITLE
Add test for TOC initialization

### DIFF
--- a/tests/frontend/nuclen-front-global.test.ts
+++ b/tests/frontend/nuclen-front-global.test.ts
@@ -1,0 +1,34 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+
+beforeEach(() => {
+  vi.resetModules();
+  document.body.innerHTML = `
+    <div class="nuclen-toc-sticky" data-offset-y="20" data-offset-x="20">
+      <nav class="nuclen-toc"></nav>
+    </div>`;
+  (window as any).nuclenTocL10n = { show: 'Show', hide: 'Hide' };
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+  delete (window as any).nuclenTocL10n;
+});
+
+describe('nuclen-toc-front lazy boot', () => {
+  it('registers DOMContentLoaded listener and attaches window handlers', async () => {
+    Object.defineProperty(document, 'readyState', { value: 'loading', configurable: true });
+    const docSpy = vi.spyOn(document, 'addEventListener');
+    const winSpy = vi.spyOn(window, 'addEventListener');
+
+    await import('../../src/modules/toc/ts/nuclen-toc-front');
+
+    expect(docSpy).toHaveBeenCalledWith('DOMContentLoaded', expect.any(Function));
+    const cb = docSpy.mock.calls.find(c => c[0] === 'DOMContentLoaded')?.[1] as () => void;
+    expect(cb).toBeTypeOf('function');
+
+    cb();
+
+    expect(winSpy).toHaveBeenCalledWith('scroll', expect.any(Function), { passive: true });
+    expect(winSpy).toHaveBeenCalledWith('resize', expect.any(Function));
+  });
+});


### PR DESCRIPTION
## Summary
- add unit test covering DOMContentLoaded init for TOC front script

## Testing
- `npm test` *(fails: vitest not found)*
- `composer lint` *(fails: command not found)*
- `composer test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685d0d23a150832781172af1503842a7


> [!NOTE]
> I'm currently writing a description for your pull request. I should be done shortly (<1 minute). Please don't edit the description field until I'm finished, or we may overwrite each other. If I find nothing to write about, I'll delete this message.
