### PR TITLE
Fix SetupService test imports

### DIFF
--- a/tests/SetupServiceTest.php
+++ b/tests/SetupServiceTest.php
@@ -13,8 +13,6 @@ namespace {
     use PHPUnit\Framework\TestCase;
     use NuclearEngagement\Services\SetupService;
     use NuclearEngagement\Services\LoggingService;
-    use NuclearEngagement\Services\SetupService;
-    use NuclearEngagement\Services\LoggingService;
 
     if (!defined('NUCLEN_PLUGIN_VERSION')) { define('NUCLEN_PLUGIN_VERSION', '1.0'); }
     if (!defined('NUCLEN_API_TIMEOUT')) { define('NUCLEN_API_TIMEOUT', 30); }


### PR DESCRIPTION
## Summary
- remove duplicate `use` statements in `SetupServiceTest`

## Testing
- `composer lint` *(fails: command not found)*
- `composer test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685e2d6c88bc83279dfbb94b31ced5c0

<!-- Korbit AI PR Description Start -->
## Description by Korbit AI

### What change is being made?

Remove duplicate import statements for `SetupService` and `LoggingService` in `SetupServiceTest.php`.

### Why are these changes being made?

The duplicate import statements were redundant and cluttered the code. Removing them improves code readability and maintenance without affecting functionality.

> Is this description stale? Ask me to generate a new description by commenting `/korbit-generate-pr-description`
<!-- Korbit AI PR Description End -->