### PR TITLE
Handle content storage errors

### DIFF
--- a/nuclear-engagement/admin/Controller/Ajax/UpdatesController.php
+++ b/nuclear-engagement/admin/Controller/Ajax/UpdatesController.php
@@ -89,15 +89,20 @@ class UpdatesController extends BaseController {
 			}
 
 				/* ── Persist & return results ───────────────────────────── */
-			if ( ! empty( $data['results'] ) && is_array( $data['results'] ) ) {
-				$first        = reset( $data['results'] );
-				$workflowType = isset( $first['questions'] ) ? 'quiz' : 'summary';
+                        if ( ! empty( $data['results'] ) && is_array( $data['results'] ) ) {
+                                $first        = reset( $data['results'] );
+                                $workflowType = isset( $first['questions'] ) ? 'quiz' : 'summary';
 
-				$this->storage->storeResults( $data['results'], $workflowType );
+                                $statuses = $this->storage->storeResults( $data['results'], $workflowType );
 
-				$response->results  = $data['results'];
-				$response->workflow = $workflowType; // NEW → lets JS forward it to /receive-content
-			}
+                                if ( array_filter( $statuses, static fn( $s ) => $s !== true ) ) {
+                                        $this->sendError( __( 'Failed to store content.', 'nuclear-engagement' ) );
+                                        return;
+                                }
+
+                                $response->results  = $data['results'];
+                                $response->workflow = $workflowType; // NEW → lets JS forward it to /receive-content
+                        }
 
 				wp_send_json_success( $response->toArray() );
 

--- a/nuclear-engagement/admin/Traits/AdminAutoGenerate.php
+++ b/nuclear-engagement/admin/Traits/AdminAutoGenerate.php
@@ -110,13 +110,19 @@ trait AdminAutoGenerate {
 						$data = $api->fetch_updates( $generation_id );
 
 			// Check if we have results
-			if ( ! empty( $data['results'] ) && is_array( $data['results'] ) ) {
-				$storage->storeResults( $data['results'], $workflow_type );
-				\NuclearEngagement\Services\LoggingService::log(
-					"Poll success for post {$post_id} ({$workflow_type}), generation {$generation_id}"
-				);
-				return;
-			}
+                        if ( ! empty( $data['results'] ) && is_array( $data['results'] ) ) {
+                                $statuses = $storage->storeResults( $data['results'], $workflow_type );
+                                if ( array_filter( $statuses, static fn( $s ) => $s !== true ) ) {
+                                        \NuclearEngagement\Services\LoggingService::notify_admin(
+                                                sprintf( 'Failed to store results for post %d', $post_id )
+                                        );
+                                } else {
+                                        \NuclearEngagement\Services\LoggingService::log(
+                                                "Poll success for post {$post_id} ({$workflow_type}), generation {$generation_id}"
+                                        );
+                                }
+                                return;
+                        }
 
 			// Check if still processing
 			if ( isset( $data['success'] ) && $data['success'] === true ) {

--- a/nuclear-engagement/front/Controller/Rest/ContentController.php
+++ b/nuclear-engagement/front/Controller/Rest/ContentController.php
@@ -85,8 +85,11 @@ class ContentController {
 
 			$contentRequest = ContentRequest::fromJson( $data );
 
-			// Store the results
-			$this->storage->storeResults( $contentRequest->results, $contentRequest->workflow );
+                        // Store the results
+                        $statuses = $this->storage->storeResults( $contentRequest->results, $contentRequest->workflow );
+                        if ( array_filter( $statuses, static fn( $s ) => $s !== true ) ) {
+                                return new \WP_Error( 'ne_store_failed', __( 'Failed to store content', 'nuclear-engagement' ), array( 'status' => 500 ) );
+                        }
 
 			// Get date from first stored item
 			reset( $contentRequest->results );

--- a/nuclear-engagement/inc/Services/GenerationPoller.php
+++ b/nuclear-engagement/inc/Services/GenerationPoller.php
@@ -77,14 +77,20 @@ class GenerationPoller {
 			// fetch_updates() checks a short cache to avoid redundant requests.
 			$data = $this->remote_api->fetch_updates( $generation_id );
 
-			if ( ! empty( $data['results'] ) && is_array( $data['results'] ) ) {
-				$this->content_storage->storeResults( $data['results'], $workflow_type );
-								\NuclearEngagement\Services\LoggingService::log(
-									"Poll success for generation {$generation_id}"
-								);
-				$this->cleanup_generation( $generation_id );
-				return;
-			}
+                        if ( ! empty( $data['results'] ) && is_array( $data['results'] ) ) {
+                                $statuses = $this->content_storage->storeResults( $data['results'], $workflow_type );
+                                if ( array_filter( $statuses, static fn( $s ) => $s !== true ) ) {
+                                        \NuclearEngagement\Services\LoggingService::notify_admin(
+                                                sprintf( 'Failed to store results for generation %s', $generation_id )
+                                        );
+                                } else {
+                                        \NuclearEngagement\Services\LoggingService::log(
+                                                "Poll success for generation {$generation_id}"
+                                        );
+                                }
+                                $this->cleanup_generation( $generation_id );
+                                return;
+                        }
 
 			if ( isset( $data['success'] ) && $data['success'] === true ) {
 								\NuclearEngagement\Services\LoggingService::log(

--- a/nuclear-engagement/inc/Services/GenerationService.php
+++ b/nuclear-engagement/inc/Services/GenerationService.php
@@ -119,10 +119,15 @@ class GenerationService {
 		$response->generationId = $request->generationId;
 
 		// Process immediate results if any
-		if ( ! empty( $result['results'] ) && is_array( $result['results'] ) ) {
-			$this->storage->storeResults( $result['results'], $request->workflowType );
-			$response->results = $result['results'];
-		}
+                if ( ! empty( $result['results'] ) && is_array( $result['results'] ) ) {
+                        $statuses = $this->storage->storeResults( $result['results'], $request->workflowType );
+                        if ( array_filter( $statuses, static fn( $s ) => $s !== true ) ) {
+                                $response->success    = false;
+                                $response->error      = 'Failed to store generated content';
+                                return $response;
+                        }
+                        $response->results = $result['results'];
+                }
 
 		return $response;
 	}

--- a/tests/AutoGenerationQueueTest.php
+++ b/tests/AutoGenerationQueueTest.php
@@ -15,8 +15,9 @@ class DummyRemoteApiService {
 
 class DummyContentStorageService {
     public array $stored = [];
-    public function storeResults(array $results, string $workflowType): void {
+    public function storeResults(array $results, string $workflowType): array {
         $this->stored[] = [$results, $workflowType];
+        return array_fill_keys(array_keys($results), true);
     }
 }
 

--- a/tests/AutoGenerationSchedulerTest.php
+++ b/tests/AutoGenerationSchedulerTest.php
@@ -13,7 +13,7 @@ class DummyRemoteApiService {
 
 class DummyContentStorageService {
     public array $stored = [];
-    public function storeResults(array $results, string $workflowType): void { $this->stored[] = [$results, $workflowType]; }
+    public function storeResults(array $results, string $workflowType): array { $this->stored[] = [$results, $workflowType]; return array_fill_keys(array_keys($results), true); }
 }
 
 class AutoGenerationSchedulerTest extends TestCase {

--- a/tests/AutoGenerationServiceTest.php
+++ b/tests/AutoGenerationServiceTest.php
@@ -20,8 +20,9 @@ class DummyRemoteApiService {
 
 class DummyContentStorageService {
     public array $stored = [];
-    public function storeResults(array $results, string $workflowType): void {
+    public function storeResults(array $results, string $workflowType): array {
         $this->stored[] = [$results, $workflowType];
+        return array_fill_keys(array_keys($results), true);
     }
 }
 

--- a/tests/ContentStorageServiceFailureTest.php
+++ b/tests/ContentStorageServiceFailureTest.php
@@ -1,0 +1,30 @@
+<?php
+namespace NuclearEngagement\Services {
+    function update_post_meta($postId, $key, $value) { return false; }
+    if (!function_exists('sanitize_text_field')) {
+        function sanitize_text_field($text) { return trim($text); }
+    }
+}
+
+namespace {
+    use PHPUnit\Framework\TestCase;
+    use NuclearEngagement\Services\ContentStorageService;
+    use NuclearEngagement\Core\SettingsRepository;
+
+    class ContentStorageServiceFailureTest extends TestCase {
+        protected function setUp(): void {
+            global $wp_options, $wp_autoload, $wp_meta;
+            $wp_options = $wp_autoload = $wp_meta = [];
+            SettingsRepository::reset_for_tests();
+        }
+
+        public function test_store_results_returns_failure_status(): void {
+            $settings = SettingsRepository::get_instance();
+            $service = new ContentStorageService($settings);
+            $data = ['summary' => 'S'];
+            $result = $service->storeResults([1 => $data], 'summary');
+            $this->assertSame('Failed to update summary data for post 1', $result[1]);
+        }
+    }
+}
+

--- a/tests/GenerationServiceSingleTest.php
+++ b/tests/GenerationServiceSingleTest.php
@@ -31,8 +31,9 @@ namespace {
 
     class DummyStorage {
         public array $stored = [];
-        public function storeResults(array $r, string $t): void {
+        public function storeResults(array $r, string $t): array {
             $this->stored[] = [$r, $t];
+            return array_fill_keys(array_keys($r), true);
         }
     }
 

--- a/tests/GenerationServiceTest.php
+++ b/tests/GenerationServiceTest.php
@@ -50,7 +50,7 @@ class GSRemoteApi {
 
 class GSStorage {
     public array $stored = [];
-    public function storeResults(array $r, string $t): void { $this->stored[] = [$r,$t]; }
+    public function storeResults(array $r, string $t): array { $this->stored[] = [$r,$t]; return array_fill_keys(array_keys($r), true); }
 }
 
 class GenerationServiceTest extends TestCase {

--- a/tests/ScheduleFailureTest.php
+++ b/tests/ScheduleFailureTest.php
@@ -33,8 +33,9 @@ namespace {
 
     class DummyContentStorageService {
         public array $stored = [];
-        public function storeResults(array $results, string $type): void {
+        public function storeResults(array $results, string $type): array {
             $this->stored[] = [$results, $type];
+            return array_fill_keys(array_keys($results), true);
         }
     }
 

--- a/tests/UpdatesControllerTest.php
+++ b/tests/UpdatesControllerTest.php
@@ -38,8 +38,9 @@ namespace {
 
     class DummyStorage {
         public array $stored = [];
-        public function storeResults(array $results, string $workflow): void {
+        public function storeResults(array $results, string $workflow): array {
             $this->stored[] = [$results, $workflow];
+            return array_fill_keys(array_keys($results), true);
         }
     }
 


### PR DESCRIPTION
## Summary
- return status array from `ContentStorageService::storeResults`
- surface storage failures to callers across the plugin
- update generation poller, admin trait, generation service, AJAX and REST controllers
- adjust unit tests and add new failure test

## Testing
- `composer lint` *(fails: command not found)*
- `composer test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685d6d4564f88327a3957ae951829541

<!-- Korbit AI PR Description Start -->
## Description by Korbit AI

### What change is being made?

Implement error handling for content storage failures by modifying methods to return status arrays and using these statuses to log errors or halt execution where necessary.

### Why are these changes being made?

To enhance reliability and debuggability by ensuring errors during content storage are logged and properly handled, informing administrators of failures, and preventing inconsistencies in data. This approach also makes testing easier by explicitly checking the results of storage operations.

> Is this description stale? Ask me to generate a new description by commenting `/korbit-generate-pr-description`
<!-- Korbit AI PR Description End -->