### PR TITLE
Fix NuclenStartGeneration mock to return awaited data

### DIFF
--- a/tests/frontend/nuclen-admin-single-generation.test.ts
+++ b/tests/frontend/nuclen-admin-single-generation.test.ts
@@ -6,7 +6,9 @@ vi.mock('../../src/admin/ts/generation/api', async () => {
   return {
     ...actual,
     nuclenFetchWithRetry,
-    NuclenStartGeneration: vi.fn(async () => nuclenFetchWithRetry()),
+    NuclenStartGeneration: vi.fn(async (...args) => {
+      return await nuclenFetchWithRetry(...args);
+    }),
   };
 });
 


### PR DESCRIPTION
## Summary
- ensure `NuclenStartGeneration` mock awaits `nuclenFetchWithRetry`

## Testing
- `composer lint` *(fails: composer not found)*
- `composer test` *(skipped: no PHP changes)*
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_685e2eb9cfcc832795ab1cfdf3d5c408


> [!NOTE]
> I'm currently writing a description for your pull request. I should be done shortly (<1 minute). Please don't edit the description field until I'm finished, or we may overwrite each other. If I find nothing to write about, I'll delete this message.
