### PR TITLE
Guard constant setup

### DIFF
--- a/nuclear-engagement/bootstrap.php
+++ b/nuclear-engagement/bootstrap.php
@@ -15,7 +15,9 @@ if ( ! defined( 'ABSPATH' ) ) {
 	exit;
 }
 
-define( 'NUCLEN_PLUGIN_DIR', plugin_dir_path( NUCLEN_PLUGIN_FILE ) );
+if ( ! defined( 'NUCLEN_PLUGIN_DIR' ) ) {
+	define( 'NUCLEN_PLUGIN_DIR', plugin_dir_path( NUCLEN_PLUGIN_FILE ) );
+}
 
 if ( ! defined( 'NUCLEN_PLUGIN_VERSION' ) ) {
 	if ( ! function_exists( 'get_file_data' ) ) {
@@ -29,7 +31,9 @@ if ( ! defined( 'NUCLEN_PLUGIN_VERSION' ) ) {
 		define( 'NUCLEN_PLUGIN_VERSION', $data['Version'] );
 }
 
-define( 'NUCLEN_ASSET_VERSION', '250625-13' );
+if ( ! defined( 'NUCLEN_ASSET_VERSION' ) ) {
+	define( 'NUCLEN_ASSET_VERSION', '250625-13' );
+}
 
 $autoload = __DIR__ . '/vendor/autoload.php';
 if ( ! file_exists( $autoload ) ) {

--- a/nuclear-engagement/inc/Core/constants.php
+++ b/nuclear-engagement/inc/Core/constants.php
@@ -1,8 +1,12 @@
 <?php
 declare(strict_types=1);
 if ( ! defined( 'ABSPATH' ) ) {
-    exit;
-}
+	exit;
+	}
+
+	if ( ! defined( 'MB_IN_BYTES' ) ) {
+	define( 'MB_IN_BYTES', 1024 * 1024 );
+	}
 
 /**
  * Plugin-wide numeric configuration.
@@ -14,7 +18,9 @@ if ( ! defined( 'ABSPATH' ) ) {
  */
 
 /** Maximum log file size in bytes. */
-define( 'NUCLEN_LOG_FILE_MAX_SIZE', MB_IN_BYTES );
+if ( ! defined( 'NUCLEN_LOG_FILE_MAX_SIZE' ) ) {
+	define( 'NUCLEN_LOG_FILE_MAX_SIZE', MB_IN_BYTES );
+}
 
 /** Enable buffered logging. */
 define( 'NUCLEN_BUFFER_LOGS', true );


### PR DESCRIPTION
## Summary
- avoid redefining plugin constants when bootstrap.php is loaded multiple times
- define `MB_IN_BYTES` when WordPress doesn't supply it

## Testing
- `composer lint` *(fails: command not found)*
- `composer test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685e301e9ca88327b0ef23018306727d

<!-- Korbit AI PR Description Start -->
## Description by Korbit AI

### What change is being made?

Add guards to ensure constants in `bootstrap.php` and `constants.php` are only defined if not already defined.

### Why are these changes being made?

These changes prevent potential errors and conflicts that could arise if the constants were to be defined multiple times, which is a common best practice in PHP to ensure script reliability, particularly in environments where multiple files may attempt to define the same constants.

> Is this description stale? Ask me to generate a new description by commenting `/korbit-generate-pr-description`
<!-- Korbit AI PR Description End -->