### PR TITLE
Fix dispatch and async waits in generation tests

### DIFF
--- a/tests/frontend/nuclen-admin-single-generation.test.ts
+++ b/tests/frontend/nuclen-admin-single-generation.test.ts
@@ -65,7 +65,8 @@ describe('nuclen-admin-single-generation', () => {
       });
 
     const btn = document.querySelector<HTMLButtonElement>('.nuclen-generate-single')!;
-    btn.click();
+    btn.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+    await Promise.resolve();
     await Promise.resolve();
 
     expect(api.nuclenFetchWithRetry).toHaveBeenCalled();
@@ -91,7 +92,8 @@ describe('nuclen-admin-single-generation', () => {
       });
 
     const btn = document.querySelector<HTMLButtonElement>('.nuclen-generate-single')!;
-    btn.click();
+    btn.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+    await Promise.resolve();
     await Promise.resolve();
 
     expect(utils.alertApiError).toHaveBeenCalledWith('fail');


### PR DESCRIPTION
## Summary
- trigger button clicks via dispatched `MouseEvent`
- ensure all queued Promises resolve before making assertions

## Testing
- `composer lint` *(fails: command not found)*
- `composer test` *(fails: command not found)*
- `npm run test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_685d343a5a808327901fe743fee172d8

<!-- Korbit AI PR Description Start -->
## Description by Korbit AI

### What change is being made?

Replace `click()` with `dispatchEvent(new MouseEvent('click', { bubbles: true }))` and add `await Promise.resolve()` in the generation tests.

### Why are these changes being made?

This change ensures that click events are properly dispatched and asynchronously handled within the tests, enhancing reliability and closely simulating actual user interactions. The alterations address synchronization issues and make the tests more robust against false positives related to event handling and asynchronous logic.

> Is this description stale? Ask me to generate a new description by commenting `/korbit-generate-pr-description`
<!-- Korbit AI PR Description End -->