### PR TITLE
Fix single-generation test mocks

### DIFF
--- a/tests/frontend/nuclen-admin-single-generation.test.ts
+++ b/tests/frontend/nuclen-admin-single-generation.test.ts
@@ -5,6 +5,11 @@ vi.mock('../../src/admin/ts/nuclen-admin-generate', async () => {
   return { ...actual, NuclenPollAndPullUpdates: vi.fn() };
 });
 
+vi.mock('../../src/admin/ts/generation/api', async () => {
+  const actual: any = await vi.importActual('../../src/admin/ts/generation/api');
+  return { ...actual, nuclenFetchWithRetry: vi.fn() };
+});
+
 vi.mock('../../src/admin/ts/single/single-generation-utils', () => ({
   alertApiError: vi.fn(),
   populateQuizMetaBox: vi.fn(),
@@ -42,9 +47,7 @@ describe('nuclen-admin-single-generation', () => {
       pollOpts = opts;
     });
 
-    vi
-      .spyOn(api, 'nuclenFetchWithRetry')
-      .mockResolvedValueOnce({
+    (api.nuclenFetchWithRetry as vi.Mock).mockResolvedValueOnce({
         ok: true,
         status: 200,
         data: { success: true, generation_id: 'gid' },
@@ -69,9 +72,7 @@ describe('nuclen-admin-single-generation', () => {
   });
 
   it('displays error when generation fails', async () => {
-    vi
-      .spyOn(api, 'nuclenFetchWithRetry')
-      .mockResolvedValueOnce({
+    (api.nuclenFetchWithRetry as vi.Mock).mockResolvedValueOnce({
         ok: false,
         status: 500,
         data: null,


### PR DESCRIPTION
## Summary
- fix nuclen-admin-single-generation tests by mocking `nuclenFetchWithRetry`

## Testing
- `composer lint` *(fails: command not found)*
- `composer test` *(fails: command not found)*
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_685d113ebe6c8327bb2140e2ab44bdd2


> [!NOTE]
> I'm currently writing a description for your pull request. I should be done shortly (<1 minute). Please don't edit the description field until I'm finished, or we may overwrite each other. If I find nothing to write about, I'll delete this message.
