### PR TITLE
Move quiz HTML into templates

### DIFF
--- a/nuclear-engagement/front/QuizView.php
+++ b/nuclear-engagement/front/QuizView.php
@@ -7,76 +7,74 @@ if ( ! defined( 'ABSPATH' ) ) {
 }
 
 class QuizView {
-	public function container( array $settings ): string {
-		$html = '<section id="nuclen-quiz-container" class="nuclen-quiz">';
-		if ( trim( $settings['html_before'] ) !== '' ) {
-			$html .= $this->startMessage( $settings['html_before'] );
-		}
-		$html .= $this->title( $settings['quiz_title'] );
-		$html .= $this->progressBar();
-		$html .= $this->questionContainer();
-		$html .= $this->answersContainer();
-		$html .= $this->resultContainer();
-		$html .= $this->explanationContainer();
-		$html .= $this->nextButton();
-		$html .= $this->finalResultContainer();
-		$html .= '</section>';
-		return $html;
-	}
+	   public function container( array $settings ): string {
+		   $data = array(
+			   'start_message'		  => '',
+			   'title'			  => $this->title( $settings['quiz_title'] ),
+			   'progress_bar'		  => $this->progressBar(),
+			   'question_container'	  => $this->questionContainer(),
+			   'answers_container'	  => $this->answersContainer(),
+			   'result_container'	  => $this->resultContainer(),
+			   'explanation_container' => $this->explanationContainer(),
+			   'next_button'		  => $this->nextButton(),
+			   'final_result_container' => $this->finalResultContainer(),
+		   );
 
-	public function attribution( bool $show ): string {
-		if ( ! $show ) {
-			return '';
-		}
-		return sprintf(
-			'<div class="nuclen-attribution">%s <a rel="nofollow" href="https://www.nuclearengagement.com" target="_blank">%s</a></div>',
-			esc_html__( 'Quiz by', 'nuclear-engagement' ),
-			esc_html__( 'Nuclear Engagement', 'nuclear-engagement' )
-		);
-	}
+		   if ( trim( $settings['html_before'] ) !== '' ) {
+			   $data['start_message'] = $this->startMessage( $settings['html_before'] );
+		   }
 
-	private function startMessage( string $html_before ): string {
-		return sprintf(
-			'<div id="nuclen-quiz-start-message" class="nuclen-fg">%s</div>',
-			shortcode_unautop( $html_before )
-		);
-	}
+		   return $this->render( 'container', $data );
+	   }
 
-	private function title( string $title ): string {
-		return sprintf(
-			'<h2 id="nuclen-quiz-title" class="nuclen-fg">%s</h2>',
-			esc_html( $title )
-		);
-	}
+	   public function attribution( bool $show ): string {
+		   return $this->render( 'attribution', array( 'show' => $show ) );
+	   }
 
-	private function progressBar(): string {
-		return '<div id="nuclen-quiz-progress-bar-container"><div id="nuclen-quiz-progress-bar"></div></div>';
-	}
+	   private function startMessage( string $html_before ): string {
+		   return $this->render( 'start-message', array( 'html_before' => $html_before ) );
+	   }
 
-	private function questionContainer(): string {
-		return '<div id="nuclen-quiz-question-container" class="nuclen-fg"></div>';
-	}
+	   private function title( string $title ): string {
+		   return $this->render( 'title', array( 'title' => $title ) );
+	   }
 
-	private function answersContainer(): string {
-		return '<div id="nuclen-quiz-answers-container" class="nuclen-quiz-answers-grid"></div>';
-	}
+	   private function progressBar(): string {
+		   return $this->render( 'progress-bar' );
+	   }
 
-	private function resultContainer(): string {
-		return '<div id="nuclen-quiz-result-container"></div>';
-	}
+	   private function questionContainer(): string {
+		   return $this->render( 'question-container' );
+	   }
 
-	private function explanationContainer(): string {
-		return '<div id="nuclen-quiz-explanation-container" class="nuclen-fg nuclen-quiz-hidden"></div>';
-	}
+	   private function answersContainer(): string {
+		   return $this->render( 'answers-container' );
+	   }
 
-	private function nextButton(): string {
-		return sprintf(
-			'<button id="nuclen-quiz-next-button" class="nuclen-quiz-hidden">%s</button>',
-			esc_html__( 'Next', 'nuclear-engagement' )
-		);
-	}
+	   private function resultContainer(): string {
+		   return $this->render( 'result-container' );
+	   }
 
-	private function finalResultContainer(): string {
-		return '<div id="nuclen-quiz-final-result-container"></div>';
-	}
+	   private function explanationContainer(): string {
+		   return $this->render( 'explanation-container' );
+	   }
+
+	   private function nextButton(): string {
+		   return $this->render( 'next-button' );
+	   }
+
+	   private function finalResultContainer(): string {
+		   return $this->render( 'final-result-container' );
+	   }
+
+	   private function render( string $slug, array $data = array() ): string {
+		   $template = locate_template( array( 'nuclear-engagement/quiz/' . $slug . '.php' ), false, false );
+		   if ( '' === $template ) {
+			   $template = NUCLEN_PLUGIN_DIR . 'templates/front/quiz/' . $slug . '.php';
+		   }
+		   ob_start();
+		   extract( $data, EXTR_SKIP );
+		   include $template;
+		   return ob_get_clean();
+	   }
 }

--- a/nuclear-engagement/templates/front/quiz/answers-container.php
+++ b/nuclear-engagement/templates/front/quiz/answers-container.php
@@ -1,0 +1,7 @@
+<?php
+declare(strict_types=1);
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+?>
+<div id="nuclen-quiz-answers-container" class="nuclen-quiz-answers-grid"></div>

--- a/nuclear-engagement/templates/front/quiz/attribution.php
+++ b/nuclear-engagement/templates/front/quiz/attribution.php
@@ -1,0 +1,9 @@
+<?php
+declare(strict_types=1);
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+?>
+<?php if ( $show ) : ?>
+<div class="nuclen-attribution"><?php echo esc_html__( 'Quiz by', 'nuclear-engagement' ); ?> <a rel="nofollow" href="https://www.nuclearengagement.com" target="_blank"><?php echo esc_html__( 'Nuclear Engagement', 'nuclear-engagement' ); ?></a></div>
+<?php endif; ?>

--- a/nuclear-engagement/templates/front/quiz/container.php
+++ b/nuclear-engagement/templates/front/quiz/container.php
@@ -1,0 +1,17 @@
+<?php
+declare(strict_types=1);
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+?>
+<section id="nuclen-quiz-container" class="nuclen-quiz">
+<?php echo $start_message; ?>
+<?php echo $title; ?>
+<?php echo $progress_bar; ?>
+<?php echo $question_container; ?>
+<?php echo $answers_container; ?>
+<?php echo $result_container; ?>
+<?php echo $explanation_container; ?>
+<?php echo $next_button; ?>
+<?php echo $final_result_container; ?>
+</section>

--- a/nuclear-engagement/templates/front/quiz/explanation-container.php
+++ b/nuclear-engagement/templates/front/quiz/explanation-container.php
@@ -1,0 +1,7 @@
+<?php
+declare(strict_types=1);
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+?>
+<div id="nuclen-quiz-explanation-container" class="nuclen-fg nuclen-quiz-hidden"></div>

--- a/nuclear-engagement/templates/front/quiz/final-result-container.php
+++ b/nuclear-engagement/templates/front/quiz/final-result-container.php
@@ -1,0 +1,7 @@
+<?php
+declare(strict_types=1);
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+?>
+<div id="nuclen-quiz-final-result-container"></div>

--- a/nuclear-engagement/templates/front/quiz/next-button.php
+++ b/nuclear-engagement/templates/front/quiz/next-button.php
@@ -1,0 +1,7 @@
+<?php
+declare(strict_types=1);
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+?>
+<button id="nuclen-quiz-next-button" class="nuclen-quiz-hidden"><?php echo esc_html__( 'Next', 'nuclear-engagement' ); ?></button>

--- a/nuclear-engagement/templates/front/quiz/progress-bar.php
+++ b/nuclear-engagement/templates/front/quiz/progress-bar.php
@@ -1,0 +1,7 @@
+<?php
+declare(strict_types=1);
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+?>
+<div id="nuclen-quiz-progress-bar-container"><div id="nuclen-quiz-progress-bar"></div></div>

--- a/nuclear-engagement/templates/front/quiz/question-container.php
+++ b/nuclear-engagement/templates/front/quiz/question-container.php
@@ -1,0 +1,7 @@
+<?php
+declare(strict_types=1);
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+?>
+<div id="nuclen-quiz-question-container" class="nuclen-fg"></div>

--- a/nuclear-engagement/templates/front/quiz/result-container.php
+++ b/nuclear-engagement/templates/front/quiz/result-container.php
@@ -1,0 +1,7 @@
+<?php
+declare(strict_types=1);
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+?>
+<div id="nuclen-quiz-result-container"></div>

--- a/nuclear-engagement/templates/front/quiz/start-message.php
+++ b/nuclear-engagement/templates/front/quiz/start-message.php
@@ -1,0 +1,9 @@
+<?php
+declare(strict_types=1);
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+?>
+<div id="nuclen-quiz-start-message" class="nuclen-fg">
+<?php echo shortcode_unautop( $html_before ); ?>
+</div>

--- a/nuclear-engagement/templates/front/quiz/title.php
+++ b/nuclear-engagement/templates/front/quiz/title.php
@@ -1,0 +1,7 @@
+<?php
+declare(strict_types=1);
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+?>
+<h2 id="nuclen-quiz-title" class="nuclen-fg"><?php echo esc_html( $title ); ?></h2>

--- a/tests/wp-stubs.php
+++ b/tests/wp-stubs.php
@@ -40,3 +40,9 @@ if (!function_exists('wp_remote_retrieve_body')) {
     }
 }
 
+if (!function_exists('locate_template')) {
+    function locate_template($names, $load = false, $require_once = true, $args = []) {
+        return '';
+    }
+}
+


### PR DESCRIPTION
## Summary
- extract QuizView markup into partials under `templates/front/quiz`
- render templates using `locate_template`
- stub `locate_template` for tests

## Testing
- `composer lint` *(fails: command not found)*
- `composer test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685e33a06134832785e49a9f03361807


> [!NOTE]
> I'm currently writing a description for your pull request. I should be done shortly (<1 minute). Please don't edit the description field until I'm finished, or we may overwrite each other. If I find nothing to write about, I'll delete this message.
