### PR TITLE
Add Maestro e2e workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -61,3 +61,16 @@ jobs:
 
       - name: Run tests
         run: composer test --working-dir=nuclear-engagement
+
+  e2e:
+    runs-on: ubuntu-latest
+    needs: build
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+      - name: Install Maestro
+        run: |
+          curl -Ls "https://get.maestro.mobile.dev" | bash
+          echo "$HOME/.maestro/bin" >> $GITHUB_PATH
+      - name: Run end-to-end tests
+        run: bash scripts/run-e2e.sh

--- a/README.md
+++ b/README.md
@@ -50,6 +50,12 @@ Run the JavaScript tests with:
 npm run test
 ```
 
+Run the end-to-end flows using [Maestro](https://maestro.mobile.dev):
+
+```bash
+bash scripts/run-e2e.sh
+```
+
 Run static analysis using PHPStan:
 
 ```bash

--- a/docs/DEV_WORKFLOW.md
+++ b/docs/DEV_WORKFLOW.md
@@ -71,6 +71,16 @@ npm run lint
   ```bash
   npm run test
   ```
+ - **Run end-to-end flows**
+   Install the [Maestro](https://maestro.mobile.dev) CLI and execute the YAML
+   flows from the `e2e/` folder. The CLI can be installed with:
+   ```bash
+   curl -Ls "https://get.maestro.mobile.dev" | bash
+   ```
+   Then run the flows with:
+  ```bash
+  bash scripts/run-e2e.sh
+  ```
 
 ## Typical workflow
 

--- a/scripts/run-e2e.sh
+++ b/scripts/run-e2e.sh
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+FLOWS_DIR="$ROOT/e2e"
+
+if ! command -v maestro >/dev/null 2>&1; then
+  echo "Maestro CLI is required. Install it from https://maestro.mobile.dev" >&2
+  exit 1
+fi
+
+maestro test "$FLOWS_DIR" "$@"


### PR DESCRIPTION
## Summary
- add `run-e2e.sh` helper for Maestro flows
- run Maestro in CI
- document running e2e tests locally
- mention e2e workflow in README

## Testing
- `npm run lint` *(fails: Cannot find package '@typescript-eslint/eslint-plugin')*
- `npm run test` *(fails: vitest not found)*
- `composer lint` *(fails: command not found)*
- `composer test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685d6b4471cc83278d73ca7853acc24f

<!-- Korbit AI PR Description Start -->
## Description by Korbit AI

### What change is being made?

Add a new end-to-end testing workflow using Maestro to the CI configuration and update relevant documentation and scripts to support running these tests.

### Why are these changes being made?

This addition enhances the CI pipeline by incorporating end-to-end testing to ensure comprehensive test coverage. The chosen solution leverages Maestro, a tool that simplifies the execution of e2e flows, offering a streamlined approach to maintain test reliability and consistency, which is crucial for catching issues early in the development lifecycle.

> Is this description stale? Ask me to generate a new description by commenting `/korbit-generate-pr-description`
<!-- Korbit AI PR Description End -->