### PR TITLE
Fix TypeScript lint warnings

### DIFF
--- a/src/admin/ts/generate/generate-page-utils.ts
+++ b/src/admin/ts/generate/generate-page-utils.ts
@@ -34,7 +34,7 @@ export async function nuclenCheckCreditsAjax(): Promise<number> {
   if (window.nuclenAjax.nonce) {
     formData.append('security', window.nuclenAjax.nonce);
   }
-  const result = await nuclenFetchWithRetry<any>(window.nuclenAjax.ajax_url, {
+  const result = await nuclenFetchWithRetry(window.nuclenAjax.ajax_url, {
     method: 'POST',
     body: formData,
     credentials: 'same-origin',

--- a/src/admin/ts/generate/step1.ts
+++ b/src/admin/ts/generate/step1.ts
@@ -33,7 +33,7 @@ export function initStep1(elements: GeneratePageElements): void {
     const filters: NuclenFilterValues = nuclenCollectFilters();
     nuclenAppendFilters(formData, filters);
 
-    const result = await nuclenFetchWithRetry<any>(window.nuclenAjax.ajax_url || '', {
+    const result = await nuclenFetchWithRetry(window.nuclenAjax.ajax_url || '', {
       method: 'POST',
       body: formData,
       credentials: 'same-origin',
@@ -100,10 +100,11 @@ export function initStep1(elements: GeneratePageElements): void {
         nuclenShowElement(elements.submitBtn);
         elements.submitBtn.disabled = false;
       }
-    } catch (err: any) {
+    } catch (err: unknown) {
       logger.error('Error fetching remaining credits:', err);
+      const message = err instanceof Error ? err.message : 'Unknown error';
       if (elements.creditsInfoEl) {
-        elements.creditsInfoEl.textContent = `Unable to retrieve your credits: ${err.message}`;
+        elements.creditsInfoEl.textContent = `Unable to retrieve your credits: ${message}`;
       }
       if (elements.submitBtn) {
         elements.submitBtn.disabled = false;

--- a/src/admin/ts/generate/step2.ts
+++ b/src/admin/ts/generate/step2.ts
@@ -85,9 +85,10 @@ export function initStep2(elements: GeneratePageElements): void {
           nuclenShowElement(elements.restartBtn);
         },
       });
-    } catch (error: any) {
+    } catch (error: unknown) {
       nuclenUpdateProgressBarStep(elements.stepBar3, 'failed');
-      nuclenAlertApiError(error.message);
+      const message = error instanceof Error ? error.message : 'Unknown error';
+      nuclenAlertApiError(message);
       if (elements.submitBtn) {
         elements.submitBtn.disabled = false;
       }

--- a/src/admin/ts/generation/api.ts
+++ b/src/admin/ts/generation/api.ts
@@ -7,7 +7,7 @@ export interface NuclenFetchResult<T> {
   error?: string;
 }
 
-export async function nuclenFetchWithRetry<T = any>(
+export async function nuclenFetchWithRetry<T = unknown>(
   url: string,
   options: RequestInit,
   retries = 3,
@@ -36,7 +36,7 @@ export async function nuclenFetchWithRetry<T = any>(
       }
 
       return { ok: false, status, data, error: bodyText };
-    } catch (error: any) {
+    } catch (error: unknown) {
       lastError = error as Error;
       if (attempt === retries) {
         break;
@@ -78,7 +78,7 @@ export async function nuclenFetchUpdates(generationId?: string) {
     formData.append('generation_id', generationId);
   }
 
-  const result = await nuclenFetchWithRetry<any>(window.nuclenAjax.ajax_url, {
+  const result = await nuclenFetchWithRetry(window.nuclenAjax.ajax_url, {
     method: 'POST',
     body: formData,
     credentials: 'same-origin',
@@ -91,7 +91,7 @@ export async function nuclenFetchUpdates(generationId?: string) {
   return result.data;
 }
 
-export async function NuclenStartGeneration(dataToSend: Record<string, any>) {
+export async function NuclenStartGeneration(dataToSend: Record<string, unknown>) {
   if (!window.nuclenAdminVars || !window.nuclenAdminVars.ajax_url) {
     throw new Error('Missing WP Ajax config (nuclenAdminVars.ajax_url).');
   }
@@ -104,7 +104,7 @@ export async function NuclenStartGeneration(dataToSend: Record<string, any>) {
   }
   formData.append('security', window.nuclenAjax.nonce);
 
-  const result = await nuclenFetchWithRetry<any>(window.nuclenAdminVars.ajax_url, {
+  const result = await nuclenFetchWithRetry(window.nuclenAdminVars.ajax_url, {
     method: 'POST',
     body: formData,
     credentials: 'same-origin',

--- a/src/admin/ts/generation/polling.ts
+++ b/src/admin/ts/generation/polling.ts
@@ -3,14 +3,14 @@ import { nuclenFetchUpdates } from './api';
 export function NuclenPollAndPullUpdates({
   intervalMs = 5000,
   generationId,
-  onProgress = (_processed: number, _total: number) => {},
-  onComplete = (_finalData: any) => {},
+  onProgress = (() => {}) as (processed: number, total: number) => void,
+  onComplete = (_finalData: unknown) => {},
   onError = (_errMsg: string) => {},
 }: {
   intervalMs?: number;
   generationId: string;
   onProgress?: (processed: number, total: number) => void;
-  onComplete?: (finalData: any) => void;
+  onComplete?: (finalData: unknown) => void;
   onError?: (errMsg: string) => void;
 }) {
   const pollInterval = setInterval(async () => {
@@ -46,9 +46,10 @@ export function NuclenPollAndPullUpdates({
           workflow,
         });
       }
-    } catch (err: any) {
+    } catch (err: unknown) {
       clearInterval(pollInterval);
-      onError(err.message);
+      const message = err instanceof Error ? err.message : 'Unknown error';
+      onError(message);
     }
   }, intervalMs);
 }

--- a/src/admin/ts/generation/results.ts
+++ b/src/admin/ts/generation/results.ts
@@ -19,7 +19,7 @@ export function nuclenAlertApiError(errMsg: string): void {
   }
 }
 
-export async function nuclenStoreGenerationResults(workflow: string, results: any) {
+export async function nuclenStoreGenerationResults(workflow: string, results: unknown) {
   const payload = { workflow, results };
   let resp: Response;
   try {
@@ -37,7 +37,7 @@ export async function nuclenStoreGenerationResults(workflow: string, results: an
     displayError('Network error');
     return { ok: false, data: { message: 'Network error' } };
   }
-  let data: any = null;
+  let data: unknown = null;
   if (resp.ok) {
     try {
       data = await resp.json();

--- a/src/admin/ts/nuclen-admin-onboarding.ts
+++ b/src/admin/ts/nuclen-admin-onboarding.ts
@@ -119,7 +119,7 @@ export interface NuclenPointer {
         }
 
         try {
-          const result = await nuclenFetchWithRetry<any>(ajaxurl, {
+          const result = await nuclenFetchWithRetry(ajaxurl, {
             method: 'POST',
             credentials: 'same-origin',
             headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
@@ -129,7 +129,7 @@ export interface NuclenPointer {
             logger.error('Failed to dismiss pointer:', result.error);
             displayError('Failed to dismiss pointer.');
           }
-        } catch (err: any) {
+        } catch (err: unknown) {
           logger.error('Error dismissing pointer:', err);
           displayError('Network error while dismissing pointer.');
         }

--- a/src/admin/ts/single/single-generation-handlers.ts
+++ b/src/admin/ts/single/single-generation-handlers.ts
@@ -78,8 +78,9 @@ export function initSingleGenerationButtons(): void {
           btn.disabled = false;
         },
       });
-    } catch (err: any) {
-      alertApiError(err.message);
+    } catch (err: unknown) {
+      const message = err instanceof Error ? err.message : 'Unknown error';
+      alertApiError(message);
       btn.textContent = 'Generate';
       btn.disabled = false;
     }

--- a/src/admin/ts/single/single-generation-utils.ts
+++ b/src/admin/ts/single/single-generation-utils.ts
@@ -3,7 +3,10 @@ export {
   nuclenStoreGenerationResults as storeGenerationResults,
 } from '../generation/results';
 
-export function populateQuizMetaBox(postResult: any, finalDate?: string): void {
+export function populateQuizMetaBox(
+  postResult: Record<string, unknown>,
+  finalDate?: string
+): void {
   const { date, questions } = postResult;
   const newDate = finalDate || date;
   const dateField = document.querySelector<HTMLInputElement>('input[name="nuclen_quiz_data[date]"]');
@@ -40,7 +43,10 @@ export function populateQuizMetaBox(postResult: any, finalDate?: string): void {
   }
 }
 
-export function populateSummaryMetaBox(postResult: any, finalDate?: string): void {
+export function populateSummaryMetaBox(
+  postResult: Record<string, unknown>,
+  finalDate?: string
+): void {
   const { date, summary } = postResult;
   const newDate = finalDate || date;
   const dateField = document.querySelector<HTMLInputElement>('input[name="nuclen_summary_data[date]"]');

--- a/src/admin/ts/utils/api.ts
+++ b/src/admin/ts/utils/api.ts
@@ -11,7 +11,10 @@ export async function apiRequest(url: string, options: RequestInit): Promise<Res
       throw new Error(`HTTP ${response.status}`);
     }
     return response;
-  } catch (err: any) {
-    throw new Error(err.message || 'Network error');
+  } catch (err: unknown) {
+    if (err instanceof Error) {
+      throw new Error(err.message || 'Network error');
+    }
+    throw new Error('Network error');
   }
 }

--- a/src/admin/ts/utils/logger.ts
+++ b/src/admin/ts/utils/logger.ts
@@ -1,11 +1,11 @@
-export function log(...args: any[]): void {
+export function log(...args: unknown[]): void {
   console.log(...args);
 }
 
-export function warn(...args: any[]): void {
+export function warn(...args: unknown[]): void {
   console.warn(...args);
 }
 
-export function error(...args: any[]): void {
+export function error(...args: unknown[]): void {
   console.error(...args);
 }


### PR DESCRIPTION
## Summary
- clean up unexpected `any` usages
- adjust unused parameters in polling util
- update single generation handler utilities

## Testing
- `composer lint` *(fails: command not found)*
- `composer test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685d18de07e083278337de0aba5d1939

<!-- Korbit AI PR Description Start -->
## Description by Korbit AI

### What change is being made?

Fix TypeScript lint warnings by replacing `any` with `unknown`, improving error handling, and updating function signatures to use more specific types.

### Why are these changes being made?

To enhance type safety and adhere to TypeScript best practices by avoiding the `any` type, making code more robust and maintainable. These changes will help to prevent potential runtime errors and improve code readability and maintainability.

> Is this description stale? Ask me to generate a new description by commenting `/korbit-generate-pr-description`
<!-- Korbit AI PR Description End -->