### PR TITLE
Fix phpunit test namespace

### DIFF
--- a/tests/ActivatorDeactivatorTest.php
+++ b/tests/ActivatorDeactivatorTest.php
@@ -89,6 +89,8 @@ require_once dirname(__DIR__) . '/nuclear-engagement/inc/Core/Deactivator.php';
 }
 
 namespace {
+use PHPUnit\Framework\TestCase;
+
 class ActivatorDeactivatorTest extends TestCase {
     protected function setUp(): void {
         global $wpdb, $wp_options, $wp_autoload, $transients, $update_option_calls, $cleared_hooks;


### PR DESCRIPTION
## Summary
- include `PHPUnit\Framework\TestCase` in `ActivatorDeactivatorTest`

## Testing
- `composer lint` *(fails: command not found)*
- `composer test` *(fails: command not found)*
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_685d1ff331fc8327b84523cdb5261c75


> [!NOTE]
> I'm currently writing a description for your pull request. I should be done shortly (<1 minute). Please don't edit the description field until I'm finished, or we may overwrite each other. If I find nothing to write about, I'll delete this message.
