### PR TITLE
Refactor app password workflow

### DIFF
--- a/nuclear-engagement/admin/SetupHandlersTrait.php
+++ b/nuclear-engagement/admin/SetupHandlersTrait.php
@@ -68,75 +68,29 @@ trait SetupHandlersTrait {
 	--------------------------------------------------------------
 	#  STEP 2 – Generate & store plugin App Password
 	--------------------------------------------------------------*/
-	public function nuclen_handle_generate_app_password( $bypass_nonce = false ): void {
+       public function nuclen_handle_generate_app_password( $bypass_nonce = false ): void {
 
-		if ( ! $bypass_nonce ) {
-			if ( ! isset( $_POST['nuclen_generate_app_password_nonce'] ) ||
-				! wp_verify_nonce( sanitize_text_field( wp_unslash( $_POST['nuclen_generate_app_password_nonce'] ) ), 'nuclen_generate_app_password_action' )
-			) {
-				$this->nuclen_redirect_with_error( 'Invalid nonce.' );
-			}
-		}
-		if ( ! current_user_can( 'manage_options' ) ) {
-			$this->nuclen_redirect_with_error( 'Insufficient permissions.' );
-		}
+$this->validate_generate_nonce( $bypass_nonce );
 
-		$settings = $this->nuclen_get_settings_repository();
-		if ( ! $settings->get_bool( 'connected', false ) || empty( $settings->get( 'api_key' ) ) ) {
-			$this->nuclen_redirect_with_error( 'Please complete Step 1 first.' );
-		}
+$settings = $this->nuclen_get_settings_repository();
+if ( ! $settings->get_bool( 'connected', false ) || empty( $settings->get( 'api_key' ) ) ) {
+$this->nuclen_redirect_with_error( 'Please complete Step 1 first.' );
+}
 
-		// Get the current app setup data
-		$app_setup = get_option( 'nuclear_engagement_setup', array() );
+list( $new_password, $uuid, $current_user ) = $this->create_app_password();
+$api_key                                  = $settings->get( 'api_key' );
+if ( empty( $api_key ) ) {
+$this->nuclen_redirect_with_error( 'API key is missing. Please complete Step 1 first.' );
+}
 
-		// ──────────────────────────────────────────────────────────
-		// Generate a new random password & UUID
-		// ──────────────────────────────────────────────────────────
-		$new_password = wp_generate_password( 32, false, false );
-		$uuid         = wp_generate_uuid4();
-		$current_user = wp_get_current_user();
+if ( ! $this->send_credentials_to_saas( $api_key, $new_password, $uuid, $current_user ) ) {
+$this->nuclen_redirect_with_error( 'Failed to send App Password to the SaaS.' );
+}
 
-		// Get API key from settings
-		$api_key = $settings->get( 'api_key' );
-		if ( empty( $api_key ) ) {
-			$this->nuclen_redirect_with_error( 'API key is missing. Please complete Step 1 first.' );
-		}
+$this->persist_app_password( $new_password, $uuid );
 
-				// Send credentials to SaaS (keep payload identical to old format)
-				$setup_service = $this->nuclen_get_setup_service();
-				$ok            = $setup_service->send_app_password(
-					array(
-						'appApiKey'     => $api_key,
-						'siteUrl'       => get_site_url(),
-						'wpUserLogin'   => $current_user->user_login,
-						'wpAppPassword' => $new_password, // same key, new value
-						'wpAppPassUuid' => $uuid,
-					)
-				);
-		if ( ! $ok ) {
-			$this->nuclen_redirect_with_error( 'Failed to send App Password to the SaaS.' );
-		}
-
-		// Update SettingsRepository first
-		$settings = $this->nuclen_get_settings_repository();
-		$settings->set( 'wp_app_pass_created', true )
-				->set( 'wp_app_pass_uuid', $uuid )
-				->set( 'plugin_password', $new_password )
-				->set( 'connected', true ) // Ensure connected is also set
-				->save();
-
-		// Then update the legacy options for backward compatibility
-		$app_setup['wp_app_pass_created'] = true;
-		$app_setup['wp_app_pass_uuid']    = $uuid;
-		$app_setup['plugin_password']     = $new_password;
-		$app_setup['connected']           = true; // Ensure connected is also set in legacy option
-		update_option( 'nuclear_engagement_setup', $app_setup );
-
-		// Clear any caches that might be holding old values
-		wp_cache_delete( 'nuclear_engagement_setup', 'options' );
-
-		$this->nuclen_redirect_with_success( 'Setup completed – you are ready to go!' );
-	}
+$this->nuclen_redirect_with_success( 'Setup completed – you are ready to go!' );
+}
 
 	/*
 	--------------------------------------------------------------
@@ -187,8 +141,58 @@ trait SetupHandlersTrait {
 						->set( 'plugin_password', '' )
 						->save();
 
-				$this->nuclen_redirect_with_success( 'App Password revoked.' );
+$this->nuclen_redirect_with_success( 'App Password revoked.' );
+}
+
+	private function validate_generate_nonce( $bypass ): void {
+	if ( ! $bypass ) {
+	if ( ! isset( $_POST['nuclen_generate_app_password_nonce'] ) ||
+	! wp_verify_nonce( sanitize_text_field( wp_unslash( $_POST['nuclen_generate_app_password_nonce'] ) ), 'nuclen_generate_app_password_action' )
+	) {
+	$this->nuclen_redirect_with_error( 'Invalid nonce.' );
 	}
+	}
+	if ( ! current_user_can( 'manage_options' ) ) {
+	$this->nuclen_redirect_with_error( 'Insufficient permissions.' );
+	}
+	}
+		
+		private function create_app_password(): array {
+		$new_password = wp_generate_password( 32, false, false );
+		$uuid         = wp_generate_uuid4();
+		$current_user = wp_get_current_user();
+		return array( $new_password, $uuid, $current_user );
+		}
+		
+		private function send_credentials_to_saas( string $api_key, string $password, string $uuid, $user ): bool {
+		$setup_service = $this->nuclen_get_setup_service();
+		return $setup_service->send_app_password(
+		array(
+		'appApiKey'     => $api_key,
+		'siteUrl'       => get_site_url(),
+		'wpUserLogin'   => $user->user_login,
+		'wpAppPassword' => $password,
+		'wpAppPassUuid' => $uuid,
+		)
+		);
+		}
+		
+		private function persist_app_password( string $password, string $uuid ): void {
+		$settings = $this->nuclen_get_settings_repository();
+		$settings->set( 'wp_app_pass_created', true )
+		->set( 'wp_app_pass_uuid', $uuid )
+		->set( 'plugin_password', $password )
+		->set( 'connected', true )
+		->save();
+		
+		$app_setup                        = get_option( 'nuclear_engagement_setup', array() );
+		$app_setup['wp_app_pass_created'] = true;
+		$app_setup['wp_app_pass_uuid']    = $uuid;
+		$app_setup['plugin_password']     = $password;
+		$app_setup['connected']           = true;
+		update_option( 'nuclear_engagement_setup', $app_setup );
+		wp_cache_delete( 'nuclear_engagement_setup', 'options' );
+		}
 
 
 	private function nuclen_redirect_with_error( $msg ): void {


### PR DESCRIPTION
## Summary
- add helper methods for generating app passwords
- use new helpers in `nuclen_handle_generate_app_password`

## Testing
- `composer lint`
- `composer test`

------
https://chatgpt.com/codex/tasks/task_e_685e3c73e144832798a6f7af0c596cb6


> [!NOTE]
> I'm currently writing a description for your pull request. I should be done shortly (<1 minute). Please don't edit the description field until I'm finished, or we may overwrite each other. If I find nothing to write about, I'll delete this message.
