### PR TITLE
Fix single generation tests

### DIFF
--- a/tests/frontend/nuclen-admin-single-generation.test.ts
+++ b/tests/frontend/nuclen-admin-single-generation.test.ts
@@ -2,7 +2,12 @@ import { describe, it, beforeAll, beforeEach, afterEach, expect, vi } from 'vite
 
 vi.mock('../../src/admin/ts/generation/api', async () => {
   const actual: any = await vi.importActual('../../src/admin/ts/generation/api');
-  return { ...actual, nuclenFetchWithRetry: vi.fn() };
+  const nuclenFetchWithRetry = vi.fn();
+  return {
+    ...actual,
+    nuclenFetchWithRetry,
+    NuclenStartGeneration: vi.fn(async () => nuclenFetchWithRetry()),
+  };
 });
 
 // Re-export mocked generation helpers so NuclenStartGeneration uses the stubbed
@@ -39,7 +44,7 @@ describe('nuclen-admin-single-generation', () => {
   });
 
   afterEach(() => {
-    vi.restoreAllMocks();
+    vi.clearAllMocks();
     document.body.innerHTML = '';
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     delete (window as any).nuclenAdminVars;


### PR DESCRIPTION
## Summary
- keep mocks active between tests in single generation test suite
- ensure NuclenStartGeneration uses stubbed nuclenFetchWithRetry

## Testing
- `composer lint` *(fails: composer not installed)*
- `composer test` *(fails: composer not installed)*
- `npx vitest run tests/frontend/nuclen-admin-single-generation.test.ts` *(fails: npm registry blocked)*

------
https://chatgpt.com/codex/tasks/task_e_685d21ef313083278859ff6dd6057f55