### PR TITLE
Add quiz loader and simplify metabox traits

### DIFF
--- a/nuclear-engagement/admin/Admin.php
+++ b/nuclear-engagement/admin/Admin.php
@@ -50,9 +50,7 @@ class Admin {
 		$this->settings_repository = $settings_repository;
 		$this->container           = $container;
 
-		// Meta-boxes
-		add_action( 'add_meta_boxes', array( $this, 'nuclen_add_quiz_data_meta_box' ) );
-		add_action( 'save_post', array( $this, 'nuclen_save_quiz_data_meta' ) );
+// Meta-boxes handled by module loader
 
 		// AJAX & assets
 		add_action( 'wp_ajax_nuclen_fetch_app_updates', array( $this, 'nuclen_fetch_app_updates' ) );

--- a/nuclear-engagement/admin/Traits/AdminQuizMetabox.php
+++ b/nuclear-engagement/admin/Traits/AdminQuizMetabox.php
@@ -15,25 +15,20 @@ if ( ! defined( 'ABSPATH' ) ) {
 }
 
 trait AdminQuizMetabox {
-	private ?Quiz_Admin $quiz_admin = null;
+       private function create_quiz_admin(): Quiz_Admin {
+               $service = new Quiz_Service();
+               return new Quiz_Admin( $this->nuclen_get_settings_repository(), $service );
+       }
 
-	private function get_quiz_admin(): Quiz_Admin {
-		if ( $this->quiz_admin === null ) {
-			$service          = new Quiz_Service();
-			$this->quiz_admin = new Quiz_Admin( $this->nuclen_get_settings_repository(), $service );
-		}
-		return $this->quiz_admin;
-	}
+       public function nuclen_add_quiz_data_meta_box() {
+               $this->create_quiz_admin()->add_meta_box();
+       }
 
-	public function nuclen_add_quiz_data_meta_box() {
-		$this->get_quiz_admin()->add_meta_box();
-	}
+       public function nuclen_render_quiz_data_meta_box( $post ) {
+               $this->create_quiz_admin()->render_meta_box( $post );
+       }
 
-	public function nuclen_render_quiz_data_meta_box( $post ) {
-		$this->get_quiz_admin()->render_meta_box( $post );
-	}
-
-	public function nuclen_save_quiz_data_meta( $post_id ) {
-		$this->get_quiz_admin()->save_meta( (int) $post_id );
-	}
+       public function nuclen_save_quiz_data_meta( $post_id ) {
+               $this->create_quiz_admin()->save_meta( (int) $post_id );
+       }
 }

--- a/nuclear-engagement/front/traits/ShortcodesTrait.php
+++ b/nuclear-engagement/front/traits/ShortcodesTrait.php
@@ -24,29 +24,17 @@ if ( ! defined( 'ABSPATH' ) ) {
 }
 
 trait ShortcodesTrait {
-	private ?QuizShortcode $quiz_shortcode       = null;
-	private ?SummaryShortcode $summary_shortcode = null;
+       private ?SummaryShortcode $summary_shortcode = null;
 
-	private function get_quiz_shortcode(): QuizShortcode {
-		if ( $this->quiz_shortcode === null ) {
-				$this->quiz_shortcode = new QuizShortcode(
-					$this->nuclen_get_settings_repository(),
-					$this,
-					new Quiz_Service()
-				);
-		}
-		return $this->quiz_shortcode;
-	}
-
-	private function get_summary_shortcode(): SummaryShortcode {
-		if ( $this->summary_shortcode === null ) {
-			$this->summary_shortcode = new SummaryShortcode(
-				$this->nuclen_get_settings_repository(),
-				$this
-			);
-		}
-		return $this->summary_shortcode;
-	}
+       private function get_summary_shortcode(): SummaryShortcode {
+               if ( $this->summary_shortcode === null ) {
+                       $this->summary_shortcode = new SummaryShortcode(
+                               $this->nuclen_get_settings_repository(),
+                               $this
+                       );
+               }
+               return $this->summary_shortcode;
+       }
 
 	/* ---------- Auto-insert into content ---------- */
 	public function nuclen_auto_insert_shortcodes( $content ) {
@@ -95,10 +83,15 @@ trait ShortcodesTrait {
 		return $before_content . $content . $after_content;
 	}
 
-	/* ---------- Shortcode registrations ---------- */
-	public function nuclen_register_quiz_shortcode() {
-		$this->get_quiz_shortcode()->register();
-	}
+       /* ---------- Shortcode registrations ---------- */
+       public function nuclen_register_quiz_shortcode() {
+               $sc = new QuizShortcode(
+                       $this->nuclen_get_settings_repository(),
+                       $this,
+                       new Quiz_Service()
+               );
+               $sc->register();
+       }
 
 	public function nuclen_register_summary_shortcode() {
 		$this->get_summary_shortcode()->register();

--- a/nuclear-engagement/inc/Modules/Quiz/loader.php
+++ b/nuclear-engagement/inc/Modules/Quiz/loader.php
@@ -1,0 +1,63 @@
+<?php
+/**
+ * File: modules/quiz/loader.php
+ *
+ * Loads the Nuclen Quiz module.
+ *
+ * @package NuclearEngagement
+ */
+
+declare(strict_types=1);
+
+namespace NuclearEngagement\Modules\Quiz;
+
+if ( ! defined( 'ABSPATH' ) ) {
+        exit;
+}
+
+use NuclearEngagement\Core\SettingsRepository;
+use NuclearEngagement\Front\FrontClass;
+use NuclearEngagement\Core\Container;
+
+/*
+------------------------------------------------------------------
+ * Local constants (prefixed, module-scoped)
+ * ------------------------------------------------------------------
+*/
+if ( ! defined( 'NUCLEN_QUIZ_DIR' ) ) {
+        define( 'NUCLEN_QUIZ_DIR', __DIR__ . '/' );
+}
+
+/*
+------------------------------------------------------------------
+ * Includes
+ * ------------------------------------------------------------------
+*/
+require_once NUCLEN_QUIZ_DIR . 'Quiz_Service.php';
+require_once NUCLEN_QUIZ_DIR . 'Quiz_Admin.php';
+require_once NUCLEN_QUIZ_DIR . 'Quiz_Shortcode.php';
+
+/*
+------------------------------------------------------------------
+ * Spin-up
+ * ------------------------------------------------------------------
+*/
+add_action(
+        'plugins_loaded',
+        static function () {
+                $settings = SettingsRepository::get_instance();
+                $service  = new Quiz_Service();
+
+                if ( is_admin() ) {
+                        ( new Quiz_Admin( $settings, $service ) )->register_hooks();
+                } else {
+                        $front = new FrontClass(
+                                'nuclear-engagement',
+                                defined( 'NUCLEN_PLUGIN_VERSION' ) ? NUCLEN_PLUGIN_VERSION : '1.0.0',
+                                $settings,
+                                new Container()
+                        );
+                        ( new Quiz_Shortcode( $settings, $front, $service ) )->register();
+                }
+        }
+);


### PR DESCRIPTION
## Summary
- add a loader for the Quiz module
- rely on loader-created instances
- simplify `AdminQuizMetabox` and `ShortcodesTrait`
- remove old meta box hooks from `Admin`

## Testing
- `composer lint` *(fails: command not found)*
- `composer test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685e3c6e3bc4832785cba26ddbac8205

<!-- Korbit AI PR Description Start -->
## Description by Korbit AI

### What change is being made?
Implement a quiz module loader to manage the initialization and hookup of quiz-related features, and simplify metabox and shortcode traits by removing persistent state.

### Why are these changes being made?
The introduction of the quiz module loader centralizes the quiz feature activation process, ensuring clean separation of admin and frontend concerns. The simplification of metabox and shortcode traits eliminates unnecessary state, reducing complexity and potential issues from stale data, while using a more direct instantiation approach. This enhances maintainability and aligns with existing architectural practices.

> Is this description stale? Ask me to generate a new description by commenting `/korbit-generate-pr-description`
<!-- Korbit AI PR Description End -->