### PR TITLE
Refactor settings page save logic

### DIFF
--- a/nuclear-engagement/admin/Traits/SettingsPageSaveTrait.php
+++ b/nuclear-engagement/admin/Traits/SettingsPageSaveTrait.php
@@ -24,221 +24,243 @@ trait SettingsPageSaveTrait {
 	 * @param array &$new_settings Output: new sanitized settings.
 	 * @return bool                True if a save occurred.
 	 */
-	protected function nuclen_handle_save_settings( array &$settings, array $defaults, array &$new_settings ): bool {
+        protected function nuclen_handle_save_settings( array &$settings, array $defaults, array &$new_settings ): bool {
 
-		/* ───────── Bail if not a form submission ───────── */
-		if (
-			! isset( $_POST['nuclen_save_settings'] ) ||
-			! check_admin_referer( 'nuclen_settings_nonce', 'nuclen_settings_nonce_field', false )
-		) {
-			return false;
-		}
+                /* ───────── Bail if not a form submission ───────── */
+                if (
+                        ! isset( $_POST['nuclen_save_settings'] ) ||
+                        ! check_admin_referer( 'nuclen_settings_nonce', 'nuclen_settings_nonce_field', false )
+                ) {
+                        return false;
+                }
 
-		/* ───────── 1) COLLECT RAW INPUTS ───────── */
-		$raw = array();
+                $raw          = $this->nuclen_collect_input();
+                $new_settings = $this->nuclen_sanitize_and_defaults( $raw, $defaults );
+                $settings     = $this->nuclen_persist_settings( $new_settings );
 
-		// theme preset
-		$raw['theme'] = isset( $_POST['nuclen_theme'] )
-			? sanitize_text_field( wp_unslash( $_POST['nuclen_theme'] ) )
-			: '';
+                if ( 'custom' === $settings['theme'] && method_exists( $this, 'nuclen_write_custom_css' ) ) {
+                        $this->nuclen_write_custom_css( $settings );
+                }
 
-		// map <form field> → <settings key>
-		$field_map = array(
-			/* —— Quiz style —— */
-			'nuclen_font_size'                        => 'font_size',
-			'nuclen_font_color'                       => 'font_color',
-			'nuclen_bg_color'                         => 'bg_color',
-			'nuclen_quiz_border_color'                => 'quiz_border_color',
-			'nuclen_quiz_border_style'                => 'quiz_border_style',
-			'nuclen_quiz_border_width'                => 'quiz_border_width',
-			'nuclen_quiz_border_radius'               => 'quiz_border_radius',
-			'nuclen_quiz_shadow_color'                => 'quiz_shadow_color',
-			'nuclen_quiz_shadow_blur'                 => 'quiz_shadow_blur',
+                $this->nuclen_output_save_notice();
 
-			'nuclen_quiz_answer_button_bg_color'      => 'quiz_answer_button_bg_color',
-			'nuclen_quiz_answer_button_border_color'  => 'quiz_answer_button_border_color',
-			'nuclen_quiz_answer_button_border_width'  => 'quiz_answer_button_border_width',
-			'nuclen_quiz_answer_button_border_radius' => 'quiz_answer_button_border_radius',
+                return true;
+        }
 
-			'nuclen_quiz_progress_bar_fg_color'       => 'quiz_progress_bar_fg_color',
-			'nuclen_quiz_progress_bar_bg_color'       => 'quiz_progress_bar_bg_color',
-			'nuclen_quiz_progress_bar_height'         => 'quiz_progress_bar_height',
+        /**
+         * Collect raw input values from $_POST.
+         */
+        private function nuclen_collect_input(): array {
+                $raw = array();
 
-			/* —— Summary style —— */
-			'nuclen_summary_font_size'                => 'summary_font_size',
-			'nuclen_summary_font_color'               => 'summary_font_color',
-			'nuclen_summary_bg_color'                 => 'summary_bg_color',
-			'nuclen_summary_border_color'             => 'summary_border_color',
-			'nuclen_summary_border_style'             => 'summary_border_style',
-			'nuclen_summary_border_width'             => 'summary_border_width',
-			'nuclen_summary_border_radius'            => 'summary_border_radius',
-			'nuclen_summary_shadow_color'             => 'summary_shadow_color',
-			'nuclen_summary_shadow_blur'              => 'summary_shadow_blur',
+                // theme preset
+                $raw['theme'] = isset( $_POST['nuclen_theme'] )
+                        ? sanitize_text_field( wp_unslash( $_POST['nuclen_theme'] ) )
+                        : '';
 
-			/* —— TOC style —— */
-			'nuclen_toc_font_size'                    => 'toc_font_size',
-			'nuclen_toc_font_color'                   => 'toc_font_color',
-			'nuclen_toc_bg_color'                     => 'toc_bg_color',
-			'nuclen_toc_border_color'                 => 'toc_border_color',
-			'nuclen_toc_border_style'                 => 'toc_border_style',
-			'nuclen_toc_heading_levels'               => 'toc_heading_levels',
-			'nuclen_toc_show_toggle'                  => 'toc_show_toggle',
-			'nuclen_toc_show_content'                 => 'toc_show_content',
-			'nuclen_toc_border_width'                 => 'toc_border_width',
-			'nuclen_toc_border_radius'                => 'toc_border_radius',
-			'nuclen_toc_shadow_color'                 => 'toc_shadow_color',
-			'nuclen_toc_shadow_blur'                  => 'toc_shadow_blur',
-			'nuclen_toc_link_color'                   => 'toc_link_color',
-			'nuclen_toc_title'                        => 'toc_title',
+                // map <form field> → <settings key>
+                $field_map = array(
+                        /* —— Quiz style —— */
+                        'nuclen_font_size'                        => 'font_size',
+                        'nuclen_font_color'                       => 'font_color',
+                        'nuclen_bg_color'                         => 'bg_color',
+                        'nuclen_quiz_border_color'                => 'quiz_border_color',
+                        'nuclen_quiz_border_style'                => 'quiz_border_style',
+                        'nuclen_quiz_border_width'                => 'quiz_border_width',
+                        'nuclen_quiz_border_radius'               => 'quiz_border_radius',
+                        'nuclen_quiz_shadow_color'                => 'quiz_shadow_color',
+                        'nuclen_quiz_shadow_blur'                 => 'quiz_shadow_blur',
 
-			/* —— NEW – sticky TOC options & z-index —— */
-			'toc_zindex'                              => 'toc_z_index',
-			'toc_sticky_offset_x'                     => 'toc_sticky_offset_x',
-			'toc_sticky_offset_y'                     => 'toc_sticky_offset_y',
-			'toc_sticky_max_width'                    => 'toc_sticky_max_width',
+                        'nuclen_quiz_answer_button_bg_color'      => 'quiz_answer_button_bg_color',
+                        'nuclen_quiz_answer_button_border_color'  => 'quiz_answer_button_border_color',
+                        'nuclen_quiz_answer_button_border_width'  => 'quiz_answer_button_border_width',
+                        'nuclen_quiz_answer_button_border_radius' => 'quiz_answer_button_border_radius',
 
-			/* —— Legacy generic —— */
-			'nuclen_border_color'                     => 'border_color',
-			'nuclen_border_style'                     => 'border_style',
-			'nuclen_border_width'                     => 'border_width',
+                        'nuclen_quiz_progress_bar_fg_color'       => 'quiz_progress_bar_fg_color',
+                        'nuclen_quiz_progress_bar_bg_color'       => 'quiz_progress_bar_bg_color',
+                        'nuclen_quiz_progress_bar_height'         => 'quiz_progress_bar_height',
 
-			/* —— Quiz structure —— */
-			'nuclen_questions_per_quiz'               => 'questions_per_quiz',
-			'nuclen_answers_per_question'             => 'answers_per_question',
+                        /* —— Summary style —— */
+                        'nuclen_summary_font_size'                => 'summary_font_size',
+                        'nuclen_summary_font_color'               => 'summary_font_color',
+                        'nuclen_summary_bg_color'                 => 'summary_bg_color',
+                        'nuclen_summary_border_color'             => 'summary_border_color',
+                        'nuclen_summary_border_style'             => 'summary_border_style',
+                        'nuclen_summary_border_width'             => 'summary_border_width',
+                        'nuclen_summary_border_radius'            => 'summary_border_radius',
+                        'nuclen_summary_shadow_color'             => 'summary_shadow_color',
+                        'nuclen_summary_shadow_blur'              => 'summary_shadow_blur',
 
-			/* —— Placement —— */
-			'nuclen_display_summary'                  => 'display_summary',
-			'nuclen_display_quiz'                     => 'display_quiz',
-			'nuclen_display_toc'                      => 'display_toc',
-			'toc_sticky'                              => 'toc_sticky',
-		);
+                        /* —— TOC style —— */
+                        'nuclen_toc_font_size'                    => 'toc_font_size',
+                        'nuclen_toc_font_color'                   => 'toc_font_color',
+                        'nuclen_toc_bg_color'                     => 'toc_bg_color',
+                        'nuclen_toc_border_color'                 => 'toc_border_color',
+                        'nuclen_toc_border_style'                 => 'toc_border_style',
+                        'nuclen_toc_heading_levels'               => 'toc_heading_levels',
+                        'nuclen_toc_show_toggle'                  => 'toc_show_toggle',
+                        'nuclen_toc_show_content'                 => 'toc_show_content',
+                        'nuclen_toc_border_width'                 => 'toc_border_width',
+                        'nuclen_toc_border_radius'                => 'toc_border_radius',
+                        'nuclen_toc_shadow_color'                 => 'toc_shadow_color',
+                        'nuclen_toc_shadow_blur'                  => 'toc_shadow_blur',
+                        'nuclen_toc_link_color'                   => 'toc_link_color',
+                        'nuclen_toc_title'                        => 'toc_title',
 
-		foreach ( $field_map as $post_key => $opt_key ) {
-			if ( isset( $_POST[ $post_key ] ) ) {
-				$raw[ $opt_key ] = sanitize_text_field( wp_unslash( $_POST[ $post_key ] ) );
-			}
-		}
+                        /* —— NEW – sticky TOC options & z-index —— */
+                        'toc_zindex'                              => 'toc_z_index',
+                        'toc_sticky_offset_x'                     => 'toc_sticky_offset_x',
+                        'toc_sticky_offset_y'                     => 'toc_sticky_offset_y',
+                        'toc_sticky_max_width'                    => 'toc_sticky_max_width',
 
-		/* —— TOC Heading Levels —— */
-		$raw['toc_heading_levels'] = isset( $_POST['nuclear_engagement_settings']['toc_heading_levels'] )
-			? array_map( 'intval', (array) $_POST['nuclear_engagement_settings']['toc_heading_levels'] )
-			: range( 2, 6 );
+                        /* —— Legacy generic —— */
+                        'nuclen_border_color'                     => 'border_color',
+                        'nuclen_border_style'                     => 'border_style',
+                        'nuclen_border_width'                     => 'border_width',
 
-		/* —— Custom HTML & titles —— */
-		$raw['custom_quiz_html_before']  = isset( $_POST['custom_quiz_html_before'] )
-			? wp_kses_post( wp_unslash( $_POST['custom_quiz_html_before'] ) )
-			: '';
-		$raw['custom_quiz_html_after']   = isset( $_POST['custom_quiz_html_after'] )
-			? wp_kses_post( wp_unslash( $_POST['custom_quiz_html_after'] ) )
-			: '';
-		$raw['quiz_title']               = isset( $_POST['quiz_title'] ) ? sanitize_text_field( wp_unslash( $_POST['quiz_title'] ) ) : '';
-		$raw['summary_title']            = isset( $_POST['summary_title'] ) ? sanitize_text_field( wp_unslash( $_POST['summary_title'] ) ) : '';
-		$raw['quiz_label_retake_test']   = isset( $_POST['quiz_label_retake_test'] )
-			? sanitize_text_field( wp_unslash( $_POST['quiz_label_retake_test'] ) )
-			: '';
-		$raw['quiz_label_your_score']    = isset( $_POST['quiz_label_your_score'] )
-			? sanitize_text_field( wp_unslash( $_POST['quiz_label_your_score'] ) )
-			: '';
-		$raw['quiz_label_perfect']       = isset( $_POST['quiz_label_perfect'] )
-			? sanitize_text_field( wp_unslash( $_POST['quiz_label_perfect'] ) )
-			: '';
-		$raw['quiz_label_well_done']     = isset( $_POST['quiz_label_well_done'] )
-			? sanitize_text_field( wp_unslash( $_POST['quiz_label_well_done'] ) )
-			: '';
-		$raw['quiz_label_retake_prompt'] = isset( $_POST['quiz_label_retake_prompt'] )
-			? sanitize_text_field( wp_unslash( $_POST['quiz_label_retake_prompt'] ) )
-			: '';
-		$raw['quiz_label_correct']       = isset( $_POST['quiz_label_correct'] )
-			? sanitize_text_field( wp_unslash( $_POST['quiz_label_correct'] ) )
-			: '';
-		$raw['quiz_label_your_answer']   = isset( $_POST['quiz_label_your_answer'] )
-			? sanitize_text_field( wp_unslash( $_POST['quiz_label_your_answer'] ) )
-			: '';
+                        /* —— Quiz structure —— */
+                        'nuclen_questions_per_quiz'               => 'questions_per_quiz',
+                        'nuclen_answers_per_question'             => 'answers_per_question',
 
-		/* —— Opt-in block —— */
-		$raw['enable_optin']      = isset( $_POST['enable_optin'] ) ? (bool) wp_unslash( $_POST['enable_optin'] ) : false;
-		$raw['optin_position']    = isset( $_POST['nuclen_optin_position'] )
-			? sanitize_text_field( wp_unslash( $_POST['nuclen_optin_position'] ) )
-			: 'with_results';
-		$raw['optin_mandatory']   = isset( $_POST['optin_mandatory'] ) ? (bool) wp_unslash( $_POST['optin_mandatory'] ) : false;
-		$raw['optin_prompt_text'] = isset( $_POST['optin_prompt_text'] ) ? sanitize_text_field( wp_unslash( $_POST['optin_prompt_text'] ) ) : '';
-		$raw['optin_button_text'] = isset( $_POST['optin_button_text'] ) ? sanitize_text_field( wp_unslash( $_POST['optin_button_text'] ) ) : '';
-		if ( isset( $_POST['optin_webhook'] ) ) {
-			$raw['optin_webhook'] = esc_url_raw( trim( sanitize_text_field( wp_unslash( $_POST['optin_webhook'] ) ) ) );
-		}
+                        /* —— Placement —— */
+                        'nuclen_display_summary'                  => 'display_summary',
+                        'nuclen_display_quiz'                     => 'display_quiz',
+                        'nuclen_display_toc'                      => 'display_toc',
+                        'toc_sticky'                              => 'toc_sticky',
+                );
 
-		/* —— Flags & generation —— */
-		$raw['update_last_modified']                          = isset( $_POST['update_last_modified'] ) ? (bool) wp_unslash( $_POST['update_last_modified'] ) : false;
-		$raw['auto_generate_quiz_on_publish']                 = isset( $_POST['auto_generate_quiz_on_publish'] ) ? (bool) wp_unslash( $_POST['auto_generate_quiz_on_publish'] ) : false;
-		$raw['auto_generate_summary_on_publish']              = isset( $_POST['auto_generate_summary_on_publish'] ) ? (bool) wp_unslash( $_POST['auto_generate_summary_on_publish'] ) : false;
-				$raw['show_attribution']                      = isset( $_POST['show_attribution'] ) ? (bool) wp_unslash( $_POST['show_attribution'] ) : false;
-				$raw['delete_settings_on_uninstall']          = isset( $_POST['delete_settings_on_uninstall'] ) ? (bool) wp_unslash( $_POST['delete_settings_on_uninstall'] ) : false;
-				$raw['delete_generated_content_on_uninstall'] = isset( $_POST['delete_generated_content_on_uninstall'] ) ? (bool) wp_unslash( $_POST['delete_generated_content_on_uninstall'] ) : false;
-				$raw['delete_optin_data_on_uninstall']        = isset( $_POST['delete_optin_data_on_uninstall'] ) ? (bool) wp_unslash( $_POST['delete_optin_data_on_uninstall'] ) : false;
-				$raw['delete_log_file_on_uninstall']          = isset( $_POST['delete_log_file_on_uninstall'] ) ? (bool) wp_unslash( $_POST['delete_log_file_on_uninstall'] ) : false;
-				$raw['delete_custom_css_on_uninstall']        = isset( $_POST['delete_custom_css_on_uninstall'] ) ? (bool) wp_unslash( $_POST['delete_custom_css_on_uninstall'] ) : false;
+                foreach ( $field_map as $post_key => $opt_key ) {
+                        if ( isset( $_POST[ $post_key ] ) ) {
+                                $raw[ $opt_key ] = sanitize_text_field( wp_unslash( $_POST[ $post_key ] ) );
+                        }
+                }
 
-		/* —— Generation post types —— */
-		$posted_types                 = filter_input(
-			INPUT_POST,
-			'nuclen_generation_post_types',
-			FILTER_SANITIZE_FULL_SPECIAL_CHARS,
-			FILTER_REQUIRE_ARRAY
-		);
-		$raw['generation_post_types'] = is_array( $posted_types )
-			? array_map( 'sanitize_text_field', wp_unslash( $posted_types ) )
-			: array( 'post' );
+                /* —— TOC Heading Levels —— */
+                $raw['toc_heading_levels'] = isset( $_POST['nuclear_engagement_settings']['toc_heading_levels'] )
+                        ? array_map( 'intval', (array) $_POST['nuclear_engagement_settings']['toc_heading_levels'] )
+                        : range( 2, 6 );
 
-		/* ───────── 2) SANITIZE & SAVE ───────── */
-		$new_settings = $this->nuclen_sanitize_settings( $raw );
+                /* —— Custom HTML & titles —— */
+                $raw['custom_quiz_html_before']  = isset( $_POST['custom_quiz_html_before'] )
+                        ? wp_kses_post( wp_unslash( $_POST['custom_quiz_html_before'] ) )
+                        : '';
+                $raw['custom_quiz_html_after']   = isset( $_POST['custom_quiz_html_after'] )
+                        ? wp_kses_post( wp_unslash( $_POST['custom_quiz_html_after'] ) )
+                        : '';
+                $raw['quiz_title']               = isset( $_POST['quiz_title'] ) ? sanitize_text_field( wp_unslash( $_POST['quiz_title'] ) ) : '';
+                $raw['summary_title']            = isset( $_POST['summary_title'] ) ? sanitize_text_field( wp_unslash( $_POST['summary_title'] ) ) : '';
+                $raw['quiz_label_retake_test']   = isset( $_POST['quiz_label_retake_test'] )
+                        ? sanitize_text_field( wp_unslash( $_POST['quiz_label_retake_test'] ) )
+                        : '';
+                $raw['quiz_label_your_score']    = isset( $_POST['quiz_label_your_score'] )
+                        ? sanitize_text_field( wp_unslash( $_POST['quiz_label_your_score'] ) )
+                        : '';
+                $raw['quiz_label_perfect']       = isset( $_POST['quiz_label_perfect'] )
+                        ? sanitize_text_field( wp_unslash( $_POST['quiz_label_perfect'] ) )
+                        : '';
+                $raw['quiz_label_well_done']     = isset( $_POST['quiz_label_well_done'] )
+                        ? sanitize_text_field( wp_unslash( $_POST['quiz_label_well_done'] ) )
+                        : '';
+                $raw['quiz_label_retake_prompt'] = isset( $_POST['quiz_label_retake_prompt'] )
+                        ? sanitize_text_field( wp_unslash( $_POST['quiz_label_retake_prompt'] ) )
+                        : '';
+                $raw['quiz_label_correct']       = isset( $_POST['quiz_label_correct'] )
+                        ? sanitize_text_field( wp_unslash( $_POST['quiz_label_correct'] ) )
+                        : '';
+                $raw['quiz_label_your_answer']   = isset( $_POST['quiz_label_your_answer'] )
+                        ? sanitize_text_field( wp_unslash( $_POST['quiz_label_your_answer'] ) )
+                        : '';
 
-		/* Keep additional TOC keys that sanitiser may not yet know about */
-		$toc_keys = array(
-			// colours etc.
-			'toc_font_color',
-			'toc_bg_color',
-			'toc_border_color',
-			'toc_border_style',
-			'toc_border_width',
-			'toc_border_radius',
-			'toc_shadow_color',
-			'toc_shadow_blur',
-			'toc_link_color',
-			'toc_heading_levels',
-			// ► NEW ◄ sticky & z-index keys
-			'toc_z_index',
-			'toc_sticky_offset_x',
-			'toc_sticky_offset_y',
-			'toc_sticky_max_width',
-		);
-		foreach ( $toc_keys as $k ) {
-			if ( isset( $raw[ $k ] ) && $raw[ $k ] !== '' ) {
-				$new_settings[ $k ] = $raw[ $k ];
-			}
-		}
+                /* —— Opt-in block —— */
+                $raw['enable_optin']      = isset( $_POST['enable_optin'] ) ? (bool) wp_unslash( $_POST['enable_optin'] ) : false;
+                $raw['optin_position']    = isset( $_POST['nuclen_optin_position'] )
+                        ? sanitize_text_field( wp_unslash( $_POST['nuclen_optin_position'] ) )
+                        : 'with_results';
+                $raw['optin_mandatory']   = isset( $_POST['optin_mandatory'] ) ? (bool) wp_unslash( $_POST['optin_mandatory'] ) : false;
+                $raw['optin_prompt_text'] = isset( $_POST['optin_prompt_text'] ) ? sanitize_text_field( wp_unslash( $_POST['optin_prompt_text'] ) ) : '';
+                $raw['optin_button_text'] = isset( $_POST['optin_button_text'] ) ? sanitize_text_field( wp_unslash( $_POST['optin_button_text'] ) ) : '';
+                if ( isset( $_POST['optin_webhook'] ) ) {
+                        $raw['optin_webhook'] = esc_url_raw( trim( sanitize_text_field( wp_unslash( $_POST['optin_webhook'] ) ) ) );
+                }
 
-		// Get the settings repository and save all settings
-		$settings_repo = $this->nuclen_get_settings_repository();
-		foreach ( $new_settings as $key => $value ) {
-			$settings_repo->set( $key, $value );
-		}
+                /* —— Flags & generation —— */
+                $raw['update_last_modified']                          = isset( $_POST['update_last_modified'] ) ? (bool) wp_unslash( $_POST['update_last_modified'] ) : false;
+                $raw['auto_generate_quiz_on_publish']                 = isset( $_POST['auto_generate_quiz_on_publish'] ) ? (bool) wp_unslash( $_POST['auto_generate_quiz_on_publish'] ) : false;
+                $raw['auto_generate_summary_on_publish']              = isset( $_POST['auto_generate_summary_on_publish'] ) ? (bool) wp_unslash( $_POST['auto_generate_summary_on_publish'] ) : false;
+                $raw['show_attribution']                      = isset( $_POST['show_attribution'] ) ? (bool) wp_unslash( $_POST['show_attribution'] ) : false;
+                $raw['delete_settings_on_uninstall']          = isset( $_POST['delete_settings_on_uninstall'] ) ? (bool) wp_unslash( $_POST['delete_settings_on_uninstall'] ) : false;
+                $raw['delete_generated_content_on_uninstall'] = isset( $_POST['delete_generated_content_on_uninstall'] ) ? (bool) wp_unslash( $_POST['delete_generated_content_on_uninstall'] ) : false;
+                $raw['delete_optin_data_on_uninstall']        = isset( $_POST['delete_optin_data_on_uninstall'] ) ? (bool) wp_unslash( $_POST['delete_optin_data_on_uninstall'] ) : false;
+                $raw['delete_log_file_on_uninstall']          = isset( $_POST['delete_log_file_on_uninstall'] ) ? (bool) wp_unslash( $_POST['delete_log_file_on_uninstall'] ) : false;
+                $raw['delete_custom_css_on_uninstall']        = isset( $_POST['delete_custom_css_on_uninstall'] ) ? (bool) wp_unslash( $_POST['delete_custom_css_on_uninstall'] ) : false;
 
-		// Actually save the settings to the database
-		$settings_repo->save();
+                /* —— Generation post types —— */
+                $posted_types                 = filter_input(
+                        INPUT_POST,
+                        'nuclen_generation_post_types',
+                        FILTER_SANITIZE_FULL_SPECIAL_CHARS,
+                        FILTER_REQUIRE_ARRAY
+                );
+                $raw['generation_post_types'] = is_array( $posted_types )
+                        ? array_map( 'sanitize_text_field', wp_unslash( $posted_types ) )
+                        : array( 'post' );
 
-		// Update the settings array with the saved values
-		// Note: get_all() already merges with defaults internally
-		$settings = $settings_repo->get_all();
+                return $raw;
+        }
 
-		/* Immediately regenerate custom CSS when using the custom theme */
-		if ( 'custom' === $settings['theme'] && method_exists( $this, 'nuclen_write_custom_css' ) ) {
-			$this->nuclen_write_custom_css( $settings );
-		}
+        /**
+         * Sanitize input and merge with defaults.
+         */
+        private function nuclen_sanitize_and_defaults( array $raw, array $defaults ): array {
+                $new_settings = $this->nuclen_sanitize_settings( $raw );
 
-		echo '<div class="notice notice-success"><p>' .
-			esc_html__( 'Settings saved.', 'nuclear-engagement' ) .
-			'</p></div>';
+                $toc_keys = array(
+                        'toc_font_color',
+                        'toc_bg_color',
+                        'toc_border_color',
+                        'toc_border_style',
+                        'toc_border_width',
+                        'toc_border_radius',
+                        'toc_shadow_color',
+                        'toc_shadow_blur',
+                        'toc_link_color',
+                        'toc_heading_levels',
+                        'toc_z_index',
+                        'toc_sticky_offset_x',
+                        'toc_sticky_offset_y',
+                        'toc_sticky_max_width',
+                );
 
-		return true;
-	}
+                foreach ( $toc_keys as $k ) {
+                        if ( isset( $raw[ $k ] ) && $raw[ $k ] !== '' ) {
+                                $new_settings[ $k ] = $raw[ $k ];
+                        }
+                }
+
+                return wp_parse_args( $new_settings, $defaults );
+        }
+
+        /**
+         * Persist the sanitized settings and return the saved array.
+         */
+        private function nuclen_persist_settings( array $new_settings ): array {
+                $settings_repo = $this->nuclen_get_settings_repository();
+
+                foreach ( $new_settings as $key => $value ) {
+                        $settings_repo->set( $key, $value );
+                }
+
+                $settings_repo->save();
+
+                return $settings_repo->get_all();
+        }
+
+        /**
+         * Output the success admin notice after saving settings.
+         */
+        private function nuclen_output_save_notice(): void {
+                echo '<div class="notice notice-success"><p>' .
+                        esc_html__( 'Settings saved.', 'nuclear-engagement' ) .
+                        '</p></div>';
+        }
 }

--- a/tests/SettingsPageSaveTraitTest.php
+++ b/tests/SettingsPageSaveTraitTest.php
@@ -1,0 +1,77 @@
+<?php
+namespace {
+    use PHPUnit\Framework\TestCase;
+    use NuclearEngagement\Admin\Traits\SettingsPageSaveTrait;
+    use NuclearEngagement\Admin\SettingsSanitizeTrait;
+    use NuclearEngagement\Core\SettingsRepository;
+    use NuclearEngagement\Core\Defaults;
+
+    if (!function_exists('sanitize_text_field')) {
+        function sanitize_text_field($t) { return is_string($t) ? trim($t) : $t; }
+    }
+    if (!function_exists('wp_unslash')) { function wp_unslash($v){ return $v; } }
+    if (!function_exists('wp_kses_post')) { function wp_kses_post($v){ return $v; } }
+    if (!function_exists('check_admin_referer')) { function check_admin_referer($a,$b,$c=false){ return true; } }
+    if (!function_exists('esc_url_raw')) { function esc_url_raw($u){ return $u; } }
+    if (!function_exists('filter_input')) { function filter_input($type,$name,$filter=null,$opt=null){ return $_POST[$name] ?? null; } }
+
+    class DummySettingsPage {
+        use SettingsPageSaveTrait;
+        use SettingsSanitizeTrait;
+        public function nuclen_get_settings_repository() { return SettingsRepository::get_instance(); }
+    }
+
+    class SettingsPageSaveTraitTest extends TestCase {
+        private DummySettingsPage $page;
+
+        protected function setUp(): void {
+            global $wp_options;
+            $wp_options = [];
+            SettingsRepository::reset_for_tests();
+            $this->page = new DummySettingsPage();
+            $_POST = [];
+        }
+
+        public function test_collect_input_returns_expected_keys(): void {
+            $_POST['nuclen_theme'] = 'dark';
+            $_POST['nuclen_font_size'] = '20';
+            $_POST['nuclen_display_quiz'] = 'before';
+            $_POST['nuclear_engagement_settings']['toc_heading_levels'] = [2,3];
+            $ref = new \ReflectionMethod($this->page, 'nuclen_collect_input');
+            $ref->setAccessible(true);
+            $result = $ref->invoke($this->page);
+            $this->assertSame('dark', $result['theme']);
+            $this->assertSame('20', $result['font_size']);
+            $this->assertSame('before', $result['display_quiz']);
+            $this->assertSame([2,3], $result['toc_heading_levels']);
+        }
+
+        public function test_sanitize_and_defaults_merges_defaults(): void {
+            $raw = ['font_size' => '15'];
+            $defaults = Defaults::nuclen_get_default_settings();
+            $ref = new \ReflectionMethod($this->page, 'nuclen_sanitize_and_defaults');
+            $ref->setAccessible(true);
+            $result = $ref->invoke($this->page, $raw, $defaults);
+            $this->assertSame(15, $result['font_size']);
+            $this->assertSame($defaults['font_color'], $result['font_color']);
+        }
+
+        public function test_persist_settings_saves_via_repository(): void {
+            $ref = new \ReflectionMethod($this->page, 'nuclen_persist_settings');
+            $ref->setAccessible(true);
+            $saved = $ref->invoke($this->page, ['theme' => 'dark']);
+            $repo = SettingsRepository::get_instance();
+            $this->assertSame('dark', $repo->get('theme'));
+            $this->assertSame('dark', $saved['theme']);
+        }
+
+        public function test_output_save_notice_prints_html(): void {
+            $ref = new \ReflectionMethod($this->page, 'nuclen_output_save_notice');
+            $ref->setAccessible(true);
+            ob_start();
+            $ref->invoke($this->page);
+            $html = ob_get_clean();
+            $this->assertStringContainsString('Settings saved.', $html);
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- refactor SettingsPageSaveTrait to delegate to helper methods
- add unit tests covering new helpers

## Testing
- `composer lint` *(fails: command not found)*
- `composer test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685d7830929883278644d7744230016c

<!-- Korbit AI PR Description Start -->
## Description by Korbit AI

### What change is being made?
Refactor the save logic for the settings page by extracting distinct operations into private methods for input collection, sanitization, and settings persistence, while introducing unit tests for these operations.

### Why are these changes being made?
This refactoring aims to improve code maintainability and readability by breaking down a monolithic function into smaller, well-defined methods, which enhances modularity and facilitates easier testing. Additionally, introducing unit tests ensures that the new refactored code performs operations as expected, thereby increasing the reliability of the settings page save logic.

> Is this description stale? Ask me to generate a new description by commenting `/korbit-generate-pr-description`
<!-- Korbit AI PR Description End -->