### PR TITLE
Fix single-generation test mocking

### DIFF
--- a/tests/frontend/nuclen-admin-single-generation.test.ts
+++ b/tests/frontend/nuclen-admin-single-generation.test.ts
@@ -1,13 +1,19 @@
 import { describe, it, beforeAll, beforeEach, afterEach, expect, vi } from 'vitest';
 
-vi.mock('../../src/admin/ts/nuclen-admin-generate', async () => {
-  const actual: any = await vi.importActual('../../src/admin/ts/nuclen-admin-generate');
-  return { ...actual, NuclenPollAndPullUpdates: vi.fn() };
-});
-
 vi.mock('../../src/admin/ts/generation/api', async () => {
   const actual: any = await vi.importActual('../../src/admin/ts/generation/api');
   return { ...actual, nuclenFetchWithRetry: vi.fn() };
+});
+
+// Re-export mocked generation helpers so NuclenStartGeneration uses the stubbed
+// nuclenFetchWithRetry above.
+vi.mock('../../src/admin/ts/nuclen-admin-generate', async () => {
+  const api = await import('../../src/admin/ts/generation/api');
+  const { NuclenPollAndPullUpdates } = await vi.importActual('../../src/admin/ts/generation/polling');
+  return {
+    ...api,
+    NuclenPollAndPullUpdates: vi.fn(),
+  };
 });
 
 vi.mock('../../src/admin/ts/single/single-generation-utils', () => ({


### PR DESCRIPTION
## Summary
- update `nuclen-admin-single-generation.test.ts` to re-export mocked helpers
  so `NuclenStartGeneration` uses the stubbed `nuclenFetchWithRetry`

## Testing
- `composer lint` *(fails: command not found)*
- `composer test` *(fails: command not found)*
- `npm run test` *(fails: vitest: not found)*

------
https://chatgpt.com/codex/tasks/task_e_685d1cfdc3b08327ad892d9e10554454