### PR TITLE
Exclude vendor dir from PHPStan analysis

### DIFF
--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -3,5 +3,7 @@ parameters:
     paths:
         - nuclear-engagement
         - tests
+    excludes_analyse:
+        - nuclear-engagement/vendor/*
     bootstrapFiles:
         - nuclear-engagement/vendor/php-stubs/wordpress-stubs/wordpress-stubs.php


### PR DESCRIPTION
## Summary
- PHPStan analysis was including `nuclear-engagement/vendor` which inflated memory use
- exclude the vendor directory via `excludes_analyse`

## Testing
- `composer lint` *(fails: command not found)*
- `composer test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685e30412e088327ac85881b82e6636a


> [!NOTE]
> I'm currently writing a description for your pull request. I should be done shortly (<1 minute). Please don't edit the description field until I'm finished, or we may overwrite each other. If I find nothing to write about, I'll delete this message.
