### PR TITLE
Refactor opt-in export to service

### DIFF
--- a/nuclear-engagement/inc/OptinData.php
+++ b/nuclear-engagement/inc/OptinData.php
@@ -176,67 +176,7 @@ class OptinData {
 	 * ------------------------------------------------------------------- */
 	public static function handle_export(): void {
 
-		/* Permission check */
-		if ( ! current_user_can( 'manage_options' ) ) {
-			wp_die( __( 'Insufficient permissions.', 'nuclear-engagement' ), 403 );
-		}
-
-		/* Nonce check – accept from GET or POST */
-		$nonce = $_REQUEST['_wpnonce'] ?? '';
-		if ( ! wp_verify_nonce( $nonce, 'nuclen_export_optin' ) ) {
-			wp_die( __( 'Invalid nonce.', 'nuclear-engagement' ), 400 );
-		}
-
-				global $wpdb;
-
-		if ( ob_get_length() ) {
-				ob_end_clean();
-		}
-				nocache_headers();
-				header( 'Content-Type: text/csv; charset=utf-8' );
-				header( 'Content-Disposition: attachment; filename=nuclen_optins_' . gmdate( 'Y-m-d' ) . '.csv' );
-
-				$out = fopen( 'php://output', 'w' );
-		if ( false === $out ) {
-				LoggingService::log( 'Failed to open output stream for CSV export' );
-				wp_die( __( 'Unable to generate export.', 'nuclear-engagement' ), 500 );
-		}
-
-		if ( false === fputcsv( $out, array( 'datetime', 'url', 'name', 'email' ) ) ) { // headings
-				LoggingService::log( 'Failed writing CSV header' );
-		}
-
-				$limit  = 500;
-				$offset = 0;
-		do {
-				$rows = $wpdb->get_results(
-					$wpdb->prepare(
-						'SELECT submitted_at AS datetime,
-                                                       url,
-                                                       name,
-                                                       email
-                                          FROM ' . self::table_name() . '
-                                          ORDER BY submitted_at DESC
-                                          LIMIT %d OFFSET %d',
-						$limit,
-						$offset
-					),
-					ARRAY_A
-				);
-
-			foreach ( $rows as $r ) {
-				$r['name']  = self::escape_csv_field( $r['name'] );
-				$r['email'] = self::escape_csv_field( $r['email'] );
-				$r['url']   = self::escape_csv_field( $r['url'] );
-				if ( false === fputcsv( $out, $r ) ) {
-						LoggingService::log( 'Failed writing CSV row' );
-				}
-			}
-
-				$offset += $limit;
-		} while ( count( $rows ) === $limit );
-
-				fclose( $out );
-				exit;
+       $service = new \NuclearEngagement\Services\OptinExportService();
+       $service->stream_csv();
 	}
 }

--- a/nuclear-engagement/inc/Services/OptinExportService.php
+++ b/nuclear-engagement/inc/Services/OptinExportService.php
@@ -1,0 +1,84 @@
+<?php
+declare(strict_types=1);
+/**
+ * Handles streaming the opt-in CSV export.
+ *
+ * @package NuclearEngagement\\Services
+ */
+
+namespace NuclearEngagement\\Services;
+
+use NuclearEngagement\\OptinData;
+use NuclearEngagement\\Services\\LoggingService;
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+class OptinExportService {
+	/**
+	 * Stream the opt-in CSV file to the browser.
+	 */
+	public function stream_csv(): void {
+	    if ( ! current_user_can( 'manage_options' ) ) {
+	        wp_die( __( 'Insufficient permissions.', 'nuclear-engagement' ), 403 );
+	    }
+
+	    $nonce = $_REQUEST['_wpnonce'] ?? '';
+	    if ( ! wp_verify_nonce( $nonce, 'nuclen_export_optin' ) ) {
+	        wp_die( __( 'Invalid nonce.', 'nuclear-engagement' ), 400 );
+	    }
+
+	    global $wpdb;
+
+	    if ( ob_get_length() ) {
+	        ob_end_clean();
+	    }
+	    nocache_headers();
+	    header( 'Content-Type: text/csv; charset=utf-8' );
+	    header( 'Content-Disposition: attachment; filename=nuclen_optins_' . gmdate( 'Y-m-d' ) . '.csv' );
+
+	    $out = fopen( 'php://output', 'w' );
+	    if ( false === $out ) {
+	        LoggingService::log( 'Failed to open output stream for CSV export' );
+	        wp_die( __( 'Unable to generate export.', 'nuclear-engagement' ), 500 );
+	    }
+
+	    if ( false === fputcsv( $out, array( 'datetime', 'url', 'name', 'email' ) ) ) {
+	        LoggingService::log( 'Failed writing CSV header' );
+	    }
+
+	    $limit  = 500;
+	    $offset = 0;
+	    do {
+	        $rows = $wpdb->get_results(
+	            $wpdb->prepare(
+	                "SELECT submitted_at AS datetime,
+	                    url,
+	                    name,
+	                    email
+	                FROM " . OptinData::table_name() . "
+	                ORDER BY submitted_at DESC
+	                LIMIT %d OFFSET %d",
+	                $limit,
+	                $offset
+	            ),
+	            ARRAY_A
+	        );
+
+	        foreach ( $rows as $r ) {
+	            $r['name']  = OptinData::escape_csv_field( $r['name'] );
+	            $r['email'] = OptinData::escape_csv_field( $r['email'] );
+	            $r['url']   = OptinData::escape_csv_field( $r['url'] );
+	            if ( false === fputcsv( $out, $r ) ) {
+	                LoggingService::log( 'Failed writing CSV row' );
+	            }
+	        }
+
+	        $offset += $limit;
+	    } while ( count( $rows ) === $limit );
+
+	    fclose( $out );
+	    exit;
+	}
+}

--- a/tests/OptinExportControllerTest.php
+++ b/tests/OptinExportControllerTest.php
@@ -1,8 +1,17 @@
 <?php
-namespace NuclearEngagement {
-    class OptinData {
+namespace NuclearEngagement\Services {
+    class OptinExportService {
         public static int $calls = 0;
-        public static function handle_export(): void { self::$calls++; }
+        public function stream_csv(): void { self::$calls++; }
+    }
+}
+
+namespace NuclearEngagement {
+    use NuclearEngagement\Services\OptinExportService;
+    class OptinData {
+        public static function handle_export(): void {
+            ( new OptinExportService() )->stream_csv();
+        }
     }
 }
 
@@ -13,13 +22,13 @@ namespace {
 
     class OptinExportControllerTest extends TestCase {
         protected function setUp(): void {
-            \NuclearEngagement\OptinData::$calls = 0;
+            \NuclearEngagement\Services\OptinExportService::$calls = 0;
         }
 
         public function test_handle_invokes_export(): void {
             $c = new OptinExportController();
             $c->handle();
-            $this->assertSame(1, \NuclearEngagement\OptinData::$calls);
+            $this->assertSame(1, \NuclearEngagement\Services\OptinExportService::$calls);
         }
     }
 }


### PR DESCRIPTION
## Summary
- create `OptinExportService` with `stream_csv()` handling CSV logic
- delegate `OptinData::handle_export()` to the new service
- adjust controller test to expect service invocation

## Testing
- `composer lint` *(fails: command not found)*
- `composer test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685e3c707974832799120f4cb8b10609

<!-- Korbit AI PR Description Start -->
## Description by Korbit AI

### What change is being made?

Refactor the opt-in export functionality by moving it from `OptinData::handle_export` to a new `OptinExportService` class.

### Why are these changes being made?

This refactoring improves the code's maintainability and readability by decoupling the concerns between data handling and export logic, making the codebase easier to manage and extend in the future. This also aligns with common software engineering practices of single responsibility principle, facilitating better separation of concerns within the code structure.

> Is this description stale? Ask me to generate a new description by commenting `/korbit-generate-pr-description`
<!-- Korbit AI PR Description End -->