### PR TITLE
Add DevMenu mock to jest setup

### DIFF
--- a/jest.setup.js
+++ b/jest.setup.js
@@ -1,0 +1,3 @@
+jest.mock('react-native/Libraries/Utilities/DevMenu', () => ({
+  reload: jest.fn()
+}));


### PR DESCRIPTION
## Summary
- add `jest.setup.js` mocking React Native's DevMenu

## Testing
- `composer lint` *(fails: composer not found)*
- `composer test` *(fails: composer not found)*
- `npm install` *(fails: no internet access)*
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_685d12e1026083279565182c410b767d

<!-- Korbit AI PR Description Start -->
## Description by Korbit AI

### What change is being made?

Add a mock for the `DevMenu` module in the Jest setup file.

### Why are these changes being made?

The `DevMenu` module needs to be mocked to prevent errors related to native modules not being available in a Jest testing environment. This change ensures that tests depending on `DevMenu` can run smoothly without actual implementation.

> Is this description stale? Ask me to generate a new description by commenting `/korbit-generate-pr-description`
<!-- Korbit AI PR Description End -->