### PR TITLE
Fix namespace position in tests

### DIFF
--- a/tests/ContentControllerTest.php
+++ b/tests/ContentControllerTest.php
@@ -1,9 +1,4 @@
 <?php
-use PHPUnit\Framework\TestCase;
-use NuclearEngagement\Front\Controller\Rest\ContentController;
-use NuclearEngagement\Core\SettingsRepository;
-use NuclearEngagement\Services\ContentStorageService;
-
 namespace NuclearEngagement\Services {
     class LoggingService {
         public static array $logs = [];
@@ -17,6 +12,10 @@ namespace NuclearEngagement\Services {
 }
 
 namespace {
+    use PHPUnit\Framework\TestCase;
+    use NuclearEngagement\Front\Controller\Rest\ContentController;
+    use NuclearEngagement\Core\SettingsRepository;
+    use NuclearEngagement\Services\ContentStorageService;
     if (!function_exists('__')) {
         function __($t, $d = null) { return $t; }
     }

--- a/tests/ContentStorageServiceTest.php
+++ b/tests/ContentStorageServiceTest.php
@@ -1,8 +1,4 @@
 <?php
-use PHPUnit\Framework\TestCase;
-use NuclearEngagement\Services\ContentStorageService;
-use NuclearEngagement\Core\SettingsRepository;
-
 namespace NuclearEngagement\Services {
     function update_post_meta($postId, $key, $value) {
         $GLOBALS['wp_meta'][$postId][$key] = $value;
@@ -14,6 +10,9 @@ namespace NuclearEngagement\Services {
 }
 
 namespace {
+    use PHPUnit\Framework\TestCase;
+    use NuclearEngagement\Services\ContentStorageService;
+    use NuclearEngagement\Core\SettingsRepository;
     class ContentStorageServiceTest extends TestCase {
         protected function setUp(): void {
             global $wp_options, $wp_autoload, $wp_meta;

--- a/tests/DashboardDataServiceTest.php
+++ b/tests/DashboardDataServiceTest.php
@@ -1,7 +1,4 @@
 <?php
-use PHPUnit\Framework\TestCase;
-use NuclearEngagement\Services\DashboardDataService;
-
 namespace NuclearEngagement\Services {
     class LoggingService {
         public static array $logs = [];
@@ -10,6 +7,8 @@ namespace NuclearEngagement\Services {
 }
 
 namespace {
+    use PHPUnit\Framework\TestCase;
+    use NuclearEngagement\Services\DashboardDataService;
 
 if ( ! function_exists( 'date_i18n' ) ) {
     function date_i18n( $format, $timestamp ) { return date( $format, $timestamp ); }

--- a/tests/GenerationServiceSingleTest.php
+++ b/tests/GenerationServiceSingleTest.php
@@ -1,9 +1,4 @@
 <?php
-use PHPUnit\Framework\TestCase;
-use NuclearEngagement\Services\GenerationService;
-use NuclearEngagement\Core\SettingsRepository;
-use NuclearEngagement\Services\ApiException;
-
 // Stub LoggingService to avoid filesystem calls
 namespace NuclearEngagement\Services {
     class LoggingService {
@@ -18,6 +13,10 @@ namespace NuclearEngagement\Services {
 }
 
 namespace {
+    use PHPUnit\Framework\TestCase;
+    use NuclearEngagement\Services\GenerationService;
+    use NuclearEngagement\Core\SettingsRepository;
+    use NuclearEngagement\Services\ApiException;
     class DummyGenApi {
         public ?\Exception $exception = null;
         public array $response = [];

--- a/tests/MetaboxUpdateErrorTest.php
+++ b/tests/MetaboxUpdateErrorTest.php
@@ -1,6 +1,4 @@
 <?php
-use PHPUnit\Framework\TestCase;
-
 namespace NuclearEngagement\Admin {
     function current_user_can($cap, $id) { return true; }
     function wp_unslash($val) { return $val; }
@@ -25,6 +23,7 @@ namespace NuclearEngagement\Services {
 }
 
 namespace {
+    use PHPUnit\Framework\TestCase;
     require_once dirname(__DIR__) . '/nuclear-engagement/admin/Traits/AdminQuizMetabox.php';
     require_once dirname(__DIR__) . '/nuclear-engagement/admin/Traits/AdminSummaryMetabox.php';
 

--- a/tests/NuclenTOCHeadingsTest.php
+++ b/tests/NuclenTOCHeadingsTest.php
@@ -1,6 +1,7 @@
 <?php
-use PHPUnit\Framework\TestCase;
-use NuclearEngagement\Modules\TOC\Nuclen_TOC_Headings;
+namespace {
+    use PHPUnit\Framework\TestCase;
+    use NuclearEngagement\Modules\TOC\Nuclen_TOC_Headings;
 
 // ------------------------------------------------------
 // Constants and WordPress function stubs
@@ -35,6 +36,8 @@ if (!function_exists('__')) { function __($t, $d = null) { return $t; } }
 if (!function_exists('apply_filters')) { function apply_filters($hook, $value) { return $value; } }
 if (!function_exists('wp_strip_all_tags')) { function wp_strip_all_tags($t){ return strip_tags($t); } }
 if (!function_exists('get_the_ID')) { function get_the_ID() { return $GLOBALS['current_post_id'] ?? 0; } }
+
+}
 
 namespace NuclearEngagement\Modules\TOC {
     if (!function_exists('apply_filters')) {

--- a/tests/NuclenTOCRenderTest.php
+++ b/tests/NuclenTOCRenderTest.php
@@ -1,8 +1,9 @@
 <?php
-use PHPUnit\Framework\TestCase;
-use NuclearEngagement\Modules\TOC\Nuclen_TOC_Render;
-use NuclearEngagement\Core\SettingsRepository;
-use NuclearEngagement\Core\Container;
+namespace {
+    use PHPUnit\Framework\TestCase;
+    use NuclearEngagement\Modules\TOC\Nuclen_TOC_Render;
+    use NuclearEngagement\Core\SettingsRepository;
+    use NuclearEngagement\Core\Container;
 
 // ------------------------------------------------------
 // Constants and WordPress function stubs
@@ -55,7 +56,6 @@ if (!function_exists('wp_localize_script')) { function wp_localize_script($h,$o,
 if (!function_exists('is_singular')) { function is_singular(){ return true; } }
 if (!function_exists('get_the_ID')) { function get_the_ID(){ return $GLOBALS['current_post_id'] ?? 0; } }
 
-namespace {
     require_once NUCLEN_TOC_DIR . 'includes/polyfills.php';
     require_once NUCLEN_TOC_DIR . 'includes/class-nuclen-toc-utils.php';
     require_once NUCLEN_TOC_DIR . 'includes/class-nuclen-toc-view.php';

--- a/tests/SetupHandlersTraitTest.php
+++ b/tests/SetupHandlersTraitTest.php
@@ -1,11 +1,4 @@
 <?php
-use PHPUnit\Framework\TestCase;
-use NuclearEngagement\Core\SettingsRepository;
-use NuclearEngagement\Core\Container;
-
-class RedirectException extends \Exception {}
-
-// Stub SetupService inside the plugin namespace
 namespace NuclearEngagement\Services {
     class SetupService {
         public bool $validate_return = true;
@@ -24,6 +17,12 @@ namespace NuclearEngagement\Services {
 }
 
 namespace {
+    use PHPUnit\Framework\TestCase;
+    use NuclearEngagement\Core\SettingsRepository;
+    use NuclearEngagement\Core\Container;
+
+    class RedirectException extends \Exception {}
+
     // Global stubs for WordPress functions
     if (!function_exists('current_user_can')) {
         function current_user_can($cap) {


### PR DESCRIPTION
## Summary
- ensure namespaces precede `use` statements in several test files
- keep WordPress test stubs inside proper namespace blocks

## Testing
- `composer lint` *(fails: command not found)*
- `composer phpstan -- --memory-limit=1G` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685d2c28d2dc8327882f6f30a07a6a2f