### PR TITLE
Refactor LoggingService to instance style

### DIFF
--- a/nuclear-engagement/inc/Services/LoggingService.php
+++ b/nuclear-engagement/inc/Services/LoggingService.php
@@ -11,220 +11,199 @@ declare(strict_types=1);
 namespace NuclearEngagement\Services;
 
 if ( ! defined( 'ABSPATH' ) ) {
-    exit;
+	exit;
 }
 
 class LoggingService {
-    /**
-     * Admin notice service instance.
-     */
-    private static ?AdminNoticeService $notices = null;
+	/** Current service instance. */
+	private static ?self $instance = null;
 
-    public function __construct( AdminNoticeService $notices ) {
-        self::$notices = $notices;
-    }
+	/** Admin notice service instance. */
+	private AdminNoticeService $notices;
 
-        /**
-         * @var array<string> Buffered log messages.
-         */
-    private static array $buffer = array();
+	/** Buffered log messages. */
+	private array $buffer = array();
 
-        /**
-         * Whether the shutdown hook has been registered.
-         */
-    private static bool $shutdown_registered = false;
+	/** Whether the shutdown hook has been registered. */
+	private bool $shutdown_registered = false;
 
-    /**
-     * Get directory, path and URL for the log file.
-     */
-    public static function get_log_file_info(): array {
-            $upload_dir = wp_upload_dir();
+	public function __construct( AdminNoticeService $notices ) {
+	    $this->notices  = $notices;
+	    self::$instance = $this;
+	}
 
-        if ( ! empty( $upload_dir['error'] ) ) {
-                error_log( '[Nuclear Engagement] ' . $upload_dir['error'] );
-                self::add_admin_notice( 'Uploads directory unavailable. Using plugin directory for logs.' );
-                $fallback_dir = rtrim( NUCLEN_PLUGIN_DIR, '/' ) . '/logs';
-                return array(
-                    'dir'  => $fallback_dir,
-                    'path' => $fallback_dir . '/log.txt',
-                    'url'  => '',
-                );
-        }
+	/** Retrieve the active instance. */
+	private static function instance(): self {
+	    if ( null === self::$instance ) {
+	        throw new \RuntimeException( 'LoggingService not initialized' );
+	    }
+	    return self::$instance;
+	}
 
-            $log_folder = $upload_dir['basedir'] . '/nuclear-engagement';
-            $log_file   = $log_folder . '/log.txt';
-            $log_url    = $upload_dir['baseurl'] . '/nuclear-engagement/log.txt';
+	/** Forward static calls to the current instance. */
+	public static function __callStatic( string $name, array $arguments ) {
+	    $instance = self::instance();
+	    if ( ! method_exists( $instance, $name ) ) {
+	        throw new \BadMethodCallException( "Method {$name} does not exist" );
+	    }
+	    return $instance->$name( ...$arguments );
+	}
 
-            return array(
-                'dir'  => $log_folder,
-                'path' => $log_file,
-                'url'  => $log_url,
-            );
-    }
+	/** Get directory, path and URL for the log file. */
+	public function get_log_file_info(): array {
+	    $upload_dir = wp_upload_dir();
 
-    /**
-     * Store an admin notice and ensure the hook is registered.
-     */
-    private static function add_admin_notice( string $message ): void {
-        if ( null === self::$notices ) {
-            return;
-        }
+	    if ( ! empty( $upload_dir['error'] ) ) {
+	        error_log( '[Nuclear Engagement] ' . $upload_dir['error'] );
+	        $this->add_admin_notice( 'Uploads directory unavailable. Using plugin directory for logs.' );
+	        $fallback_dir = rtrim( NUCLEN_PLUGIN_DIR, '/' ) . '/logs';
+	        return array(
+	            'dir'  => $fallback_dir,
+	            'path' => $fallback_dir . '/log.txt',
+	            'url'  => '',
+	        );
+	    }
 
-        self::$notices->add( $message );
-    }
+	    $log_folder = $upload_dir['basedir'] . '/nuclear-engagement';
+	    $log_file   = $log_folder . '/log.txt';
+	    $log_url    = $upload_dir['baseurl'] . '/nuclear-engagement/log.txt';
 
-    /**
-     * Public helper to show an admin error notice.
-     */
-    public static function notify_admin( string $message ): void {
-        self::add_admin_notice( $message );
-    }
+	    return array(
+	        'dir'  => $log_folder,
+	        'path' => $log_file,
+	        'url'  => $log_url,
+	    );
+	}
 
-    /**
-     * Debug level logging, only when WP_DEBUG is true.
-     */
-    public static function debug( string $message ): void {
-        if ( defined( 'WP_DEBUG' ) && WP_DEBUG ) {
-                self::log( '[DEBUG] ' . $message );
-        }
-    }
+	/** Store an admin notice and ensure the hook is registered. */
+	private function add_admin_notice( string $message ): void {
+	    $this->notices->add( $message );
+	}
 
-        /**
-         * Log an exception including file and line. When WP_DEBUG is true
-         * append a short stack trace.
-         */
-    public static function log_exception( \Throwable $e ): void {
-            $msg = $e->getMessage() . ' in ' . $e->getFile() . ':' . $e->getLine();
-        if ( defined( 'WP_DEBUG' ) && WP_DEBUG ) {
-                $trace_lines = explode( "\n", $e->getTraceAsString() );
-                $trace       = implode( ' | ', array_slice( $trace_lines, 0, 3 ) );
-                $msg        .= ' Stack trace: ' . $trace;
-        }
-            self::log( $msg );
-    }
+	/** Public helper to show an admin error notice. */
+	public function notify_admin( string $message ): void {
+	    $this->add_admin_notice( $message );
+	}
 
+	/** Debug level logging, only when WP_DEBUG is true. */
+	public function debug( string $message ): void {
+	    if ( defined( 'WP_DEBUG' ) && WP_DEBUG ) {
+	        $this->log( '[DEBUG] ' . $message );
+	    }
+	}
 
+	/** Log an exception including file and line. */
+	public function log_exception( \Throwable $e ): void {
+	    $msg = $e->getMessage() . ' in ' . $e->getFile() . ':' . $e->getLine();
+	    if ( defined( 'WP_DEBUG' ) && WP_DEBUG ) {
+	        $trace_lines = explode( "\n", $e->getTraceAsString() );
+	        $trace       = implode( ' | ', array_slice( $trace_lines, 0, 3 ) );
+	        $msg        .= ' Stack trace: ' . $trace;
+	    }
+	    $this->log( $msg );
+	}
 
-    /**
-     * Fallback when writing to the log fails.
-     */
-    private static function fallback( string $original, string $error ): void {
-            $timestamp = gmdate( 'Y-m-d H:i:s' );
-            error_log( "[Nuclear Engagement] [$timestamp] {$original} - {$error}" );
-            self::add_admin_notice( $error );
-    }
+	/** Fallback when writing to the log fails. */
+	private function fallback( string $original, string $error ): void {
+	    $timestamp = gmdate( 'Y-m-d H:i:s' );
+	    error_log( "[Nuclear Engagement] [{$timestamp}] {$original} - {$error}" );
+	    $this->add_admin_notice( $error );
+	}
 
-        /**
-         * Determine if logging should be buffered.
-         */
-    private static function use_buffer(): bool {
-            $default = defined( 'NUCLEN_BUFFER_LOGS' ) ? (bool) NUCLEN_BUFFER_LOGS : true;
+	/** Determine if logging should be buffered. */
+	private function use_buffer(): bool {
+	    $default = defined( 'NUCLEN_BUFFER_LOGS' ) ? (bool) NUCLEN_BUFFER_LOGS : true;
+	    return (bool) apply_filters( 'nuclen_enable_log_buffer', $default );
+	}
 
-            /**
-             * Filters whether logging should buffer messages until shutdown.
-             *
-             * @param bool $use_buffer Current setting.
-             */
-            return (bool) apply_filters( 'nuclen_enable_log_buffer', $default );
-    }
+	/** Flush buffered messages to the log file. */
+	public function flush(): void {
+	    if ( empty( $this->buffer ) ) {
+	        return;
+	    }
 
-        /**
-         * Flush buffered messages to the log file.
-         */
-    public static function flush(): void {
-        if ( empty( self::$buffer ) ) {
-                return;
-        }
+	    $this->write_messages( $this->buffer );
+	    $this->buffer = array();
+	}
 
-            self::write_messages( self::$buffer );
-            self::$buffer = array();
-    }
+	/** Write one or more messages to the log. */
+	private function write_messages( array $messages ): void {
+	    $info       = $this->get_log_file_info();
+	    $log_folder = $info['dir'];
+	    $log_file   = $info['path'];
+	    $max_size   = defined( 'NUCLEN_LOG_FILE_MAX_SIZE' ) ? NUCLEN_LOG_FILE_MAX_SIZE : MB_IN_BYTES;
 
-        /**
-         * Write one or more messages to the log.
-         *
-         * @param array<string> $messages Messages to write.
-         */
-    private static function write_messages( array $messages ): void {
-            $info       = self::get_log_file_info();
-            $log_folder = $info['dir'];
-            $log_file   = $info['path'];
-            $max_size   = defined( 'NUCLEN_LOG_FILE_MAX_SIZE' ) ? NUCLEN_LOG_FILE_MAX_SIZE : MB_IN_BYTES;
+	    if ( ! file_exists( $log_folder ) ) {
+	        if ( ! wp_mkdir_p( $log_folder ) ) {
+	            foreach ( $messages as $msg ) {
+	                $this->fallback( $msg, 'Failed to create log directory: ' . $log_folder );
+	            }
+	            return;
+	        }
+	    }
 
-        if ( ! file_exists( $log_folder ) ) {
-            if ( ! wp_mkdir_p( $log_folder ) ) {
-                foreach ( $messages as $msg ) {
-                        self::fallback( $msg, 'Failed to create log directory: ' . $log_folder );
-                }
-                return;
-            }
-        }
+	    if ( ! is_writable( $log_folder ) ) {
+	        foreach ( $messages as $msg ) {
+	            $this->fallback( $msg, 'Log directory not writable: ' . $log_folder );
+	        }
+	        return;
+	    }
 
-        if ( ! is_writable( $log_folder ) ) {
-            foreach ( $messages as $msg ) {
-                    self::fallback( $msg, 'Log directory not writable: ' . $log_folder );
-            }
-                return;
-        }
+	    if ( file_exists( $log_file ) && ! is_writable( $log_file ) ) {
+	        foreach ( $messages as $msg ) {
+	            $this->fallback( $msg, 'Log file not writable: ' . $log_file );
+	        }
+	        return;
+	    }
 
-        if ( file_exists( $log_file ) && ! is_writable( $log_file ) ) {
-            foreach ( $messages as $msg ) {
-                    self::fallback( $msg, 'Log file not writable: ' . $log_file );
-            }
-                return;
-        }
+	    if ( file_exists( $log_file ) && filesize( $log_file ) > $max_size ) {
+	        $timestamped = $log_folder . '/log-' . gmdate( 'Y-m-d-His' ) . '.txt';
+	        $renamed     = rename( $log_file, $timestamped );
+	        if ( ! $renamed ) {
+	            foreach ( $messages as $msg ) {
+	                $this->fallback( $msg, 'Failed to rotate log file: ' . $timestamped );
+	            }
+	        }
+	    }
 
-        if ( file_exists( $log_file ) && filesize( $log_file ) > $max_size ) {
-                $timestamped = $log_folder . '/log-' . gmdate( 'Y-m-d-His' ) . '.txt';
-                $renamed     = rename( $log_file, $timestamped );
-            if ( ! $renamed ) {
-                foreach ( $messages as $msg ) {
-                    self::fallback( $msg, 'Failed to rotate log file: ' . $timestamped );
-                }
-            }
-        }
+	    $data = '';
+	    if ( ! file_exists( $log_file ) ) {
+	        $timestamp = gmdate( 'Y-m-d H:i:s' );
+	        $data     .= "[{$timestamp}] Log file created\n";
+	    }
 
-            $data = '';
-        if ( ! file_exists( $log_file ) ) {
-                $timestamp = gmdate( 'Y-m-d H:i:s' );
-                $data     .= "[$timestamp] Log file created\n";
-        }
+	    foreach ( $messages as $msg ) {
+	        $timestamp = gmdate( 'Y-m-d H:i:s' );
+	        $data     .= "[{$timestamp}] {$msg}\n";
+	    }
 
-        foreach ( $messages as $msg ) {
-                $timestamp = gmdate( 'Y-m-d H:i:s' );
-                $data     .= "[$timestamp] {$msg}\n";
-        }
+	    if ( file_put_contents( $log_file, $data, FILE_APPEND | LOCK_EX ) === false ) {
+	        foreach ( $messages as $msg ) {
+	            $this->fallback( $msg, 'Failed to write to log file: ' . $log_file );
+	        }
+	    }
+	}
 
-        if ( file_put_contents( $log_file, $data, FILE_APPEND | LOCK_EX ) === false ) {
-            foreach ( $messages as $msg ) {
-                    self::fallback( $msg, 'Failed to write to log file: ' . $log_file );
-            }
-        }
-    }
+	/** Append a message to the plugin log file. */
+	public function log( string $message ): void {
+	    if ( $message === '' ) {
+	        return;
+	    }
 
-    /**
-     * Append a message to the plugin log file.
-     */
-    public static function log( string $message ): void {
-        if ( $message === '' ) {
-                return;
-        }
+	    $message = wp_strip_all_tags( $message );
+	    if ( strlen( $message ) > 1000 ) {
+	        $message = substr( $message, 0, 1000 ) . '...';
+	    }
 
-            // Strip any HTML and limit length to avoid leaking sensitive data
-            $message = wp_strip_all_tags( $message );
-        if ( strlen( $message ) > 1000 ) {
-                $message = substr( $message, 0, 1000 ) . '...';
-        }
+	    if ( $this->use_buffer() ) {
+	        $this->buffer[] = $message;
+	        if ( ! $this->shutdown_registered ) {
+	            register_shutdown_function( array( self::class, 'flush' ) );
+	            $this->shutdown_registered = true;
+	        }
+	        return;
+	    }
 
-        if ( self::use_buffer() ) {
-                self::$buffer[] = $message;
-            if ( ! self::$shutdown_registered ) {
-                    register_shutdown_function( array( self::class, 'flush' ) );
-                    self::$shutdown_registered = true;
-            }
-                return;
-        }
-
-            self::write_messages( array( $message ) );
-    }
+	    $this->write_messages( array( $message ) );
+	}
 }

--- a/tests/LoggingServiceTest.php
+++ b/tests/LoggingServiceTest.php
@@ -1,199 +1,200 @@
 <?php
 namespace NuclearEngagement\Services {
-    function add_action(...$args) {
-        $GLOBALS['ls_actions'][] = $args;
-    }
-    function file_put_contents($file, $data, $flags = 0) {
-        $GLOBALS['ls_puts'][] = $file;
-        return \file_put_contents($file, $data, $flags);
-    }
-    function register_shutdown_function($cb) {
-        $GLOBALS['ls_shutdown'][] = $cb;
-    }
-    function error_log($msg) {
-        $GLOBALS['ls_errors'][] = $msg;
-    }
-    function rename($from, $to) {
-        if (!empty($GLOBALS['ls_rename_fail'])) {
-            return false;
-        }
-        return \rename($from, $to);
-    }
-    if (!function_exists('apply_filters')) {
-        function apply_filters($hook, $value) {
-            if ($hook === 'nuclen_enable_log_buffer' && isset($GLOBALS['ls_filter_buffer'])) {
-                return $GLOBALS['ls_filter_buffer'];
-            }
-            return $value;
-        }
-    }
-    if (!function_exists('esc_html')) {
-        function esc_html($text) { return $text; }
-    }
+	function add_action(...$args) {
+	    $GLOBALS['ls_actions'][] = $args;
+	}
+	function file_put_contents($file, $data, $flags = 0) {
+	    $GLOBALS['ls_puts'][] = $file;
+	    return \file_put_contents($file, $data, $flags);
+	}
+	function register_shutdown_function($cb) {
+	    $GLOBALS['ls_shutdown'][] = $cb;
+	}
+	function error_log($msg) {
+	    $GLOBALS['ls_errors'][] = $msg;
+	}
+	function rename($from, $to) {
+	    if (!empty($GLOBALS['ls_rename_fail'])) {
+	        return false;
+	    }
+	    return \rename($from, $to);
+	}
+	if (!function_exists('apply_filters')) {
+	    function apply_filters($hook, $value) {
+	        if ($hook === 'nuclen_enable_log_buffer' && isset($GLOBALS['ls_filter_buffer'])) {
+	            return $GLOBALS['ls_filter_buffer'];
+	        }
+	        return $value;
+	    }
+	}
+	if (!function_exists('esc_html')) {
+	    function esc_html($text) { return $text; }
+	}
 
-    class AdminNoticeService {
-        public array $messages = [];
-        public function add(string $msg): void {
-            $this->messages[] = $msg;
-            add_action('admin_notices', [$this, 'render']);
-        }
-        public function render(): void {}
-    }
+	class AdminNoticeService {
+	    public array $messages = [];
+	    public function add(string $msg): void {
+	        $this->messages[] = $msg;
+	        add_action('admin_notices', [$this, 'render']);
+	    }
+	    public function render(): void {}
+	}
 }
 
 namespace {
-    use PHPUnit\Framework\TestCase;
-    use NuclearEngagement\Services\LoggingService;
-    use NuclearEngagement\Services\AdminNoticeService;
-    class LoggingServiceTest extends TestCase {
-        private static string $plugin_dir;
+	use PHPUnit\Framework\TestCase;
+	use NuclearEngagement\Services\LoggingService;
+	use NuclearEngagement\Services\AdminNoticeService;
+	class LoggingServiceTest extends TestCase {
+	    private static string $plugin_dir;
+	    private LoggingService $logger;
 
-        public static function setUpBeforeClass(): void {
-            self::$plugin_dir = sys_get_temp_dir() . '/ls_plugin_' . uniqid();
-            if (!defined('NUCLEN_PLUGIN_DIR')) {
-                define('NUCLEN_PLUGIN_DIR', self::$plugin_dir . '/');
-            }
-        }
-        protected function setUp(): void {
-            $GLOBALS['ls_actions'] = [];
-            $GLOBALS['ls_errors'] = [];
-            $GLOBALS['ls_puts'] = [];
-            $GLOBALS['ls_shutdown'] = [];
-            $GLOBALS['test_upload_basedir'] = sys_get_temp_dir() . '/ls_' . uniqid();
-            mkdir($GLOBALS['test_upload_basedir']);
-            $GLOBALS['ls_filter_buffer'] = false;
-            $GLOBALS['ls_rename_fail'] = false;
-            if (!is_dir(self::$plugin_dir)) {
-                mkdir(self::$plugin_dir, 0777, true);
-            }
+	    public static function setUpBeforeClass(): void {
+	        self::$plugin_dir = sys_get_temp_dir() . '/ls_plugin_' . uniqid();
+	        if (!defined('NUCLEN_PLUGIN_DIR')) {
+	            define('NUCLEN_PLUGIN_DIR', self::$plugin_dir . '/');
+	        }
+	    }
+	    protected function setUp(): void {
+	        $GLOBALS['ls_actions'] = [];
+	        $GLOBALS['ls_errors'] = [];
+	        $GLOBALS['ls_puts'] = [];
+	        $GLOBALS['ls_shutdown'] = [];
+	        $GLOBALS['test_upload_basedir'] = sys_get_temp_dir() . '/ls_' . uniqid();
+	        mkdir($GLOBALS['test_upload_basedir']);
+	        $GLOBALS['ls_filter_buffer'] = false;
+	        $GLOBALS['ls_rename_fail'] = false;
+	        if (!is_dir(self::$plugin_dir)) {
+	            mkdir(self::$plugin_dir, 0777, true);
+	        }
 
-            new LoggingService(new AdminNoticeService());
-        }
+	        $this->logger = new LoggingService(new AdminNoticeService());
+	    }
 
-        protected function tearDown(): void {
-            LoggingService::flush();
-            foreach ($GLOBALS['ls_shutdown'] as $cb) {
-                $cb();
-            }
-            unset($GLOBALS['ls_filter_buffer']);
-            unset($GLOBALS['ls_rename_fail']);
-            $base = $GLOBALS['test_upload_basedir'];
-            foreach (glob("$base/*") as $file) {
-                @unlink($file);
-            }
-            @rmdir($base);
-            if (is_dir(self::$plugin_dir)) {
-                array_map('unlink', glob(self::$plugin_dir . '/*'));
-                rmdir(self::$plugin_dir);
-            }
-        }
+	    protected function tearDown(): void {
+	        $this->logger->flush();
+	        foreach ($GLOBALS['ls_shutdown'] as $cb) {
+	            $cb();
+	        }
+	        unset($GLOBALS['ls_filter_buffer']);
+	        unset($GLOBALS['ls_rename_fail']);
+	        $base = $GLOBALS['test_upload_basedir'];
+	        foreach (glob("$base/*") as $file) {
+	            @unlink($file);
+	        }
+	        @rmdir($base);
+	        if (is_dir(self::$plugin_dir)) {
+	            array_map('unlink', glob(self::$plugin_dir . '/*'));
+	            rmdir(self::$plugin_dir);
+	        }
+	    }
 
-        public function test_unwritable_directory_triggers_fallback(): void {
-            chmod($GLOBALS['test_upload_basedir'], 0555);
-            LoggingService::log('test message');
-            $this->assertSame(['test message'], $GLOBALS['ls_errors']);
-            $this->assertSame('admin_notices', $GLOBALS['ls_actions'][0][0]);
-        }
+	    public function test_unwritable_directory_triggers_fallback(): void {
+	        chmod($GLOBALS['test_upload_basedir'], 0555);
+	        $this->logger->log('test message');
+	        $this->assertSame(['test message'], $GLOBALS['ls_errors']);
+	        $this->assertSame('admin_notices', $GLOBALS['ls_actions'][0][0]);
+	    }
 
-        public function test_logs_message_to_file_when_writable(): void {
-            LoggingService::log('hello world');
-            $info = LoggingService::get_log_file_info();
-            $this->assertFileExists($info['path']);
-            $contents = file_get_contents($info['path']);
-            $this->assertStringContainsString('hello world', $contents);
-        }
+	    public function test_logs_message_to_file_when_writable(): void {
+	        $this->logger->log('hello world');
+	        $info = $this->logger->get_log_file_info();
+	        $this->assertFileExists($info['path']);
+	        $contents = file_get_contents($info['path']);
+	        $this->assertStringContainsString('hello world', $contents);
+	    }
 
-        public function test_debug_logs_only_when_constant_defined(): void {
-            LoggingService::debug('no constant');
-            $info = LoggingService::get_log_file_info();
-            $this->assertFileDoesNotExist($info['path']);
+	    public function test_debug_logs_only_when_constant_defined(): void {
+	        $this->logger->debug('no constant');
+	        $info = $this->logger->get_log_file_info();
+	        $this->assertFileDoesNotExist($info['path']);
 
-            if (!defined('WP_DEBUG')) {
-                define('WP_DEBUG', true);
-            }
-            LoggingService::debug('debug message');
-            $this->assertFileExists($info['path']);
-            $contents = file_get_contents($info['path']);
-            $this->assertStringContainsString('[DEBUG] debug message', $contents);
-        }
+	        if (!defined('WP_DEBUG')) {
+	            define('WP_DEBUG', true);
+	        }
+	        $this->logger->debug('debug message');
+	        $this->assertFileExists($info['path']);
+	        $contents = file_get_contents($info['path']);
+	        $this->assertStringContainsString('[DEBUG] debug message', $contents);
+	    }
 
-        public function test_logs_strip_html_and_truncate_long_message(): void {
-            $long = '<p>' . str_repeat('a', 1005) . '</p>';
-            LoggingService::log($long);
-            $info = LoggingService::get_log_file_info();
-            $this->assertFileExists($info['path']);
-            $contents = file_get_contents($info['path']);
-            $expected = str_repeat('a', 1000) . '...';
-            $this->assertStringContainsString($expected, $contents);
-            $this->assertStringNotContainsString('<p>', $contents);
-        }
+	    public function test_logs_strip_html_and_truncate_long_message(): void {
+	        $long = '<p>' . str_repeat('a', 1005) . '</p>';
+	        $this->logger->log($long);
+	        $info = $this->logger->get_log_file_info();
+	        $this->assertFileExists($info['path']);
+	        $contents = file_get_contents($info['path']);
+	        $expected = str_repeat('a', 1000) . '...';
+	        $this->assertStringContainsString($expected, $contents);
+	        $this->assertStringNotContainsString('<p>', $contents);
+	    }
 
-        public function test_buffered_logging_single_write(): void {
-            $GLOBALS['ls_filter_buffer'] = true;
-            for ($i = 0; $i < 5; $i++) {
-                LoggingService::log("msg $i");
-            }
-            $info = LoggingService::get_log_file_info();
-            $this->assertFileDoesNotExist($info['path']);
+	    public function test_buffered_logging_single_write(): void {
+	        $GLOBALS['ls_filter_buffer'] = true;
+	        for ($i = 0; $i < 5; $i++) {
+	            $this->logger->log("msg $i");
+	        }
+	        $info = $this->logger->get_log_file_info();
+	        $this->assertFileDoesNotExist($info['path']);
 
-            LoggingService::flush();
+	        $this->logger->flush();
 
-            $this->assertFileExists($info['path']);
-            $this->assertCount(1, $GLOBALS['ls_puts']);
-            $contents = file_get_contents($info['path']);
-            $this->assertStringContainsString('msg 4', $contents);
-        }
+	        $this->assertFileExists($info['path']);
+	        $this->assertCount(1, $GLOBALS['ls_puts']);
+	        $contents = file_get_contents($info['path']);
+	        $this->assertStringContainsString('msg 4', $contents);
+	    }
 
-        public function test_rotation_failure_triggers_fallback(): void {
-            if (!defined('NUCLEN_LOG_FILE_MAX_SIZE')) {
-                define('NUCLEN_LOG_FILE_MAX_SIZE', 1);
-            }
-            $info = LoggingService::get_log_file_info();
-            if (!file_exists($info['dir'])) {
-                mkdir($info['dir'], 0777, true);
-            }
-            file_put_contents($info['path'], 'aa');
-            $GLOBALS['ls_rename_fail'] = true;
+	    public function test_rotation_failure_triggers_fallback(): void {
+	        if (!defined('NUCLEN_LOG_FILE_MAX_SIZE')) {
+	            define('NUCLEN_LOG_FILE_MAX_SIZE', 1);
+	        }
+	        $info = $this->logger->get_log_file_info();
+	        if (!file_exists($info['dir'])) {
+	            mkdir($info['dir'], 0777, true);
+	        }
+	        file_put_contents($info['path'], 'aa');
+	        $GLOBALS['ls_rename_fail'] = true;
 
-            LoggingService::log('rotate');
+	        $this->logger->log('rotate');
 
-            $this->assertNotEmpty($GLOBALS['ls_errors']);
-            $this->assertStringContainsString('Failed to rotate log file', $GLOBALS['ls_errors'][0]);
-        }
+	        $this->assertNotEmpty($GLOBALS['ls_errors']);
+	        $this->assertStringContainsString('Failed to rotate log file', $GLOBALS['ls_errors'][0]);
+	    }
 
-        public function test_upload_dir_error_returns_fallback_info(): void {
-            $GLOBALS['test_upload_error'] = 'fail';
-            $info = LoggingService::get_log_file_info();
-            $expected_dir = rtrim(NUCLEN_PLUGIN_DIR, '/') . '/logs';
-            $this->assertSame($expected_dir, $info['dir']);
-            $this->assertSame($expected_dir . '/log.txt', $info['path']);
-            $this->assertSame('', $info['url']);
-            $this->assertSame('admin_notices', $GLOBALS['ls_actions'][0][0]);
-            $this->assertNotEmpty($GLOBALS['ls_errors']);
-            unset($GLOBALS['test_upload_error']);
-        }
+	    public function test_upload_dir_error_returns_fallback_info(): void {
+	        $GLOBALS['test_upload_error'] = 'fail';
+	        $info = $this->logger->get_log_file_info();
+	        $expected_dir = rtrim(NUCLEN_PLUGIN_DIR, '/') . '/logs';
+	        $this->assertSame($expected_dir, $info['dir']);
+	        $this->assertSame($expected_dir . '/log.txt', $info['path']);
+	        $this->assertSame('', $info['url']);
+	        $this->assertSame('admin_notices', $GLOBALS['ls_actions'][0][0]);
+	        $this->assertNotEmpty($GLOBALS['ls_errors']);
+	        unset($GLOBALS['test_upload_error']);
+	    }
 
-        public function test_log_exception_without_debug(): void {
-            $e = new \Exception('oops');
-            LoggingService::log_exception($e);
-            $info = LoggingService::get_log_file_info();
-            $this->assertFileExists($info['path']);
-            $contents = file_get_contents($info['path']);
-            $this->assertStringContainsString('oops in', $contents);
-            $this->assertStringNotContainsString('Stack trace:', $contents);
-        }
+	    public function test_log_exception_without_debug(): void {
+	        $e = new \Exception('oops');
+	        $this->logger->log_exception($e);
+	        $info = $this->logger->get_log_file_info();
+	        $this->assertFileExists($info['path']);
+	        $contents = file_get_contents($info['path']);
+	        $this->assertStringContainsString('oops in', $contents);
+	        $this->assertStringNotContainsString('Stack trace:', $contents);
+	    }
 
-        public function test_log_exception_with_debug(): void {
-            if (!defined('WP_DEBUG')) {
-                define('WP_DEBUG', true);
-            }
-            $e = new \Exception('boom');
-            LoggingService::log_exception($e);
-            $info = LoggingService::get_log_file_info();
-            $this->assertFileExists($info['path']);
-            $contents = file_get_contents($info['path']);
-            $this->assertStringContainsString('boom in', $contents);
-            $this->assertStringContainsString('Stack trace:', $contents);
-        }
-    }
+	    public function test_log_exception_with_debug(): void {
+	        if (!defined('WP_DEBUG')) {
+	            define('WP_DEBUG', true);
+	        }
+	        $e = new \Exception('boom');
+	        $this->logger->log_exception($e);
+	        $info = $this->logger->get_log_file_info();
+	        $this->assertFileExists($info['path']);
+	        $contents = file_get_contents($info['path']);
+	        $this->assertStringContainsString('boom in', $contents);
+	        $this->assertStringContainsString('Stack trace:', $contents);
+	    }
+	}
 }


### PR DESCRIPTION
## Summary
- make `LoggingService` instance based and add `__callStatic`
- adjust `LoggingServiceTest` to use the new instance API

## Testing
- `composer lint` *(fails: `composer` not installed)*
- `composer test` *(fails: `composer` not installed)*

------
https://chatgpt.com/codex/tasks/task_e_685e3c7594988327be1a7464f6aade0d

<!-- Korbit AI PR Description Start -->
## Description by Korbit AI

### What change is being made?

Refactor `LoggingService` to use an instance-based approach instead of a static one, and update associated tests accordingly.

### Why are these changes being made?

This refactor enhances object-oriented principles by encapsulating state and behavior in instance methods, thus improving maintainability and testability. This approach allows better dependency management and future expansions and aligns with modern PHP practices by decoupling services from the static state.

> Is this description stale? Ask me to generate a new description by commenting `/korbit-generate-pr-description`
<!-- Korbit AI PR Description End -->