### PR TITLE
Add RemoteRequest unit test

### DIFF
--- a/tests/RemoteRequestTest.php
+++ b/tests/RemoteRequestTest.php
@@ -1,0 +1,35 @@
+<?php
+namespace NuclearEngagement\Services\Remote {
+    function wp_remote_post(string $url, array $args = []) {
+        $GLOBALS['rr_called'] = ['url' => $url, 'args' => $args];
+        return null;
+    }
+    function wp_json_encode($data) { return json_encode($data); }
+}
+
+namespace {
+    use PHPUnit\Framework\TestCase;
+    use NuclearEngagement\Services\Remote\RemoteRequest;
+
+    if (!defined('NUCLEN_PLUGIN_VERSION')) { define('NUCLEN_PLUGIN_VERSION', '1.0'); }
+    if (!defined('NUCLEN_API_TIMEOUT')) { define('NUCLEN_API_TIMEOUT', 30); }
+
+    class RemoteRequestTest extends TestCase {
+        protected function setUp(): void {
+            unset($GLOBALS['rr_called']);
+        }
+
+        public function test_post_sends_json_request_with_headers(): void {
+            $req = new RemoteRequest();
+            $req->post('/path', ['data' => 1], 'key');
+
+            $this->assertArrayHasKey('rr_called', $GLOBALS);
+            $called = $GLOBALS['rr_called'];
+            $this->assertSame('https://app.nuclearengagement.com/api/path', $called['url']);
+            $this->assertSame(json_encode(['data' => 1]), $called['args']['body']);
+            $this->assertSame('application/json', $called['args']['headers']['Content-Type']);
+            $this->assertSame('key', $called['args']['headers']['X-API-Key']);
+            $this->assertStringContainsString(NUCLEN_PLUGIN_VERSION, $called['args']['user-agent']);
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- add test for `RemoteRequest::post` to verify WP request arguments

## Testing
- `composer lint` *(fails: command not found)*
- `composer test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685d7884bf8483279e3cada694f0e9d3

<!-- Korbit AI PR Description Start -->
## Description by Korbit AI

### What change is being made?

Add a unit test named `RemoteRequestTest` to `tests/RemoteRequestTest.php` for verifying the behavior of the `RemoteRequest` class's `post` method, ensuring it sends a JSON request with appropriate headers.

### Why are these changes being made?

This unit test is being introduced to validate the functionality of the `RemoteRequest` class's `post` method, particularly focusing on its ability to correctly format and send JSON post requests with the necessary headers. This test ensures that the implementation aligns with expected behavior, aiding in maintaining code stability and reliability.

> Is this description stale? Ask me to generate a new description by commenting `/korbit-generate-pr-description`
<!-- Korbit AI PR Description End -->