### PR TITLE
Refactor TOC utils extraction

### DIFF
--- a/nuclear-engagement/inc/Modules/TOC/includes/Nuclen_TOC_Utils.php
+++ b/nuclear-engagement/inc/Modules/TOC/includes/Nuclen_TOC_Utils.php
@@ -58,8 +58,8 @@ final class Nuclen_TOC_Utils {
 	 *     'id'    => 'slugified-id'
 	 * ]
 	 */
-	public static function extract( string $html, array $heading_levels, int $post_id = 0 ): array {
-				$t0 = microtime( true );
+       public static function extract( string $html, array $heading_levels, int $post_id = 0 ): array {
+                               $t0 = microtime( true );
 
 				// If no specific levels provided, use defaults (2-6).
 		if ( empty( $heading_levels ) ) {
@@ -92,67 +92,13 @@ final class Nuclen_TOC_Utils {
 			}
 		}
 
-				// Generate cache key based on content and heading levels.
-				$key       = md5( $html ) . '_' . implode( '', $heading_levels );
-				$transient = 'nuclen_toc_' . $key;
-				$hit       = wp_cache_get( $key, self::CACHE_GROUP );
-		if ( false === $hit ) {
-				$hit = get_transient( $transient );
-		}
+                               list( $key, $transient, $hit ) = self::get_cached_headings( $html, $heading_levels );
+               if ( false !== $hit ) {
+                               self::$last_parse_ms = (int) round( ( microtime( true ) - $t0 ) * 1000 );
+                               return $hit;
+               }
 
-		if ( false !== $hit ) {
-				self::$ids_in_post   = array_fill_keys( wp_list_pluck( $hit, 'id' ), true );
-				self::$last_parse_ms = (int) round( ( microtime( true ) - $t0 ) * 1000 );
-				return $hit;
-		}
-
-				$out               = array();
-				self::$ids_in_post = array();
-
-		if ( nuclen_str_contains( $html, '<h' ) ) {
-				libxml_use_internal_errors( true );
-				$dom = new \DOMDocument();
-				$dom->loadHTML( '<meta http-equiv="Content-Type" content="text/html; charset=utf-8">' . $html, \LIBXML_HTML_NOIMPLIED | \LIBXML_HTML_NODEFDTD );
-				libxml_clear_errors();
-
-				$xpath = new \DOMXPath( $dom );
-				$nodes = $xpath->query( '//h1|//h2|//h3|//h4|//h5|//h6' );
-
-			foreach ( $nodes as $node ) {
-						$tag = strtolower( $node->nodeName );
-						$lvl = (int) substr( $tag, 1 );
-
-						// Skip if not in allowed levels or has skip classes/attributes.
-				if ( ! in_array( $lvl, $heading_levels, true ) ) {
-					continue;
-				}
-				if ( preg_match( '/\bno-?toc\b/i', $node->getAttribute( 'class' ) ) ) {
-					continue;
-				}
-						$data_toc = $node->getAttribute( 'data-toc' );
-				if ( '' !== $data_toc && strtolower( $data_toc ) === 'false' ) {
-						continue;
-				}
-
-						$inner = self::inner_html( $node );
-						$text  = trim( wp_strip_all_tags( $inner ) );
-				if ( '' === $text ) {
-						continue;
-				}
-
-						$id = $node->hasAttribute( 'id' )
-								? sanitize_html_class( $node->getAttribute( 'id' ) )
-								: self::unique_id_from_text( $text );
-
-						$out[] = array(
-							'tag'   => $tag,
-							'level' => $lvl,
-							'text'  => $text,
-							'inner' => $inner,
-							'id'    => $id,
-						);
-			}
-		}
+                               $out = self::parse_headings( $html, $heading_levels );
 
 				wp_cache_set( $key, $out, self::CACHE_GROUP, self::CACHE_TTL );
 				set_transient( $transient, $out, self::CACHE_TTL );
@@ -160,11 +106,90 @@ final class Nuclen_TOC_Utils {
 				return $out;
 	}
 
-		/*
-		 * ----------------------------------------------------------
-		 * Helpers
-		 * ----------------------------------------------------------
-		 */
+        /*
+         * ----------------------------------------------------------
+         * Helpers
+         * ----------------------------------------------------------
+         */
+
+       /**
+        * Retrieve cached headings if available and return cache identifiers.
+        *
+        * @param string $html           Raw HTML content.
+        * @param array  $heading_levels Sanitized heading levels.
+        * @return array{0:string,1:string,2:mixed} [$key, $transient, $hit]
+        */
+       private static function get_cached_headings( string $html, array $heading_levels ): array {
+                       $key       = md5( $html ) . '_' . implode( '', $heading_levels );
+                       $transient = 'nuclen_toc_' . $key;
+                       $hit       = wp_cache_get( $key, self::CACHE_GROUP );
+               if ( false === $hit ) {
+                       $hit = get_transient( $transient );
+               }
+               if ( false !== $hit ) {
+                       self::$ids_in_post = array_fill_keys( wp_list_pluck( $hit, 'id' ), true );
+               }
+                       return array( $key, $transient, $hit );
+       }
+
+       /**
+        * Parse headings from HTML using DOM operations.
+        *
+        * @param string $html           Raw HTML content.
+        * @param array  $heading_levels Sanitized heading levels.
+        * @return array[] Parsed heading data.
+        */
+       private static function parse_headings( string $html, array $heading_levels ): array {
+                       $out               = array();
+                       self::$ids_in_post = array();
+
+               if ( nuclen_str_contains( $html, '<h' ) ) {
+                       libxml_use_internal_errors( true );
+                       $dom = new \DOMDocument();
+                       $dom->loadHTML( '<meta http-equiv="Content-Type" content="text/html; charset=utf-8">' . $html, \LIBXML_HTML_NOIMPLIED | \LIBXML_HTML_NODEFDTD );
+                       libxml_clear_errors();
+
+                       $xpath = new \DOMXPath( $dom );
+                       $nodes = $xpath->query( '//h1|//h2|//h3|//h4|//h5|//h6' );
+
+                       foreach ( $nodes as $node ) {
+                                       $tag = strtolower( $node->nodeName );
+                                       $lvl = (int) substr( $tag, 1 );
+
+                                       // Skip if not in allowed levels or has skip classes/attributes.
+                               if ( ! in_array( $lvl, $heading_levels, true ) ) {
+                                       continue;
+                               }
+                               if ( preg_match( '/\bno-?toc\b/i', $node->getAttribute( 'class' ) ) ) {
+                                       continue;
+                               }
+                                       $data_toc = $node->getAttribute( 'data-toc' );
+                               if ( '' !== $data_toc && strtolower( $data_toc ) === 'false' ) {
+                                       continue;
+                               }
+
+                                       $inner = self::inner_html( $node );
+                                       $text  = trim( wp_strip_all_tags( $inner ) );
+                               if ( '' === $text ) {
+                                       continue;
+                               }
+
+                                       $id = $node->hasAttribute( 'id' )
+                                                       ? sanitize_html_class( $node->getAttribute( 'id' ) )
+                                                       : self::unique_id_from_text( $text );
+
+                                       $out[] = array(
+                                               'tag'   => $tag,
+                                               'level' => $lvl,
+                                               'text'  => $text,
+                                               'inner' => $inner,
+                                               'id'    => $id,
+                                       );
+                       }
+               }
+
+                       return $out;
+       }
 
 		/**
 		 * Generate a unique slug from heading text.


### PR DESCRIPTION
## Summary
- refactor `Nuclen_TOC_Utils::extract` for readability
- move DOM parsing to new `parse_headings` helper
- add `get_cached_headings` helper for cache lookup

## Testing
- `composer lint` *(fails: command not found)*
- `composer test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685e2cfed2208327aa4c617212d8ffa7


> [!NOTE]
> I'm currently writing a description for your pull request. I should be done shortly (<1 minute). Please don't edit the description field until I'm finished, or we may overwrite each other. If I find nothing to write about, I'll delete this message.
