### PR TITLE
Update Utils namespace references

### DIFF
--- a/nuclear-engagement/admin/Admin.php
+++ b/nuclear-engagement/admin/Admin.php
@@ -14,7 +14,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 	exit;
 }
 
-use NuclearEngagement\Utils;
+use NuclearEngagement\Utils\Utils;
 use NuclearEngagement\Core\SettingsRepository;
 use NuclearEngagement\Core\Container;
 use NuclearEngagement\Admin\Traits\AdminMetaboxes;

--- a/nuclear-engagement/admin/Controller/Ajax/UpdatesController.php
+++ b/nuclear-engagement/admin/Controller/Ajax/UpdatesController.php
@@ -15,7 +15,7 @@ use NuclearEngagement\Services\RemoteApiService;
 use NuclearEngagement\Services\ContentStorageService;
 use NuclearEngagement\Responses\UpdatesResponse;
 use NuclearEngagement\Services\ApiException;
-use NuclearEngagement\Utils;
+use NuclearEngagement\Utils\Utils;
 
 if ( ! defined( 'ABSPATH' ) ) {
 	exit;

--- a/nuclear-engagement/admin/Dashboard.php
+++ b/nuclear-engagement/admin/Dashboard.php
@@ -14,7 +14,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 	exit;
 }
 
-use NuclearEngagement\Utils;
+use NuclearEngagement\Utils\Utils;
 use NuclearEngagement\Services\DashboardDataService;
 use NuclearEngagement\Core\SettingsRepository;
 

--- a/nuclear-engagement/admin/Traits/SettingsPageCustomCSSTrait.php
+++ b/nuclear-engagement/admin/Traits/SettingsPageCustomCSSTrait.php
@@ -123,7 +123,7 @@ trait SettingsPageCustomCSSTrait {
 }
 CSS;
 
-				$css_info = \NuclearEngagement\Utils::nuclen_get_custom_css_info();
+                                $css_info = \NuclearEngagement\Utils\Utils::nuclen_get_custom_css_info();
 		if ( empty( $css_info ) ) {
 				\NuclearEngagement\Services\LoggingService::notify_admin( __( 'Could not create custom CSS directory.', 'nuclear-engagement' ) );
 				return;

--- a/nuclear-engagement/front/Controller/Rest/ContentController.php
+++ b/nuclear-engagement/front/Controller/Rest/ContentController.php
@@ -13,7 +13,7 @@ namespace NuclearEngagement\Front\Controller\Rest;
 use NuclearEngagement\Requests\ContentRequest;
 use NuclearEngagement\Services\ContentStorageService;
 use NuclearEngagement\Core\SettingsRepository;
-use NuclearEngagement\Utils;
+use NuclearEngagement\Utils\Utils;
 
 if ( ! defined( 'ABSPATH' ) ) {
 	exit;

--- a/nuclear-engagement/front/FrontClass.php
+++ b/nuclear-engagement/front/FrontClass.php
@@ -22,7 +22,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 }
 
 
-use NuclearEngagement\Utils;
+use NuclearEngagement\Utils\Utils;
 use NuclearEngagement\Core\SettingsRepository;
 use NuclearEngagement\Core\Container;
 

--- a/nuclear-engagement/front/traits/AssetsTrait.php
+++ b/nuclear-engagement/front/traits/AssetsTrait.php
@@ -36,7 +36,7 @@ trait AssetsTrait {
 				);
 		}
 
-			$css_info = \NuclearEngagement\Utils::nuclen_get_custom_css_info();
+                        $css_info = \NuclearEngagement\Utils\Utils::nuclen_get_custom_css_info();
 		if ( empty( $css_info ) || empty( $css_info['url'] ) ) {
 				\NuclearEngagement\Services\LoggingService::log( 'Invalid custom CSS info - skipping' );
 				return array(

--- a/nuclear-engagement/inc/Services/ContentStorageService.php
+++ b/nuclear-engagement/inc/Services/ContentStorageService.php
@@ -11,7 +11,7 @@ declare(strict_types=1);
 namespace NuclearEngagement\Services;
 
 use NuclearEngagement\Core\SettingsRepository;
-use NuclearEngagement\Utils;
+use NuclearEngagement\Utils\Utils;
 
 if ( ! defined( 'ABSPATH' ) ) {
 	exit;

--- a/nuclear-engagement/inc/Services/GenerationService.php
+++ b/nuclear-engagement/inc/Services/GenerationService.php
@@ -13,7 +13,7 @@ namespace NuclearEngagement\Services;
 use NuclearEngagement\Requests\GenerateRequest;
 use NuclearEngagement\Responses\GenerationResponse;
 use NuclearEngagement\Core\SettingsRepository;
-use NuclearEngagement\Utils;
+use NuclearEngagement\Utils\Utils;
 use NuclearEngagement\Services\ApiException;
 
 if ( ! defined( 'ABSPATH' ) ) {

--- a/nuclear-engagement/inc/Services/SetupService.php
+++ b/nuclear-engagement/inc/Services/SetupService.php
@@ -13,7 +13,7 @@ declare( strict_types = 1 );
 
 namespace NuclearEngagement\Services;
 
-use NuclearEngagement\Utils;
+use NuclearEngagement\Utils\Utils;
 use NuclearEngagement\Services\Remote\RemoteRequest;
 
 // If this file is called directly, abort.

--- a/nuclear-engagement/inc/Utils/Utils.php
+++ b/nuclear-engagement/inc/Utils/Utils.php
@@ -12,7 +12,7 @@
  */
 declare(strict_types=1);
 
-namespace NuclearEngagement;
+namespace NuclearEngagement\Utils;
 
 if ( ! defined( 'ABSPATH' ) ) {
 	exit;

--- a/nuclear-engagement/uninstall.php
+++ b/nuclear-engagement/uninstall.php
@@ -92,7 +92,7 @@ if ( $delete_log ) {
 
 // Remove custom theme file if requested.
 if ( $delete_css ) {
-				$info = \NuclearEngagement\Utils::nuclen_get_custom_css_info();
+                                $info = \NuclearEngagement\Utils\Utils::nuclen_get_custom_css_info();
 	if ( ! empty( $info ) && file_exists( $info['path'] ) ) {
 					wp_delete_file( $info['path'] );
 	}

--- a/tests/UtilsTest.php
+++ b/tests/UtilsTest.php
@@ -14,7 +14,7 @@ namespace NuclearEngagement\Services {
 
 namespace {
     use PHPUnit\Framework\TestCase;
-    use NuclearEngagement\Utils;
+    use NuclearEngagement\Utils\Utils;
     class UtilsTest extends TestCase {
         protected function setUp(): void {
             $GLOBALS['test_upload_basedir'] = sys_get_temp_dir() . '/ut_' . uniqid();


### PR DESCRIPTION
## Summary
- adjust namespace for `Utils` to `NuclearEngagement\Utils`
- update references across services, controllers, admin and test files
- keep uninstall loader for Utils and update FQCN
- regenerate autoloader *(composer unavailable in environment)*

## Testing
- `composer dump-autoload` *(fails: command not found)*
- `composer lint` *(fails: command not found)*
- `composer test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685d70aa22088327a3996a63e8bc3e04