### PR TITLE
Add post data caching and invalidation hooks

### DIFF
--- a/nuclear-engagement/bootstrap.php
+++ b/nuclear-engagement/bootstrap.php
@@ -218,10 +218,11 @@ function nuclear_engagement_run_plugin() {
 }
 
 function nuclear_engagement_init() {
-	try {
-		InventoryCache::register_hooks();
-		PostsQueryService::register_hooks();
-	} catch ( \Throwable $e ) {
+        try {
+                InventoryCache::register_hooks();
+                PostsQueryService::register_hooks();
+                \NuclearEngagement\Services\PostDataFetcher::register_hooks();
+        } catch ( \Throwable $e ) {
 		\NuclearEngagement\Services\LoggingService::log( 'Nuclear Engagement: Cache registration failed - ' . $e->getMessage() );
 		add_action(
 			'admin_notices',

--- a/nuclear-engagement/inc/Core/ContainerRegistrar.php
+++ b/nuclear-engagement/inc/Core/ContainerRegistrar.php
@@ -75,14 +75,15 @@ final class ContainerRegistrar {
 					)
 				);
 
-		$container->register(
-			'generation_service',
-			static fn( Container $c ) => new GenerationService(
-				$c->get( 'settings' ),
-				$c->get( 'remote_api' ),
-				$c->get( 'content_storage' )
-			)
-		);
+                $container->register(
+                        'generation_service',
+                        static fn( Container $c ) => new GenerationService(
+                                $c->get( 'settings' ),
+                                $c->get( 'remote_api' ),
+                                $c->get( 'content_storage' ),
+                                new PostDataFetcher()
+                        )
+                );
 
 		$container->register( 'pointer_service', static fn() => new PointerService() );
 				$container->register( 'posts_query_service', static fn() => new PostsQueryService() );

--- a/nuclear-engagement/inc/Services/GenerationService.php
+++ b/nuclear-engagement/inc/Services/GenerationService.php
@@ -15,6 +15,7 @@ use NuclearEngagement\Responses\GenerationResponse;
 use NuclearEngagement\Core\SettingsRepository;
 use NuclearEngagement\Utils;
 use NuclearEngagement\Services\ApiException;
+use NuclearEngagement\Services\PostDataFetcher;
 
 if ( ! defined( 'ABSPATH' ) ) {
 	exit;
@@ -41,7 +42,12 @@ class GenerationService {
 	/**
 	 * @var ContentStorageService
 	 */
-	private ContentStorageService $storage;
+        private ContentStorageService $storage;
+
+        /**
+         * @var PostDataFetcher
+         */
+        private PostDataFetcher $fetcher;
 
 	/**
 	 * @var Utils
@@ -55,19 +61,21 @@ class GenerationService {
 	 * @param RemoteApiService      $api
 	 * @param ContentStorageService $storage
 	 */
-	public function __construct(
-		SettingsRepository $settings,
-		RemoteApiService $api,
-		ContentStorageService $storage
-	) {
-			$this->settings = $settings;
-			$this->api      = $api;
-			$this->storage  = $storage;
-			$this->utils    = new Utils();
-		if ( defined( 'NUCLEN_GENERATION_POLL_DELAY' ) ) {
-				$this->pollDelay = (int) constant( 'NUCLEN_GENERATION_POLL_DELAY' );
-		}
-	}
+        public function __construct(
+                SettingsRepository $settings,
+                RemoteApiService $api,
+                ContentStorageService $storage,
+                ?PostDataFetcher $fetcher = null
+        ) {
+                $this->settings = $settings;
+                $this->api      = $api;
+                $this->storage  = $storage;
+                $this->fetcher  = $fetcher ?: new PostDataFetcher();
+                $this->utils    = new Utils();
+                if ( defined( 'NUCLEN_GENERATION_POLL_DELAY' ) ) {
+                        $this->pollDelay = (int) constant( 'NUCLEN_GENERATION_POLL_DELAY' );
+                }
+        }
 
 	/**
 	 * Generate content for multiple posts
@@ -192,36 +200,24 @@ class GenerationService {
 	 * @param string $postStatus
 	 * @return array
 	 */
-	private function getPostsData( array $postIds, string $postType, string $postStatus ): array {
-		global $wpdb;
+        private function getPostsData( array $postIds, string $postType, string $postStatus ): array {
+                $data      = array();
+                $postsById = array();
 
-		$data      = array();
-		$postsById = array();
+                $chunkSize = defined( 'NUCLEN_POST_FETCH_CHUNK' ) ? (int) constant( 'NUCLEN_POST_FETCH_CHUNK' ) : 200;
+                $chunks    = count( $postIds ) <= $chunkSize ? array( $postIds ) : array_chunk( $postIds, $chunkSize );
 
-		$chunkSize = defined( 'NUCLEN_POST_FETCH_CHUNK' ) ? (int) constant( 'NUCLEN_POST_FETCH_CHUNK' ) : 200;
-		$chunks    = count( $postIds ) <= $chunkSize ? array( $postIds ) : array_chunk( $postIds, $chunkSize );
+                foreach ( $chunks as $chunk ) {
+                        $posts = $this->fetcher->fetch( $chunk );
 
-		foreach ( $chunks as $chunk ) {
-			$placeholders = implode( ',', array_fill( 0, count( $chunk ), '%d' ) );
-			$sql          = $wpdb->prepare(
-				"SELECT ID, post_title, post_content
-                 FROM {$wpdb->posts}
-                 WHERE ID IN ($placeholders)
-                   AND post_type = %s
-                   AND post_status = %s",
-				array_merge( $chunk, array( $postType, $postStatus ) )
-			);
-
-			$posts = $wpdb->get_results( $sql );
-
-			foreach ( $posts as $post ) {
-				$postsById[ (int) $post->ID ] = array(
-					'id'      => (int) $post->ID,
-					'title'   => $post->post_title,
-					'content' => wp_strip_all_tags( $post->post_content ),
-				);
-			}
-		}
+                        foreach ( $posts as $post ) {
+                                $postsById[ (int) $post->ID ] = array(
+                                        'id'      => (int) $post->ID,
+                                        'title'   => $post->post_title,
+                                        'content' => wp_strip_all_tags( $post->post_content ),
+                                );
+                        }
+                }
 
 		foreach ( $postIds as $id ) {
 			if ( isset( $postsById[ $id ] ) ) {

--- a/tests/PostDataFetcherTest.php
+++ b/tests/PostDataFetcherTest.php
@@ -14,9 +14,40 @@ namespace {
         public $postmeta = 'wp_postmeta';
         public string $last_error = '';
         public array $args = [];
+        public int $calls = 0;
         public function prepare($sql, ...$args) { $this->args = $args; return 'SQL'; }
-        public function get_results($sql) { $this->last_error = 'fail'; return []; }
+        public function get_results($sql) {
+            $this->calls++;
+            if ($this->last_error) { return []; }
+            $ids = array_slice($this->args, 2);
+            $rows = [];
+            foreach ($ids as $id) {
+                $rows[] = (object)[ 'ID'=>$id, 'post_title'=>'T'.$id, 'post_content'=>'C'.$id ];
+            }
+            return $rows;
+        }
     }
+
+    if (!isset($GLOBALS['wp_cache'])) { $GLOBALS['wp_cache'] = []; }
+    if (!function_exists('wp_cache_get')) {
+        function wp_cache_get($key, $group = '', $force = false, &$found = null) {
+            $found = isset($GLOBALS['wp_cache'][$group][$key]);
+            return $GLOBALS['wp_cache'][$group][$key] ?? false;
+        }
+    }
+    if (!function_exists('wp_cache_set')) {
+        function wp_cache_set($key, $value, $group = '', $ttl = 0) {
+            $GLOBALS['wp_cache'][$group][$key] = $value;
+        }
+    }
+    if (!function_exists('wp_cache_flush_group')) {
+        function wp_cache_flush_group($group) { unset($GLOBALS['wp_cache'][$group]); }
+    }
+    if (!function_exists('wp_cache_flush')) {
+        function wp_cache_flush() { $GLOBALS['wp_cache'] = []; }
+    }
+    if (!function_exists('get_current_blog_id')) { function get_current_blog_id(){ return 1; } }
+    if (!function_exists('add_action')) { function add_action(...$a){} }
 
     require_once __DIR__ . '/../nuclear-engagement/inc/Services/PostDataFetcher.php';
 
@@ -25,6 +56,7 @@ namespace {
             global $wpdb;
             $wpdb = new PDF_WPDB();
             \NuclearEngagement\Services\LoggingService::$logs = [];
+            $GLOBALS['wp_cache'] = [];
         }
 
         public function test_fetch_logs_error_and_returns_empty_array(): void {
@@ -32,6 +64,28 @@ namespace {
             $rows = $fetcher->fetch([1]);
             $this->assertSame([], $rows);
             $this->assertSame(['Post fetch error: fail'], \NuclearEngagement\Services\LoggingService::$logs);
+        }
+
+        public function test_fetch_uses_cache(): void {
+            global $wpdb;
+            $wpdb->last_error = '';
+            $fetcher = new PostDataFetcher();
+            $rows1 = $fetcher->fetch([1]);
+            $this->assertSame(1, $wpdb->calls);
+            $rows2 = $fetcher->fetch([1]);
+            $this->assertSame(1, $wpdb->calls, 'second call should use cache');
+            $this->assertEquals($rows1, $rows2);
+        }
+
+        public function test_clear_cache_forces_refetch(): void {
+            global $wpdb;
+            $wpdb->last_error = '';
+            $fetcher = new PostDataFetcher();
+            $fetcher->fetch([2]);
+            $this->assertSame(1, $wpdb->calls);
+            PostDataFetcher::clear_cache();
+            $fetcher->fetch([2]);
+            $this->assertSame(2, $wpdb->calls);
         }
     }
 }


### PR DESCRIPTION
## Summary
- cache fetched post data via `wp_cache`
- clear cached entries on post updates
- use cached fetcher inside `GenerationService`
- register hooks in bootstrap
- update unit tests for caching behavior

## Testing
- `composer install` *(fails: command not found)*
- `composer lint` *(fails: command not found)*
- `composer test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685d6d20cf748327830df9c1d2d5bd01

<!-- Korbit AI PR Description Start -->
## Description by Korbit AI

### What change is being made?

Add post data caching and invalidation hooks by integrating a new `PostDataFetcher` service, which caches fetched post data for 30 seconds and registers hooks to clear cached entries when posts are modified.

### Why are these changes being made?

These changes optimize the performance of fetching post data by reducing redundant database queries through caching. The new approach improves efficiency by leveraging temporary caching and ensures data consistency with invalidation hooks that clear the cache when relevant post changes occur. This design enhances scalability and maintains the integrity of data processing operations.

> Is this description stale? Ask me to generate a new description by commenting `/korbit-generate-pr-description`
<!-- Korbit AI PR Description End -->