### PR TITLE
Fix duplicate aliasing in SetupHandlersTrait

### DIFF
--- a/nuclear-engagement/admin/SetupHandlersTrait.php
+++ b/nuclear-engagement/admin/SetupHandlersTrait.php
@@ -15,8 +15,6 @@ declare(strict_types=1);
 
 namespace NuclearEngagement\Admin;
 
-use NuclearEngagement\Core\SettingsRepository;
-use NuclearEngagement\Services\SetupService;
 
 if ( ! defined( 'ABSPATH' ) ) {
 	exit;


### PR DESCRIPTION
## Summary
- remove unused import statements from `SetupHandlersTrait`

## Testing
- `composer lint` *(fails: command not found)*
- `composer test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685e255b3b4883278dfb8f781770b213

<!-- Korbit AI PR Description Start -->
## Description by Korbit AI

### What change is being made?

Remove duplicate aliasing of `SettingsRepository` and `SetupService` in `SetupHandlersTrait.php`.

### Why are these changes being made?

The imported classes were not used within the file, leading to unnecessary aliasing that could cause confusion or maintenance overhead. Removing these lines cleans up the code and adheres to best practices by ensuring only necessary dependencies are imported.

> Is this description stale? Ask me to generate a new description by commenting `/korbit-generate-pr-description`
<!-- Korbit AI PR Description End -->