### PR TITLE
Fix namespace placement in tests

### DIFF
--- a/tests/AssetVersionsTest.php
+++ b/tests/AssetVersionsTest.php
@@ -1,7 +1,4 @@
 <?php
-use PHPUnit\Framework\TestCase;
-use NuclearEngagement\Core\AssetVersions;
-
 namespace NuclearEngagement {
     function time() {
         return $GLOBALS['av_now'] ?? \time();
@@ -9,6 +6,9 @@ namespace NuclearEngagement {
 }
 
 namespace {
+    use PHPUnit\Framework\TestCase;
+    use NuclearEngagement\Core\AssetVersions;
+
     class AssetVersionsTest extends TestCase {
         private static string $dir;
 

--- a/tests/BlocksTest.php
+++ b/tests/BlocksTest.php
@@ -1,7 +1,4 @@
 <?php
-use PHPUnit\Framework\TestCase;
-use NuclearEngagement\Core\Blocks;
-
 namespace NuclearEngagement\Services {
     class LoggingService {
         public static array $logs = [];
@@ -12,6 +9,8 @@ namespace NuclearEngagement\Services {
 }
 
 namespace {
+    use PHPUnit\Framework\TestCase;
+    use NuclearEngagement\Core\Blocks;
     function register_block_type(string $name, array $args): void {
         $GLOBALS['block_regs'][$name] = $args;
     }

--- a/tests/BootstrapTest.php
+++ b/tests/BootstrapTest.php
@@ -1,5 +1,4 @@
 <?php
-
 namespace BootstrapTestNS {
     $GLOBALS['test_actions'] = [];
     $GLOBALS['test_activation'] = [];

--- a/tests/GenerateControllerTest.php
+++ b/tests/GenerateControllerTest.php
@@ -1,8 +1,4 @@
 <?php
-use PHPUnit\Framework\TestCase;
-use NuclearEngagement\Admin\Controller\Ajax\GenerateController;
-use NuclearEngagement\Requests\GenerateRequest;
-
 namespace NuclearEngagement\Services {
     class GenerationService {
         public array $received = [];
@@ -22,6 +18,9 @@ namespace NuclearEngagement\Responses {
 }
 
 namespace {
+    use PHPUnit\Framework\TestCase;
+    use NuclearEngagement\Admin\Controller\Ajax\GenerateController;
+    use NuclearEngagement\Requests\GenerateRequest;
     if (!function_exists('check_ajax_referer')) { function check_ajax_referer($a,$f,$d=false){ return true; } }
     if (!function_exists('current_user_can')) { function current_user_can($c){ return true; } }
     if (!function_exists('wp_send_json_success')) { function wp_send_json_success($d){ $GLOBALS['json_response']=['success',$d]; } }

--- a/tests/GenerationServiceSingleTest.php
+++ b/tests/GenerationServiceSingleTest.php
@@ -1,6 +1,6 @@
 <?php
-// Stub LoggingService to avoid filesystem calls
 namespace NuclearEngagement\Services {
+    // Stub LoggingService to avoid filesystem calls
     class LoggingService {
         public static array $logs = [];
         public static function log(string $msg): void {

--- a/tests/LoggingServiceTest.php
+++ b/tests/LoggingServiceTest.php
@@ -1,8 +1,4 @@
 <?php
-use PHPUnit\Framework\TestCase;
-use NuclearEngagement\Services\LoggingService;
-use NuclearEngagement\Services\AdminNoticeService;
-
 namespace NuclearEngagement\Services {
     function add_action(...$args) {
         $GLOBALS['ls_actions'][] = $args;
@@ -46,6 +42,9 @@ namespace NuclearEngagement\Services {
 }
 
 namespace {
+    use PHPUnit\Framework\TestCase;
+    use NuclearEngagement\Services\LoggingService;
+    use NuclearEngagement\Services\AdminNoticeService;
     class LoggingServiceTest extends TestCase {
         private static string $plugin_dir;
 

--- a/tests/MetaRegistrationTest.php
+++ b/tests/MetaRegistrationTest.php
@@ -1,7 +1,4 @@
 <?php
-use PHPUnit\Framework\TestCase;
-use NuclearEngagement\Core\MetaRegistration;
-
 namespace NuclearEngagement {
     if (!function_exists('sanitize_text_field')) {
         function sanitize_text_field($text) { return trim($text); }
@@ -18,6 +15,8 @@ namespace NuclearEngagement {
 }
 
 namespace {
+    use PHPUnit\Framework\TestCase;
+    use NuclearEngagement\Core\MetaRegistration;
     require_once dirname(__DIR__) . '/nuclear-engagement/inc/Core/MetaRegistration.php';
 
     class MetaRegistrationTest extends TestCase {

--- a/tests/NuclenTOCMetaCacheTest.php
+++ b/tests/NuclenTOCMetaCacheTest.php
@@ -1,8 +1,4 @@
 <?php
-use PHPUnit\Framework\TestCase;
-use NuclearEngagement\Modules\TOC\Nuclen_TOC_Utils;
-use NuclearEngagement\Modules\TOC\Nuclen_TOC_Headings;
-
 namespace NuclearEngagement\Modules\TOC {
     function update_post_meta($postId, $key, $value){
         $GLOBALS['wp_meta'][$postId][$key] = $value; return true;
@@ -11,6 +7,9 @@ namespace NuclearEngagement\Modules\TOC {
 }
 
 namespace {
+    use PHPUnit\Framework\TestCase;
+    use NuclearEngagement\Modules\TOC\Nuclen_TOC_Utils;
+    use NuclearEngagement\Modules\TOC\Nuclen_TOC_Headings;
     if (!defined('HOUR_IN_SECONDS')) { define('HOUR_IN_SECONDS', 3600); }
     if (!defined('NUCLEN_TOC_DIR')) { define('NUCLEN_TOC_DIR', dirname(__DIR__).'/nuclear-engagement/inc/Modules/TOC/'); }
     if (!defined('NUCLEN_TOC_URL')) { define('NUCLEN_TOC_URL', 'http://example.com/'); }

--- a/tests/OnboardingTest.php
+++ b/tests/OnboardingTest.php
@@ -1,8 +1,7 @@
 <?php
-use PHPUnit\Framework\TestCase;
-use NuclearEngagement\Admin\Onboarding;
-
 namespace {
+    use PHPUnit\Framework\TestCase;
+    use NuclearEngagement\Admin\Onboarding;
     if (!function_exists('wp_enqueue_style')) {
         function wp_enqueue_style($handle) { $GLOBALS['enqueued_styles'][] = $handle; }
     }

--- a/tests/OptinExportControllerTest.php
+++ b/tests/OptinExportControllerTest.php
@@ -1,7 +1,4 @@
 <?php
-use PHPUnit\Framework\TestCase;
-use NuclearEngagement\Admin\Controller\OptinExportController;
-
 namespace NuclearEngagement {
     class OptinData {
         public static int $calls = 0;
@@ -10,6 +7,8 @@ namespace NuclearEngagement {
 }
 
 namespace {
+    use PHPUnit\Framework\TestCase;
+    use NuclearEngagement\Admin\Controller\OptinExportController;
     require_once __DIR__ . '/../nuclear-engagement/admin/Controller/OptinExportController.php';
 
     class OptinExportControllerTest extends TestCase {

--- a/tests/PluginTest.php
+++ b/tests/PluginTest.php
@@ -1,10 +1,4 @@
 <?php
-use PHPUnit\Framework\TestCase;
-use NuclearEngagement\Core\Plugin;
-use NuclearEngagement\Core\Container;
-use NuclearEngagement\Core\SettingsRepository;
-use NuclearEngagement\Core\Defaults;
-
 namespace NuclearEngagement\Core {
     function register_activation_hook($file, $callback) {
         $GLOBALS['ph_activation'][] = [$file, $callback];
@@ -77,6 +71,11 @@ namespace NuclearEngagement {
 }
 
 namespace {
+    use PHPUnit\Framework\TestCase;
+    use NuclearEngagement\Core\Plugin;
+    use NuclearEngagement\Core\Container;
+    use NuclearEngagement\Core\SettingsRepository;
+    use NuclearEngagement\Core\Defaults;
     if (!defined('NUCLEN_PLUGIN_DIR')) {
         define('NUCLEN_PLUGIN_DIR', dirname(__DIR__) . '/nuclear-engagement/');
     }

--- a/tests/PointerControllerTest.php
+++ b/tests/PointerControllerTest.php
@@ -1,8 +1,4 @@
 <?php
-use PHPUnit\Framework\TestCase;
-use NuclearEngagement\Admin\Controller\Ajax\PointerController;
-use NuclearEngagement\Services\PointerService;
-
 namespace NuclearEngagement\Services {
     class LoggingService {
         public static array $exceptions = [];
@@ -13,6 +9,9 @@ namespace NuclearEngagement\Services {
 }
 
 namespace {
+    use PHPUnit\Framework\TestCase;
+    use NuclearEngagement\Admin\Controller\Ajax\PointerController;
+    use NuclearEngagement\Services\PointerService;
     if (!function_exists('check_ajax_referer')) {
         function check_ajax_referer($a, $f, $d = false) { return true; }
     }

--- a/tests/PostDataFetcherTest.php
+++ b/tests/PostDataFetcherTest.php
@@ -1,7 +1,4 @@
 <?php
-use PHPUnit\Framework\TestCase;
-use NuclearEngagement\Services\PostDataFetcher;
-
 namespace NuclearEngagement\Services {
     class LoggingService {
         public static array $logs = [];
@@ -10,6 +7,8 @@ namespace NuclearEngagement\Services {
 }
 
 namespace {
+    use PHPUnit\Framework\TestCase;
+    use NuclearEngagement\Services\PostDataFetcher;
     class PDF_WPDB {
         public $posts = 'wp_posts';
         public $postmeta = 'wp_postmeta';

--- a/tests/PostMetaMigrationTest.php
+++ b/tests/PostMetaMigrationTest.php
@@ -1,8 +1,6 @@
 <?php
-use PHPUnit\Framework\TestCase;
-
-// Stub LoggingService to capture log messages
 namespace NuclearEngagement\Services {
+    // Stub LoggingService to capture log messages
     class LoggingService {
         public static array $logs = [];
         public static function log(string $msg): void {
@@ -12,6 +10,7 @@ namespace NuclearEngagement\Services {
 }
 
 namespace {
+    use PHPUnit\Framework\TestCase;
     use NuclearEngagement\Services\LoggingService;
 
     class PostMetaMigrationTest extends TestCase {

--- a/tests/PostsCountControllerTest.php
+++ b/tests/PostsCountControllerTest.php
@@ -1,8 +1,4 @@
 <?php
-use PHPUnit\Framework\TestCase;
-use NuclearEngagement\Admin\Controller\Ajax\PostsCountController;
-use NuclearEngagement\Requests\PostsCountRequest;
-
 namespace NuclearEngagement\Services {
     class LoggingService {
         public static array $exceptions = [];
@@ -11,6 +7,9 @@ namespace NuclearEngagement\Services {
 }
 
 namespace {
+    use PHPUnit\Framework\TestCase;
+    use NuclearEngagement\Admin\Controller\Ajax\PostsCountController;
+    use NuclearEngagement\Requests\PostsCountRequest;
     // ------------------------------------------------------
     // Basic stubs for WordPress AJAX functions
     // ------------------------------------------------------

--- a/tests/PostsQueryServiceTest.php
+++ b/tests/PostsQueryServiceTest.php
@@ -1,8 +1,4 @@
 <?php
-use PHPUnit\Framework\TestCase;
-use NuclearEngagement\Services\PostsQueryService;
-use NuclearEngagement\Requests\PostsCountRequest;
-
 namespace NuclearEngagement\Services {
     // Simplified LoggingService stub
     class LoggingService {
@@ -12,6 +8,9 @@ namespace NuclearEngagement\Services {
 }
 
 namespace {
+    use PHPUnit\Framework\TestCase;
+    use NuclearEngagement\Services\PostsQueryService;
+    use NuclearEngagement\Requests\PostsCountRequest;
     if (!defined('MINUTE_IN_SECONDS')) { define('MINUTE_IN_SECONDS', 60); }
 
     // ------------------------------------------------------

--- a/tests/PublishGenerationHandlerTest.php
+++ b/tests/PublishGenerationHandlerTest.php
@@ -1,8 +1,4 @@
 <?php
-use PHPUnit\Framework\TestCase;
-use NuclearEngagement\Services\PublishGenerationHandler;
-use NuclearEngagement\Core\SettingsRepository;
-
 namespace NuclearEngagement\Services {
     class LoggingService {
         public static array $logs = [];
@@ -11,6 +7,9 @@ namespace NuclearEngagement\Services {
 }
 
 namespace {
+    use PHPUnit\Framework\TestCase;
+    use NuclearEngagement\Services\PublishGenerationHandler;
+    use NuclearEngagement\Core\SettingsRepository;
     if (!function_exists('current_user_can')) {
         function current_user_can($cap, $id = 0) { return $GLOBALS['can_publish'] ?? true; }
     }

--- a/tests/QuizServiceFailureTest.php
+++ b/tests/QuizServiceFailureTest.php
@@ -1,7 +1,4 @@
 <?php
-use PHPUnit\Framework\TestCase;
-use NuclearEngagement\Modules\Quiz\Quiz_Service;
-
 namespace NuclearEngagement\Modules\Quiz {
     function update_post_meta($postId, $key, $value) { return false; }
     function delete_post_meta($postId, $key) {}
@@ -20,6 +17,8 @@ namespace NuclearEngagement\Services {
 }
 
 namespace {
+    use PHPUnit\Framework\TestCase;
+    use NuclearEngagement\Modules\Quiz\Quiz_Service;
     class QuizServiceFailureTest extends TestCase {
         protected function setUp(): void {
             \NuclearEngagement\Services\LoggingService::$logs = [];

--- a/tests/QuizShortcodeViewTest.php
+++ b/tests/QuizShortcodeViewTest.php
@@ -1,15 +1,14 @@
 <?php
-use PHPUnit\Framework\TestCase;
-use NuclearEngagement\Front\QuizShortcode;
-use NuclearEngagement\Front\QuizView;
-use NuclearEngagement\Core\SettingsRepository;
-
 namespace NuclearEngagement\Front {
     function get_the_ID() { return $GLOBALS['current_post_id'] ?? 0; }
     function maybe_unserialize($data) { return is_string($data) ? unserialize($data) : $data; }
 }
 
 namespace {
+    use PHPUnit\Framework\TestCase;
+    use NuclearEngagement\Front\QuizShortcode;
+    use NuclearEngagement\Front\QuizView;
+    use NuclearEngagement\Core\SettingsRepository;
     if (!function_exists('esc_html')) { function esc_html($t) { return $t; } }
     if (!function_exists('esc_html__')) { function esc_html__($t,$d=null){ return $t; } }
     if (!function_exists('__')) { function __($t,$d=null){ return $t; } }

--- a/tests/RemoteApiServiceTest.php
+++ b/tests/RemoteApiServiceTest.php
@@ -1,9 +1,4 @@
 <?php
-use PHPUnit\Framework\TestCase;
-use NuclearEngagement\Services\RemoteApiService;
-use NuclearEngagement\Services\ApiException;
-use NuclearEngagement\Core\SettingsRepository;
-
 namespace NuclearEngagement\Services {
     class LoggingService {
         public static array $logs = [];
@@ -16,6 +11,10 @@ namespace NuclearEngagement\Services {
 }
 
 namespace {
+    use PHPUnit\Framework\TestCase;
+    use NuclearEngagement\Services\RemoteApiService;
+    use NuclearEngagement\Services\ApiException;
+    use NuclearEngagement\Core\SettingsRepository;
 if (!function_exists('__')) {
     function __($t, $d = null) { return $t; }
 }

--- a/tests/ScheduleFailureTest.php
+++ b/tests/ScheduleFailureTest.php
@@ -1,9 +1,4 @@
 <?php
-use PHPUnit\Framework\TestCase;
-use NuclearEngagement\Services\AutoGenerationService;
-use NuclearEngagement\Services\GenerationPoller;
-use NuclearEngagement\Core\SettingsRepository;
-
 namespace NuclearEngagement\Services {
     if (!class_exists('NuclearEngagement\\Services\\LoggingService')) {
         class LoggingService {
@@ -19,6 +14,10 @@ namespace NuclearEngagement\Services {
 }
 
 namespace {
+    use PHPUnit\Framework\TestCase;
+    use NuclearEngagement\Services\AutoGenerationService;
+    use NuclearEngagement\Services\GenerationPoller;
+    use NuclearEngagement\Core\SettingsRepository;
     class DummyRemoteApiService {
         public array $updates = [];
         public $generateResponse = [];

--- a/tests/SetupServiceTest.php
+++ b/tests/SetupServiceTest.php
@@ -1,8 +1,4 @@
 <?php
-use PHPUnit\Framework\TestCase;
-use NuclearEngagement\Services\SetupService;
-use NuclearEngagement\Services\LoggingService;
-
 namespace NuclearEngagement\Services {
     class LoggingService {
         public static array $logs = [];
@@ -14,6 +10,9 @@ namespace NuclearEngagement\Services {
 }
 
 namespace {
+    use PHPUnit\Framework\TestCase;
+    use NuclearEngagement\Services\SetupService;
+    use NuclearEngagement\Services\LoggingService;
     use NuclearEngagement\Services\SetupService;
     use NuclearEngagement\Services\LoggingService;
 

--- a/tests/SummaryMetaboxFailureTest.php
+++ b/tests/SummaryMetaboxFailureTest.php
@@ -1,7 +1,4 @@
 <?php
-use PHPUnit\Framework\TestCase;
-use NuclearEngagement\Modules\Summary\Nuclen_Summary_Metabox;
-
 namespace NuclearEngagement\Modules\Summary {
     function current_user_can($cap, $id) { return true; }
     function wp_unslash($val) { return $val; }
@@ -22,6 +19,8 @@ namespace NuclearEngagement\Services {
 }
 
 namespace {
+    use PHPUnit\Framework\TestCase;
+    use NuclearEngagement\Modules\Summary\Nuclen_Summary_Metabox;
     class DummyRepo {
         public function get($key, $default = 0) { return 0; }
     }

--- a/tests/SummaryShortcodeViewTest.php
+++ b/tests/SummaryShortcodeViewTest.php
@@ -1,12 +1,11 @@
 <?php
-use PHPUnit\Framework\TestCase;
-use NuclearEngagement\Modules\Summary\Nuclen_Summary_Shortcode as SummaryShortcode;
-use NuclearEngagement\Modules\Summary\Nuclen_Summary_View as SummaryView;
-use NuclearEngagement\Core\SettingsRepository;
-
-function get_the_ID() { return $GLOBALS['current_post_id'] ?? 0; }
-
 namespace {
+    use PHPUnit\Framework\TestCase;
+    use NuclearEngagement\Modules\Summary\Nuclen_Summary_Shortcode as SummaryShortcode;
+    use NuclearEngagement\Modules\Summary\Nuclen_Summary_View as SummaryView;
+    use NuclearEngagement\Core\SettingsRepository;
+
+    function get_the_ID() { return $GLOBALS['current_post_id'] ?? 0; }
     if (!function_exists('esc_html')) {
         function esc_html($t) { return $t; }
     }

--- a/tests/UpdatesControllerTest.php
+++ b/tests/UpdatesControllerTest.php
@@ -1,8 +1,4 @@
 <?php
-use PHPUnit\Framework\TestCase;
-use NuclearEngagement\Admin\Controller\Ajax\UpdatesController;
-use NuclearEngagement\Services\ApiException;
-
 namespace NuclearEngagement\Services {
     class LoggingService {
         public static array $logs = [];
@@ -12,6 +8,9 @@ namespace NuclearEngagement\Services {
 }
 
 namespace {
+    use PHPUnit\Framework\TestCase;
+    use NuclearEngagement\Admin\Controller\Ajax\UpdatesController;
+    use NuclearEngagement\Services\ApiException;
     if (!function_exists('check_ajax_referer')) { function check_ajax_referer($a,$f,$d=false){ return true; } }
     if (!function_exists('current_user_can')) { function current_user_can($c){ return true; } }
     if (!function_exists('wp_send_json_success')) { function wp_send_json_success($d){ $GLOBALS['json_response']=['success',$d]; } }

--- a/tests/UtilsTest.php
+++ b/tests/UtilsTest.php
@@ -1,7 +1,4 @@
 <?php
-use PHPUnit\Framework\TestCase;
-use NuclearEngagement\Utils;
-
 namespace NuclearEngagement {
     function get_option($name, $default = '') {
         return $GLOBALS['ut_options'][$name] ?? $default;
@@ -16,6 +13,8 @@ namespace NuclearEngagement\Services {
 }
 
 namespace {
+    use PHPUnit\Framework\TestCase;
+    use NuclearEngagement\Utils;
     class UtilsTest extends TestCase {
         protected function setUp(): void {
             $GLOBALS['test_upload_basedir'] = sys_get_temp_dir() . '/ut_' . uniqid();

--- a/tests/VersionServiceTest.php
+++ b/tests/VersionServiceTest.php
@@ -1,7 +1,4 @@
 <?php
-use PHPUnit\Framework\TestCase;
-use NuclearEngagement\Services\VersionService;
-
 namespace NuclearEngagement {
     class AssetVersions {
         public static function get(string $key): string {
@@ -11,6 +8,8 @@ namespace NuclearEngagement {
 }
 
 namespace {
+    use PHPUnit\Framework\TestCase;
+    use NuclearEngagement\Services\VersionService;
     if (!function_exists('apply_filters')) {
         function apply_filters($hook, $value, ...$args) {
             if ($hook === 'nuclen_asset_version' && isset($GLOBALS['vs_filter'])) {


### PR DESCRIPTION
## Summary
- ensure namespace declarations immediately follow `<?php` in tests
- move use statements inside their respective namespaces

## Testing
- `composer phpstan` *(fails: command not found)*
- `composer lint` *(fails: command not found)*
- `composer test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685d3439128c83279594b2bf9e7e641a

<!-- Korbit AI PR Description Start -->
## Description by Korbit AI

### What change is being made?

Reformat test files to move `use` statements inside the global namespace block.

### Why are these changes being made?

These changes improve code organization by ensuring that all `use` statements are correctly placed within the global namespace, making it clear what external dependencies each test relies on. This resolves issues with namespace scoping which could lead to potential conflicts or misunderstandings of the code structure.

> Is this description stale? Ask me to generate a new description by commenting `/korbit-generate-pr-description`
<!-- Korbit AI PR Description End -->