### PR TITLE
Fix ESLint config env property

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -24,18 +24,18 @@ export default [
       'jest.setup.js'
     ],
     languageOptions: {
-      env: {
-        node: true
+      globals: {
+        module: 'readonly',
+        require: 'readonly',
+        process: 'readonly',
+        __dirname: 'readonly',
+        __filename: 'readonly'
       }
     }
   },
   {
     files: ['**/*.ts'],
     languageOptions: {
-      env: {
-        browser: true,
-        es2021: true
-      },
       parser: tsParser,
       parserOptions: {
         project: tsconfigPath,


### PR DESCRIPTION
## Summary
- fix ESLint flat config by removing deprecated `env` option

## Testing
- `composer lint` *(fails: composer not found)*
- `composer test` *(fails: composer not found)*
- `npm run lint` *(fails: missing dependencies and network access)*

------
https://chatgpt.com/codex/tasks/task_e_685d1aa481d88327944504ae31ed3e6b

<!-- Korbit AI PR Description Start -->
## Description by Korbit AI

### What change is being made?

Replace the `env` property with the `globals` property in the ESLint configuration for better control over global variables.

### Why are these changes being made?

The previous use of the `env` property was not as effective for defining global variables as using the `globals` property, which offers a clearer and more restrictive approach by setting core Node.js variables to read-only. This change ensures more precise linting and prevents potential issues with mutable global variables.

> Is this description stale? Ask me to generate a new description by commenting `/korbit-generate-pr-description`
<!-- Korbit AI PR Description End -->