### PR TITLE
Handle failed generation start

### DIFF
--- a/src/admin/ts/single/single-generation-handlers.ts
+++ b/src/admin/ts/single/single-generation-handlers.ts
@@ -31,10 +31,24 @@ export function initSingleGenerationButtons(): void {
     btn.textContent = 'Generating...';
 
     try {
-      const startResp: StartGenerationResponse = await NuclenStartGeneration({
+      const startResp: StartGenerationResponse | {
+        ok: boolean;
+        status: number;
+        error?: string;
+        data?: { generation_id?: string; [key: string]: unknown };
+        generation_id?: string;
+      } = await NuclenStartGeneration({
         nuclen_selected_post_ids: JSON.stringify([postId]),
         nuclen_selected_generate_workflow: workflow,
       });
+
+      if ('ok' in startResp && !startResp.ok) {
+        alertApiError((startResp as { error?: string }).error || 'Generation failed');
+        btn.textContent = 'Generate';
+        btn.disabled = false;
+        return;
+      }
+
       const generationId =
         startResp.data?.generation_id ||
         startResp.generation_id ||


### PR DESCRIPTION
## Summary
- check `NuclenStartGeneration` result before polling

## Testing
- `npm run lint` *(fails: Cannot find package)*
- `composer lint` *(fails: command not found)*
- `composer test` *(fails: command not found)*
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_685e25819c788327ad9639c83afba27c

<!-- Korbit AI PR Description Start -->
## Description by Korbit AI

### What change is being made?

Enhance the `initSingleGenerationButtons` function to handle and alert users when the `NuclenStartGeneration` API call fails, ensuring the button state resets to 'Generate' and re-enables upon failure.

### Why are these changes being made?

These changes address scenarios where generation start requests fail, providing users with feedback via alerts while maintaining UI consistency by resetting and re-enabling the button. This approach improves user experience by clearly communicating errors and preserving expected interaction flows.

> Is this description stale? Ask me to generate a new description by commenting `/korbit-generate-pr-description`
<!-- Korbit AI PR Description End -->