### PR TITLE
Fix test class name conflicts

### DIFF
--- a/tests/AutoGenerationQueueTest.php
+++ b/tests/AutoGenerationQueueTest.php
@@ -4,7 +4,7 @@ use NuclearEngagement\Services\AutoGenerationQueue;
 use NuclearEngagement\Core\SettingsRepository;
 use NuclearEngagement\Modules\Summary\Summary_Service;
 
-class DummyRemoteApiService {
+class QueueDummyRemoteApiService {
     public array $updates = [];
     public $generateResponse = [];
     public array $lastData = [];
@@ -14,7 +14,7 @@ class DummyRemoteApiService {
     }
 }
 
-class DummyContentStorageService {
+class QueueDummyContentStorageService {
     public array $stored = [];
     public function storeResults(array $results, string $workflowType): array {
         $this->stored[] = [$results, $workflowType];
@@ -22,7 +22,7 @@ class DummyContentStorageService {
     }
 }
 
-class AQ_WPDB {
+class Queue_WPDB {
     public $posts = 'wp_posts';
     public $postmeta = 'wp_postmeta';
     public array $args = [];
@@ -55,17 +55,17 @@ class AQ_WPDB {
 }
 
 class AutoGenerationQueueTest extends TestCase {
-    private DummyRemoteApiService $api;
+    private QueueDummyRemoteApiService $api;
     protected function setUp(): void {
         global $wp_options, $wp_autoload, $wp_posts, $wp_meta, $wp_events, $wpdb;
         $wp_options = $wp_autoload = $wp_posts = $wp_meta = $wp_events = [];
-        $wpdb = new AQ_WPDB();
+        $wpdb = new Queue_WPDB();
         SettingsRepository::reset_for_tests();
     }
 
     private function makeQueue(): AutoGenerationQueue {
-        $this->api = new DummyRemoteApiService();
-        $storage   = new DummyContentStorageService();
+        $this->api = new QueueDummyRemoteApiService();
+        $storage   = new QueueDummyContentStorageService();
         return new AutoGenerationQueue($this->api, $storage, new \NuclearEngagement\Services\PostDataFetcher());
     }
 

--- a/tests/AutoGenerationSchedulerTest.php
+++ b/tests/AutoGenerationSchedulerTest.php
@@ -3,7 +3,7 @@ use PHPUnit\Framework\TestCase;
 use NuclearEngagement\Services\AutoGenerationScheduler;
 use NuclearEngagement\Core\SettingsRepository;
 
-class DummyRemoteApiService {
+class SchedulerDummyRemoteApiService {
     public array $updates = [];
     public $generateResponse = [];
     public array $lastData = [];
@@ -11,7 +11,7 @@ class DummyRemoteApiService {
     public function fetch_updates(string $id): array { return $this->updates[$id] ?? []; }
 }
 
-class DummyContentStorageService {
+class SchedulerDummyContentStorageService {
     public array $stored = [];
     public function storeResults(array $results, string $workflowType): array { $this->stored[] = [$results, $workflowType]; return array_fill_keys(array_keys($results), true); }
 }
@@ -23,10 +23,10 @@ class AutoGenerationSchedulerTest extends TestCase {
         SettingsRepository::reset_for_tests();
     }
 
-    private function makeScheduler(?DummyRemoteApiService $api = null): AutoGenerationScheduler {
+    private function makeScheduler(?SchedulerDummyRemoteApiService $api = null): AutoGenerationScheduler {
         $settings = SettingsRepository::get_instance();
-        $api      = $api ?: new DummyRemoteApiService();
-        $storage  = new DummyContentStorageService();
+        $api      = $api ?: new SchedulerDummyRemoteApiService();
+        $storage  = new SchedulerDummyContentStorageService();
         $poller   = new \NuclearEngagement\Services\GenerationPoller($settings, $api, $storage);
         return new AutoGenerationScheduler($poller);
     }
@@ -35,7 +35,7 @@ class AutoGenerationSchedulerTest extends TestCase {
         global $wp_options;
         $id = 'gen123';
         $wp_options['nuclen_active_generations'] = [ $id => ['foo'=>'bar'] ];
-        $api = new DummyRemoteApiService();
+        $api = new SchedulerDummyRemoteApiService();
         $api->updates[$id] = ['results' => ['1'=>['ok']]];
         $scheduler = $this->makeScheduler($api);
         $scheduler->poll_generation($id, 'quiz', [1], 1);

--- a/tests/GenerationPollerTest.php
+++ b/tests/GenerationPollerTest.php
@@ -13,14 +13,14 @@ namespace {
     use NuclearEngagement\Services\GenerationPoller;
     use NuclearEngagement\Core\SettingsRepository;
 
-    class DummyRemoteApiService {
+    class PollerDummyRemoteApiService {
         public array $updates = [];
         public function fetch_updates(string $id): array {
             return $this->updates[$id] ?? [];
         }
     }
 
-    class DummyContentStorageService {
+    class PollerDummyContentStorageService {
         public array $calls = [];
         public function storeResults(array $results, string $workflow): array {
             $this->calls[] = [$results, $workflow];
@@ -37,13 +37,13 @@ namespace {
             SettingsRepository::reset_for_tests();
         }
 
-        private function makePoller(?DummyRemoteApiService $api = null, ?DummyContentStorageService $store = null): GenerationPoller {
+        private function makePoller(?PollerDummyRemoteApiService $api = null, ?PollerDummyContentStorageService $store = null): GenerationPoller {
             $settings = SettingsRepository::get_instance();
             $settings->set_bool('connected', true)
                      ->set_bool('wp_app_pass_created', true)
                      ->save();
-            $api = $api ?: new DummyRemoteApiService();
-            $store = $store ?: new DummyContentStorageService();
+            $api = $api ?: new PollerDummyRemoteApiService();
+            $store = $store ?: new PollerDummyContentStorageService();
             return new GenerationPoller($settings, $api, $store);
         }
 
@@ -67,9 +67,9 @@ namespace {
             global $wp_options, $wp_events;
             $id = 'gid1';
             $wp_options['nuclen_active_generations'] = [$id => ['foo']];
-            $api = new DummyRemoteApiService();
+            $api = new PollerDummyRemoteApiService();
             $api->updates[$id] = ['results' => ['1' => ['ok']]];
-            $store = new DummyContentStorageService();
+            $store = new PollerDummyContentStorageService();
             $poller = $this->makePoller($api, $store);
             $poller->poll_generation($id, 'quiz', [1], 1);
             $this->assertCount(1, $store->calls);

--- a/tests/ScheduleFailureTest.php
+++ b/tests/ScheduleFailureTest.php
@@ -19,7 +19,7 @@ namespace {
     use NuclearEngagement\Services\GenerationPoller;
     use NuclearEngagement\Core\SettingsRepository;
     use NuclearEngagement\Modules\Summary\Summary_Service;
-    class DummyRemoteApiService {
+    class ScheduleFailDummyRemoteApiService {
         public array $updates = [];
         public $generateResponse = [];
         public array $lastData = [];
@@ -32,7 +32,7 @@ namespace {
         }
     }
 
-    class DummyContentStorageService {
+    class ScheduleFailDummyContentStorageService {
         public array $stored = [];
         public function storeResults(array $results, string $type): array {
             $this->stored[] = [$results, $type];
@@ -40,7 +40,7 @@ namespace {
         }
     }
 
-    class AQ_WPDB {
+    class ScheduleFail_WPDB {
         public $posts = 'wp_posts';
         public $postmeta = 'wp_postmeta';
         public array $args = [];
@@ -63,16 +63,16 @@ namespace {
         protected function setUp(): void {
             global $wp_options, $wp_autoload, $wp_posts, $wp_meta, $wp_events, $wpdb;
             $wp_options = $wp_autoload = $wp_posts = $wp_meta = $wp_events = [];
-            $wpdb = new AQ_WPDB();
+            $wpdb = new ScheduleFail_WPDB();
             \NuclearEngagement\Services\LoggingService::$logs = [];
             \NuclearEngagement\Services\LoggingService::$notices = [];
             SettingsRepository::reset_for_tests();
         }
 
-        private function makeService(?DummyRemoteApiService $api = null): AutoGenerationService {
+        private function makeService(?ScheduleFailDummyRemoteApiService $api = null): AutoGenerationService {
             $settings = SettingsRepository::get_instance();
-            $api      = $api ?: new DummyRemoteApiService();
-            $storage  = new DummyContentStorageService();
+            $api      = $api ?: new ScheduleFailDummyRemoteApiService();
+            $storage  = new ScheduleFailDummyContentStorageService();
             $poller    = new GenerationPoller($settings, $api, $storage);
             $scheduler = new \NuclearEngagement\Services\AutoGenerationScheduler($poller);
             $queue     = new \NuclearEngagement\Services\AutoGenerationQueue($api, $storage, new \NuclearEngagement\Services\PostDataFetcher());
@@ -100,8 +100,8 @@ namespace {
 
         public function test_poller_failure_notifies_admin(): void {
             $settings = SettingsRepository::get_instance();
-            $api      = new DummyRemoteApiService();
-            $storage  = new DummyContentStorageService();
+            $api      = new ScheduleFailDummyRemoteApiService();
+            $storage  = new ScheduleFailDummyContentStorageService();
             $poller   = new GenerationPoller($settings, $api, $storage);
             $poller->poll_generation('gid', 'quiz', [1], 1);
             $this->assertNotEmpty(\NuclearEngagement\Services\LoggingService::$notices);


### PR DESCRIPTION
## Summary
- give dummy test classes unique names to prevent redeclaration errors

## Testing
- `composer lint` *(fails: command not found)*
- `composer test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685e2d30b1ac8327a541862c17e5c3c5

<!-- Korbit AI PR Description Start -->
## Description by Korbit AI

### What change is being made?

Rename test class names to prevent conflicts by adding context-specific prefixes like `Queue`, `Scheduler`, `Service`, `Poller`, and `ScheduleFail` to the `DummyRemoteApiService`, `DummyContentStorageService`, and `AQ_WPDB` classes across multiple test files.

### Why are these changes being made?

These changes address naming conflicts among test classes that were likely causing issues due to shared names across different test files. By adding context-specific prefixes, the test classes are now clearly differentiated, reducing the chance of ambiguity and improving the maintainability and readability of the test code.

> Is this description stale? Ask me to generate a new description by commenting `/korbit-generate-pr-description`
<!-- Korbit AI PR Description End -->