### PR TITLE
Fix namespace in AdminNoticeServiceTest

### DIFF
--- a/tests/AdminNoticeServiceTest.php
+++ b/tests/AdminNoticeServiceTest.php
@@ -1,7 +1,4 @@
 <?php
-use PHPUnit\Framework\TestCase;
-use NuclearEngagement\Services\AdminNoticeService;
-
 namespace NuclearEngagement\Services {
     function add_action(...$args) {
         $GLOBALS['ans_actions'][] = $args;
@@ -12,6 +9,8 @@ namespace NuclearEngagement\Services {
 }
 
 namespace {
+    use PHPUnit\Framework\TestCase;
+    use NuclearEngagement\Services\AdminNoticeService;
     class AdminNoticeServiceTest extends TestCase {
         protected function setUp(): void {
             $GLOBALS['ans_actions'] = [];


### PR DESCRIPTION
## Summary
- fix invalid namespace declaration order in AdminNoticeServiceTest

## Testing
- `composer lint` *(fails: command not found)*
- `composer test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685d3316f4888327b30a3e81057488a4

<!-- Korbit AI PR Description Start -->
## Description by Korbit AI

### What change is being made?

Relocate the use statements for `TestCase` and `AdminNoticeService` from the `NuclearEngagement\Services` namespace to the global namespace in the `AdminNoticeServiceTest.php` file.

### Why are these changes being made?

The change corrects the namespace usage, ensuring the `TestCase` and `AdminNoticeService` are properly utilized within the global scope where `AdminNoticeServiceTest` resides, thus preventing any potential namespace collisions or autoloading issues during test execution.

> Is this description stale? Ask me to generate a new description by commenting `/korbit-generate-pr-description`
<!-- Korbit AI PR Description End -->