### PR TITLE
Introduce summary meta constants

### DIFF
--- a/nuclear-engagement/admin/Dashboard.php
+++ b/nuclear-engagement/admin/Dashboard.php
@@ -17,6 +17,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 use NuclearEngagement\Utils\Utils;
 use NuclearEngagement\Services\DashboardDataService;
 use NuclearEngagement\Core\SettingsRepository;
+use NuclearEngagement\Modules\Summary\Summary_Service;
 
 global $wpdb;
 
@@ -142,7 +143,7 @@ if ( null === $inventory_cache ) {
                 JOIN {$wpdb->term_taxonomy}  tt ON tt.term_taxonomy_id = tr.term_taxonomy_id AND tt.taxonomy = 'category'
                 JOIN {$wpdb->terms}          t  ON t.term_id = tt.term_id
                 LEFT JOIN {$wpdb->postmeta}  pm_q ON pm_q.post_id = p.ID AND pm_q.meta_key = 'nuclen-quiz-data'
-                LEFT JOIN {$wpdb->postmeta}  pm_s ON pm_s.post_id = p.ID AND pm_s.meta_key = 'nuclen-summary-data'
+                LEFT JOIN {$wpdb->postmeta}  pm_s ON pm_s.post_id = p.ID AND pm_s.meta_key = '" . Summary_Service::META_KEY . "'
                 WHERE p.post_type  IN ($placeholders_pt)
                   AND p.post_status IN ($placeholders_st)
                 GROUP BY t.term_id",

--- a/nuclear-engagement/admin/Traits/AdminAutoGenerate.php
+++ b/nuclear-engagement/admin/Traits/AdminAutoGenerate.php
@@ -64,8 +64,8 @@ trait AdminAutoGenerate {
 
 		// Auto-generate summary
 		if ( $gen_summary ) {
-			// Skip if summary is protected
-			$protected = get_post_meta( $post->ID, 'nuclen_summary_protected', true );
+                        // Skip if summary is protected
+                        $protected = get_post_meta( $post->ID, \NuclearEngagement\Modules\Summary\Summary_Service::PROTECTED_KEY, true );
 			if ( ! $protected ) {
 				$this->nuclen_generate_single( $post->ID, 'summary' );
 			}

--- a/nuclear-engagement/bootstrap.php
+++ b/nuclear-engagement/bootstrap.php
@@ -187,7 +187,7 @@ function nuclen_update_migrate_post_meta() {
 	$wpdb->query(
 		$wpdb->prepare(
 			"UPDATE {$wpdb->postmeta} SET meta_key = %s WHERE meta_key = %s",
-			'nuclen-summary-data',
+                        \NuclearEngagement\Modules\Summary\Summary_Service::META_KEY,
 			'ne-summary-data'
 		)
 	);

--- a/nuclear-engagement/front/Controller/Rest/ContentController.php
+++ b/nuclear-engagement/front/Controller/Rest/ContentController.php
@@ -14,6 +14,7 @@ use NuclearEngagement\Requests\ContentRequest;
 use NuclearEngagement\Services\ContentStorageService;
 use NuclearEngagement\Core\SettingsRepository;
 use NuclearEngagement\Utils\Utils;
+use NuclearEngagement\Modules\Summary\Summary_Service;
 
 if ( ! defined( 'ABSPATH' ) ) {
 	exit;
@@ -94,7 +95,7 @@ class ContentController {
 			// Get date from first stored item
 			reset( $contentRequest->results );
 			$firstPostId = key( $contentRequest->results );
-			$metaKey     = $contentRequest->workflow === 'quiz' ? 'nuclen-quiz-data' : 'nuclen-summary-data';
+                        $metaKey     = $contentRequest->workflow === 'quiz' ? 'nuclen-quiz-data' : Summary_Service::META_KEY;
 			$stored      = get_post_meta( $firstPostId, $metaKey, true );
 			$date        = is_array( $stored ) && ! empty( $stored['date'] ) ? $stored['date'] : '';
 

--- a/nuclear-engagement/front/traits/AssetsTrait.php
+++ b/nuclear-engagement/front/traits/AssetsTrait.php
@@ -15,6 +15,7 @@ declare(strict_types=1);
 namespace NuclearEngagement\Front;
 
 use NuclearEngagement\Core\AssetVersions;
+use NuclearEngagement\Modules\Summary\Summary_Service;
 
 if ( ! defined( 'ABSPATH' ) ) {
 	exit;
@@ -93,8 +94,8 @@ trait AssetsTrait {
 			}
 		}
 
-		if ( $display_summary !== 'manual' && $display_summary !== 'none' ) {
-			$summary_meta = get_post_meta( $post_id, 'nuclen-summary-data', true );
+                if ( $display_summary !== 'manual' && $display_summary !== 'none' ) {
+                        $summary_meta = get_post_meta( $post_id, Summary_Service::META_KEY, true );
 			if ( is_array( $summary_meta ) && ! empty( trim( $summary_meta['summary'] ?? '' ) ) ) {
 				return true;
 			}

--- a/nuclear-engagement/inc/Core/Activator.php
+++ b/nuclear-engagement/inc/Core/Activator.php
@@ -7,6 +7,7 @@ namespace NuclearEngagement\Core;
 use NuclearEngagement\Core\SettingsRepository;
 use NuclearEngagement\OptinData;
 use NuclearEngagement\Core\AssetVersions;
+use NuclearEngagement\Modules\Summary\Summary_Service;
 
 if ( ! defined( 'ABSPATH' ) ) {
     exit;
@@ -52,9 +53,9 @@ class Activator {
             $table   = $wpdb->postmeta;
             $indexes = array(
                 'nuclen_quiz_data_idx'         => 'nuclen-quiz-data',
-                'nuclen_summary_data_idx'      => 'nuclen-summary-data',
+                'nuclen_summary_data_idx'      => Summary_Service::META_KEY,
                 'nuclen_quiz_protected_idx'    => 'nuclen_quiz_protected',
-                'nuclen_summary_protected_idx' => 'nuclen_summary_protected',
+                'nuclen_summary_protected_idx' => Summary_Service::PROTECTED_KEY,
             );
 
             foreach ( $indexes as $index => $meta_key ) {

--- a/nuclear-engagement/inc/Core/MetaRegistration.php
+++ b/nuclear-engagement/inc/Core/MetaRegistration.php
@@ -11,6 +11,7 @@ declare(strict_types=1);
 namespace NuclearEngagement\Core;
 
 use function NuclearEngagement\nuclen_settings_array;
+use NuclearEngagement\Modules\Summary\Summary_Service;
 
 if ( ! defined( 'ABSPATH' ) ) {
     exit;
@@ -69,7 +70,7 @@ class MetaRegistration {
             // Register summary data meta
             register_post_meta(
                 $post_type,
-                'nuclen-summary-data',
+                Summary_Service::META_KEY,
                 array(
                     'type'              => 'string',
                     'description'       => 'Nuclear Engagement summary data',
@@ -82,7 +83,7 @@ class MetaRegistration {
 
             register_post_meta(
                 $post_type,
-                'nuclen_summary_protected',
+                Summary_Service::PROTECTED_KEY,
                 array(
                     'type'              => 'boolean',
                     'description'       => 'Nuclear Engagement summary protection flag',

--- a/nuclear-engagement/inc/Modules/Summary/Summary_Service.php
+++ b/nuclear-engagement/inc/Modules/Summary/Summary_Service.php
@@ -1,0 +1,18 @@
+<?php
+declare(strict_types=1);
+/**
+ * Summary data storage constants.
+ *
+ * @package NuclearEngagement\Modules\Summary
+ */
+
+namespace NuclearEngagement\Modules\Summary;
+
+if ( ! defined( 'ABSPATH' ) ) {
+    exit;
+}
+
+final class Summary_Service {
+    public const META_KEY      = 'nuclen-summary-data';
+    public const PROTECTED_KEY = 'nuclen_summary_protected';
+}

--- a/nuclear-engagement/inc/Modules/Summary/includes/Nuclen_Summary_Metabox.php
+++ b/nuclear-engagement/inc/Modules/Summary/includes/Nuclen_Summary_Metabox.php
@@ -14,6 +14,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 }
 
 use NuclearEngagement\Core\SettingsRepository;
+use NuclearEngagement\Modules\Summary\Summary_Service;
 
 final class Nuclen_Summary_Metabox {
 
@@ -57,7 +58,7 @@ final class Nuclen_Summary_Metabox {
 	 * ---------------------------------------------------------------------- */
 
 	public function nuclen_render_summary_data_meta_box( $post ) {
-		$summary_data = get_post_meta( $post->ID, 'nuclen-summary-data', true );
+                $summary_data = get_post_meta( $post->ID, Summary_Service::META_KEY, true );
 		if ( ! empty( $summary_data ) ) {
 			$summary_data = maybe_unserialize( $summary_data );
 		} else {
@@ -73,7 +74,7 @@ final class Nuclen_Summary_Metabox {
 		$summary = $summary_data['summary'] ?? '';
 		$date    = $summary_data['date'] ?? '';
 
-		$summary_protected = get_post_meta( $post->ID, 'nuclen_summary_protected', true );
+                $summary_protected = get_post_meta( $post->ID, Summary_Service::PROTECTED_KEY, true );
 
 				require NUCLEN_PLUGIN_DIR . 'templates/admin/summary-metabox.php';
 	}
@@ -108,7 +109,7 @@ final class Nuclen_Summary_Metabox {
 		);
 
 		/* ---- Save to DB --------------------------------------------------- */
-		$updated = update_post_meta( $post_id, 'nuclen-summary-data', $formatted );
+                $updated = update_post_meta( $post_id, Summary_Service::META_KEY, $formatted );
 		if ( false === $updated ) {
 			\NuclearEngagement\Services\LoggingService::log( 'Failed to update summary data for post ' . $post_id );
 			\NuclearEngagement\Services\LoggingService::notify_admin( 'Failed to update summary data for post ' . $post_id );
@@ -140,14 +141,14 @@ final class Nuclen_Summary_Metabox {
 		}
 
 		/* ---- Protected flag ---------------------------------------------- */
-		if ( isset( $_POST['nuclen_summary_protected'] ) && $_POST['nuclen_summary_protected'] === '1' ) {
-			$updated_prot = update_post_meta( $post_id, 'nuclen_summary_protected', 1 );
-			if ( false === $updated_prot ) {
-				\NuclearEngagement\Services\LoggingService::log( 'Failed to update summary protected flag for post ' . $post_id );
-				\NuclearEngagement\Services\LoggingService::notify_admin( 'Failed to update summary protected flag for post ' . $post_id );
-			}
-		} else {
-			delete_post_meta( $post_id, 'nuclen_summary_protected' );
-		}
+                if ( isset( $_POST[ Summary_Service::PROTECTED_KEY ] ) && $_POST[ Summary_Service::PROTECTED_KEY ] === '1' ) {
+                        $updated_prot = update_post_meta( $post_id, Summary_Service::PROTECTED_KEY, 1 );
+                        if ( false === $updated_prot ) {
+                                \NuclearEngagement\Services\LoggingService::log( 'Failed to update summary protected flag for post ' . $post_id );
+                                \NuclearEngagement\Services\LoggingService::notify_admin( 'Failed to update summary protected flag for post ' . $post_id );
+                        }
+                } else {
+                        delete_post_meta( $post_id, Summary_Service::PROTECTED_KEY );
+                }
 	}
 }

--- a/nuclear-engagement/inc/Modules/Summary/includes/Nuclen_Summary_Shortcode.php
+++ b/nuclear-engagement/inc/Modules/Summary/includes/Nuclen_Summary_Shortcode.php
@@ -5,6 +5,7 @@ namespace NuclearEngagement\Modules\Summary;
 
 use NuclearEngagement\Core\SettingsRepository;
 use NuclearEngagement\Front\FrontClass;
+use NuclearEngagement\Modules\Summary\Summary_Service;
 
 if ( ! defined( 'ABSPATH' ) ) {
 	exit;
@@ -41,10 +42,10 @@ final class Nuclen_Summary_Shortcode {
 		return $html;
 	}
 
-	private function getSummaryData() {
-		$post_id = get_the_ID();
-		return get_post_meta( $post_id, 'nuclen-summary-data', true );
-	}
+        private function getSummaryData() {
+                $post_id = get_the_ID();
+                return get_post_meta( $post_id, Summary_Service::META_KEY, true );
+        }
 
 	private function isValidSummaryData( $summary_data ): bool {
 		return ! empty( $summary_data ) && ! empty( trim( $summary_data['summary'] ?? '' ) );

--- a/nuclear-engagement/inc/Services/ContentStorageService.php
+++ b/nuclear-engagement/inc/Services/ContentStorageService.php
@@ -12,6 +12,7 @@ namespace NuclearEngagement\Services;
 
 use NuclearEngagement\Core\SettingsRepository;
 use NuclearEngagement\Utils\Utils;
+use NuclearEngagement\Modules\Summary\Summary_Service;
 
 if ( ! defined( 'ABSPATH' ) ) {
     exit;
@@ -189,7 +190,7 @@ class ContentStorageService {
             'date'    => $data['date'] ?? current_time( 'mysql' ),
         );
 
-        if ( ! update_post_meta( $postId, 'nuclen-summary-data', $formatted ) ) {
+        if ( ! update_post_meta( $postId, Summary_Service::META_KEY, $formatted ) ) {
             throw new \RuntimeException( "Failed to update summary data for post {$postId}" );
         }
     }

--- a/nuclear-engagement/inc/Services/DashboardDataService.php
+++ b/nuclear-engagement/inc/Services/DashboardDataService.php
@@ -10,6 +10,8 @@ declare(strict_types=1);
 
 namespace NuclearEngagement\Services;
 
+use NuclearEngagement\Modules\Summary\Summary_Service;
+
 if ( ! defined( 'ABSPATH' ) ) {
     exit;
 }
@@ -141,7 +143,7 @@ class DashboardDataService {
                    SUM(CASE WHEN pm_s.meta_id IS NULL THEN 1 ELSE 0 END) AS summary_without
             FROM {$wpdb->posts} p
             LEFT JOIN {$wpdb->postmeta} pm_q ON pm_q.post_id = p.ID AND pm_q.meta_key = 'nuclen-quiz-data'
-            LEFT JOIN {$wpdb->postmeta} pm_s ON pm_s.post_id = p.ID AND pm_s.meta_key = 'nuclen-summary-data'
+            LEFT JOIN {$wpdb->postmeta} pm_s ON pm_s.post_id = p.ID AND pm_s.meta_key = '" . Summary_Service::META_KEY . "'
             WHERE p.post_type IN ($placeholders_pt)
               AND p.post_status IN ($placeholders_st)
             GROUP BY $group_by",

--- a/nuclear-engagement/inc/Services/GenerationService.php
+++ b/nuclear-engagement/inc/Services/GenerationService.php
@@ -16,6 +16,7 @@ use NuclearEngagement\Core\SettingsRepository;
 use NuclearEngagement\Utils\Utils;
 use NuclearEngagement\Services\ApiException;
 use NuclearEngagement\Services\PostDataFetcher;
+use NuclearEngagement\Modules\Summary\Summary_Service;
 
 if ( ! defined( 'ABSPATH' ) ) {
     exit;
@@ -241,7 +242,7 @@ class GenerationService {
      * @return bool
      */
     private function isProtected( int $postId, string $workflowType ): bool {
-        $metaKey = $workflowType === 'quiz' ? 'nuclen_quiz_protected' : 'nuclen_summary_protected';
+        $metaKey = $workflowType === 'quiz' ? 'nuclen_quiz_protected' : Summary_Service::PROTECTED_KEY;
         return (bool) get_post_meta( $postId, $metaKey, true );
     }
 }

--- a/nuclear-engagement/inc/Services/PostDataFetcher.php
+++ b/nuclear-engagement/inc/Services/PostDataFetcher.php
@@ -10,6 +10,8 @@ declare(strict_types=1);
 
 namespace NuclearEngagement\Services;
 
+use NuclearEngagement\Modules\Summary\Summary_Service;
+
 if ( ! defined( 'ABSPATH' ) ) {
     exit;
 }
@@ -85,7 +87,7 @@ class PostDataFetcher {
                AND pmq.meta_id IS NULL
                AND pms.meta_id IS NULL
              ORDER BY FIELD(p.ID, $order_ids)",
-            array_merge( array( 'nuclen_quiz_protected', 'nuclen_summary_protected' ), $ids )
+            array_merge( array( 'nuclen_quiz_protected', Summary_Service::PROTECTED_KEY ), $ids )
         );
 
                $rows = $wpdb->get_results( $sql );

--- a/nuclear-engagement/inc/Services/PostsQueryService.php
+++ b/nuclear-engagement/inc/Services/PostsQueryService.php
@@ -12,6 +12,7 @@ namespace NuclearEngagement\Services;
 
 use NuclearEngagement\Requests\PostsCountRequest;
 use NuclearEngagement\Services\LoggingService;
+use NuclearEngagement\Modules\Summary\Summary_Service;
 
 if ( ! defined( 'ABSPATH' ) ) {
     exit;
@@ -136,7 +137,7 @@ class PostsQueryService {
 
         // Skip existing data if not allowing regeneration
         if ( ! $request->allowRegenerate ) {
-            $metaKey     = $request->workflow === 'quiz' ? 'nuclen-quiz-data' : 'nuclen-summary-data';
+            $metaKey     = $request->workflow === 'quiz' ? 'nuclen-quiz-data' : Summary_Service::META_KEY;
             $metaQuery[] = array(
                 'key'     => $metaKey,
                 'compare' => 'NOT EXISTS',
@@ -145,7 +146,7 @@ class PostsQueryService {
 
         // Skip protected data if not allowed
         if ( ! $request->regenerateProtected ) {
-            $protectedKey = $request->workflow === 'quiz' ? 'nuclen_quiz_protected' : 'nuclen_summary_protected';
+            $protectedKey = $request->workflow === 'quiz' ? 'nuclen_quiz_protected' : Summary_Service::PROTECTED_KEY;
             $metaQuery[]  = array(
                 'relation' => 'OR',
                 array(
@@ -214,13 +215,13 @@ class PostsQueryService {
         }
 
         if ( ! $request->allowRegenerate ) {
-                $meta_key = $request->workflow === 'quiz' ? 'nuclen-quiz-data' : 'nuclen-summary-data';
+                $meta_key = $request->workflow === 'quiz' ? 'nuclen-quiz-data' : Summary_Service::META_KEY;
                 $joins[]  = $wpdb->prepare( "LEFT JOIN {$wpdb->postmeta} pm_exist ON pm_exist.post_id = p.ID AND pm_exist.meta_key = %s", $meta_key );
                 $wheres[] = 'pm_exist.meta_id IS NULL';
         }
 
         if ( ! $request->regenerateProtected ) {
-                $prot_key = $request->workflow === 'quiz' ? 'nuclen_quiz_protected' : 'nuclen_summary_protected';
+                $prot_key = $request->workflow === 'quiz' ? 'nuclen_quiz_protected' : Summary_Service::PROTECTED_KEY;
                 $joins[]  = $wpdb->prepare( "LEFT JOIN {$wpdb->postmeta} pm_prot ON pm_prot.post_id = p.ID AND pm_prot.meta_key = %s", $prot_key );
                 $wheres[] = "(pm_prot.meta_id IS NULL OR pm_prot.meta_value != '1')";
         }

--- a/nuclear-engagement/inc/Services/PublishGenerationHandler.php
+++ b/nuclear-engagement/inc/Services/PublishGenerationHandler.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 namespace NuclearEngagement\Services;
 
 use NuclearEngagement\Core\SettingsRepository;
+use NuclearEngagement\Modules\Summary\Summary_Service;
 
 if ( ! defined( 'ABSPATH' ) ) {
         exit;
@@ -88,7 +89,7 @@ class PublishGenerationHandler {
         }
 
         if ( $gen_summary ) {
-            $protected = get_post_meta( $post->ID, 'nuclen_summary_protected', true );
+            $protected = get_post_meta( $post->ID, Summary_Service::PROTECTED_KEY, true );
             if ( ! $protected ) {
                 $args = array( $post->ID, 'summary' );
                 if ( ! wp_next_scheduled( AutoGenerationService::START_HOOK, $args ) ) {

--- a/nuclear-engagement/templates/admin/summary-metabox.php
+++ b/nuclear-engagement/templates/admin/summary-metabox.php
@@ -1,12 +1,14 @@
 <?php
 if ( ! defined( 'ABSPATH' ) ) {
-	exit;
+        exit;
 }
+
+use NuclearEngagement\Modules\Summary\Summary_Service;
 
 wp_nonce_field( 'nuclen_summary_data_nonce', 'nuclen_summary_data_nonce' );
 ?>
 <div><label>
-	<input type="checkbox" name="nuclen_summary_protected" value="1" <?php checked( $summary_protected, 1 ); ?> />
+        <input type="checkbox" name="<?php echo esc_attr( Summary_Service::PROTECTED_KEY ); ?>" value="1" <?php checked( $summary_protected, 1 ); ?> />
 	<?php esc_html_e( 'Protected?', 'nuclear-engagement' ); ?>
 	<span nuclen-tooltip="<?php esc_attr_e( 'Tick this box and save post to prevent overwriting during bulk generation.', 'nuclear-engagement' ); ?>">🛈</span>
 </label></div>

--- a/nuclear-engagement/uninstall.php
+++ b/nuclear-engagement/uninstall.php
@@ -64,15 +64,15 @@ $delete_css       = ! empty( $settings['delete_custom_css_on_uninstall'] );
 
 // Delete generated content from post meta if requested.
 if ( $delete_generated ) {
-				$meta_keys = array(
-					'nuclen-quiz-data',
-					'nuclen-summary-data',
-					'nuclen_quiz_protected',
-					'nuclen_summary_protected',
-				);
-				foreach ( $meta_keys as $mk ) {
-						delete_post_meta_by_key( $mk );
-				}
+                                $meta_keys = array(
+                                        'nuclen-quiz-data',
+                                        \NuclearEngagement\Modules\Summary\Summary_Service::META_KEY,
+                                        'nuclen_quiz_protected',
+                                        \NuclearEngagement\Modules\Summary\Summary_Service::PROTECTED_KEY,
+                                );
+                                foreach ( $meta_keys as $mk ) {
+                                                delete_post_meta_by_key( $mk );
+                                }
 }
 
 // Delete plugin settings if requested.

--- a/tests/AutoGenerationQueueTest.php
+++ b/tests/AutoGenerationQueueTest.php
@@ -2,6 +2,7 @@
 use PHPUnit\Framework\TestCase;
 use NuclearEngagement\Services\AutoGenerationQueue;
 use NuclearEngagement\Core\SettingsRepository;
+use NuclearEngagement\Modules\Summary\Summary_Service;
 
 class DummyRemoteApiService {
     public array $updates = [];
@@ -40,7 +41,7 @@ class AQ_WPDB {
             if ($p->post_status !== 'publish') {
                 continue;
             }
-            if (!empty($GLOBALS['wp_meta'][$id]['nuclen_quiz_protected']) || !empty($GLOBALS['wp_meta'][$id]['nuclen_summary_protected'])) {
+            if (!empty($GLOBALS['wp_meta'][$id]['nuclen_quiz_protected']) || !empty($GLOBALS['wp_meta'][$id][Summary_Service::PROTECTED_KEY])) {
                 continue;
             }
             $rows[] = (object) [

--- a/tests/AutoGenerationServiceTest.php
+++ b/tests/AutoGenerationServiceTest.php
@@ -3,6 +3,7 @@ use PHPUnit\Framework\TestCase;
 use NuclearEngagement\Services\AutoGenerationService;
 use NuclearEngagement\Core\SettingsRepository;
 use NuclearEngagement\Services\ApiException;
+use NuclearEngagement\Modules\Summary\Summary_Service;
 
 class DummyRemoteApiService {
     public array $updates = [];
@@ -38,7 +39,7 @@ class AQ_WPDB {
             if (!isset($GLOBALS['wp_posts'][$id])) { continue; }
             $p = $GLOBALS['wp_posts'][$id];
             if ($p->post_status !== 'publish') { continue; }
-            if (!empty($GLOBALS['wp_meta'][$id]['nuclen_quiz_protected']) || !empty($GLOBALS['wp_meta'][$id]['nuclen_summary_protected'])) {
+            if (!empty($GLOBALS['wp_meta'][$id]['nuclen_quiz_protected']) || !empty($GLOBALS['wp_meta'][$id][Summary_Service::PROTECTED_KEY])) {
                 continue;
             }
             $rows[] = (object) [ 'ID' => $p->ID, 'post_title' => $p->post_title, 'post_content' => $p->post_content ];

--- a/tests/ContentControllerTest.php
+++ b/tests/ContentControllerTest.php
@@ -16,6 +16,7 @@ namespace {
     use NuclearEngagement\Front\Controller\Rest\ContentController;
     use NuclearEngagement\Core\SettingsRepository;
     use NuclearEngagement\Services\ContentStorageService;
+    use NuclearEngagement\Modules\Summary\Summary_Service;
     if (!function_exists('__')) {
         function __($t, $d = null) { return $t; }
     }
@@ -55,7 +56,7 @@ namespace {
         public array $stored = [];
         public function storeResults(array $results, string $workflowType): array {
             global $wp_meta;
-            $metaKey = $workflowType === 'quiz' ? 'nuclen-quiz-data' : 'nuclen-summary-data';
+            $metaKey = $workflowType === 'quiz' ? 'nuclen-quiz-data' : Summary_Service::META_KEY;
             foreach ($results as $id => $data) {
                 $wp_meta[$id][$metaKey] = $data;
             }

--- a/tests/GenerationServiceTest.php
+++ b/tests/GenerationServiceTest.php
@@ -4,6 +4,7 @@ use NuclearEngagement\Services\GenerationService;
 use NuclearEngagement\Core\SettingsRepository;
 use NuclearEngagement\Requests\GenerateRequest;
 use NuclearEngagement\Services\ApiException;
+use NuclearEngagement\Modules\Summary\Summary_Service;
 
 class GS_WPDB {
     public $posts = 'wp_posts';
@@ -26,7 +27,7 @@ class GS_WPDB {
             if (!isset($GLOBALS['wp_posts'][$id])) { continue; }
             $p = $GLOBALS['wp_posts'][$id];
             if ($p->post_status !== 'publish') { continue; }
-            if (!empty($GLOBALS['wp_meta'][$id]['nuclen_quiz_protected']) || !empty($GLOBALS['wp_meta'][$id]['nuclen_summary_protected'])) { continue; }
+            if (!empty($GLOBALS['wp_meta'][$id]['nuclen_quiz_protected']) || !empty($GLOBALS['wp_meta'][$id][Summary_Service::PROTECTED_KEY])) { continue; }
             $rows[] = (object) [
                 'ID' => $p->ID,
                 'post_title' => $p->post_title,

--- a/tests/PostsQueryServiceTest.php
+++ b/tests/PostsQueryServiceTest.php
@@ -11,6 +11,7 @@ namespace {
     use PHPUnit\Framework\TestCase;
     use NuclearEngagement\Services\PostsQueryService;
     use NuclearEngagement\Requests\PostsCountRequest;
+    use NuclearEngagement\Modules\Summary\Summary_Service;
     if (!defined('MINUTE_IN_SECONDS')) { define('MINUTE_IN_SECONDS', 60); }
 
     // ------------------------------------------------------
@@ -100,11 +101,11 @@ namespace {
 
             $expected_meta = [
                 'relation' => 'AND',
-                [ 'key' => 'nuclen-summary-data', 'compare' => 'NOT EXISTS' ],
+                [ 'key' => Summary_Service::META_KEY, 'compare' => 'NOT EXISTS' ],
                 [
                     'relation' => 'OR',
-                    [ 'key' => 'nuclen_summary_protected', 'compare' => 'NOT EXISTS' ],
-                    [ 'key' => 'nuclen_summary_protected', 'value' => '1', 'compare' => '!=' ],
+                    [ 'key' => Summary_Service::PROTECTED_KEY, 'compare' => 'NOT EXISTS' ],
+                    [ 'key' => Summary_Service::PROTECTED_KEY, 'value' => '1', 'compare' => '!=' ],
                 ],
             ];
 

--- a/tests/ScheduleFailureTest.php
+++ b/tests/ScheduleFailureTest.php
@@ -18,6 +18,7 @@ namespace {
     use NuclearEngagement\Services\AutoGenerationService;
     use NuclearEngagement\Services\GenerationPoller;
     use NuclearEngagement\Core\SettingsRepository;
+    use NuclearEngagement\Modules\Summary\Summary_Service;
     class DummyRemoteApiService {
         public array $updates = [];
         public $generateResponse = [];
@@ -51,7 +52,7 @@ namespace {
                 if (!isset($GLOBALS['wp_posts'][$id])) { continue; }
                 $p = $GLOBALS['wp_posts'][$id];
                 if ($p->post_status !== 'publish') { continue; }
-                if (!empty($GLOBALS['wp_meta'][$id]['nuclen_quiz_protected']) || !empty($GLOBALS['wp_meta'][$id]['nuclen_summary_protected'])) { continue; }
+                if (!empty($GLOBALS['wp_meta'][$id]['nuclen_quiz_protected']) || !empty($GLOBALS['wp_meta'][$id][Summary_Service::PROTECTED_KEY])) { continue; }
                 $rows[] = (object) [ 'ID' => $p->ID, 'post_title' => $p->post_title, 'post_content' => $p->post_content ];
             }
             return $rows;

--- a/tests/SummaryMetaboxFailureTest.php
+++ b/tests/SummaryMetaboxFailureTest.php
@@ -21,6 +21,7 @@ namespace NuclearEngagement\Services {
 namespace {
     use PHPUnit\Framework\TestCase;
     use NuclearEngagement\Modules\Summary\Nuclen_Summary_Metabox;
+    use NuclearEngagement\Modules\Summary\Summary_Service;
     class DummyRepo {
         public function get($key, $default = 0) { return 0; }
     }
@@ -49,7 +50,7 @@ namespace {
         }
 
         public function test_protected_flag_logs_on_failure(): void {
-            $_POST['nuclen_summary_protected'] = '1';
+            $_POST[Summary_Service::PROTECTED_KEY] = '1';
             $box = new Nuclen_Summary_Metabox(new DummyRepo());
             $box->nuclen_save_summary_data_meta(2);
             $expected = [

--- a/tests/SummaryShortcodeViewTest.php
+++ b/tests/SummaryShortcodeViewTest.php
@@ -3,6 +3,7 @@ namespace {
     use PHPUnit\Framework\TestCase;
     use NuclearEngagement\Modules\Summary\Nuclen_Summary_Shortcode as SummaryShortcode;
     use NuclearEngagement\Modules\Summary\Nuclen_Summary_View as SummaryView;
+    use NuclearEngagement\Modules\Summary\Summary_Service;
     use NuclearEngagement\Core\SettingsRepository;
 
     function get_the_ID() { return $GLOBALS['current_post_id'] ?? 0; }
@@ -40,7 +41,7 @@ namespace {
         public function test_render_outputs_markup_with_valid_data(): void {
             global $wp_meta, $current_post_id;
             $current_post_id = 1;
-            $wp_meta[1]['nuclen-summary-data'] = ['summary' => '<p>Hi</p>'];
+            $wp_meta[1][Summary_Service::META_KEY] = ['summary' => '<p>Hi</p>'];
 
             $settings = SettingsRepository::get_instance();
             $settings->set_string('summary_title', 'Facts')->set_bool('show_attribution', true)->save();
@@ -58,7 +59,7 @@ namespace {
         public function test_render_returns_empty_string_when_data_invalid(): void {
             global $wp_meta, $current_post_id;
             $current_post_id = 2;
-            $wp_meta[2]['nuclen-summary-data'] = ['summary' => ''];
+            $wp_meta[2][Summary_Service::META_KEY] = ['summary' => ''];
 
             $front = new DummyFront();
             $sc = $this->makeShortcode($front);

--- a/tests/UninstallTest.php
+++ b/tests/UninstallTest.php
@@ -1,5 +1,6 @@
 <?php
 use PHPUnit\Framework\TestCase;
+use NuclearEngagement\Modules\Summary\Summary_Service;
 
 if (!defined('WP_UNINSTALL_PLUGIN')) {
     define('WP_UNINSTALL_PLUGIN', true);
@@ -66,7 +67,7 @@ class UninstallTest extends TestCase {
                 'nuclen_quiz_protected' => '1',
             ],
             2 => [
-                'nuclen-summary-data' => 's',
+                Summary_Service::META_KEY => 's',
             ],
         ];
 
@@ -117,7 +118,7 @@ class UninstallTest extends TestCase {
         $this->assertFileDoesNotExist($this->baseDir . '/nuclear-engagement/log.txt');
         $this->assertFileDoesNotExist($this->baseDir . '/nuclear-engagement/nuclen-theme-custom.css');
 
-        $this->assertSame(['nuclen-quiz-data', 'nuclen-summary-data', 'nuclen_quiz_protected', 'nuclen_summary_protected'], $GLOBALS['deleted_meta_keys']);
+        $this->assertSame(['nuclen-quiz-data', Summary_Service::META_KEY, 'nuclen_quiz_protected', Summary_Service::PROTECTED_KEY], $GLOBALS['deleted_meta_keys']);
         $expected_files = [
             $this->baseDir . '/nuclear-engagement/log.txt',
             $this->baseDir . '/nuclear-engagement/nuclen-theme-custom.css',


### PR DESCRIPTION
## Summary
- define `Summary_Service` with `META_KEY` and `PROTECTED_KEY`
- replace literal summary meta keys with constants throughout PHP
- update templates to output the new constants
- update unit tests to reference `Summary_Service`

## Testing
- `composer lint` *(fails: composer not installed)*
- `composer test` *(fails: composer not installed)*

------
https://chatgpt.com/codex/tasks/task_e_685d7832c2dc8327b5cffd79c88ec07f