### PR TITLE
Fix namespace block in ActivatorDeactivatorTest

### DIFF
--- a/tests/ActivatorDeactivatorTest.php
+++ b/tests/ActivatorDeactivatorTest.php
@@ -85,9 +85,10 @@ namespace {
     require_once dirname(__DIR__) . '/nuclear-engagement/inc/OptinData.php';
     require_once dirname(__DIR__) . '/nuclear-engagement/inc/Core/AssetVersions.php';
     require_once dirname(__DIR__) . '/nuclear-engagement/inc/Core/Activator.php';
-    require_once dirname(__DIR__) . '/nuclear-engagement/inc/Core/Deactivator.php';
+require_once dirname(__DIR__) . '/nuclear-engagement/inc/Core/Deactivator.php';
 }
 
+namespace {
 class ActivatorDeactivatorTest extends TestCase {
     protected function setUp(): void {
         global $wpdb, $wp_options, $wp_autoload, $transients, $update_option_calls, $cleared_hooks;
@@ -121,4 +122,5 @@ class ActivatorDeactivatorTest extends TestCase {
         ];
         $this->assertSame($expected, $cleared_hooks);
     }
+}
 }


### PR DESCRIPTION
## Summary
- fix fatal error by wrapping `ActivatorDeactivatorTest` in a namespace block

## Testing
- `composer lint` *(fails: composer not found)*
- `composer test` *(fails: composer not found)*

------
https://chatgpt.com/codex/tasks/task_e_685d1a8fb2b88327a262863cf60a208c