### PR TITLE
Fix phpstan vendor include path

### DIFF
--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -1,5 +1,5 @@
 includes:
-    - vendor/php-stubs/wordpress-stubs/wordpress-stubs.php
+    - nuclear-engagement/vendor/php-stubs/wordpress-stubs/wordpress-stubs.php
 
 parameters:
     level: 6


### PR DESCRIPTION
## Summary
- fix vendor path for PHPStan stubs

## Testing
- `composer lint --working-dir=nuclear-engagement` *(fails: composer not found)*
- `composer test --working-dir=nuclear-engagement` *(fails: composer not found)*

------
https://chatgpt.com/codex/tasks/task_e_685d21cb6d688327af7aaff8ccb495f9

<!-- Korbit AI PR Description Start -->
## Description by Korbit AI

### What change is being made?

Update the include path for the phpstan vendor from `vendor/php-stubs/wordpress-stubs/wordpress-stubs.php` to `nuclear-engagement/vendor/php-stubs/wordpress-stubs/wordpress-stubs.php`.

### Why are these changes being made?

The path correction ensures that phpstan can accurately include the necessary stubs from the correct directory, likely due to a change in the project's directory structure. This update aligns the configuration with the current project setup to maintain proper static analysis functionality.

> Is this description stale? Ask me to generate a new description by commenting `/korbit-generate-pr-description`
<!-- Korbit AI PR Description End -->