### PR TITLE
Fix namespace declaration for PHP 8 compatibility

### DIFF
--- a/tests/ActivatorDeactivatorTest.php
+++ b/tests/ActivatorDeactivatorTest.php
@@ -1,10 +1,9 @@
 <?php
-use PHPUnit\Framework\TestCase;
-use NuclearEngagement\Core\Activator;
-use NuclearEngagement\Core\Deactivator;
-use NuclearEngagement\Services\AutoGenerationService;
-
 namespace {
+    use PHPUnit\Framework\TestCase;
+    use NuclearEngagement\Core\Activator;
+    use NuclearEngagement\Core\Deactivator;
+    use NuclearEngagement\Services\AutoGenerationService;
     if (!defined('NUCLEN_PLUGIN_DIR')) {
         define('NUCLEN_PLUGIN_DIR', dirname(__DIR__) . '/nuclear-engagement/');
     }


### PR DESCRIPTION
## Summary
- move `use` statements inside the namespace block in `ActivatorDeactivatorTest.php`

## Testing
- `composer test` *(fails: composer not installed)*

------
https://chatgpt.com/codex/tasks/task_e_685d14e0bd588327a498203c32b5ff93

<!-- Korbit AI PR Description Start -->
## Description by Korbit AI

### What change is being made?

Move the namespace declaration outside of the global namespace block to ensure PHP 8 compatibility.

### Why are these changes being made?

PHP 8 requires that namespace declarations be properly scoped to enhance code interoperability and maintain forward compatibility. This change adheres to the new behavior by moving all `use` statements outside the global namespace, resolving potential conflicts and keeping the style consistent with modern standards.

> Is this description stale? Ask me to generate a new description by commenting `/korbit-generate-pr-description`
<!-- Korbit AI PR Description End -->