### PR TITLE
Fix ESLint browser globals

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -17,8 +17,25 @@ if (!fs.existsSync(tsconfigPath)) {
 export default [
   js.configs.recommended,
   {
+    files: [
+      'eslint.config.js',
+      'vite.config.js',
+      'vitest.config.ts',
+      'jest.setup.js'
+    ],
+    languageOptions: {
+      env: {
+        node: true
+      }
+    }
+  },
+  {
     files: ['**/*.ts'],
     languageOptions: {
+      env: {
+        browser: true,
+        es2021: true
+      },
       parser: tsParser,
       parserOptions: {
         project: tsconfigPath,


### PR DESCRIPTION
## Summary
- tell ESLint that TypeScript runs in the browser
- mark config files as Node

## Testing
- `composer lint` *(fails: command not found)*
- `composer test` *(fails: command not found)*
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_685d18c946a8832780302cf3d1e6d20e

<!-- Korbit AI PR Description Start -->
## Description by Korbit AI

### What change is being made?

Add specific environment settings to ESLint configuration for Node.js files and TypeScript files by enabling Node.js globals for configuration files and browser globals for TypeScript files.

### Why are these changes being made?

The changes are being made to ensure ESLint recognizes the appropriate environment globals for files, which helps in preventing linting errors related to missing global variables specific to Node.js and browser environments. This approach provides better context awareness for ESLint, enhancing code quality and maintainability.

> Is this description stale? Ask me to generate a new description by commenting `/korbit-generate-pr-description`
<!-- Korbit AI PR Description End -->