### PR TITLE
Refactor activation hooks into Installer class

### DIFF
--- a/nuclear-engagement/inc/Core/Installer.php
+++ b/nuclear-engagement/inc/Core/Installer.php
@@ -1,0 +1,71 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NuclearEngagement\Core;
+
+use NuclearEngagement\Core\Defaults;
+use NuclearEngagement\Core\SettingsRepository;
+use NuclearEngagement\Core\Activator;
+use NuclearEngagement\Core\Deactivator;
+use NuclearEngagement\Modules\Summary\Summary_Service;
+use NuclearEngagement\Services\LoggingService;
+
+if ( ! defined( 'ABSPATH' ) ) {
+exit;
+}
+
+class Installer {
+public function activate(): void {
+$defaults = Defaults::nuclen_get_default_settings();
+$settings = SettingsRepository::get_instance( $defaults );
+Activator::nuclen_activate( $settings );
+}
+
+public function deactivate(): void {
+$settings = SettingsRepository::get_instance();
+Deactivator::nuclen_deactivate( $settings );
+}
+
+public function migrate_post_meta(): void {
+if ( get_option( 'nuclen_meta_migration_done' ) ) {
+return;
+}
+
+global $wpdb;
+
+$check_error = static function () use ( $wpdb ) {
+if ( ! empty( $wpdb->last_error ) ) {
+LoggingService::log( 'Meta migration error: ' . $wpdb->last_error );
+update_option( 'nuclen_meta_migration_error', $wpdb->last_error );
+return false;
+}
+return true;
+};
+
+$wpdb->query(
+$wpdb->prepare(
+"UPDATE {$wpdb->postmeta} SET meta_key = %s WHERE meta_key = %s",
+Summary_Service::META_KEY,
+'ne-summary-data'
+)
+);
+if ( ! $check_error() ) {
+return;
+}
+
+$wpdb->query(
+$wpdb->prepare(
+"UPDATE {$wpdb->postmeta} SET meta_key = %s WHERE meta_key = %s",
+'nuclen-quiz-data',
+'ne-quiz-data'
+)
+);
+if ( ! $check_error() ) {
+return;
+}
+
+delete_option( 'nuclen_meta_migration_error' );
+update_option( 'nuclen_meta_migration_done', true );
+}
+}

--- a/tests/BootstrapTest.php
+++ b/tests/BootstrapTest.php
@@ -44,10 +44,14 @@ namespace {
             $this->assertTrue($found_init, 'init hook not registered');
             $this->assertNotEmpty($GLOBALS['test_activation']);
             $this->assertNotEmpty($GLOBALS['test_deactivation']);
-            $this->assertSame('nuclear_engagement_activate_plugin', $GLOBALS['test_activation'][0][1]);
-            $this->assertSame('nuclear_engagement_deactivate_plugin', $GLOBALS['test_deactivation'][0][1]);
             $this->assertSame(NUCLEN_PLUGIN_FILE, $GLOBALS['test_activation'][0][0]);
             $this->assertSame(NUCLEN_PLUGIN_FILE, $GLOBALS['test_deactivation'][0][0]);
+            $this->assertIsArray($GLOBALS['test_activation'][0][1]);
+            $this->assertInstanceOf(\NuclearEngagement\Core\Installer::class, $GLOBALS['test_activation'][0][1][0]);
+            $this->assertSame('activate', $GLOBALS['test_activation'][0][1][1]);
+            $this->assertIsArray($GLOBALS['test_deactivation'][0][1]);
+            $this->assertInstanceOf(\NuclearEngagement\Core\Installer::class, $GLOBALS['test_deactivation'][0][1][0]);
+            $this->assertSame('deactivate', $GLOBALS['test_deactivation'][0][1][1]);
         }
     }
 }

--- a/tests/PostMetaMigrationTest.php
+++ b/tests/PostMetaMigrationTest.php
@@ -47,7 +47,8 @@ namespace {
 
         public function test_logs_error_and_sets_option_on_failure(): void {
             $this->load_bootstrap();
-            \nuclen_update_migrate_post_meta();
+            $installer = new \NuclearEngagement\Core\Installer();
+            $installer->migrate_post_meta();
             $this->assertNotEmpty(LoggingService::$logs);
             $this->assertSame('fail', get_option('nuclen_meta_migration_error'));
             $this->assertFalse(get_option('nuclen_meta_migration_done'));


### PR DESCRIPTION
## Summary
- create `Installer` class for activation, deactivation and migration
- hook installer methods in `bootstrap.php`
- update tests for new installer hooks

## Testing
- `composer lint` *(fails: command not found)*
- `composer test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685e35ff03b48327938bfdf739bd7b3d