### PR TITLE
Fix phpstan configuration

### DIFF
--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -1,8 +1,7 @@
-includes:
-    - nuclear-engagement/vendor/php-stubs/wordpress-stubs/wordpress-stubs.php
-
 parameters:
     level: 6
     paths:
         - nuclear-engagement
         - tests
+    bootstrapFiles:
+        - nuclear-engagement/vendor/php-stubs/wordpress-stubs/wordpress-stubs.php


### PR DESCRIPTION
## Summary
- load WordPress stubs through `bootstrapFiles` instead of `includes`

## Testing
- `composer lint` *(fails: composer not found)*
- `composer test` *(fails: composer not found)*

------
https://chatgpt.com/codex/tasks/task_e_685d23def91083279db03b99729b3931