### PR TITLE
Fix TypeScript any usage

### DIFF
--- a/src/admin/ts/blocks/nuclen-editor-blocks.ts
+++ b/src/admin/ts/blocks/nuclen-editor-blocks.ts
@@ -1,10 +1,16 @@
 (function(){
-  if (!window.wp || !window.wp.blocks || !window.wp.element || !window.wp.i18n) {
+  interface WPGlobal {
+    blocks?: { registerBlockType: (...args: unknown[]) => void };
+    element?: { createElement: (...args: unknown[]) => unknown };
+    i18n?: { __: (...args: unknown[]) => string };
+  }
+  const wp = window.wp as WPGlobal;
+  if (!wp || !wp.blocks || !wp.element || !wp.i18n) {
     return;
   }
-  const { registerBlockType } = window.wp.blocks;
-  const { createElement } = window.wp.element;
-  const { __ } = window.wp.i18n;
+  const { registerBlockType } = wp.blocks;
+  const { createElement } = wp.element;
+  const { __ } = wp.i18n;
   registerBlockType('nuclear-engagement/quiz', {
     apiVersion: 2,
     title: __('Quiz', 'nuclear-engagement'),

--- a/src/admin/ts/generate/step1.ts
+++ b/src/admin/ts/generate/step1.ts
@@ -15,6 +15,17 @@ import {
 import { displayError } from '../utils/displayError';
 import * as logger from '../utils/logger';
 
+interface PostsCountResponse {
+  success: boolean;
+  message?: string;
+  data: {
+    count: number;
+    post_ids: string[];
+    message?: string;
+    [key: string]: unknown;
+  };
+}
+
 export function initStep1(elements: GeneratePageElements): void {
   elements.getPostsBtn?.addEventListener('click', async () => {
     if (!window.nuclenAjax || !window.nuclenAjax.ajax_url) {
@@ -33,11 +44,14 @@ export function initStep1(elements: GeneratePageElements): void {
     const filters: NuclenFilterValues = nuclenCollectFilters();
     nuclenAppendFilters(formData, filters);
 
-    const result = await nuclenFetchWithRetry(window.nuclenAjax.ajax_url || '', {
-      method: 'POST',
-      body: formData,
-      credentials: 'same-origin',
-    });
+    const result = await nuclenFetchWithRetry<PostsCountResponse>(
+      window.nuclenAjax.ajax_url || '',
+      {
+        method: 'POST',
+        body: formData,
+        credentials: 'same-origin',
+      }
+    );
     if (!result.ok) {
       logger.error('Error retrieving post count:', result.error);
       if (elements.postsCountEl) {
@@ -45,7 +59,7 @@ export function initStep1(elements: GeneratePageElements): void {
       }
       return;
     }
-    const data = result.data;
+    const data = result.data as PostsCountResponse;
     if (!data.success) {
       if (elements.postsCountEl) {
         elements.postsCountEl.innerText = 'Error retrieving post count.';

--- a/src/admin/ts/generation/polling.ts
+++ b/src/admin/ts/generation/polling.ts
@@ -1,24 +1,24 @@
 import { nuclenFetchUpdates } from './api';
+import type { PollingUpdateData, PollingUpdateResponse } from './api';
 
 export function NuclenPollAndPullUpdates({
   intervalMs = 5000,
   generationId,
   onProgress = (() => {}) as (processed: number, total: number) => void,
-  onComplete = (_finalData: unknown) => {},
+  onComplete = (_finalData: PollingUpdateData) => {},
   onError = (_errMsg: string) => {},
 }: {
   intervalMs?: number;
   generationId: string;
   onProgress?: (processed: number, total: number) => void;
-  onComplete?: (finalData: unknown) => void;
+  onComplete?: (finalData: PollingUpdateData) => void;
   onError?: (errMsg: string) => void;
 }) {
   const pollInterval = setInterval(async () => {
     try {
-      const pollResults = await nuclenFetchUpdates(generationId);
+      const pollResults: PollingUpdateResponse = await nuclenFetchUpdates(generationId);
       if (!pollResults.success) {
-        const errMsg =
-          pollResults.message || pollResults.data?.message || 'Polling error';
+        const errMsg = pollResults.message || 'Polling error';
         throw new Error(errMsg);
       }
 

--- a/src/admin/ts/nuclen-globals.d.ts
+++ b/src/admin/ts/nuclen-globals.d.ts
@@ -2,7 +2,7 @@
 export {};
 
 declare global {
-  const wp: any;
+  const wp: Record<string, unknown>;
   interface Window {
     nuclenAjax?: {
       ajax_url?: string;
@@ -15,7 +15,7 @@ declare global {
       rest_receive_content?: string;
       rest_nonce?: string;
     };
-    tinymce?: any;
-    wp?: any;
+    tinymce?: Record<string, unknown>;
+    wp?: Record<string, unknown>;
   }
 }

--- a/src/admin/ts/single/single-generation-utils.ts
+++ b/src/admin/ts/single/single-generation-utils.ts
@@ -3,8 +3,19 @@ export {
   nuclenStoreGenerationResults as storeGenerationResults,
 } from '../generation/results';
 
+export interface PostResult {
+  date?: string;
+  summary?: string;
+  questions?: Array<{
+    question?: string;
+    answers?: string[];
+    explanation?: string;
+  }>;
+  [key: string]: unknown;
+}
+
 export function populateQuizMetaBox(
-  postResult: Record<string, unknown>,
+  postResult: PostResult,
   finalDate?: string
 ): void {
   const { date, questions } = postResult;
@@ -44,7 +55,7 @@ export function populateQuizMetaBox(
 }
 
 export function populateSummaryMetaBox(
-  postResult: Record<string, unknown>,
+  postResult: PostResult,
   finalDate?: string
 ): void {
   const { date, summary } = postResult;
@@ -57,10 +68,19 @@ export function populateSummaryMetaBox(
   }
 
   if (typeof window.tinymce !== 'undefined') {
-    const editor = window.tinymce.get('nuclen_summary_data_summary');
+    const tiny = window.tinymce as {
+      get?: (id: string) => {
+        setContent?: (html: string) => void;
+        save?: () => void;
+      };
+    };
+    let editor: { setContent?: (html: string) => void; save?: () => void } | undefined;
+    if (typeof tiny.get === 'function') {
+      editor = tiny.get('nuclen_summary_data_summary');
+    }
     if (editor && typeof editor.setContent === 'function') {
       editor.setContent(summary || '');
-      editor.save();
+      editor.save?.();
     } else {
       const summaryField = document.querySelector<HTMLTextAreaElement>('textarea[name="nuclen_summary_data[summary]"]');
       if (summaryField) {

--- a/src/front/ts/logger.ts
+++ b/src/front/ts/logger.ts
@@ -1,9 +1,9 @@
-export function log(...args: any[]): void {
+export function log(...args: unknown[]): void {
   console.log(...args);
 }
-export function warn(...args: any[]): void {
+export function warn(...args: unknown[]): void {
   console.warn(...args);
 }
-export function error(...args: any[]): void {
+export function error(...args: unknown[]): void {
   console.error(...args);
 }

--- a/src/front/ts/nuclen-front-global.ts
+++ b/src/front/ts/nuclen-front-global.ts
@@ -32,7 +32,7 @@ declare global {
     your_answer: string;
   };
 
-  function gtag(...args: any[]): void;
+  function gtag(...args: unknown[]): void;
 }
 
 export {};

--- a/src/front/ts/nuclen-quiz-main.ts
+++ b/src/front/ts/nuclen-quiz-main.ts
@@ -34,7 +34,7 @@ import * as logger from './logger';
 
   declare const NuclenOptinAjax: { url: string; nonce: string };
 
-  declare function gtag(...args: any[]): void;
+  declare function gtag(...args: unknown[]): void;
 
   /* ─────────────────────────────────────────────────────────────
      Entry

--- a/src/front/ts/nuclen-quiz-results.ts
+++ b/src/front/ts/nuclen-quiz-results.ts
@@ -21,7 +21,7 @@ declare const NuclenStrings: {
   your_answer: string;
 };
 
-declare function gtag(...args: any[]): void;
+declare function gtag(...args: unknown[]): void;
 
 declare global {
   interface Window {


### PR DESCRIPTION
## Summary
- remove remaining `any` types from TypeScript sources
- provide interfaces for API responses
- update single post utilities and handlers with proper types
- cast WordPress globals more safely

## Testing
- `composer lint` *(fails: composer not found)*
- `composer test` *(fails: composer not found)*
- `npm test` *(fails: vitest not found)*
- `npx tsc --noEmit`

------
https://chatgpt.com/codex/tasks/task_e_685d1bcbe6048327b7be0a25ab9f1219


> [!NOTE]
> I'm currently writing a description for your pull request. I should be done shortly (<1 minute). Please don't edit the description field until I'm finished, or we may overwrite each other. If I find nothing to write about, I'll delete this message.
