### PR TITLE
Enforce tab indentation across codebase

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -3,9 +3,9 @@ end_of_line = lf
 insert_final_newline = true
 
 [*.php]
-indent_style = space
+indent_style = tab
 indent_size = 4
 
 [*.ts]
-indent_style = space
+indent_style = tab
 indent_size = 2

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -62,7 +62,8 @@ export default [
     // won't silently change lint behavior.
     rules: {
       ...tsPlugin.configs.recommended.rules,
-      '@typescript-eslint/no-explicit-any': 'off'
+      '@typescript-eslint/no-explicit-any': 'off',
+      indent: ['error', 'tab']
     }
   }
 ];

--- a/nuclear-engagement/admin/Controller/Ajax/UpdatesController.php
+++ b/nuclear-engagement/admin/Controller/Ajax/UpdatesController.php
@@ -89,20 +89,20 @@ class UpdatesController extends BaseController {
 			}
 
 				/* ── Persist & return results ───────────────────────────── */
-                        if ( ! empty( $data['results'] ) && is_array( $data['results'] ) ) {
-                                $first        = reset( $data['results'] );
-                                $workflowType = isset( $first['questions'] ) ? 'quiz' : 'summary';
+						if ( ! empty( $data['results'] ) && is_array( $data['results'] ) ) {
+								$first        = reset( $data['results'] );
+								$workflowType = isset( $first['questions'] ) ? 'quiz' : 'summary';
 
-                                $statuses = $this->storage->storeResults( $data['results'], $workflowType );
+								$statuses = $this->storage->storeResults( $data['results'], $workflowType );
 
-                                if ( array_filter( $statuses, static fn( $s ) => $s !== true ) ) {
-                                        $this->sendError( __( 'Failed to store content.', 'nuclear-engagement' ) );
-                                        return;
-                                }
+								if ( array_filter( $statuses, static fn( $s ) => $s !== true ) ) {
+										$this->sendError( __( 'Failed to store content.', 'nuclear-engagement' ) );
+										return;
+								}
 
-                                $response->results  = $data['results'];
-                                $response->workflow = $workflowType; // NEW → lets JS forward it to /receive-content
-                        }
+								$response->results  = $data['results'];
+								$response->workflow = $workflowType; // NEW → lets JS forward it to /receive-content
+						}
 
 				wp_send_json_success( $response->toArray() );
 

--- a/nuclear-engagement/admin/Dashboard.php
+++ b/nuclear-engagement/admin/Dashboard.php
@@ -133,20 +133,20 @@ if ( null === $inventory_cache ) {
 
 		$sql_cat  = $wpdb->prepare(
 			"SELECT t.term_id,
-                       t.name AS cat_name,
-                       SUM(CASE WHEN pm_q.meta_id IS NULL THEN 0 ELSE 1 END) AS quiz_with,
-                       SUM(CASE WHEN pm_q.meta_id IS NULL THEN 1 ELSE 0 END) AS quiz_without,
-                       SUM(CASE WHEN pm_s.meta_id IS NULL THEN 0 ELSE 1 END) AS summary_with,
-                       SUM(CASE WHEN pm_s.meta_id IS NULL THEN 1 ELSE 0 END) AS summary_without
-                FROM {$wpdb->posts} p
-                JOIN {$wpdb->term_relationships} tr ON tr.object_id = p.ID
-                JOIN {$wpdb->term_taxonomy}  tt ON tt.term_taxonomy_id = tr.term_taxonomy_id AND tt.taxonomy = 'category'
-                JOIN {$wpdb->terms}          t  ON t.term_id = tt.term_id
-                LEFT JOIN {$wpdb->postmeta}  pm_q ON pm_q.post_id = p.ID AND pm_q.meta_key = 'nuclen-quiz-data'
-                LEFT JOIN {$wpdb->postmeta}  pm_s ON pm_s.post_id = p.ID AND pm_s.meta_key = '" . Summary_Service::META_KEY . "'
-                WHERE p.post_type  IN ($placeholders_pt)
-                  AND p.post_status IN ($placeholders_st)
-                GROUP BY t.term_id",
+					   t.name AS cat_name,
+					   SUM(CASE WHEN pm_q.meta_id IS NULL THEN 0 ELSE 1 END) AS quiz_with,
+					   SUM(CASE WHEN pm_q.meta_id IS NULL THEN 1 ELSE 0 END) AS quiz_without,
+					   SUM(CASE WHEN pm_s.meta_id IS NULL THEN 0 ELSE 1 END) AS summary_with,
+					   SUM(CASE WHEN pm_s.meta_id IS NULL THEN 1 ELSE 0 END) AS summary_without
+				FROM {$wpdb->posts} p
+				JOIN {$wpdb->term_relationships} tr ON tr.object_id = p.ID
+				JOIN {$wpdb->term_taxonomy}  tt ON tt.term_taxonomy_id = tr.term_taxonomy_id AND tt.taxonomy = 'category'
+				JOIN {$wpdb->terms}          t  ON t.term_id = tt.term_id
+				LEFT JOIN {$wpdb->postmeta}  pm_q ON pm_q.post_id = p.ID AND pm_q.meta_key = 'nuclen-quiz-data'
+				LEFT JOIN {$wpdb->postmeta}  pm_s ON pm_s.post_id = p.ID AND pm_s.meta_key = '" . Summary_Service::META_KEY . "'
+				WHERE p.post_type  IN ($placeholders_pt)
+				  AND p.post_status IN ($placeholders_st)
+				GROUP BY t.term_id",
 			array_merge( $sanitized_pt, $sanitized_st )
 		);
 		$cat_rows = $wpdb->get_results( $sql_cat, ARRAY_A );

--- a/nuclear-engagement/admin/SetupHandlersTrait.php
+++ b/nuclear-engagement/admin/SetupHandlersTrait.php
@@ -68,7 +68,7 @@ trait SetupHandlersTrait {
 	--------------------------------------------------------------
 	#  STEP 2 – Generate & store plugin App Password
 	--------------------------------------------------------------*/
-       public function nuclen_handle_generate_app_password( $bypass_nonce = false ): void {
+	   public function nuclen_handle_generate_app_password( $bypass_nonce = false ): void {
 
 $this->validate_generate_nonce( $bypass_nonce );
 

--- a/nuclear-engagement/admin/Traits/AdminAutoGenerate.php
+++ b/nuclear-engagement/admin/Traits/AdminAutoGenerate.php
@@ -64,8 +64,8 @@ trait AdminAutoGenerate {
 
 		// Auto-generate summary
 		if ( $gen_summary ) {
-                        // Skip if summary is protected
-                        $protected = get_post_meta( $post->ID, \NuclearEngagement\Modules\Summary\Summary_Service::PROTECTED_KEY, true );
+						// Skip if summary is protected
+						$protected = get_post_meta( $post->ID, \NuclearEngagement\Modules\Summary\Summary_Service::PROTECTED_KEY, true );
 			if ( ! $protected ) {
 				$this->nuclen_generate_single( $post->ID, 'summary' );
 			}
@@ -110,19 +110,19 @@ trait AdminAutoGenerate {
 						$data = $api->fetch_updates( $generation_id );
 
 			// Check if we have results
-                        if ( ! empty( $data['results'] ) && is_array( $data['results'] ) ) {
-                                $statuses = $storage->storeResults( $data['results'], $workflow_type );
-                                if ( array_filter( $statuses, static fn( $s ) => $s !== true ) ) {
-                                        \NuclearEngagement\Services\LoggingService::notify_admin(
-                                                sprintf( 'Failed to store results for post %d', $post_id )
-                                        );
-                                } else {
-                                        \NuclearEngagement\Services\LoggingService::log(
-                                                "Poll success for post {$post_id} ({$workflow_type}), generation {$generation_id}"
-                                        );
-                                }
-                                return;
-                        }
+						if ( ! empty( $data['results'] ) && is_array( $data['results'] ) ) {
+								$statuses = $storage->storeResults( $data['results'], $workflow_type );
+								if ( array_filter( $statuses, static fn( $s ) => $s !== true ) ) {
+										\NuclearEngagement\Services\LoggingService::notify_admin(
+												sprintf( 'Failed to store results for post %d', $post_id )
+										);
+								} else {
+										\NuclearEngagement\Services\LoggingService::log(
+												"Poll success for post {$post_id} ({$workflow_type}), generation {$generation_id}"
+										);
+								}
+								return;
+						}
 
 			// Check if still processing
 			if ( isset( $data['success'] ) && $data['success'] === true ) {

--- a/nuclear-engagement/admin/Traits/AdminQuizMetabox.php
+++ b/nuclear-engagement/admin/Traits/AdminQuizMetabox.php
@@ -15,20 +15,20 @@ if ( ! defined( 'ABSPATH' ) ) {
 }
 
 trait AdminQuizMetabox {
-       private function create_quiz_admin(): Quiz_Admin {
-               $service = new Quiz_Service();
-               return new Quiz_Admin( $this->nuclen_get_settings_repository(), $service );
-       }
+	   private function create_quiz_admin(): Quiz_Admin {
+			   $service = new Quiz_Service();
+			   return new Quiz_Admin( $this->nuclen_get_settings_repository(), $service );
+	   }
 
-       public function nuclen_add_quiz_data_meta_box() {
-               $this->create_quiz_admin()->add_meta_box();
-       }
+	   public function nuclen_add_quiz_data_meta_box() {
+			   $this->create_quiz_admin()->add_meta_box();
+	   }
 
-       public function nuclen_render_quiz_data_meta_box( $post ) {
-               $this->create_quiz_admin()->render_meta_box( $post );
-       }
+	   public function nuclen_render_quiz_data_meta_box( $post ) {
+			   $this->create_quiz_admin()->render_meta_box( $post );
+	   }
 
-       public function nuclen_save_quiz_data_meta( $post_id ) {
-               $this->create_quiz_admin()->save_meta( (int) $post_id );
-       }
+	   public function nuclen_save_quiz_data_meta( $post_id ) {
+			   $this->create_quiz_admin()->save_meta( (int) $post_id );
+	   }
 }

--- a/nuclear-engagement/admin/Traits/SettingsCollectTrait.php
+++ b/nuclear-engagement/admin/Traits/SettingsCollectTrait.php
@@ -11,234 +11,234 @@ declare(strict_types=1);
 namespace NuclearEngagement\Admin\Traits;
 
 if ( ! defined( 'ABSPATH' ) ) {
-    exit;
+	exit;
 }
 
 trait SettingsCollectTrait {
-        /**
-         * Collect raw input values from $_POST.
-         */
-       private function nuclen_collect_input(): array {
-               $raw = array();
+		/**
+		 * Collect raw input values from $_POST.
+		 */
+	   private function nuclen_collect_input(): array {
+			   $raw = array();
 
-               // theme preset
-               $raw['theme'] = isset( $_POST['nuclen_theme'] )
-                       ? sanitize_text_field( wp_unslash( $_POST['nuclen_theme'] ) )
-                       : '';
+			   // theme preset
+			   $raw['theme'] = isset( $_POST['nuclen_theme'] )
+					   ? sanitize_text_field( wp_unslash( $_POST['nuclen_theme'] ) )
+					   : '';
 
-               $raw = array_merge(
-                       $raw,
-                       $this->collect_quiz_style(),
-                       $this->collect_quiz_structure(),
-                       $this->collect_toc_options(),
-                       $this->collect_custom_text(),
-                       $this->collect_optin_options(),
-                       $this->collect_flags_and_generation()
-               );
+			   $raw = array_merge(
+					   $raw,
+					   $this->collect_quiz_style(),
+					   $this->collect_quiz_structure(),
+					   $this->collect_toc_options(),
+					   $this->collect_custom_text(),
+					   $this->collect_optin_options(),
+					   $this->collect_flags_and_generation()
+			   );
 
-               return $raw;
-       }
+			   return $raw;
+	   }
 
-       /**
-        * Collect quiz and summary style fields.
-        */
-       private function collect_quiz_style(): array {
-               $style     = array();
-               $field_map = array(
-                       /* —— Quiz style —— */
-                       'nuclen_font_size'                        => 'font_size',
-                       'nuclen_font_color'                       => 'font_color',
-                       'nuclen_bg_color'                         => 'bg_color',
-                       'nuclen_quiz_border_color'                => 'quiz_border_color',
-                       'nuclen_quiz_border_style'                => 'quiz_border_style',
-                       'nuclen_quiz_border_width'                => 'quiz_border_width',
-                       'nuclen_quiz_border_radius'               => 'quiz_border_radius',
-                       'nuclen_quiz_shadow_color'                => 'quiz_shadow_color',
-                       'nuclen_quiz_shadow_blur'                 => 'quiz_shadow_blur',
+	   /**
+		* Collect quiz and summary style fields.
+		*/
+	   private function collect_quiz_style(): array {
+			   $style     = array();
+			   $field_map = array(
+					   /* —— Quiz style —— */
+					   'nuclen_font_size'                        => 'font_size',
+					   'nuclen_font_color'                       => 'font_color',
+					   'nuclen_bg_color'                         => 'bg_color',
+					   'nuclen_quiz_border_color'                => 'quiz_border_color',
+					   'nuclen_quiz_border_style'                => 'quiz_border_style',
+					   'nuclen_quiz_border_width'                => 'quiz_border_width',
+					   'nuclen_quiz_border_radius'               => 'quiz_border_radius',
+					   'nuclen_quiz_shadow_color'                => 'quiz_shadow_color',
+					   'nuclen_quiz_shadow_blur'                 => 'quiz_shadow_blur',
 
-                       'nuclen_quiz_answer_button_bg_color'      => 'quiz_answer_button_bg_color',
-                       'nuclen_quiz_answer_button_border_color'  => 'quiz_answer_button_border_color',
-                       'nuclen_quiz_answer_button_border_width'  => 'quiz_answer_button_border_width',
-                       'nuclen_quiz_answer_button_border_radius' => 'quiz_answer_button_border_radius',
+					   'nuclen_quiz_answer_button_bg_color'      => 'quiz_answer_button_bg_color',
+					   'nuclen_quiz_answer_button_border_color'  => 'quiz_answer_button_border_color',
+					   'nuclen_quiz_answer_button_border_width'  => 'quiz_answer_button_border_width',
+					   'nuclen_quiz_answer_button_border_radius' => 'quiz_answer_button_border_radius',
 
-                       'nuclen_quiz_progress_bar_fg_color'       => 'quiz_progress_bar_fg_color',
-                       'nuclen_quiz_progress_bar_bg_color'       => 'quiz_progress_bar_bg_color',
-                       'nuclen_quiz_progress_bar_height'         => 'quiz_progress_bar_height',
+					   'nuclen_quiz_progress_bar_fg_color'       => 'quiz_progress_bar_fg_color',
+					   'nuclen_quiz_progress_bar_bg_color'       => 'quiz_progress_bar_bg_color',
+					   'nuclen_quiz_progress_bar_height'         => 'quiz_progress_bar_height',
 
-                       /* —— Summary style —— */
-                       'nuclen_summary_font_size'                => 'summary_font_size',
-                       'nuclen_summary_font_color'               => 'summary_font_color',
-                       'nuclen_summary_bg_color'                 => 'summary_bg_color',
-                       'nuclen_summary_border_color'             => 'summary_border_color',
-                       'nuclen_summary_border_style'             => 'summary_border_style',
-                       'nuclen_summary_border_width'             => 'summary_border_width',
-                       'nuclen_summary_border_radius'            => 'summary_border_radius',
-                       'nuclen_summary_shadow_color'             => 'summary_shadow_color',
-                       'nuclen_summary_shadow_blur'              => 'summary_shadow_blur',
+					   /* —— Summary style —— */
+					   'nuclen_summary_font_size'                => 'summary_font_size',
+					   'nuclen_summary_font_color'               => 'summary_font_color',
+					   'nuclen_summary_bg_color'                 => 'summary_bg_color',
+					   'nuclen_summary_border_color'             => 'summary_border_color',
+					   'nuclen_summary_border_style'             => 'summary_border_style',
+					   'nuclen_summary_border_width'             => 'summary_border_width',
+					   'nuclen_summary_border_radius'            => 'summary_border_radius',
+					   'nuclen_summary_shadow_color'             => 'summary_shadow_color',
+					   'nuclen_summary_shadow_blur'              => 'summary_shadow_blur',
 
-                       /* —— Legacy generic —— */
-                       'nuclen_border_color'                     => 'border_color',
-                       'nuclen_border_style'                     => 'border_style',
-                       'nuclen_border_width'                     => 'border_width',
-               );
+					   /* —— Legacy generic —— */
+					   'nuclen_border_color'                     => 'border_color',
+					   'nuclen_border_style'                     => 'border_style',
+					   'nuclen_border_width'                     => 'border_width',
+			   );
 
-               foreach ( $field_map as $post_key => $opt_key ) {
-                       if ( isset( $_POST[ $post_key ] ) ) {
-                               $style[ $opt_key ] = sanitize_text_field( wp_unslash( $_POST[ $post_key ] ) );
-                       }
-               }
+			   foreach ( $field_map as $post_key => $opt_key ) {
+					   if ( isset( $_POST[ $post_key ] ) ) {
+							   $style[ $opt_key ] = sanitize_text_field( wp_unslash( $_POST[ $post_key ] ) );
+					   }
+			   }
 
-               return $style;
-       }
+			   return $style;
+	   }
 
-       /**
-        * Collect quiz structure counts.
-        */
-       private function collect_quiz_structure(): array {
-               $structure  = array();
-               $field_map = array(
-                       'nuclen_questions_per_quiz'   => 'questions_per_quiz',
-                       'nuclen_answers_per_question' => 'answers_per_question',
-               );
+	   /**
+		* Collect quiz structure counts.
+		*/
+	   private function collect_quiz_structure(): array {
+			   $structure  = array();
+			   $field_map = array(
+					   'nuclen_questions_per_quiz'   => 'questions_per_quiz',
+					   'nuclen_answers_per_question' => 'answers_per_question',
+			   );
 
-               foreach ( $field_map as $post_key => $opt_key ) {
-                       if ( isset( $_POST[ $post_key ] ) ) {
-                               $structure[ $opt_key ] = sanitize_text_field( wp_unslash( $_POST[ $post_key ] ) );
-                       }
-               }
+			   foreach ( $field_map as $post_key => $opt_key ) {
+					   if ( isset( $_POST[ $post_key ] ) ) {
+							   $structure[ $opt_key ] = sanitize_text_field( wp_unslash( $_POST[ $post_key ] ) );
+					   }
+			   }
 
-               return $structure;
-       }
+			   return $structure;
+	   }
 
-       /**
-        * Collect TOC placement and style fields.
-        */
-       private function collect_toc_options(): array {
-               $toc       = array();
-               $field_map = array(
-                       'nuclen_toc_font_size'   => 'toc_font_size',
-                       'nuclen_toc_font_color'  => 'toc_font_color',
-                       'nuclen_toc_bg_color'    => 'toc_bg_color',
-                       'nuclen_toc_border_color'=> 'toc_border_color',
-                       'nuclen_toc_border_style'=> 'toc_border_style',
-                       'nuclen_toc_heading_levels' => 'toc_heading_levels',
-                       'nuclen_toc_show_toggle' => 'toc_show_toggle',
-                       'nuclen_toc_show_content'=> 'toc_show_content',
-                       'nuclen_toc_border_width'=> 'toc_border_width',
-                       'nuclen_toc_border_radius'=> 'toc_border_radius',
-                       'nuclen_toc_shadow_color'=> 'toc_shadow_color',
-                       'nuclen_toc_shadow_blur' => 'toc_shadow_blur',
-                       'nuclen_toc_link_color'  => 'toc_link_color',
-                       'nuclen_toc_title'       => 'toc_title',
-                       'toc_zindex'             => 'toc_z_index',
-                       'toc_sticky_offset_x'    => 'toc_sticky_offset_x',
-                       'toc_sticky_offset_y'    => 'toc_sticky_offset_y',
-                       'toc_sticky_max_width'   => 'toc_sticky_max_width',
-                       'nuclen_display_summary' => 'display_summary',
-                       'nuclen_display_quiz'    => 'display_quiz',
-                       'nuclen_display_toc'     => 'display_toc',
-                       'toc_sticky'             => 'toc_sticky',
-               );
+	   /**
+		* Collect TOC placement and style fields.
+		*/
+	   private function collect_toc_options(): array {
+			   $toc       = array();
+			   $field_map = array(
+					   'nuclen_toc_font_size'   => 'toc_font_size',
+					   'nuclen_toc_font_color'  => 'toc_font_color',
+					   'nuclen_toc_bg_color'    => 'toc_bg_color',
+					   'nuclen_toc_border_color'=> 'toc_border_color',
+					   'nuclen_toc_border_style'=> 'toc_border_style',
+					   'nuclen_toc_heading_levels' => 'toc_heading_levels',
+					   'nuclen_toc_show_toggle' => 'toc_show_toggle',
+					   'nuclen_toc_show_content'=> 'toc_show_content',
+					   'nuclen_toc_border_width'=> 'toc_border_width',
+					   'nuclen_toc_border_radius'=> 'toc_border_radius',
+					   'nuclen_toc_shadow_color'=> 'toc_shadow_color',
+					   'nuclen_toc_shadow_blur' => 'toc_shadow_blur',
+					   'nuclen_toc_link_color'  => 'toc_link_color',
+					   'nuclen_toc_title'       => 'toc_title',
+					   'toc_zindex'             => 'toc_z_index',
+					   'toc_sticky_offset_x'    => 'toc_sticky_offset_x',
+					   'toc_sticky_offset_y'    => 'toc_sticky_offset_y',
+					   'toc_sticky_max_width'   => 'toc_sticky_max_width',
+					   'nuclen_display_summary' => 'display_summary',
+					   'nuclen_display_quiz'    => 'display_quiz',
+					   'nuclen_display_toc'     => 'display_toc',
+					   'toc_sticky'             => 'toc_sticky',
+			   );
 
-               foreach ( $field_map as $post_key => $opt_key ) {
-                       if ( isset( $_POST[ $post_key ] ) ) {
-                               $toc[ $opt_key ] = sanitize_text_field( wp_unslash( $_POST[ $post_key ] ) );
-                       }
-               }
+			   foreach ( $field_map as $post_key => $opt_key ) {
+					   if ( isset( $_POST[ $post_key ] ) ) {
+							   $toc[ $opt_key ] = sanitize_text_field( wp_unslash( $_POST[ $post_key ] ) );
+					   }
+			   }
 
-               /* —— TOC Heading Levels —— */
-               $toc['toc_heading_levels'] = isset( $_POST['nuclear_engagement_settings']['toc_heading_levels'] )
-                       ? array_map( 'intval', (array) $_POST['nuclear_engagement_settings']['toc_heading_levels'] )
-                       : range( 2, 6 );
+			   /* —— TOC Heading Levels —— */
+			   $toc['toc_heading_levels'] = isset( $_POST['nuclear_engagement_settings']['toc_heading_levels'] )
+					   ? array_map( 'intval', (array) $_POST['nuclear_engagement_settings']['toc_heading_levels'] )
+					   : range( 2, 6 );
 
-               return $toc;
-       }
+			   return $toc;
+	   }
 
-       /**
-        * Collect custom text and label fields.
-        */
-       private function collect_custom_text(): array {
-               return array(
-                       'custom_quiz_html_before'  => isset( $_POST['custom_quiz_html_before'] )
-                               ? wp_kses_post( wp_unslash( $_POST['custom_quiz_html_before'] ) )
-                               : '',
-                       'custom_quiz_html_after'   => isset( $_POST['custom_quiz_html_after'] )
-                               ? wp_kses_post( wp_unslash( $_POST['custom_quiz_html_after'] ) )
-                               : '',
-                       'quiz_title'               => isset( $_POST['quiz_title'] ) ? sanitize_text_field( wp_unslash( $_POST['quiz_title'] ) ) : '',
-                       'summary_title'            => isset( $_POST['summary_title'] ) ? sanitize_text_field( wp_unslash( $_POST['summary_title'] ) ) : '',
-                       'quiz_label_retake_test'   => isset( $_POST['quiz_label_retake_test'] )
-                               ? sanitize_text_field( wp_unslash( $_POST['quiz_label_retake_test'] ) )
-                               : '',
-                       'quiz_label_your_score'    => isset( $_POST['quiz_label_your_score'] )
-                               ? sanitize_text_field( wp_unslash( $_POST['quiz_label_your_score'] ) )
-                               : '',
-                       'quiz_label_perfect'       => isset( $_POST['quiz_label_perfect'] )
-                               ? sanitize_text_field( wp_unslash( $_POST['quiz_label_perfect'] ) )
-                               : '',
-                       'quiz_label_well_done'     => isset( $_POST['quiz_label_well_done'] )
-                               ? sanitize_text_field( wp_unslash( $_POST['quiz_label_well_done'] ) )
-                               : '',
-                       'quiz_label_retake_prompt' => isset( $_POST['quiz_label_retake_prompt'] )
-                               ? sanitize_text_field( wp_unslash( $_POST['quiz_label_retake_prompt'] ) )
-                               : '',
-                       'quiz_label_correct'       => isset( $_POST['quiz_label_correct'] )
-                               ? sanitize_text_field( wp_unslash( $_POST['quiz_label_correct'] ) )
-                               : '',
-                       'quiz_label_your_answer'   => isset( $_POST['quiz_label_your_answer'] )
-                               ? sanitize_text_field( wp_unslash( $_POST['quiz_label_your_answer'] ) )
-                               : '',
-               );
-       }
+	   /**
+		* Collect custom text and label fields.
+		*/
+	   private function collect_custom_text(): array {
+			   return array(
+					   'custom_quiz_html_before'  => isset( $_POST['custom_quiz_html_before'] )
+							   ? wp_kses_post( wp_unslash( $_POST['custom_quiz_html_before'] ) )
+							   : '',
+					   'custom_quiz_html_after'   => isset( $_POST['custom_quiz_html_after'] )
+							   ? wp_kses_post( wp_unslash( $_POST['custom_quiz_html_after'] ) )
+							   : '',
+					   'quiz_title'               => isset( $_POST['quiz_title'] ) ? sanitize_text_field( wp_unslash( $_POST['quiz_title'] ) ) : '',
+					   'summary_title'            => isset( $_POST['summary_title'] ) ? sanitize_text_field( wp_unslash( $_POST['summary_title'] ) ) : '',
+					   'quiz_label_retake_test'   => isset( $_POST['quiz_label_retake_test'] )
+							   ? sanitize_text_field( wp_unslash( $_POST['quiz_label_retake_test'] ) )
+							   : '',
+					   'quiz_label_your_score'    => isset( $_POST['quiz_label_your_score'] )
+							   ? sanitize_text_field( wp_unslash( $_POST['quiz_label_your_score'] ) )
+							   : '',
+					   'quiz_label_perfect'       => isset( $_POST['quiz_label_perfect'] )
+							   ? sanitize_text_field( wp_unslash( $_POST['quiz_label_perfect'] ) )
+							   : '',
+					   'quiz_label_well_done'     => isset( $_POST['quiz_label_well_done'] )
+							   ? sanitize_text_field( wp_unslash( $_POST['quiz_label_well_done'] ) )
+							   : '',
+					   'quiz_label_retake_prompt' => isset( $_POST['quiz_label_retake_prompt'] )
+							   ? sanitize_text_field( wp_unslash( $_POST['quiz_label_retake_prompt'] ) )
+							   : '',
+					   'quiz_label_correct'       => isset( $_POST['quiz_label_correct'] )
+							   ? sanitize_text_field( wp_unslash( $_POST['quiz_label_correct'] ) )
+							   : '',
+					   'quiz_label_your_answer'   => isset( $_POST['quiz_label_your_answer'] )
+							   ? sanitize_text_field( wp_unslash( $_POST['quiz_label_your_answer'] ) )
+							   : '',
+			   );
+	   }
 
-       /**
-        * Collect Opt-In related fields.
-        */
-       private function collect_optin_options(): array {
-               $optin = array(
-                       'enable_optin'      => isset( $_POST['enable_optin'] ) ? (bool) wp_unslash( $_POST['enable_optin'] ) : false,
-                       'optin_position'    => isset( $_POST['nuclen_optin_position'] )
-                               ? sanitize_text_field( wp_unslash( $_POST['nuclen_optin_position'] ) )
-                               : 'with_results',
-                       'optin_mandatory'   => isset( $_POST['optin_mandatory'] ) ? (bool) wp_unslash( $_POST['optin_mandatory'] ) : false,
-                       'optin_prompt_text' => isset( $_POST['optin_prompt_text'] ) ? sanitize_text_field( wp_unslash( $_POST['optin_prompt_text'] ) ) : '',
-                       'optin_button_text' => isset( $_POST['optin_button_text'] ) ? sanitize_text_field( wp_unslash( $_POST['optin_button_text'] ) ) : '',
-               );
+	   /**
+		* Collect Opt-In related fields.
+		*/
+	   private function collect_optin_options(): array {
+			   $optin = array(
+					   'enable_optin'      => isset( $_POST['enable_optin'] ) ? (bool) wp_unslash( $_POST['enable_optin'] ) : false,
+					   'optin_position'    => isset( $_POST['nuclen_optin_position'] )
+							   ? sanitize_text_field( wp_unslash( $_POST['nuclen_optin_position'] ) )
+							   : 'with_results',
+					   'optin_mandatory'   => isset( $_POST['optin_mandatory'] ) ? (bool) wp_unslash( $_POST['optin_mandatory'] ) : false,
+					   'optin_prompt_text' => isset( $_POST['optin_prompt_text'] ) ? sanitize_text_field( wp_unslash( $_POST['optin_prompt_text'] ) ) : '',
+					   'optin_button_text' => isset( $_POST['optin_button_text'] ) ? sanitize_text_field( wp_unslash( $_POST['optin_button_text'] ) ) : '',
+			   );
 
-               if ( isset( $_POST['optin_webhook'] ) ) {
-                       $optin['optin_webhook'] = esc_url_raw( trim( sanitize_text_field( wp_unslash( $_POST['optin_webhook'] ) ) ) );
-               }
+			   if ( isset( $_POST['optin_webhook'] ) ) {
+					   $optin['optin_webhook'] = esc_url_raw( trim( sanitize_text_field( wp_unslash( $_POST['optin_webhook'] ) ) ) );
+			   }
 
-               return $optin;
-       }
+			   return $optin;
+	   }
 
-       /**
-        * Collect various flags and generation settings.
-        */
-       private function collect_flags_and_generation(): array {
-               $data = array(
-                       'update_last_modified'          => isset( $_POST['update_last_modified'] ) ? (bool) wp_unslash( $_POST['update_last_modified'] ) : false,
-                       'auto_generate_quiz_on_publish' => isset( $_POST['auto_generate_quiz_on_publish'] ) ? (bool) wp_unslash( $_POST['auto_generate_quiz_on_publish'] ) : false,
-                       'auto_generate_summary_on_publish' => isset( $_POST['auto_generate_summary_on_publish'] ) ? (bool) wp_unslash( $_POST['auto_generate_summary_on_publish'] ) : false,
-                       'show_attribution'               => isset( $_POST['show_attribution'] ) ? (bool) wp_unslash( $_POST['show_attribution'] ) : false,
-                       'delete_settings_on_uninstall'          => isset( $_POST['delete_settings_on_uninstall'] ) ? (bool) wp_unslash( $_POST['delete_settings_on_uninstall'] ) : false,
-                       'delete_generated_content_on_uninstall' => isset( $_POST['delete_generated_content_on_uninstall'] ) ? (bool) wp_unslash( $_POST['delete_generated_content_on_uninstall'] ) : false,
-                       'delete_optin_data_on_uninstall'        => isset( $_POST['delete_optin_data_on_uninstall'] ) ? (bool) wp_unslash( $_POST['delete_optin_data_on_uninstall'] ) : false,
-                       'delete_log_file_on_uninstall'          => isset( $_POST['delete_log_file_on_uninstall'] ) ? (bool) wp_unslash( $_POST['delete_log_file_on_uninstall'] ) : false,
-                       'delete_custom_css_on_uninstall'        => isset( $_POST['delete_custom_css_on_uninstall'] ) ? (bool) wp_unslash( $_POST['delete_custom_css_on_uninstall'] ) : false,
-               );
+	   /**
+		* Collect various flags and generation settings.
+		*/
+	   private function collect_flags_and_generation(): array {
+			   $data = array(
+					   'update_last_modified'          => isset( $_POST['update_last_modified'] ) ? (bool) wp_unslash( $_POST['update_last_modified'] ) : false,
+					   'auto_generate_quiz_on_publish' => isset( $_POST['auto_generate_quiz_on_publish'] ) ? (bool) wp_unslash( $_POST['auto_generate_quiz_on_publish'] ) : false,
+					   'auto_generate_summary_on_publish' => isset( $_POST['auto_generate_summary_on_publish'] ) ? (bool) wp_unslash( $_POST['auto_generate_summary_on_publish'] ) : false,
+					   'show_attribution'               => isset( $_POST['show_attribution'] ) ? (bool) wp_unslash( $_POST['show_attribution'] ) : false,
+					   'delete_settings_on_uninstall'          => isset( $_POST['delete_settings_on_uninstall'] ) ? (bool) wp_unslash( $_POST['delete_settings_on_uninstall'] ) : false,
+					   'delete_generated_content_on_uninstall' => isset( $_POST['delete_generated_content_on_uninstall'] ) ? (bool) wp_unslash( $_POST['delete_generated_content_on_uninstall'] ) : false,
+					   'delete_optin_data_on_uninstall'        => isset( $_POST['delete_optin_data_on_uninstall'] ) ? (bool) wp_unslash( $_POST['delete_optin_data_on_uninstall'] ) : false,
+					   'delete_log_file_on_uninstall'          => isset( $_POST['delete_log_file_on_uninstall'] ) ? (bool) wp_unslash( $_POST['delete_log_file_on_uninstall'] ) : false,
+					   'delete_custom_css_on_uninstall'        => isset( $_POST['delete_custom_css_on_uninstall'] ) ? (bool) wp_unslash( $_POST['delete_custom_css_on_uninstall'] ) : false,
+			   );
 
-               $posted_types = filter_input(
-                       INPUT_POST,
-                       'nuclen_generation_post_types',
-                       FILTER_SANITIZE_FULL_SPECIAL_CHARS,
-                       FILTER_REQUIRE_ARRAY
-               );
-               $data['generation_post_types'] = is_array( $posted_types )
-                       ? array_map( 'sanitize_text_field', wp_unslash( $posted_types ) )
-                       : array( 'post' );
+			   $posted_types = filter_input(
+					   INPUT_POST,
+					   'nuclen_generation_post_types',
+					   FILTER_SANITIZE_FULL_SPECIAL_CHARS,
+					   FILTER_REQUIRE_ARRAY
+			   );
+			   $data['generation_post_types'] = is_array( $posted_types )
+					   ? array_map( 'sanitize_text_field', wp_unslash( $posted_types ) )
+					   : array( 'post' );
 
-               return $data;
-       }
+			   return $data;
+	   }
 
 }

--- a/nuclear-engagement/admin/Traits/SettingsPageCustomCSSTrait.php
+++ b/nuclear-engagement/admin/Traits/SettingsPageCustomCSSTrait.php
@@ -28,102 +28,102 @@ trait SettingsPageCustomCSSTrait {
 
 		$css = <<<CSS
 :root{
-    /* ───── Quiz container ───── */
-    --nuclen-fg-color: {$s['font_color']};
-    --nuclen-quiz-font-color: {$s['font_color']};
-    --nuclen-quiz-bg-color: {$s['bg_color']};
-    --nuclen-quiz-border-color: {$s['quiz_border_color']};
-    --nuclen-quiz-border-style: {$s['quiz_border_style']};
-    --nuclen-quiz-border-width: {$s['quiz_border_width']}px;
-    --nuclen-quiz-border-radius: {$s['quiz_border_radius']}px;
-    --nuclen-quiz-shadow-color: {$s['quiz_shadow_color']};
-    --nuclen-quiz-shadow-blur: {$s['quiz_shadow_blur']}px;
+	/* ───── Quiz container ───── */
+	--nuclen-fg-color: {$s['font_color']};
+	--nuclen-quiz-font-color: {$s['font_color']};
+	--nuclen-quiz-bg-color: {$s['bg_color']};
+	--nuclen-quiz-border-color: {$s['quiz_border_color']};
+	--nuclen-quiz-border-style: {$s['quiz_border_style']};
+	--nuclen-quiz-border-width: {$s['quiz_border_width']}px;
+	--nuclen-quiz-border-radius: {$s['quiz_border_radius']}px;
+	--nuclen-quiz-shadow-color: {$s['quiz_shadow_color']};
+	--nuclen-quiz-shadow-blur: {$s['quiz_shadow_blur']}px;
 
-    /* ───── Quiz answer buttons ───── */
-    --nuclen-quiz-button-bg: {$s['quiz_answer_button_bg_color']};
-    --nuclen-quiz-button-border-color: {$s['quiz_answer_button_border_color']};
-    --nuclen-quiz-button-border-width: {$s['quiz_answer_button_border_width']}px;
-    --nuclen-quiz-button-border-radius: {$s['quiz_answer_button_border_radius']}px;
+	/* ───── Quiz answer buttons ───── */
+	--nuclen-quiz-button-bg: {$s['quiz_answer_button_bg_color']};
+	--nuclen-quiz-button-border-color: {$s['quiz_answer_button_border_color']};
+	--nuclen-quiz-button-border-width: {$s['quiz_answer_button_border_width']}px;
+	--nuclen-quiz-button-border-radius: {$s['quiz_answer_button_border_radius']}px;
 
-    /* ───── Progress bar ───── */
-    --nuclen-quiz-progress-fg: {$s['quiz_progress_bar_fg_color']};
-    --nuclen-quiz-progress-bg: {$s['quiz_progress_bar_bg_color']};
-    --nuclen-quiz-progress-height: {$s['quiz_progress_bar_height']}px;
+	/* ───── Progress bar ───── */
+	--nuclen-quiz-progress-fg: {$s['quiz_progress_bar_fg_color']};
+	--nuclen-quiz-progress-bg: {$s['quiz_progress_bar_bg_color']};
+	--nuclen-quiz-progress-height: {$s['quiz_progress_bar_height']}px;
 
-    /* ───── Summary container ───── */
-    --nuclen-summary-font-color: {$s['summary_font_color']};
-    --nuclen-summary-bg-color: {$s['summary_bg_color']};
-    --nuclen-summary-border-color: {$s['summary_border_color']};
-    --nuclen-summary-border-style: {$s['summary_border_style']};
-    --nuclen-summary-border-width: {$s['summary_border_width']}px;
-    --nuclen-summary-border-radius: {$s['summary_border_radius']}px;
-    --nuclen-summary-shadow-color: {$s['summary_shadow_color']};
-    --nuclen-summary-shadow-blur: {$s['summary_shadow_blur']}px;
+	/* ───── Summary container ───── */
+	--nuclen-summary-font-color: {$s['summary_font_color']};
+	--nuclen-summary-bg-color: {$s['summary_bg_color']};
+	--nuclen-summary-border-color: {$s['summary_border_color']};
+	--nuclen-summary-border-style: {$s['summary_border_style']};
+	--nuclen-summary-border-width: {$s['summary_border_width']}px;
+	--nuclen-summary-border-radius: {$s['summary_border_radius']}px;
+	--nuclen-summary-shadow-color: {$s['summary_shadow_color']};
+	--nuclen-summary-shadow-blur: {$s['summary_shadow_blur']}px;
 
-    /* ───── TOC container ───── */
-    --nuclen-toc-font-size: {$s['toc_font_size']}px;
-    --nuclen-toc-font-color: {$s['toc_font_color']};
-    --nuclen-toc-bg-color: {$s['toc_bg_color']};
-    --nuclen-toc-border-color: {$s['toc_border_color']};
-    --nuclen-toc-border-style: {$s['toc_border_style']};
-    --nuclen-toc-border-width: {$s['toc_border_width']}px;
-    --nuclen-toc-border-radius: {$s['toc_border_radius']}px;
-    --nuclen-toc-shadow-color: {$s['toc_shadow_color']};
-    --nuclen-toc-shadow-blur: {$s['toc_shadow_blur']}px;
-    --nuclen-toc-link: {$s['toc_link_color']};
-    --nuclen-toc-sticky-max-width: {$s['toc_sticky_max_width']}px;
+	/* ───── TOC container ───── */
+	--nuclen-toc-font-size: {$s['toc_font_size']}px;
+	--nuclen-toc-font-color: {$s['toc_font_color']};
+	--nuclen-toc-bg-color: {$s['toc_bg_color']};
+	--nuclen-toc-border-color: {$s['toc_border_color']};
+	--nuclen-toc-border-style: {$s['toc_border_style']};
+	--nuclen-toc-border-width: {$s['toc_border_width']}px;
+	--nuclen-toc-border-radius: {$s['toc_border_radius']}px;
+	--nuclen-toc-shadow-color: {$s['toc_shadow_color']};
+	--nuclen-toc-shadow-blur: {$s['toc_shadow_blur']}px;
+	--nuclen-toc-link: {$s['toc_link_color']};
+	--nuclen-toc-sticky-max-width: {$s['toc_sticky_max_width']}px;
 
-    /* ───── Legacy fallbacks ───── */
-    --nuclen-fg-color: var(--nuclen-quiz-font-color);
-    --nuclen-border-color: var(--nuclen-quiz-border-color);
-    --nuclen-border-style: var(--nuclen-quiz-border-style);
-    --nuclen-border-width: var(--nuclen-quiz-border-width);
-    --nuclen-border-radius: var(--nuclen-quiz-border-radius);
-    --nuclen-progress-fg: var(--nuclen-quiz-progress-fg);
-    --nuclen-progress-bg: var(--nuclen-quiz-progress-bg);
+	/* ───── Legacy fallbacks ───── */
+	--nuclen-fg-color: var(--nuclen-quiz-font-color);
+	--nuclen-border-color: var(--nuclen-quiz-border-color);
+	--nuclen-border-style: var(--nuclen-quiz-border-style);
+	--nuclen-border-width: var(--nuclen-quiz-border-width);
+	--nuclen-border-radius: var(--nuclen-quiz-border-radius);
+	--nuclen-progress-fg: var(--nuclen-quiz-progress-fg);
+	--nuclen-progress-bg: var(--nuclen-quiz-progress-bg);
 }
 
 /* ─── Apply variables to actual elements ─── */
 .nuclen-root .nuclen-quiz{
-    border: var(--nuclen-quiz-border-width) var(--nuclen-quiz-border-style) var(--nuclen-quiz-border-color);
-    border-radius: var(--nuclen-quiz-border-radius);
-    box-shadow: 0 0 var(--nuclen-quiz-shadow-blur) var(--nuclen-quiz-shadow-color);
-    background: var(--nuclen-quiz-bg-color);
-    color: var(--nuclen-quiz-font-color, var(--nuclen-fg-color));
+	border: var(--nuclen-quiz-border-width) var(--nuclen-quiz-border-style) var(--nuclen-quiz-border-color);
+	border-radius: var(--nuclen-quiz-border-radius);
+	box-shadow: 0 0 var(--nuclen-quiz-shadow-blur) var(--nuclen-quiz-shadow-color);
+	background: var(--nuclen-quiz-bg-color);
+	color: var(--nuclen-quiz-font-color, var(--nuclen-fg-color));
 }
 
 .nuclen-root .nuclen-summary{
-    border: var(--nuclen-summary-border-width) var(--nuclen-summary-border-style) var(--nuclen-summary-border-color);
-    border-radius: var(--nuclen-summary-border-radius);
-    box-shadow: 0 0 var(--nuclen-summary-shadow-blur) var(--nuclen-summary-shadow-color);
-    background: var(--nuclen-summary-bg-color);
-    color: var(--nuclen-summary-font-color, var(--nuclen-fg-color));
+	border: var(--nuclen-summary-border-width) var(--nuclen-summary-border-style) var(--nuclen-summary-border-color);
+	border-radius: var(--nuclen-summary-border-radius);
+	box-shadow: 0 0 var(--nuclen-summary-shadow-blur) var(--nuclen-summary-shadow-color);
+	background: var(--nuclen-summary-bg-color);
+	color: var(--nuclen-summary-font-color, var(--nuclen-fg-color));
 }
 
 .nuclen-root .nuclen-toc-wrapper{
-    font-size: var(--nuclen-toc-font-size);
-    border: var(--nuclen-toc-border-width) var(--nuclen-toc-border-style) var(--nuclen-toc-border-color);
-    border-radius: var(--nuclen-toc-border-radius);
-    box-shadow: 0 0 var(--nuclen-toc-shadow-blur) var(--nuclen-toc-shadow-color);
-    background: var(--nuclen-toc-bg-color);
-    color: var(--nuclen-toc-font-color);
+	font-size: var(--nuclen-toc-font-size);
+	border: var(--nuclen-toc-border-width) var(--nuclen-toc-border-style) var(--nuclen-toc-border-color);
+	border-radius: var(--nuclen-toc-border-radius);
+	box-shadow: 0 0 var(--nuclen-toc-shadow-blur) var(--nuclen-toc-shadow-color);
+	background: var(--nuclen-toc-bg-color);
+	color: var(--nuclen-toc-font-color);
 }
 .nuclen-root .nuclen-toc-wrapper a{
-    color: var(--nuclen-toc-link);
+	color: var(--nuclen-toc-link);
 }
 
 .nuclen-root #nuclen-quiz-progress-bar-container{
-    background: var(--nuclen-quiz-progress-bg);
-    height: var(--nuclen-quiz-progress-height);
+	background: var(--nuclen-quiz-progress-bg);
+	height: var(--nuclen-quiz-progress-height);
 }
 .nuclen-root #nuclen-quiz-progress-bar{
-    background: var(--nuclen-quiz-progress-fg);
-    height: 100%;
-    width: 0;
+	background: var(--nuclen-quiz-progress-fg);
+	height: 100%;
+	width: 0;
 }
 CSS;
 
-                                $css_info = \NuclearEngagement\Utils\Utils::nuclen_get_custom_css_info();
+								$css_info = \NuclearEngagement\Utils\Utils::nuclen_get_custom_css_info();
 		if ( empty( $css_info ) ) {
 				\NuclearEngagement\Services\LoggingService::notify_admin( __( 'Could not create custom CSS directory.', 'nuclear-engagement' ) );
 				return;

--- a/nuclear-engagement/admin/Traits/SettingsPageSaveTrait.php
+++ b/nuclear-engagement/admin/Traits/SettingsPageSaveTrait.php
@@ -16,8 +16,8 @@ if ( ! defined( 'ABSPATH' ) ) {
 
 trait SettingsPageSaveTrait {
 
-       use SettingsCollectTrait;
-       use SettingsPersistTrait;
+	   use SettingsCollectTrait;
+	   use SettingsPersistTrait;
 
 	/**
 	 * Process and save submitted settings.
@@ -27,27 +27,27 @@ trait SettingsPageSaveTrait {
 	 * @param array &$new_settings Output: new sanitized settings.
 	 * @return bool                True if a save occurred.
 	 */
-        protected function nuclen_handle_save_settings( array &$settings, array $defaults, array &$new_settings ): bool {
+		protected function nuclen_handle_save_settings( array &$settings, array $defaults, array &$new_settings ): bool {
 
-                /* ───────── Bail if not a form submission ───────── */
-                if (
-                        ! isset( $_POST['nuclen_save_settings'] ) ||
-                        ! check_admin_referer( 'nuclen_settings_nonce', 'nuclen_settings_nonce_field', false )
-                ) {
-                        return false;
-                }
+				/* ───────── Bail if not a form submission ───────── */
+				if (
+						! isset( $_POST['nuclen_save_settings'] ) ||
+						! check_admin_referer( 'nuclen_settings_nonce', 'nuclen_settings_nonce_field', false )
+				) {
+						return false;
+				}
 
-                $raw          = $this->nuclen_collect_input();
-                $new_settings = $this->nuclen_sanitize_and_defaults( $raw, $defaults );
-                $settings     = $this->nuclen_persist_settings( $new_settings );
+				$raw          = $this->nuclen_collect_input();
+				$new_settings = $this->nuclen_sanitize_and_defaults( $raw, $defaults );
+				$settings     = $this->nuclen_persist_settings( $new_settings );
 
-                if ( 'custom' === $settings['theme'] && method_exists( $this, 'nuclen_write_custom_css' ) ) {
-                        $this->nuclen_write_custom_css( $settings );
-                }
+				if ( 'custom' === $settings['theme'] && method_exists( $this, 'nuclen_write_custom_css' ) ) {
+						$this->nuclen_write_custom_css( $settings );
+				}
 
-                $this->nuclen_output_save_notice();
+				$this->nuclen_output_save_notice();
 
-                return true;
-        }
+				return true;
+		}
 
 }

--- a/nuclear-engagement/admin/Traits/SettingsPersistTrait.php
+++ b/nuclear-engagement/admin/Traits/SettingsPersistTrait.php
@@ -11,62 +11,62 @@ declare(strict_types=1);
 namespace NuclearEngagement\Admin\Traits;
 
 if ( ! defined( 'ABSPATH' ) ) {
-    exit;
+	exit;
 }
 
 trait SettingsPersistTrait {
-         * Sanitize input and merge with defaults.
-         */
-        private function nuclen_sanitize_and_defaults( array $raw, array $defaults ): array {
-                $new_settings = $this->nuclen_sanitize_settings( $raw );
+		 * Sanitize input and merge with defaults.
+		 */
+		private function nuclen_sanitize_and_defaults( array $raw, array $defaults ): array {
+				$new_settings = $this->nuclen_sanitize_settings( $raw );
 
-                $toc_keys = array(
-                        'toc_font_color',
-                        'toc_bg_color',
-                        'toc_border_color',
-                        'toc_border_style',
-                        'toc_border_width',
-                        'toc_border_radius',
-                        'toc_shadow_color',
-                        'toc_shadow_blur',
-                        'toc_link_color',
-                        'toc_heading_levels',
-                        'toc_z_index',
-                        'toc_sticky_offset_x',
-                        'toc_sticky_offset_y',
-                        'toc_sticky_max_width',
-                );
+				$toc_keys = array(
+						'toc_font_color',
+						'toc_bg_color',
+						'toc_border_color',
+						'toc_border_style',
+						'toc_border_width',
+						'toc_border_radius',
+						'toc_shadow_color',
+						'toc_shadow_blur',
+						'toc_link_color',
+						'toc_heading_levels',
+						'toc_z_index',
+						'toc_sticky_offset_x',
+						'toc_sticky_offset_y',
+						'toc_sticky_max_width',
+				);
 
-                foreach ( $toc_keys as $k ) {
-                        if ( isset( $raw[ $k ] ) && $raw[ $k ] !== '' ) {
-                                $new_settings[ $k ] = $raw[ $k ];
-                        }
-                }
+				foreach ( $toc_keys as $k ) {
+						if ( isset( $raw[ $k ] ) && $raw[ $k ] !== '' ) {
+								$new_settings[ $k ] = $raw[ $k ];
+						}
+				}
 
-                return wp_parse_args( $new_settings, $defaults );
-        }
+				return wp_parse_args( $new_settings, $defaults );
+		}
 
-        /**
-         * Persist the sanitized settings and return the saved array.
-         */
-        private function nuclen_persist_settings( array $new_settings ): array {
-                $settings_repo = $this->nuclen_get_settings_repository();
+		/**
+		 * Persist the sanitized settings and return the saved array.
+		 */
+		private function nuclen_persist_settings( array $new_settings ): array {
+				$settings_repo = $this->nuclen_get_settings_repository();
 
-                foreach ( $new_settings as $key => $value ) {
-                        $settings_repo->set( $key, $value );
-                }
+				foreach ( $new_settings as $key => $value ) {
+						$settings_repo->set( $key, $value );
+				}
 
-                $settings_repo->save();
+				$settings_repo->save();
 
-                return $settings_repo->get_all();
-        }
+				return $settings_repo->get_all();
+		}
 
-        /**
-         * Output the success admin notice after saving settings.
-         */
-        private function nuclen_output_save_notice(): void {
-                echo '<div class="notice notice-success"><p>' .
-                        esc_html__( 'Settings saved.', 'nuclear-engagement' ) .
-                        '</p></div>';
-        }
+		/**
+		 * Output the success admin notice after saving settings.
+		 */
+		private function nuclen_output_save_notice(): void {
+				echo '<div class="notice notice-success"><p>' .
+						esc_html__( 'Settings saved.', 'nuclear-engagement' ) .
+						'</p></div>';
+		}
 }

--- a/nuclear-engagement/bootstrap.php
+++ b/nuclear-engagement/bootstrap.php
@@ -172,11 +172,11 @@ function nuclear_engagement_run_plugin() {
 }
 
 function nuclear_engagement_init() {
-        try {
-                InventoryCache::register_hooks();
-                PostsQueryService::register_hooks();
-                \NuclearEngagement\Services\PostDataFetcher::register_hooks();
-        } catch ( \Throwable $e ) {
+		try {
+				InventoryCache::register_hooks();
+				PostsQueryService::register_hooks();
+				\NuclearEngagement\Services\PostDataFetcher::register_hooks();
+		} catch ( \Throwable $e ) {
 		\NuclearEngagement\Services\LoggingService::log( 'Nuclear Engagement: Cache registration failed - ' . $e->getMessage() );
 		add_action(
 			'admin_notices',

--- a/nuclear-engagement/front/traits/AssetsTrait.php
+++ b/nuclear-engagement/front/traits/AssetsTrait.php
@@ -37,7 +37,7 @@ trait AssetsTrait {
 				);
 		}
 
-                        $css_info = \NuclearEngagement\Utils\Utils::nuclen_get_custom_css_info();
+						$css_info = \NuclearEngagement\Utils\Utils::nuclen_get_custom_css_info();
 		if ( empty( $css_info ) || empty( $css_info['url'] ) ) {
 				\NuclearEngagement\Services\LoggingService::log( 'Invalid custom CSS info - skipping' );
 				return array(
@@ -94,8 +94,8 @@ trait AssetsTrait {
 			}
 		}
 
-                if ( $display_summary !== 'manual' && $display_summary !== 'none' ) {
-                        $summary_meta = get_post_meta( $post_id, Summary_Service::META_KEY, true );
+				if ( $display_summary !== 'manual' && $display_summary !== 'none' ) {
+						$summary_meta = get_post_meta( $post_id, Summary_Service::META_KEY, true );
 			if ( is_array( $summary_meta ) && ! empty( trim( $summary_meta['summary'] ?? '' ) ) ) {
 				return true;
 			}

--- a/nuclear-engagement/front/traits/ShortcodesTrait.php
+++ b/nuclear-engagement/front/traits/ShortcodesTrait.php
@@ -24,17 +24,17 @@ if ( ! defined( 'ABSPATH' ) ) {
 }
 
 trait ShortcodesTrait {
-       private ?SummaryShortcode $summary_shortcode = null;
+	   private ?SummaryShortcode $summary_shortcode = null;
 
-       private function get_summary_shortcode(): SummaryShortcode {
-               if ( $this->summary_shortcode === null ) {
-                       $this->summary_shortcode = new SummaryShortcode(
-                               $this->nuclen_get_settings_repository(),
-                               $this
-                       );
-               }
-               return $this->summary_shortcode;
-       }
+	   private function get_summary_shortcode(): SummaryShortcode {
+			   if ( $this->summary_shortcode === null ) {
+					   $this->summary_shortcode = new SummaryShortcode(
+							   $this->nuclen_get_settings_repository(),
+							   $this
+					   );
+			   }
+			   return $this->summary_shortcode;
+	   }
 
 	/* ---------- Auto-insert into content ---------- */
 	public function nuclen_auto_insert_shortcodes( $content ) {
@@ -83,15 +83,15 @@ trait ShortcodesTrait {
 		return $before_content . $content . $after_content;
 	}
 
-       /* ---------- Shortcode registrations ---------- */
-       public function nuclen_register_quiz_shortcode() {
-               $sc = new QuizShortcode(
-                       $this->nuclen_get_settings_repository(),
-                       $this,
-                       new Quiz_Service()
-               );
-               $sc->register();
-       }
+	   /* ---------- Shortcode registrations ---------- */
+	   public function nuclen_register_quiz_shortcode() {
+			   $sc = new QuizShortcode(
+					   $this->nuclen_get_settings_repository(),
+					   $this,
+					   new Quiz_Service()
+			   );
+			   $sc->register();
+	   }
 
 	public function nuclen_register_summary_shortcode() {
 		$this->get_summary_shortcode()->register();

--- a/nuclear-engagement/inc/Core/Activator.php
+++ b/nuclear-engagement/inc/Core/Activator.php
@@ -10,67 +10,67 @@ use NuclearEngagement\Core\AssetVersions;
 use NuclearEngagement\Modules\Summary\Summary_Service;
 
 if ( ! defined( 'ABSPATH' ) ) {
-    exit;
+	exit;
 }
 
 class Activator {
-    /**
-     * Plugin activation hook
-     *
-     * @param SettingsRepository|null $settings Optional settings repository instance
-     */
-    public static function nuclen_activate( ?SettingsRepository $settings = null ) {
-        // Set transient for activation redirect
-        set_transient( 'nuclen_plugin_activation_redirect', true, NUCLEN_ACTIVATION_REDIRECT_TTL );
+	/**
+	 * Plugin activation hook
+	 *
+	 * @param SettingsRepository|null $settings Optional settings repository instance
+	 */
+	public static function nuclen_activate( ?SettingsRepository $settings = null ) {
+		// Set transient for activation redirect
+		set_transient( 'nuclen_plugin_activation_redirect', true, NUCLEN_ACTIVATION_REDIRECT_TTL );
 
-        // Get default settings
-        $default_settings = Defaults::nuclen_get_default_settings();
+		// Get default settings
+		$default_settings = Defaults::nuclen_get_default_settings();
 
-        // Initialize or update settings repository with defaults
-        $settings = $settings ?: SettingsRepository::get_instance( $default_settings );
+		// Initialize or update settings repository with defaults
+		$settings = $settings ?: SettingsRepository::get_instance( $default_settings );
 
-        // Only set the setup option if it doesn't already exist
-        if ( false === get_option( 'nuclear_engagement_setup' ) ) {
-            update_option( 'nuclear_engagement_setup', $default_settings );
-        }
+		// Only set the setup option if it doesn't already exist
+		if ( false === get_option( 'nuclear_engagement_setup' ) ) {
+			update_option( 'nuclear_engagement_setup', $default_settings );
+		}
 
-                // Ensure opt-in table exists on activation
-                OptinData::maybe_create_table();
+				// Ensure opt-in table exists on activation
+				OptinData::maybe_create_table();
 
-                // Create indexes on wp_postmeta for faster lookups
-                self::maybe_create_postmeta_indexes();
+				// Create indexes on wp_postmeta for faster lookups
+				self::maybe_create_postmeta_indexes();
 
-                // Generate asset version strings for cache busting
-                AssetVersions::update_versions();
-    }
+				// Generate asset version strings for cache busting
+				AssetVersions::update_versions();
+	}
 
-        /**
-         * Create custom indexes on the postmeta table if they do not exist.
-         */
-    private static function maybe_create_postmeta_indexes(): void {
-            global $wpdb;
+		/**
+		 * Create custom indexes on the postmeta table if they do not exist.
+		 */
+	private static function maybe_create_postmeta_indexes(): void {
+			global $wpdb;
 
-            $table   = $wpdb->postmeta;
-            $indexes = array(
-                'nuclen_quiz_data_idx'         => 'nuclen-quiz-data',
-                'nuclen_summary_data_idx'      => Summary_Service::META_KEY,
-                'nuclen_quiz_protected_idx'    => 'nuclen_quiz_protected',
-                'nuclen_summary_protected_idx' => Summary_Service::PROTECTED_KEY,
-            );
+			$table   = $wpdb->postmeta;
+			$indexes = array(
+				'nuclen_quiz_data_idx'         => 'nuclen-quiz-data',
+				'nuclen_summary_data_idx'      => Summary_Service::META_KEY,
+				'nuclen_quiz_protected_idx'    => 'nuclen_quiz_protected',
+				'nuclen_summary_protected_idx' => Summary_Service::PROTECTED_KEY,
+			);
 
-            foreach ( $indexes as $index => $meta_key ) {
-                    $exists = $wpdb->get_var(
-                        $wpdb->prepare(
-                            "SHOW INDEX FROM {$table} WHERE Key_name = %s",
-                            $index
-                        )
-                    );
-                if ( $exists ) {
-                    continue;
-                }
+			foreach ( $indexes as $index => $meta_key ) {
+					$exists = $wpdb->get_var(
+						$wpdb->prepare(
+							"SHOW INDEX FROM {$table} WHERE Key_name = %s",
+							$index
+						)
+					);
+				if ( $exists ) {
+					continue;
+				}
 
-                    $sql = "CREATE INDEX {$index} ON {$table} (post_id, meta_key(191))";
-                    $wpdb->query( $sql );
-            }
-    }
+					$sql = "CREATE INDEX {$index} ON {$table} (post_id, meta_key(191))";
+					$wpdb->query( $sql );
+			}
+	}
 }

--- a/nuclear-engagement/inc/Core/AssetVersions.php
+++ b/nuclear-engagement/inc/Core/AssetVersions.php
@@ -3,63 +3,63 @@ declare(strict_types=1);
 namespace NuclearEngagement\Core;
 
 if ( ! defined( 'ABSPATH' ) ) {
-    exit;
+	exit;
 }
 
 /**
  * Handles versioning for compiled plugin assets.
  */
 final class AssetVersions {
-    private const OPTION        = 'nuclen_asset_versions';
-    private const PLUGIN_OPTION = 'nuclen_asset_versions_build';
+	private const OPTION        = 'nuclen_asset_versions';
+	private const PLUGIN_OPTION = 'nuclen_asset_versions_build';
 
-    /**
-     * Recompute asset versions when the stored plugin version differs.
-     */
-    public static function init(): void {
-        $stored = get_option( self::PLUGIN_OPTION );
-        if ( $stored !== NUCLEN_PLUGIN_VERSION ) {
-            self::update_versions();
-        }
-    }
+	/**
+	 * Recompute asset versions when the stored plugin version differs.
+	 */
+	public static function init(): void {
+		$stored = get_option( self::PLUGIN_OPTION );
+		if ( $stored !== NUCLEN_PLUGIN_VERSION ) {
+			self::update_versions();
+		}
+	}
 
-    /**
-     * Compute and store asset version strings.
-     */
-    public static function update_versions(): void {
-        update_option( self::OPTION, self::compute() );
-        update_option( self::PLUGIN_OPTION, NUCLEN_PLUGIN_VERSION );
-    }
+	/**
+	 * Compute and store asset version strings.
+	 */
+	public static function update_versions(): void {
+		update_option( self::OPTION, self::compute() );
+		update_option( self::PLUGIN_OPTION, NUCLEN_PLUGIN_VERSION );
+	}
 
-    /**
-     * Retrieve a version string for the given key.
-     */
-    public static function get( string $key ): string {
-        $versions = get_option( self::OPTION, array() );
-        return isset( $versions[ $key ] ) ? $versions[ $key ] : NUCLEN_ASSET_VERSION;
-    }
+	/**
+	 * Retrieve a version string for the given key.
+	 */
+	public static function get( string $key ): string {
+		$versions = get_option( self::OPTION, array() );
+		return isset( $versions[ $key ] ) ? $versions[ $key ] : NUCLEN_ASSET_VERSION;
+	}
 
-    /**
-     * Build the version map based on file modification times.
-     */
-    private static function compute(): array {
-        $files = array(
-            'admin_css'       => NUCLEN_PLUGIN_DIR . 'admin/css/nuclen-admin.css',
-            'admin_dashboard' => NUCLEN_PLUGIN_DIR . 'admin/css/nuclen-admin-dashboard.css',
-            'admin_js'        => NUCLEN_PLUGIN_DIR . 'admin/js/nuclen-admin.js',
-            'onboarding_js'   => NUCLEN_PLUGIN_DIR . 'admin/js/onboarding-pointers.js',
-            'front_css'       => NUCLEN_PLUGIN_DIR . 'front/css/nuclen-front.css',
-            'front_js'        => NUCLEN_PLUGIN_DIR . 'front/js/nuclen-front.js',
-            'toc_admin_css'   => NUCLEN_PLUGIN_DIR . 'inc/Modules/TOC/assets/css/nuclen-toc-admin.css',
-            'toc_admin_js'    => NUCLEN_PLUGIN_DIR . 'inc/Modules/TOC/assets/js/nuclen-toc-admin.js',
-            'toc_front_css'   => NUCLEN_PLUGIN_DIR . 'inc/Modules/TOC/assets/css/nuclen-toc-front.css',
-            'toc_front_js'    => NUCLEN_PLUGIN_DIR . 'inc/Modules/TOC/assets/js/nuclen-toc-front.js',
-        );
+	/**
+	 * Build the version map based on file modification times.
+	 */
+	private static function compute(): array {
+		$files = array(
+			'admin_css'       => NUCLEN_PLUGIN_DIR . 'admin/css/nuclen-admin.css',
+			'admin_dashboard' => NUCLEN_PLUGIN_DIR . 'admin/css/nuclen-admin-dashboard.css',
+			'admin_js'        => NUCLEN_PLUGIN_DIR . 'admin/js/nuclen-admin.js',
+			'onboarding_js'   => NUCLEN_PLUGIN_DIR . 'admin/js/onboarding-pointers.js',
+			'front_css'       => NUCLEN_PLUGIN_DIR . 'front/css/nuclen-front.css',
+			'front_js'        => NUCLEN_PLUGIN_DIR . 'front/js/nuclen-front.js',
+			'toc_admin_css'   => NUCLEN_PLUGIN_DIR . 'inc/Modules/TOC/assets/css/nuclen-toc-admin.css',
+			'toc_admin_js'    => NUCLEN_PLUGIN_DIR . 'inc/Modules/TOC/assets/js/nuclen-toc-admin.js',
+			'toc_front_css'   => NUCLEN_PLUGIN_DIR . 'inc/Modules/TOC/assets/css/nuclen-toc-front.css',
+			'toc_front_js'    => NUCLEN_PLUGIN_DIR . 'inc/Modules/TOC/assets/js/nuclen-toc-front.js',
+		);
 
-        $versions = array();
-        foreach ( $files as $key => $path ) {
-            $versions[ $key ] = file_exists( $path ) ? (string) filemtime( $path ) : (string) time();
-        }
-        return $versions;
-    }
+		$versions = array();
+		foreach ( $files as $key => $path ) {
+			$versions[ $key ] = file_exists( $path ) ? (string) filemtime( $path ) : (string) time();
+		}
+		return $versions;
+	}
 }

--- a/nuclear-engagement/inc/Core/Blocks.php
+++ b/nuclear-engagement/inc/Core/Blocks.php
@@ -3,7 +3,7 @@ declare(strict_types=1);
 namespace NuclearEngagement\Core;
 
 if ( ! defined( 'ABSPATH' ) ) {
-    exit;
+	exit;
 }
 
 /**
@@ -12,51 +12,51 @@ if ( ! defined( 'ABSPATH' ) ) {
  * enabling block editor workflows.
  */
 final class Blocks {
-    public static function register(): void {
-        if ( ! function_exists( 'register_block_type' ) ) {
-                \NuclearEngagement\Services\LoggingService::log( 'Nuclear Engagement: block registration unavailable.' );
-                return;
-        }
+	public static function register(): void {
+		if ( ! function_exists( 'register_block_type' ) ) {
+				\NuclearEngagement\Services\LoggingService::log( 'Nuclear Engagement: block registration unavailable.' );
+				return;
+		}
 
-        if ( ! wp_script_is( 'nuclen-admin', 'registered' ) ) {
-                \NuclearEngagement\Services\LoggingService::log( 'Nuclear Engagement: nuclen-admin script missing.' );
-                return;
-        }
+		if ( ! wp_script_is( 'nuclen-admin', 'registered' ) ) {
+				\NuclearEngagement\Services\LoggingService::log( 'Nuclear Engagement: nuclen-admin script missing.' );
+				return;
+		}
 
-        register_block_type(
-            'nuclear-engagement/quiz',
-            array(
-                'api_version'     => 2,
-                'title'           => __( 'Quiz', 'nuclear-engagement' ),
-                'category'        => 'widgets',
-                'icon'            => 'editor-help',
-                'render_callback' => static function (): string {
-                    $out = do_shortcode( '[nuclear_engagement_quiz]' );
-                    if ( ! is_string( $out ) || trim( $out ) === '' ) {
-                        return '<p>' . esc_html__( 'Quiz unavailable.', 'nuclear-engagement' ) . '</p>';
-                    }
-                    return $out;
-                },
-                'editor_script'   => 'nuclen-admin',
-            )
-        );
+		register_block_type(
+			'nuclear-engagement/quiz',
+			array(
+				'api_version'     => 2,
+				'title'           => __( 'Quiz', 'nuclear-engagement' ),
+				'category'        => 'widgets',
+				'icon'            => 'editor-help',
+				'render_callback' => static function (): string {
+					$out = do_shortcode( '[nuclear_engagement_quiz]' );
+					if ( ! is_string( $out ) || trim( $out ) === '' ) {
+						return '<p>' . esc_html__( 'Quiz unavailable.', 'nuclear-engagement' ) . '</p>';
+					}
+					return $out;
+				},
+				'editor_script'   => 'nuclen-admin',
+			)
+		);
 
-        register_block_type(
-            'nuclear-engagement/summary',
-            array(
-                'api_version'     => 2,
-                'title'           => __( 'Summary', 'nuclear-engagement' ),
-                'category'        => 'widgets',
-                'icon'            => 'excerpt-view',
-                'render_callback' => static function (): string {
-                    $out = do_shortcode( '[nuclear_engagement_summary]' );
-                    if ( ! is_string( $out ) || trim( $out ) === '' ) {
-                        return '<p>' . esc_html__( 'Summary unavailable.', 'nuclear-engagement' ) . '</p>';
-                    }
-                    return $out;
-                },
-                'editor_script'   => 'nuclen-admin',
-            )
-        );
-    }
+		register_block_type(
+			'nuclear-engagement/summary',
+			array(
+				'api_version'     => 2,
+				'title'           => __( 'Summary', 'nuclear-engagement' ),
+				'category'        => 'widgets',
+				'icon'            => 'excerpt-view',
+				'render_callback' => static function (): string {
+					$out = do_shortcode( '[nuclear_engagement_summary]' );
+					if ( ! is_string( $out ) || trim( $out ) === '' ) {
+						return '<p>' . esc_html__( 'Summary unavailable.', 'nuclear-engagement' ) . '</p>';
+					}
+					return $out;
+				},
+				'editor_script'   => 'nuclen-admin',
+			)
+		);
+	}
 }

--- a/nuclear-engagement/inc/Core/Container.php
+++ b/nuclear-engagement/inc/Core/Container.php
@@ -11,82 +11,82 @@ declare(strict_types=1);
 namespace NuclearEngagement\Core;
 
 if ( ! defined( 'ABSPATH' ) ) {
-    exit;
+	exit;
 }
 
 /**
  * Simple service container for dependency injection
  */
 class Container {
-    /**
-     * @var self|null Singleton instance
-     */
-    private static ?self $instance = null;
+	/**
+	 * @var self|null Singleton instance
+	 */
+	private static ?self $instance = null;
 
-    /**
-     * @var array Stored service instances
-     */
-    private array $services = array();
+	/**
+	 * @var array Stored service instances
+	 */
+	private array $services = array();
 
-    /**
-     * @var array Service factory callbacks
-     */
-    private array $factories = array();
+	/**
+	 * @var array Service factory callbacks
+	 */
+	private array $factories = array();
 
-    /**
-     * Get the singleton instance
-     *
-     * @return self
-     */
-    public static function getInstance(): self {
-        if ( self::$instance === null ) {
-            self::$instance = new self();
-        }
-        return self::$instance;
-    }
+	/**
+	 * Get the singleton instance
+	 *
+	 * @return self
+	 */
+	public static function getInstance(): self {
+		if ( self::$instance === null ) {
+			self::$instance = new self();
+		}
+		return self::$instance;
+	}
 
-    /**
-     * Register a service factory
-     *
-     * @param string   $id Service identifier
-     * @param callable $factory Factory callback
-     */
-    public function register( string $id, callable $factory ): void {
-        $this->factories[ $id ] = $factory;
-    }
+	/**
+	 * Register a service factory
+	 *
+	 * @param string   $id Service identifier
+	 * @param callable $factory Factory callback
+	 */
+	public function register( string $id, callable $factory ): void {
+		$this->factories[ $id ] = $factory;
+	}
 
-    /**
-     * Get a service instance
-     *
-     * @param string $id Service identifier
-     * @return mixed Service instance
-     * @throws \RuntimeException If service not registered
-     */
-    public function get( string $id ) {
-        if ( ! isset( $this->services[ $id ] ) ) {
-            if ( ! isset( $this->factories[ $id ] ) ) {
-                throw new \RuntimeException( "Service {$id} not registered" );
-            }
-            $this->services[ $id ] = $this->factories[ $id ]( $this );
-        }
-        return $this->services[ $id ];
-    }
+	/**
+	 * Get a service instance
+	 *
+	 * @param string $id Service identifier
+	 * @return mixed Service instance
+	 * @throws \RuntimeException If service not registered
+	 */
+	public function get( string $id ) {
+		if ( ! isset( $this->services[ $id ] ) ) {
+			if ( ! isset( $this->factories[ $id ] ) ) {
+				throw new \RuntimeException( "Service {$id} not registered" );
+			}
+			$this->services[ $id ] = $this->factories[ $id ]( $this );
+		}
+		return $this->services[ $id ];
+	}
 
-    /**
-     * Check if a service is registered
-     *
-     * @param string $id Service identifier
-     * @return bool
-     */
-    public function has( string $id ): bool {
-        return isset( $this->factories[ $id ] );
-    }
+	/**
+	 * Check if a service is registered
+	 *
+	 * @param string $id Service identifier
+	 * @return bool
+	 */
+	public function has( string $id ): bool {
+		return isset( $this->factories[ $id ] );
+	}
 
-    /**
-     * Reset the container (mainly for testing)
-     */
-    public function reset(): void {
-        $this->services  = array();
-        $this->factories = array();
-    }
+	/**
+	 * Reset the container (mainly for testing)
+	 */
+	public function reset(): void {
+		$this->services  = array();
+		$this->factories = array();
+	}
 }

--- a/nuclear-engagement/inc/Core/ContainerRegistrar.php
+++ b/nuclear-engagement/inc/Core/ContainerRegistrar.php
@@ -18,89 +18,89 @@ use NuclearEngagement\Admin\Controller\OptinExportController;
 use NuclearEngagement\Front\Controller\Rest\ContentController;
 
 if ( ! defined( 'ABSPATH' ) ) {
-    exit;
+	exit;
 }
 
 final class ContainerRegistrar {
-    public static function register( Container $container, SettingsRepository $settings ): void {
-        $container->register( 'settings', static fn() => $settings );
+	public static function register( Container $container, SettingsRepository $settings ): void {
+		$container->register( 'settings', static fn() => $settings );
 
-        $container->register( 'admin_notice_service', static fn() => new AdminNoticeService() );
-        $container->register( 'logging_service', static fn( Container $c ) => new LoggingService( $c->get( 'admin_notice_service' ) ) );
+		$container->register( 'admin_notice_service', static fn() => new AdminNoticeService() );
+		$container->register( 'logging_service', static fn( Container $c ) => new LoggingService( $c->get( 'admin_notice_service' ) ) );
 
-        $container->register( 'remote_request', static fn() => new Services\Remote\RemoteRequest() );
-        $container->register( 'api_response_handler', static fn() => new Services\Remote\ApiResponseHandler() );
-        $container->register( 'remote_api', static fn( Container $c ) => new RemoteApiService( $c->get( 'settings' ), $c->get( 'remote_request' ), $c->get( 'api_response_handler' ) ) );
-        $container->register( 'content_storage', static fn( Container $c ) => new ContentStorageService( $c->get( 'settings' ) ) );
+		$container->register( 'remote_request', static fn() => new Services\Remote\RemoteRequest() );
+		$container->register( 'api_response_handler', static fn() => new Services\Remote\ApiResponseHandler() );
+		$container->register( 'remote_api', static fn( Container $c ) => new RemoteApiService( $c->get( 'settings' ), $c->get( 'remote_request' ), $c->get( 'api_response_handler' ) ) );
+		$container->register( 'content_storage', static fn( Container $c ) => new ContentStorageService( $c->get( 'settings' ) ) );
 
-                $container->register(
-                    'generation_poller',
-                    static fn( Container $c ) => new GenerationPoller(
-                        $c->get( 'settings' ),
-                        $c->get( 'remote_api' ),
-                        $c->get( 'content_storage' )
-                    )
-                );
+				$container->register(
+					'generation_poller',
+					static fn( Container $c ) => new GenerationPoller(
+						$c->get( 'settings' ),
+						$c->get( 'remote_api' ),
+						$c->get( 'content_storage' )
+					)
+				);
 
-                $container->register(
-                    'auto_generation_queue',
-                    static fn( Container $c ) => new AutoGenerationQueue(
-                        $c->get( 'remote_api' ),
-                        $c->get( 'content_storage' ),
-                        new PostDataFetcher()
-                    )
-                );
+				$container->register(
+					'auto_generation_queue',
+					static fn( Container $c ) => new AutoGenerationQueue(
+						$c->get( 'remote_api' ),
+						$c->get( 'content_storage' ),
+						new PostDataFetcher()
+					)
+				);
 
-                $container->register(
-                    'auto_generation_scheduler',
-                    static fn( Container $c ) => new AutoGenerationScheduler(
-                        $c->get( 'generation_poller' )
-                    )
-                );
+				$container->register(
+					'auto_generation_scheduler',
+					static fn( Container $c ) => new AutoGenerationScheduler(
+						$c->get( 'generation_poller' )
+					)
+				);
 
-        $container->register(
-            'publish_generation_handler',
-            static fn( Container $c ) => new PublishGenerationHandler(
-                $c->get( 'settings' )
-            )
-        );
+		$container->register(
+			'publish_generation_handler',
+			static fn( Container $c ) => new PublishGenerationHandler(
+				$c->get( 'settings' )
+			)
+		);
 
-                $container->register(
-                    'auto_generation_service',
-                    static fn( Container $c ) => new AutoGenerationService(
-                        $c->get( 'settings' ),
-                        $c->get( 'auto_generation_queue' ),
-                        $c->get( 'auto_generation_scheduler' ),
-                        $c->get( 'publish_generation_handler' )
-                    )
-                );
+				$container->register(
+					'auto_generation_service',
+					static fn( Container $c ) => new AutoGenerationService(
+						$c->get( 'settings' ),
+						$c->get( 'auto_generation_queue' ),
+						$c->get( 'auto_generation_scheduler' ),
+						$c->get( 'publish_generation_handler' )
+					)
+				);
 
-                $container->register(
-                        'generation_service',
-                        static fn( Container $c ) => new GenerationService(
-                                $c->get( 'settings' ),
-                                $c->get( 'remote_api' ),
-                                $c->get( 'content_storage' ),
-                                new PostDataFetcher()
-                        )
-                );
+				$container->register(
+						'generation_service',
+						static fn( Container $c ) => new GenerationService(
+								$c->get( 'settings' ),
+								$c->get( 'remote_api' ),
+								$c->get( 'content_storage' ),
+								new PostDataFetcher()
+						)
+				);
 
-        $container->register( 'pointer_service', static fn() => new PointerService() );
-                $container->register( 'posts_query_service', static fn() => new PostsQueryService() );
-                $container->register( 'dashboard_data_service', static fn() => new DashboardDataService() );
-                $container->register( 'version_service', static fn() => new VersionService() );
+		$container->register( 'pointer_service', static fn() => new PointerService() );
+				$container->register( 'posts_query_service', static fn() => new PostsQueryService() );
+				$container->register( 'dashboard_data_service', static fn() => new DashboardDataService() );
+				$container->register( 'version_service', static fn() => new VersionService() );
 
-        $container->register( 'generate_controller', static fn( Container $c ) => new GenerateController( $c->get( 'generation_service' ) ) );
-        $container->register( 'updates_controller', static fn( Container $c ) => new UpdatesController( $c->get( 'remote_api' ), $c->get( 'content_storage' ) ) );
-        $container->register( 'pointer_controller', static fn( Container $c ) => new PointerController( $c->get( 'pointer_service' ) ) );
-        $container->register( 'posts_count_controller', static fn( Container $c ) => new PostsCountController( $c->get( 'posts_query_service' ) ) );
-                $container->register(
-                    'content_controller',
-                    static fn( Container $c ) => new ContentController(
-                        $c->get( 'content_storage' ),
-                        $c->get( 'settings' )
-                    )
-                );
-        $container->register( 'optin_export_controller', static fn() => new OptinExportController() );
-    }
+		$container->register( 'generate_controller', static fn( Container $c ) => new GenerateController( $c->get( 'generation_service' ) ) );
+		$container->register( 'updates_controller', static fn( Container $c ) => new UpdatesController( $c->get( 'remote_api' ), $c->get( 'content_storage' ) ) );
+		$container->register( 'pointer_controller', static fn( Container $c ) => new PointerController( $c->get( 'pointer_service' ) ) );
+		$container->register( 'posts_count_controller', static fn( Container $c ) => new PostsCountController( $c->get( 'posts_query_service' ) ) );
+				$container->register(
+					'content_controller',
+					static fn( Container $c ) => new ContentController(
+						$c->get( 'content_storage' ),
+						$c->get( 'settings' )
+					)
+				);
+		$container->register( 'optin_export_controller', static fn() => new OptinExportController() );
+	}
 }

--- a/nuclear-engagement/inc/Core/Deactivator.php
+++ b/nuclear-engagement/inc/Core/Deactivator.php
@@ -7,7 +7,7 @@ use NuclearEngagement\Core\SettingsRepository;
 use NuclearEngagement\Services\AutoGenerationService;
 
 if ( ! defined( 'ABSPATH' ) ) {
-    exit;
+	exit;
 }
 
 /**
@@ -31,28 +31,28 @@ if ( ! defined( 'ABSPATH' ) ) {
  * @author   Stefano Lodola <stefano@nuclearengagement.com>
  */
 class Deactivator {
-    /**
-     * Handle plugin deactivation
-     *
-     * @since 0.3.1
-     * @param SettingsRepository|null $settings Optional settings repository instance
-     */
-    public static function nuclen_deactivate( ?SettingsRepository $settings = null ) {
-            // Clear scheduled cron hooks
-            wp_clear_scheduled_hook( AutoGenerationService::START_HOOK );
-            wp_clear_scheduled_hook( AutoGenerationService::QUEUE_HOOK );
-            wp_clear_scheduled_hook( 'nuclen_poll_generation' );
+	/**
+	 * Handle plugin deactivation
+	 *
+	 * @since 0.3.1
+	 * @param SettingsRepository|null $settings Optional settings repository instance
+	 */
+	public static function nuclen_deactivate( ?SettingsRepository $settings = null ) {
+			// Clear scheduled cron hooks
+			wp_clear_scheduled_hook( AutoGenerationService::START_HOOK );
+			wp_clear_scheduled_hook( AutoGenerationService::QUEUE_HOOK );
+			wp_clear_scheduled_hook( 'nuclen_poll_generation' );
 
-            // Remove any pending generation records
-            delete_option( 'nuclen_active_generations' );
+			// Remove any pending generation records
+			delete_option( 'nuclen_active_generations' );
 
-            // Clear any scheduled hooks or transients if needed
-            delete_transient( 'nuclen_plugin_activation_redirect' );
+			// Clear any scheduled hooks or transients if needed
+			delete_transient( 'nuclen_plugin_activation_redirect' );
 
-        // If settings instance is provided, perform any necessary cleanup
-        if ( $settings !== null ) {
-            // Clear any cached settings if needed
-            $settings->clear_cache();
-        }
-    }
+		// If settings instance is provided, perform any necessary cleanup
+		if ( $settings !== null ) {
+			// Clear any cached settings if needed
+			$settings->clear_cache();
+		}
+	}
 }

--- a/nuclear-engagement/inc/Core/Defaults.php
+++ b/nuclear-engagement/inc/Core/Defaults.php
@@ -9,112 +9,112 @@ declare(strict_types=1);
 namespace NuclearEngagement\Core;
 
 if ( ! defined( 'ABSPATH' ) ) {
-    exit;
+	exit;
 }
 
 class Defaults {
 
-    public static function nuclen_get_default_settings() {
-        return array(
-            'theme'                                 => 'bright',
+	public static function nuclen_get_default_settings() {
+		return array(
+			'theme'                                 => 'bright',
 
-            /* ───── Quiz styling ───── */
-            'font_size'                             => '16',
-            'font_color'                            => '#000000',
-            'bg_color'                              => '#ffffff',
-            'quiz_border_color'                     => '#000000',
-            'quiz_border_style'                     => 'solid',
-            'quiz_border_width'                     => '1',
-            'quiz_border_radius'                    => '6',
-            'quiz_shadow_color'                     => 'rgba(0,0,0,0.15)',
-            'quiz_shadow_blur'                      => '8',
+			/* ───── Quiz styling ───── */
+			'font_size'                             => '16',
+			'font_color'                            => '#000000',
+			'bg_color'                              => '#ffffff',
+			'quiz_border_color'                     => '#000000',
+			'quiz_border_style'                     => 'solid',
+			'quiz_border_width'                     => '1',
+			'quiz_border_radius'                    => '6',
+			'quiz_shadow_color'                     => 'rgba(0,0,0,0.15)',
+			'quiz_shadow_blur'                      => '8',
 
-            'quiz_answer_button_bg_color'           => '#94544A',
-            'quiz_answer_button_border_color'       => '#94544A',
-            'quiz_answer_button_border_width'       => '2',
-            'quiz_answer_button_border_radius'      => '4',
+			'quiz_answer_button_bg_color'           => '#94544A',
+			'quiz_answer_button_border_color'       => '#94544A',
+			'quiz_answer_button_border_width'       => '2',
+			'quiz_answer_button_border_radius'      => '4',
 
-            'quiz_progress_bar_fg_color'            => '#1B977D',
-            'quiz_progress_bar_bg_color'            => '#e0e0e0',
-            'quiz_progress_bar_height'              => '10',
+			'quiz_progress_bar_fg_color'            => '#1B977D',
+			'quiz_progress_bar_bg_color'            => '#e0e0e0',
+			'quiz_progress_bar_height'              => '10',
 
-            /* ───── Summary styling ───── */
-            'summary_font_size'                     => '16',
-            'summary_font_color'                    => '#000000',
-            'summary_bg_color'                      => '#ffffff',
-            'summary_border_color'                  => '#000000',
-            'summary_border_style'                  => 'solid',
-            'summary_border_width'                  => '1',
-            'summary_border_radius'                 => '6',
-            'summary_shadow_color'                  => 'rgba(0,0,0,0.15)',
-            'summary_shadow_blur'                   => '8',
+			/* ───── Summary styling ───── */
+			'summary_font_size'                     => '16',
+			'summary_font_color'                    => '#000000',
+			'summary_bg_color'                      => '#ffffff',
+			'summary_border_color'                  => '#000000',
+			'summary_border_style'                  => 'solid',
+			'summary_border_width'                  => '1',
+			'summary_border_radius'                 => '6',
+			'summary_shadow_color'                  => 'rgba(0,0,0,0.15)',
+			'summary_shadow_blur'                   => '8',
 
-            /* ───── TOC styling ───── */
-            'toc_font_size'                         => '16',
-            'toc_font_color'                        => '#000000',
-            'toc_bg_color'                          => '#ffffff',
-            'toc_border_color'                      => '#000000',
-            'toc_border_style'                      => 'solid',
-            'toc_border_width'                      => '1',
-            'toc_border_radius'                     => '6',
-            'toc_shadow_color'                      => 'rgba(0,0,0,0.05)',
-            'toc_shadow_blur'                       => '8',
-            'toc_z_index'                           => '100',
-            'toc_link_color'                        => '#1e73be',
+			/* ───── TOC styling ───── */
+			'toc_font_size'                         => '16',
+			'toc_font_color'                        => '#000000',
+			'toc_bg_color'                          => '#ffffff',
+			'toc_border_color'                      => '#000000',
+			'toc_border_style'                      => 'solid',
+			'toc_border_width'                      => '1',
+			'toc_border_radius'                     => '6',
+			'toc_shadow_color'                      => 'rgba(0,0,0,0.05)',
+			'toc_shadow_blur'                       => '8',
+			'toc_z_index'                           => '100',
+			'toc_link_color'                        => '#1e73be',
 
-            /* ───── Quiz items ───── */
-            'questions_per_quiz'                    => '10',
-            'answers_per_question'                  => '4',
+			/* ───── Quiz items ───── */
+			'questions_per_quiz'                    => '10',
+			'answers_per_question'                  => '4',
 
-            /* ───── Display ───── */
-            'display_summary'                       => 'before',
-            'display_quiz'                          => 'after',
-            'display_toc'                           => 'manual',
-            'toc_sticky'                            => false, // Whether to make TOC sticky when scrolling
-            'toc_sticky_offset_x'                   => '20',   // X offset (left) for sticky TOC in pixels
-            'toc_sticky_offset_y'                   => '20',   // Y offset (top) for sticky TOC in pixels
-            'toc_sticky_max_width'                  => '300',  // Max width for sticky TOC in pixels
-            'toc_show_toggle'                       => true,   // Whether to show the TOC toggle button
-            'toc_show_content'                      => true,   // Whether to show TOC content by default (only used if toggle is enabled)
-            'toc_heading_levels'                    => array( 2, 3, 4, 5, 6 ), // Which heading levels to include in TOC (H2-H6)
-            'custom_quiz_html_before'               => '',
-            'custom_quiz_html_after'                => '',
-            'quiz_title'                            => 'Test your knowledge',
-            'summary_title'                         => 'Key Facts',
-            'toc_title'                             => 'Table of Contents',
+			/* ───── Display ───── */
+			'display_summary'                       => 'before',
+			'display_quiz'                          => 'after',
+			'display_toc'                           => 'manual',
+			'toc_sticky'                            => false, // Whether to make TOC sticky when scrolling
+			'toc_sticky_offset_x'                   => '20',   // X offset (left) for sticky TOC in pixels
+			'toc_sticky_offset_y'                   => '20',   // Y offset (top) for sticky TOC in pixels
+			'toc_sticky_max_width'                  => '300',  // Max width for sticky TOC in pixels
+			'toc_show_toggle'                       => true,   // Whether to show the TOC toggle button
+			'toc_show_content'                      => true,   // Whether to show TOC content by default (only used if toggle is enabled)
+			'toc_heading_levels'                    => array( 2, 3, 4, 5, 6 ), // Which heading levels to include in TOC (H2-H6)
+			'custom_quiz_html_before'               => '',
+			'custom_quiz_html_after'                => '',
+			'quiz_title'                            => 'Test your knowledge',
+			'summary_title'                         => 'Key Facts',
+			'toc_title'                             => 'Table of Contents',
 
-            /* ───── Quiz strings ───── */
-            'quiz_label_retake_test'                => 'Retake Test',
-            'quiz_label_your_score'                 => 'Your Score',
-            'quiz_label_perfect'                    => 'Perfect!',
-            'quiz_label_well_done'                  => 'Well done!',
-            'quiz_label_retake_prompt'              => 'Why not retake the test?',
-            'quiz_label_correct'                    => 'Correct:',
-            'quiz_label_your_answer'                => 'Your answer:',
+			/* ───── Quiz strings ───── */
+			'quiz_label_retake_test'                => 'Retake Test',
+			'quiz_label_your_score'                 => 'Your Score',
+			'quiz_label_perfect'                    => 'Perfect!',
+			'quiz_label_well_done'                  => 'Well done!',
+			'quiz_label_retake_prompt'              => 'Why not retake the test?',
+			'quiz_label_correct'                    => 'Correct:',
+			'quiz_label_your_answer'                => 'Your answer:',
 
-            /* ───── Opt-in ───── */
-            'enable_optin'                          => false,
-            'optin_webhook'                         => '',
-            'optin_position'                        => 'with_results',
-            'optin_mandatory'                       => false,
-            'optin_prompt_text'                     => 'Please enter your details to view your score:',
-            'optin_button_text'                     => 'Submit',
+			/* ───── Opt-in ───── */
+			'enable_optin'                          => false,
+			'optin_webhook'                         => '',
+			'optin_position'                        => 'with_results',
+			'optin_mandatory'                       => false,
+			'optin_prompt_text'                     => 'Please enter your details to view your score:',
+			'optin_button_text'                     => 'Submit',
 
-            /* ───── Generation ───── */
-            'update_last_modified'                  => false,
-            'auto_generate_quiz_on_publish'         => 0,
-            'auto_generate_summary_on_publish'      => 0,
-            'generation_post_types'                 => array( 'post' ),
+			/* ───── Generation ───── */
+			'update_last_modified'                  => false,
+			'auto_generate_quiz_on_publish'         => 0,
+			'auto_generate_summary_on_publish'      => 0,
+			'generation_post_types'                 => array( 'post' ),
 
-            /* ───── Attribution ───── */
-            'show_attribution'                      => false,
+			/* ───── Attribution ───── */
+			'show_attribution'                      => false,
 
-            /* ───── Uninstall ───── */
-            'delete_settings_on_uninstall'          => false,
-            'delete_generated_content_on_uninstall' => false,
-            'delete_optin_data_on_uninstall'        => false,
-            'delete_log_file_on_uninstall'          => false,
-            'delete_custom_css_on_uninstall'        => false,
-        );
-    }
+			/* ───── Uninstall ───── */
+			'delete_settings_on_uninstall'          => false,
+			'delete_generated_content_on_uninstall' => false,
+			'delete_optin_data_on_uninstall'        => false,
+			'delete_log_file_on_uninstall'          => false,
+			'delete_custom_css_on_uninstall'        => false,
+		);
+	}
 }

--- a/nuclear-engagement/inc/Core/InventoryCache.php
+++ b/nuclear-engagement/inc/Core/InventoryCache.php
@@ -11,114 +11,114 @@ declare(strict_types=1);
 namespace NuclearEngagement\Core;
 
 if ( ! defined( 'ABSPATH' ) ) {
-    exit;
+	exit;
 }
 
 final class InventoryCache {
-    /** Cache key base for inventory data. */
-    public const CACHE_KEY = 'nuclen_inventory_data';
+	/** Cache key base for inventory data. */
+	public const CACHE_KEY = 'nuclen_inventory_data';
 
-    /** Cache group used for inventory. */
-    public const CACHE_GROUP = 'nuclen_inventory';
+	/** Cache group used for inventory. */
+	public const CACHE_GROUP = 'nuclen_inventory';
 
-        /** Default cache lifetime. */
-    public const CACHE_EXPIRATION = HOUR_IN_SECONDS;
+		/** Default cache lifetime. */
+	public const CACHE_EXPIRATION = HOUR_IN_SECONDS;
 
-        /** Timestamp key for last clear operation. */
-    private const CLEAR_TS_KEY = 'nuclen_inventory_last_clear';
+		/** Timestamp key for last clear operation. */
+	private const CLEAR_TS_KEY = 'nuclen_inventory_last_clear';
 
-        /** Seconds to debounce consecutive clears. */
-    public const CLEAR_DEBOUNCE = 2;
+		/** Seconds to debounce consecutive clears. */
+	public const CLEAR_DEBOUNCE = 2;
 
-    /**
-     * Register hooks to automatically clear the cache when posts change.
-     */
-    public static function register_hooks(): void {
-        $cb = array( self::class, 'clear' );
-        foreach ( array(
-            'save_post',
-            'delete_post',
-            'deleted_post',
-            'trashed_post',
-            'untrashed_post',
-            'transition_post_status',
-            'clean_post_cache',
-        ) as $hook ) {
-            add_action( $hook, $cb );
-        }
-        foreach ( array( 'added_post_meta', 'updated_post_meta', 'deleted_post_meta' ) as $hook ) {
-            add_action( $hook, $cb );
-        }
-        foreach ( array(
-            'create_term',
-            'created_term',
-            'edit_term',
-            'edited_term',
-            'delete_term',
-            'deleted_term',
-            'set_object_terms',
-            'added_term_relationship',
-            'deleted_term_relationships',
-            'edited_terms',
-        ) as $hook ) {
-            add_action( $hook, $cb );
-        }
-        add_action( 'switch_blog', $cb );
-    }
+	/**
+	 * Register hooks to automatically clear the cache when posts change.
+	 */
+	public static function register_hooks(): void {
+		$cb = array( self::class, 'clear' );
+		foreach ( array(
+			'save_post',
+			'delete_post',
+			'deleted_post',
+			'trashed_post',
+			'untrashed_post',
+			'transition_post_status',
+			'clean_post_cache',
+		) as $hook ) {
+			add_action( $hook, $cb );
+		}
+		foreach ( array( 'added_post_meta', 'updated_post_meta', 'deleted_post_meta' ) as $hook ) {
+			add_action( $hook, $cb );
+		}
+		foreach ( array(
+			'create_term',
+			'created_term',
+			'edit_term',
+			'edited_term',
+			'delete_term',
+			'deleted_term',
+			'set_object_terms',
+			'added_term_relationship',
+			'deleted_term_relationships',
+			'edited_terms',
+		) as $hook ) {
+			add_action( $hook, $cb );
+		}
+		add_action( 'switch_blog', $cb );
+	}
 
-    /**
-     * Get the cache key for the current site.
-     */
-    private static function get_cache_key(): string {
-        return self::CACHE_KEY . '_' . get_current_blog_id();
-    }
+	/**
+	 * Get the cache key for the current site.
+	 */
+	private static function get_cache_key(): string {
+		return self::CACHE_KEY . '_' . get_current_blog_id();
+	}
 
-    /**
-     * Get cached inventory data.
-     */
-    public static function get(): ?array {
-                $key    = self::get_cache_key();
-                $found  = false;
-                $cached = wp_cache_get( $key, self::CACHE_GROUP, false, $found );
-        if ( ! $found ) {
-                $cached = get_transient( $key );
-        }
+	/**
+	 * Get cached inventory data.
+	 */
+	public static function get(): ?array {
+				$key    = self::get_cache_key();
+				$found  = false;
+				$cached = wp_cache_get( $key, self::CACHE_GROUP, false, $found );
+		if ( ! $found ) {
+				$cached = get_transient( $key );
+		}
 
-                return is_array( $cached ) ? $cached : null;
-    }
+				return is_array( $cached ) ? $cached : null;
+	}
 
-    /**
-     * Store inventory data in cache.
-     */
-    public static function set( array $data ): void {
-                $key = self::get_cache_key();
+	/**
+	 * Store inventory data in cache.
+	 */
+	public static function set( array $data ): void {
+				$key = self::get_cache_key();
 
-                wp_cache_set( $key, $data, self::CACHE_GROUP, self::CACHE_EXPIRATION );
-                set_transient( $key, $data, self::CACHE_EXPIRATION );
-    }
+				wp_cache_set( $key, $data, self::CACHE_GROUP, self::CACHE_EXPIRATION );
+				set_transient( $key, $data, self::CACHE_EXPIRATION );
+	}
 
-    /**
-     * Clear the inventory cache.
-     */
-    public static function clear(): void {
-            $now  = time();
-            $last = (int) wp_cache_get( self::CLEAR_TS_KEY, self::CACHE_GROUP );
+	/**
+	 * Clear the inventory cache.
+	 */
+	public static function clear(): void {
+			$now  = time();
+			$last = (int) wp_cache_get( self::CLEAR_TS_KEY, self::CACHE_GROUP );
 
-        if ( $last && ( $now - $last ) < self::CLEAR_DEBOUNCE ) {
-                return;
-        }
+		if ( $last && ( $now - $last ) < self::CLEAR_DEBOUNCE ) {
+				return;
+		}
 
-            wp_cache_set( self::CLEAR_TS_KEY, $now, self::CACHE_GROUP, self::CLEAR_DEBOUNCE * 2 );
+			wp_cache_set( self::CLEAR_TS_KEY, $now, self::CACHE_GROUP, self::CLEAR_DEBOUNCE * 2 );
 
-            $key = self::get_cache_key();
+			$key = self::get_cache_key();
 
-            wp_cache_delete( $key, self::CACHE_GROUP );
-            delete_transient( $key );
+			wp_cache_delete( $key, self::CACHE_GROUP );
+			delete_transient( $key );
 
-        if ( function_exists( 'wp_cache_flush_group' ) ) {
-                    wp_cache_flush_group( self::CACHE_GROUP );
-        }
+		if ( function_exists( 'wp_cache_flush_group' ) ) {
+					wp_cache_flush_group( self::CACHE_GROUP );
+		}
 
-                \NuclearEngagement\Services\DashboardDataService::clear_cache();
-    }
+				\NuclearEngagement\Services\DashboardDataService::clear_cache();
+	}
 }

--- a/nuclear-engagement/inc/Core/Loader.php
+++ b/nuclear-engagement/inc/Core/Loader.php
@@ -3,42 +3,42 @@ declare(strict_types=1);
 namespace NuclearEngagement\Core;
 
 if ( ! defined( 'ABSPATH' ) ) {
-    exit;
+	exit;
 }
 
 
 class Loader {
-    protected $actions = array();
-    protected $filters = array();
+	protected $actions = array();
+	protected $filters = array();
 
-    public function nuclen_add_action( $hook, $component, $callback, $priority = 10, $accepted_args = 1 ) {
-        $this->actions = $this->nuclen_add( $this->actions, $hook, $component, $callback, $priority, $accepted_args );
-    }
+	public function nuclen_add_action( $hook, $component, $callback, $priority = 10, $accepted_args = 1 ) {
+		$this->actions = $this->nuclen_add( $this->actions, $hook, $component, $callback, $priority, $accepted_args );
+	}
 
-    public function nuclen_add_filter( $hook, $component, $callback, $priority = 10, $accepted_args = 1 ) {
-        $this->filters = $this->nuclen_add( $this->filters, $hook, $component, $callback, $priority, $accepted_args );
-    }
+	public function nuclen_add_filter( $hook, $component, $callback, $priority = 10, $accepted_args = 1 ) {
+		$this->filters = $this->nuclen_add( $this->filters, $hook, $component, $callback, $priority, $accepted_args );
+	}
 
-    private function nuclen_add( $hooks, $hook, $component, $callback, $priority, $accepted_args ) {
-        $hooks[] = array(
-            'hook'          => $hook,
-            'component'     => $component,
-            'callback'      => $callback,
-            'priority'      => $priority,
-            'accepted_args' => $accepted_args,
-        );
-        return $hooks;
-    }
+	private function nuclen_add( $hooks, $hook, $component, $callback, $priority, $accepted_args ) {
+		$hooks[] = array(
+			'hook'          => $hook,
+			'component'     => $component,
+			'callback'      => $callback,
+			'priority'      => $priority,
+			'accepted_args' => $accepted_args,
+		);
+		return $hooks;
+	}
 
-    public function nuclen_run() {
-        // Register all filters
-        foreach ( $this->filters as $hook ) {
-            add_filter( $hook['hook'], array( $hook['component'], $hook['callback'] ), $hook['priority'], $hook['accepted_args'] );
-        }
+	public function nuclen_run() {
+		// Register all filters
+		foreach ( $this->filters as $hook ) {
+			add_filter( $hook['hook'], array( $hook['component'], $hook['callback'] ), $hook['priority'], $hook['accepted_args'] );
+		}
 
-        // Register all actions
-        foreach ( $this->actions as $hook ) {
-            add_action( $hook['hook'], array( $hook['component'], $hook['callback'] ), $hook['priority'], $hook['accepted_args'] );
-        }
-    }
+		// Register all actions
+		foreach ( $this->actions as $hook ) {
+			add_action( $hook['hook'], array( $hook['component'], $hook['callback'] ), $hook['priority'], $hook['accepted_args'] );
+		}
+	}
 }

--- a/nuclear-engagement/inc/Core/MetaRegistration.php
+++ b/nuclear-engagement/inc/Core/MetaRegistration.php
@@ -14,7 +14,7 @@ use function NuclearEngagement\nuclen_settings_array;
 use NuclearEngagement\Modules\Summary\Summary_Service;
 
 if ( ! defined( 'ABSPATH' ) ) {
-    exit;
+	exit;
 }
 
 /**
@@ -24,170 +24,170 @@ if ( ! defined( 'ABSPATH' ) ) {
  */
 class MetaRegistration {
 
-    /**
-     * Initialize meta registration
-     */
-    public static function init(): void {
-        add_action( 'init', array( self::class, 'register_meta_keys' ), 5 );
-    }
+	/**
+	 * Initialize meta registration
+	 */
+	public static function init(): void {
+		add_action( 'init', array( self::class, 'register_meta_keys' ), 5 );
+	}
 
-    /**
-     * Register all plugin meta keys
-     */
-    public static function register_meta_keys(): void {
-        // Get allowed post types from settings
-        $post_types = nuclen_settings_array( 'generation_post_types', array( 'post' ) );
+	/**
+	 * Register all plugin meta keys
+	 */
+	public static function register_meta_keys(): void {
+		// Get allowed post types from settings
+		$post_types = nuclen_settings_array( 'generation_post_types', array( 'post' ) );
 
-        // Register quiz data meta
-        foreach ( $post_types as $post_type ) {
-            register_post_meta(
-                $post_type,
-                'nuclen-quiz-data',
-                array(
-                    'type'              => 'string',
-                    'description'       => 'Nuclear Engagement quiz data',
-                    'single'            => true,
-                    'show_in_rest'      => false,
-                    'sanitize_callback' => array( self::class, 'sanitize_quiz_data' ),
-                    'auth_callback'     => array( self::class, 'auth_callback' ),
-                )
-            );
+		// Register quiz data meta
+		foreach ( $post_types as $post_type ) {
+			register_post_meta(
+				$post_type,
+				'nuclen-quiz-data',
+				array(
+					'type'              => 'string',
+					'description'       => 'Nuclear Engagement quiz data',
+					'single'            => true,
+					'show_in_rest'      => false,
+					'sanitize_callback' => array( self::class, 'sanitize_quiz_data' ),
+					'auth_callback'     => array( self::class, 'auth_callback' ),
+				)
+			);
 
-            register_post_meta(
-                $post_type,
-                'nuclen_quiz_protected',
-                array(
-                    'type'              => 'boolean',
-                    'description'       => 'Nuclear Engagement quiz protection flag',
-                    'single'            => true,
-                    'show_in_rest'      => false,
-                    'default'           => false,
-                    'sanitize_callback' => 'rest_sanitize_boolean',
-                    'auth_callback'     => array( self::class, 'auth_callback' ),
-                )
-            );
+			register_post_meta(
+				$post_type,
+				'nuclen_quiz_protected',
+				array(
+					'type'              => 'boolean',
+					'description'       => 'Nuclear Engagement quiz protection flag',
+					'single'            => true,
+					'show_in_rest'      => false,
+					'default'           => false,
+					'sanitize_callback' => 'rest_sanitize_boolean',
+					'auth_callback'     => array( self::class, 'auth_callback' ),
+				)
+			);
 
-            // Register summary data meta
-            register_post_meta(
-                $post_type,
-                Summary_Service::META_KEY,
-                array(
-                    'type'              => 'string',
-                    'description'       => 'Nuclear Engagement summary data',
-                    'single'            => true,
-                    'show_in_rest'      => false,
-                    'sanitize_callback' => array( self::class, 'sanitize_summary_data' ),
-                    'auth_callback'     => array( self::class, 'auth_callback' ),
-                )
-            );
+			// Register summary data meta
+			register_post_meta(
+				$post_type,
+				Summary_Service::META_KEY,
+				array(
+					'type'              => 'string',
+					'description'       => 'Nuclear Engagement summary data',
+					'single'            => true,
+					'show_in_rest'      => false,
+					'sanitize_callback' => array( self::class, 'sanitize_summary_data' ),
+					'auth_callback'     => array( self::class, 'auth_callback' ),
+				)
+			);
 
-            register_post_meta(
-                $post_type,
-                Summary_Service::PROTECTED_KEY,
-                array(
-                    'type'              => 'boolean',
-                    'description'       => 'Nuclear Engagement summary protection flag',
-                    'single'            => true,
-                    'show_in_rest'      => false,
-                    'default'           => false,
-                    'sanitize_callback' => 'rest_sanitize_boolean',
-                    'auth_callback'     => array( self::class, 'auth_callback' ),
-                )
-            );
-        }
-    }
+			register_post_meta(
+				$post_type,
+				Summary_Service::PROTECTED_KEY,
+				array(
+					'type'              => 'boolean',
+					'description'       => 'Nuclear Engagement summary protection flag',
+					'single'            => true,
+					'show_in_rest'      => false,
+					'default'           => false,
+					'sanitize_callback' => 'rest_sanitize_boolean',
+					'auth_callback'     => array( self::class, 'auth_callback' ),
+				)
+			);
+		}
+	}
 
-    /**
-     * Sanitize quiz data before saving
-     *
-     * @param mixed $meta_value
-     * @return mixed
-     */
-    public static function sanitize_quiz_data( $meta_value ) {
-        if ( ! is_array( $meta_value ) ) {
-            return '';
-        }
+	/**
+	 * Sanitize quiz data before saving
+	 *
+	 * @param mixed $meta_value
+	 * @return mixed
+	 */
+	public static function sanitize_quiz_data( $meta_value ) {
+		if ( ! is_array( $meta_value ) ) {
+			return '';
+		}
 
-        // Ensure required structure
-        $sanitized = array(
-            'date'      => '',
-            'questions' => array(),
-        );
+		// Ensure required structure
+		$sanitized = array(
+			'date'      => '',
+			'questions' => array(),
+		);
 
-        if ( isset( $meta_value['date'] ) ) {
-            $sanitized['date'] = sanitize_text_field( $meta_value['date'] );
-        }
+		if ( isset( $meta_value['date'] ) ) {
+			$sanitized['date'] = sanitize_text_field( $meta_value['date'] );
+		}
 
-        if ( isset( $meta_value['questions'] ) && is_array( $meta_value['questions'] ) ) {
-            foreach ( $meta_value['questions'] as $question ) {
-                if ( is_array( $question ) ) {
-                    $sanitized['questions'][] = array(
-                        'question'    => wp_kses_post( $question['question'] ?? '' ),
-                        'answers'     => array_map( 'wp_kses_post', (array) ( $question['answers'] ?? array() ) ),
-                        'explanation' => wp_kses_post( $question['explanation'] ?? '' ),
-                    );
-                }
-            }
-        }
+		if ( isset( $meta_value['questions'] ) && is_array( $meta_value['questions'] ) ) {
+			foreach ( $meta_value['questions'] as $question ) {
+				if ( is_array( $question ) ) {
+					$sanitized['questions'][] = array(
+						'question'    => wp_kses_post( $question['question'] ?? '' ),
+						'answers'     => array_map( 'wp_kses_post', (array) ( $question['answers'] ?? array() ) ),
+						'explanation' => wp_kses_post( $question['explanation'] ?? '' ),
+					);
+				}
+			}
+		}
 
-        return $sanitized;
-    }
+		return $sanitized;
+	}
 
-    /**
-     * Sanitize summary data before saving
-     *
-     * @param mixed $meta_value
-     * @return mixed
-     */
-    public static function sanitize_summary_data( $meta_value ) {
-        if ( ! is_array( $meta_value ) ) {
-            return '';
-        }
+	/**
+	 * Sanitize summary data before saving
+	 *
+	 * @param mixed $meta_value
+	 * @return mixed
+	 */
+	public static function sanitize_summary_data( $meta_value ) {
+		if ( ! is_array( $meta_value ) ) {
+			return '';
+		}
 
-        $allowed_html = array(
-            'a'      => array(
-                'href'   => array(),
-                'title'  => array(),
-                'target' => array(),
-            ),
-            'br'     => array(),
-            'em'     => array(),
-            'strong' => array(),
-            'p'      => array(),
-            'ul'     => array(),
-            'ol'     => array(),
-            'li'     => array(),
-            'h1'     => array(),
-            'h2'     => array(),
-            'h3'     => array(),
-            'h4'     => array(),
-            'div'    => array( 'class' => array() ),
-            'span'   => array( 'class' => array() ),
-        );
+		$allowed_html = array(
+			'a'      => array(
+				'href'   => array(),
+				'title'  => array(),
+				'target' => array(),
+			),
+			'br'     => array(),
+			'em'     => array(),
+			'strong' => array(),
+			'p'      => array(),
+			'ul'     => array(),
+			'ol'     => array(),
+			'li'     => array(),
+			'h1'     => array(),
+			'h2'     => array(),
+			'h3'     => array(),
+			'h4'     => array(),
+			'div'    => array( 'class' => array() ),
+			'span'   => array( 'class' => array() ),
+		);
 
-        return array(
-            'date'    => sanitize_text_field( $meta_value['date'] ?? '' ),
-            'summary' => wp_kses( $meta_value['summary'] ?? '', $allowed_html ),
-        );
-    }
+		return array(
+			'date'    => sanitize_text_field( $meta_value['date'] ?? '' ),
+			'summary' => wp_kses( $meta_value['summary'] ?? '', $allowed_html ),
+		);
+	}
 
-    /**
-     * Authorization callback for meta updates
-     *
-     * @param bool   $allowed
-     * @param string $meta_key
-     * @param int    $object_id
-     * @param int    $user_id
-     * @param string $cap
-     * @param array  $caps
-     * @return bool
-     */
-    public static function auth_callback( $allowed, $meta_key, $object_id, $user_id, $cap, $caps ) {
-        // Check if user can edit this post
-        if ( ! user_can( $user_id, 'edit_post', $object_id ) ) {
-            return false;
-        }
+	/**
+	 * Authorization callback for meta updates
+	 *
+	 * @param bool   $allowed
+	 * @param string $meta_key
+	 * @param int    $object_id
+	 * @param int    $user_id
+	 * @param string $cap
+	 * @param array  $caps
+	 * @return bool
+	 */
+	public static function auth_callback( $allowed, $meta_key, $object_id, $user_id, $cap, $caps ) {
+		// Check if user can edit this post
+		if ( ! user_can( $user_id, 'edit_post', $object_id ) ) {
+			return false;
+		}
 
-        return $allowed;
-    }
+		return $allowed;
+	}
 }

--- a/nuclear-engagement/inc/Core/ModuleLoader.php
+++ b/nuclear-engagement/inc/Core/ModuleLoader.php
@@ -3,26 +3,26 @@ declare(strict_types=1);
 namespace NuclearEngagement\Core;
 
 if ( ! defined( 'ABSPATH' ) ) {
-    exit;
+	exit;
 }
 
 class ModuleLoader {
-    private string $base_dir;
+	private string $base_dir;
 
-    public function __construct( string $base_dir = NUCLEN_PLUGIN_DIR ) {
-        $this->base_dir = rtrim( $base_dir, '/\\' ) . '/';
-    }
+	public function __construct( string $base_dir = NUCLEN_PLUGIN_DIR ) {
+		$this->base_dir = rtrim( $base_dir, '/\\' ) . '/';
+	}
 
-    public function load_all(): void {
-        $pattern = $this->base_dir . 'inc/Modules/*/loader.php';
-        $files   = glob( $pattern );
-        if ( ! is_array( $files ) ) {
-            return;
-        }
-        foreach ( $files as $file ) {
-            if ( file_exists( $file ) ) {
-                require_once $file;
-            }
-        }
-    }
+	public function load_all(): void {
+		$pattern = $this->base_dir . 'inc/Modules/*/loader.php';
+		$files   = glob( $pattern );
+		if ( ! is_array( $files ) ) {
+			return;
+		}
+		foreach ( $files as $file ) {
+			if ( file_exists( $file ) ) {
+				require_once $file;
+			}
+		}
+	}
 }

--- a/nuclear-engagement/inc/Core/Plugin.php
+++ b/nuclear-engagement/inc/Core/Plugin.php
@@ -11,7 +11,7 @@ declare(strict_types=1);
 namespace NuclearEngagement\Core;
 
 if ( ! defined( 'ABSPATH' ) ) {
-    exit;
+	exit;
 }
 
 use NuclearEngagement\Admin\Admin;
@@ -28,179 +28,179 @@ use NuclearEngagement\Core\ContainerRegistrar;
 
 class Plugin {
 
-        protected $loader;
-    protected string $plugin_name;
-    protected string $version;
-    protected SettingsRepository $settings_repository;
+		protected $loader;
+	protected string $plugin_name;
+	protected string $version;
+	protected SettingsRepository $settings_repository;
 
-    /**
-     * @var Container
-     */
-    private Container $container;
+	/**
+	 * @var Container
+	 */
+	private Container $container;
 
-    public function __construct() {
-        $this->version     = defined( 'NUCLEN_PLUGIN_VERSION' ) ? NUCLEN_PLUGIN_VERSION : '1.0.0';
-        $this->plugin_name = 'nuclear-engagement';
+	public function __construct() {
+		$this->version     = defined( 'NUCLEN_PLUGIN_VERSION' ) ? NUCLEN_PLUGIN_VERSION : '1.0.0';
+		$this->plugin_name = 'nuclear-engagement';
 
-        // Initialize settings repository with defaults
-        $defaults                  = Defaults::nuclen_get_default_settings();
-        $this->settings_repository = SettingsRepository::get_instance( $defaults );
+		// Initialize settings repository with defaults
+		$defaults                  = Defaults::nuclen_get_default_settings();
+		$this->settings_repository = SettingsRepository::get_instance( $defaults );
 
-        /* ───── Ensure DB table exists on activation ───── */
-        register_activation_hook(
-            dirname( __DIR__ ) . '/nuclear-engagement.php',
-            function () {
-                if ( ! \NuclearEngagement\OptinData::table_exists() ) {
-                    $created = \NuclearEngagement\OptinData::maybe_create_table();
-                    if ( ! $created ) {
-                        \NuclearEngagement\Services\LoggingService::notify_admin(
-                            'Nuclear Engagement could not create required database tables.'
-                        );
-                    }
-                }
-            }
-        );
+		/* ───── Ensure DB table exists on activation ───── */
+		register_activation_hook(
+			dirname( __DIR__ ) . '/nuclear-engagement.php',
+			function () {
+				if ( ! \NuclearEngagement\OptinData::table_exists() ) {
+					$created = \NuclearEngagement\OptinData::maybe_create_table();
+					if ( ! $created ) {
+						\NuclearEngagement\Services\LoggingService::notify_admin(
+							'Nuclear Engagement could not create required database tables.'
+						);
+					}
+				}
+			}
+		);
 
-        $this->nuclen_load_dependencies();
-        $this->container = Container::getInstance();
-        ContainerRegistrar::register( $this->container, $this->settings_repository );
-        // Register hooks for auto-generation on every request
-        $auto_generation_service = $this->container->get( 'auto_generation_service' );
-        $auto_generation_service->register_hooks();
-        $this->nuclen_define_admin_hooks();
-        $this->nuclen_define_public_hooks();
-    }
+		$this->nuclen_load_dependencies();
+		$this->container = Container::getInstance();
+		ContainerRegistrar::register( $this->container, $this->settings_repository );
+		// Register hooks for auto-generation on every request
+		$auto_generation_service = $this->container->get( 'auto_generation_service' );
+		$auto_generation_service->register_hooks();
+		$this->nuclen_define_admin_hooks();
+		$this->nuclen_define_public_hooks();
+	}
 
-    /*
-    ─────────────────────────────────────────────
-        Dependencies & Loader
-    ──────────────────────────────────────────── */
-    private function nuclen_load_dependencies() {
+	/*
+	─────────────────────────────────────────────
+		Dependencies & Loader
+	──────────────────────────────────────────── */
+	private function nuclen_load_dependencies() {
 
-        /* ► Ensure OptinData hooks are registered */
-        OptinData::init();
+		/* ► Ensure OptinData hooks are registered */
+		OptinData::init();
 
-                ( new ModuleLoader() )->load_all();
-                $this->loader = new Loader();
-    }
+				( new ModuleLoader() )->load_all();
+				$this->loader = new Loader();
+	}
 
-    /*
-    ─────────────────────────────────────────────
-        Admin-side hooks
-    ──────────────────────────────────────────── */
-    private function nuclen_define_admin_hooks() {
+	/*
+	─────────────────────────────────────────────
+		Admin-side hooks
+	──────────────────────────────────────────── */
+	private function nuclen_define_admin_hooks() {
 
-        $plugin_admin = new Admin( $this->nuclen_get_plugin_name(), $this->nuclen_get_version(), $this->settings_repository, $this->container );
+		$plugin_admin = new Admin( $this->nuclen_get_plugin_name(), $this->nuclen_get_version(), $this->settings_repository, $this->container );
 
-        // Enqueue
-        $this->loader->nuclen_add_action( 'admin_enqueue_scripts', $plugin_admin, 'wp_enqueue_styles' );
-        $this->loader->nuclen_add_action( 'admin_enqueue_scripts', $plugin_admin, 'wp_enqueue_scripts' );
-        $this->loader->nuclen_add_action( 'admin_enqueue_scripts', $plugin_admin, 'nuclen_enqueue_dashboard_styles' );
-        $this->loader->nuclen_add_action( 'admin_enqueue_scripts', $plugin_admin, 'nuclen_enqueue_generate_page_scripts' );
+		// Enqueue
+		$this->loader->nuclen_add_action( 'admin_enqueue_scripts', $plugin_admin, 'wp_enqueue_styles' );
+		$this->loader->nuclen_add_action( 'admin_enqueue_scripts', $plugin_admin, 'wp_enqueue_scripts' );
+		$this->loader->nuclen_add_action( 'admin_enqueue_scripts', $plugin_admin, 'nuclen_enqueue_dashboard_styles' );
+		$this->loader->nuclen_add_action( 'admin_enqueue_scripts', $plugin_admin, 'nuclen_enqueue_generate_page_scripts' );
 
-        // Admin Menu
-        $this->loader->nuclen_add_action( 'admin_menu', $plugin_admin, 'nuclen_add_admin_menu' );
+		// Admin Menu
+		$this->loader->nuclen_add_action( 'admin_menu', $plugin_admin, 'nuclen_add_admin_menu' );
 
-        // AJAX - now using controllers
-        $generate_controller    = $this->container->get( 'generate_controller' );
-        $updates_controller     = $this->container->get( 'updates_controller' );
-        $posts_count_controller = $this->container->get( 'posts_count_controller' );
+		// AJAX - now using controllers
+		$generate_controller    = $this->container->get( 'generate_controller' );
+		$updates_controller     = $this->container->get( 'updates_controller' );
+		$posts_count_controller = $this->container->get( 'posts_count_controller' );
 
-        $this->loader->nuclen_add_action( 'wp_ajax_nuclen_trigger_generation', $generate_controller, 'handle' );
-        $this->loader->nuclen_add_action( 'wp_ajax_nuclen_fetch_app_updates', $updates_controller, 'handle' );
-        $this->loader->nuclen_add_action( 'wp_ajax_nuclen_get_posts_count', $posts_count_controller, 'handle' );
+		$this->loader->nuclen_add_action( 'wp_ajax_nuclen_trigger_generation', $generate_controller, 'handle' );
+		$this->loader->nuclen_add_action( 'wp_ajax_nuclen_fetch_app_updates', $updates_controller, 'handle' );
+		$this->loader->nuclen_add_action( 'wp_ajax_nuclen_get_posts_count', $posts_count_controller, 'handle' );
 
-        // Setup actions
-        $setup = new \NuclearEngagement\Admin\Setup( $this->settings_repository );
-        $this->loader->nuclen_add_action( 'admin_menu', $setup, 'nuclen_add_setup_page' );
-        $this->loader->nuclen_add_action( 'admin_post_nuclen_connect_app', $setup, 'nuclen_handle_connect_app' );
-        $this->loader->nuclen_add_action( 'admin_post_nuclen_generate_app_password', $setup, 'nuclen_handle_generate_app_password' );
-        $this->loader->nuclen_add_action( 'admin_post_nuclen_reset_api_key', $setup, 'nuclen_handle_reset_api_key' );
-        $this->loader->nuclen_add_action( 'admin_post_nuclen_reset_wp_app_connection', $setup, 'nuclen_handle_reset_wp_app_connection' );
+		// Setup actions
+		$setup = new \NuclearEngagement\Admin\Setup( $this->settings_repository );
+		$this->loader->nuclen_add_action( 'admin_menu', $setup, 'nuclen_add_setup_page' );
+		$this->loader->nuclen_add_action( 'admin_post_nuclen_connect_app', $setup, 'nuclen_handle_connect_app' );
+		$this->loader->nuclen_add_action( 'admin_post_nuclen_generate_app_password', $setup, 'nuclen_handle_generate_app_password' );
+		$this->loader->nuclen_add_action( 'admin_post_nuclen_reset_api_key', $setup, 'nuclen_handle_reset_api_key' );
+		$this->loader->nuclen_add_action( 'admin_post_nuclen_reset_wp_app_connection', $setup, 'nuclen_handle_reset_wp_app_connection' );
 
-        // Onboarding pointers - use controller
-        $onboarding = new Onboarding();
-        $onboarding->nuclen_register_hooks();
+		// Onboarding pointers - use controller
+		$onboarding = new Onboarding();
+		$onboarding->nuclen_register_hooks();
 
-        // Replace pointer dismiss with controller
-        $pointer_controller = $this->container->get( 'pointer_controller' );
-        remove_action( 'wp_ajax_nuclen_dismiss_pointer', array( $onboarding, 'nuclen_ajax_dismiss_pointer' ) );
-        $this->loader->nuclen_add_action( 'wp_ajax_nuclen_dismiss_pointer', $pointer_controller, 'dismiss' );
+		// Replace pointer dismiss with controller
+		$pointer_controller = $this->container->get( 'pointer_controller' );
+		remove_action( 'wp_ajax_nuclen_dismiss_pointer', array( $onboarding, 'nuclen_ajax_dismiss_pointer' ) );
+		$this->loader->nuclen_add_action( 'wp_ajax_nuclen_dismiss_pointer', $pointer_controller, 'dismiss' );
 
-        /* Opt-in CSV export */
-        $optin_export_controller = $this->container->get( 'optin_export_controller' );
-        $this->loader->nuclen_add_action( 'admin_post_nuclen_export_optin', $optin_export_controller, 'handle' );
-        $this->loader->nuclen_add_action( 'wp_ajax_nuclen_export_optin', $optin_export_controller, 'handle' );
-    }
+		/* Opt-in CSV export */
+		$optin_export_controller = $this->container->get( 'optin_export_controller' );
+		$this->loader->nuclen_add_action( 'admin_post_nuclen_export_optin', $optin_export_controller, 'handle' );
+		$this->loader->nuclen_add_action( 'wp_ajax_nuclen_export_optin', $optin_export_controller, 'handle' );
+	}
 
-    /*
-    ─────────────────────────────────────────────
-        Front-end hooks
-    ──────────────────────────────────────────── */
-    private function nuclen_define_public_hooks() {
-        $plugin_public = new FrontClass( $this->nuclen_get_plugin_name(), $this->nuclen_get_version(), $this->settings_repository, $this->container );
+	/*
+	─────────────────────────────────────────────
+		Front-end hooks
+	──────────────────────────────────────────── */
+	private function nuclen_define_public_hooks() {
+		$plugin_public = new FrontClass( $this->nuclen_get_plugin_name(), $this->nuclen_get_version(), $this->settings_repository, $this->container );
 
-        $this->loader->nuclen_add_action( 'wp_enqueue_scripts', $plugin_public, 'wp_enqueue_styles' );
-        $this->loader->nuclen_add_action( 'wp_enqueue_scripts', $plugin_public, 'wp_enqueue_scripts' );
+		$this->loader->nuclen_add_action( 'wp_enqueue_scripts', $plugin_public, 'wp_enqueue_styles' );
+		$this->loader->nuclen_add_action( 'wp_enqueue_scripts', $plugin_public, 'wp_enqueue_scripts' );
 
-        // REST API - use controller
-        add_action(
-            'rest_api_init',
-            function () {
-                $contentController = $this->container->get( 'content_controller' );
-                register_rest_route(
-                    'nuclear-engagement/v1',
-                    '/receive-content',
-                    array(
-                        'methods'             => 'POST',
-                        'callback'            => array( $contentController, 'handle' ),
-                        'permission_callback' => array( $contentController, 'permissions' ),
-                    )
-                );
-            }
-        );
+		// REST API - use controller
+		add_action(
+			'rest_api_init',
+			function () {
+				$contentController = $this->container->get( 'content_controller' );
+				register_rest_route(
+					'nuclear-engagement/v1',
+					'/receive-content',
+					array(
+						'methods'             => 'POST',
+						'callback'            => array( $contentController, 'handle' ),
+						'permission_callback' => array( $contentController, 'permissions' ),
+					)
+				);
+			}
+		);
 
-        $this->loader->nuclen_add_action( 'init', $plugin_public, 'nuclen_register_quiz_shortcode' );
-        $this->loader->nuclen_add_action( 'init', $plugin_public, 'nuclen_register_summary_shortcode' );
-        $this->loader->nuclen_add_filter( 'the_content', $plugin_public, 'nuclen_auto_insert_shortcodes', 50 );
-        $this->loader->nuclen_add_action( 'init', '\\NuclearEngagement\\Blocks', 'register' );
-    }
+		$this->loader->nuclen_add_action( 'init', $plugin_public, 'nuclen_register_quiz_shortcode' );
+		$this->loader->nuclen_add_action( 'init', $plugin_public, 'nuclen_register_summary_shortcode' );
+		$this->loader->nuclen_add_filter( 'the_content', $plugin_public, 'nuclen_auto_insert_shortcodes', 50 );
+		$this->loader->nuclen_add_action( 'init', '\\NuclearEngagement\\Blocks', 'register' );
+	}
 
-    /*
-    ─────────────────────────────────────────────
-        Boilerplate
-    ──────────────────────────────────────────── */
-    public function nuclen_run() {
-        $this->loader->nuclen_run();
-    }
+	/*
+	─────────────────────────────────────────────
+		Boilerplate
+	──────────────────────────────────────────── */
+	public function nuclen_run() {
+		$this->loader->nuclen_run();
+	}
 
-    public function nuclen_get_plugin_name() {
-        return $this->plugin_name;
-    }
+	public function nuclen_get_plugin_name() {
+		return $this->plugin_name;
+	}
 
-    public function nuclen_get_loader() {
-        return $this->loader;
-    }
+	public function nuclen_get_loader() {
+		return $this->loader;
+	}
 
-    public function nuclen_get_version() {
-        return $this->version;
-    }
+	public function nuclen_get_version() {
+		return $this->version;
+	}
 
-    /**
-     * Get the settings repository instance.
-     *
-     * @return SettingsRepository
-     */
-    public function nuclen_get_settings_repository() {
-        return $this->settings_repository;
-    }
+	/**
+	 * Get the settings repository instance.
+	 *
+	 * @return SettingsRepository
+	 */
+	public function nuclen_get_settings_repository() {
+		return $this->settings_repository;
+	}
 
-    /**
-     * Get the container instance (mainly for testing)
-     *
-     * @return Container
-     */
-    public function get_container(): Container {
-        return $this->container;
-    }
+	/**
+	 * Get the container instance (mainly for testing)
+	 *
+	 * @return Container
+	 */
+	public function get_container(): Container {
+		return $this->container;
+	}
 }

--- a/nuclear-engagement/inc/Core/SettingsCache.php
+++ b/nuclear-engagement/inc/Core/SettingsCache.php
@@ -15,7 +15,7 @@ namespace NuclearEngagement\Core;
 
 // If this file is called directly, abort.
 if ( ! defined( 'ABSPATH' ) ) {
-    exit;
+	exit;
 }
 
 /**
@@ -28,102 +28,102 @@ if ( ! defined( 'ABSPATH' ) ) {
  */
 final class SettingsCache {
 
-    /**
-     * Cache group used for settings.
-     *
-     * @since 1.0.0
-     * @var string
-     */
-    public const CACHE_GROUP = 'nuclen_settings';
+	/**
+	 * Cache group used for settings.
+	 *
+	 * @since 1.0.0
+	 * @var string
+	 */
+	public const CACHE_GROUP = 'nuclen_settings';
 
-    /**
-     * Default cache lifetime in seconds.
-     *
-     * @since 1.0.0
-     * @var int
-     */
-    public const CACHE_EXPIRATION = HOUR_IN_SECONDS; // 1 hour.
+	/**
+	 * Default cache lifetime in seconds.
+	 *
+	 * @since 1.0.0
+	 * @var int
+	 */
+	public const CACHE_EXPIRATION = HOUR_IN_SECONDS; // 1 hour.
 
 
-    /**
-     * Register WordPress hooks.
-     *
-     * @since 1.0.0
-     */
-    public function register_hooks(): void {
-        add_action( 'updated_option', array( $this, 'maybe_invalidate_cache' ), 10, 3 );
-        add_action( 'deleted_option', array( $this, 'maybe_invalidate_cache' ), 10, 1 );
-        add_action( 'switch_blog', array( $this, 'invalidate_cache' ) );
-    }
+	/**
+	 * Register WordPress hooks.
+	 *
+	 * @since 1.0.0
+	 */
+	public function register_hooks(): void {
+		add_action( 'updated_option', array( $this, 'maybe_invalidate_cache' ), 10, 3 );
+		add_action( 'deleted_option', array( $this, 'maybe_invalidate_cache' ), 10, 1 );
+		add_action( 'switch_blog', array( $this, 'invalidate_cache' ) );
+	}
 
-    /**
-     * Generate a cache key for the current site.
-     *
-     * @since 1.0.0
-     *
-     * @return string The cache key.
-     */
-    public function get_cache_key(): string {
-        return 'settings_' . get_current_blog_id();
-    }
+	/**
+	 * Generate a cache key for the current site.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @return string The cache key.
+	 */
+	public function get_cache_key(): string {
+		return 'settings_' . get_current_blog_id();
+	}
 
-    /**
-     * Get cached settings.
-     *
-     * @since 1.0.0
-     *
-     * @return array|null Cached settings array or null if not found.
-     */
-    public function get(): ?array {
-        $cached = wp_cache_get( $this->get_cache_key(), self::CACHE_GROUP );
-        return is_array( $cached ) ? $cached : null;
-    }
+	/**
+	 * Get cached settings.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @return array|null Cached settings array or null if not found.
+	 */
+	public function get(): ?array {
+		$cached = wp_cache_get( $this->get_cache_key(), self::CACHE_GROUP );
+		return is_array( $cached ) ? $cached : null;
+	}
 
-    /**
-     * Cache settings.
-     *
-     * @since 1.0.0
-     *
-     * @param array $settings Settings array to cache.
-     */
-    public function set( array $settings ): void {
-        wp_cache_set( $this->get_cache_key(), $settings, self::CACHE_GROUP, self::CACHE_EXPIRATION );
-    }
+	/**
+	 * Cache settings.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @param array $settings Settings array to cache.
+	 */
+	public function set( array $settings ): void {
+		wp_cache_set( $this->get_cache_key(), $settings, self::CACHE_GROUP, self::CACHE_EXPIRATION );
+	}
 
-    /**
-     * Invalidate the settings cache.
-     *
-     * @since 1.0.0
-     */
-    public function invalidate_cache(): void {
-        $key = $this->get_cache_key();
-        wp_cache_delete( $key, self::CACHE_GROUP );
-        if ( function_exists( 'wp_cache_flush_group' ) ) {
-            wp_cache_flush_group( self::CACHE_GROUP );
-        } else {
-            wp_cache_flush();
-        }
-    }
+	/**
+	 * Invalidate the settings cache.
+	 *
+	 * @since 1.0.0
+	 */
+	public function invalidate_cache(): void {
+		$key = $this->get_cache_key();
+		wp_cache_delete( $key, self::CACHE_GROUP );
+		if ( function_exists( 'wp_cache_flush_group' ) ) {
+			wp_cache_flush_group( self::CACHE_GROUP );
+		} else {
+			wp_cache_flush();
+		}
+	}
 
-    /**
-     * Invalidate cache when relevant options are updated.
-     *
-     * @since 1.0.0
-     *
-     * @param string $option Name of the option being updated.
-     */
-    public function maybe_invalidate_cache( $option ): void {
-        if ( SettingsRepository::OPTION === $option ) {
-            $this->invalidate_cache();
-        }
-    }
+	/**
+	 * Invalidate cache when relevant options are updated.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @param string $option Name of the option being updated.
+	 */
+	public function maybe_invalidate_cache( $option ): void {
+		if ( SettingsRepository::OPTION === $option ) {
+			$this->invalidate_cache();
+		}
+	}
 
-    /**
-     * Clear all cached settings.
-     *
-     * @since 1.0.0
-     */
-    public function clear(): void {
-        $this->invalidate_cache();
-    }
+	/**
+	 * Clear all cached settings.
+	 *
+	 * @since 1.0.0
+	 */
+	public function clear(): void {
+		$this->invalidate_cache();
+	}
 }

--- a/nuclear-engagement/inc/Core/SettingsRepository.php
+++ b/nuclear-engagement/inc/Core/SettingsRepository.php
@@ -18,7 +18,7 @@ use NuclearEngagement\Core\SettingsCache;
 
 // If this file is called directly, abort.
 if ( ! defined( 'ABSPATH' ) ) {
-    exit;
+	exit;
 }
 
 /**
@@ -31,115 +31,115 @@ if ( ! defined( 'ABSPATH' ) ) {
  */
 final class SettingsRepository {
 
-    /**
-     * The option name used to store settings in the database.
-     *
-     * @since 1.0.0
-     * @var string
-     */
-    const OPTION = 'nuclear_engagement_settings';
+	/**
+	 * The option name used to store settings in the database.
+	 *
+	 * @since 1.0.0
+	 * @var string
+	 */
+	const OPTION = 'nuclear_engagement_settings';
 
-    /**
-     * Maximum size (in bytes) for settings to be autoloaded.
-     *
-     * @since 1.0.0
-     * @var int
-     */
-    const MAX_AUTOLOAD_SIZE = 512000;
-
-
-    /**
-     * Singleton instance.
-     *
-     * @since 1.0.0
-     * @var SettingsRepository|null
-     */
-    private static ?self $instance = null;
-
-    /**
-     * Default settings values.
-     *
-     * @since 1.0.0
-     * @var array
-     */
-    private array $defaults = array();
-
-    /**
-     * Pending changes not yet saved.
-     *
-     * @since 1.0.0
-     * @var array
-     */
-    private array $pending = array();
-
-    /**
-     * Cache handler.
-     *
-     * @since 1.0.0
-     * @var SettingsCache
-     */
-    private SettingsCache $cache;
-
-    use \NuclearEngagement\Traits\SettingsGettersTrait;
-    use \NuclearEngagement\Traits\SettingsPersistenceTrait;
-    use \NuclearEngagement\Traits\SettingsCacheTrait;
-    use \NuclearEngagement\Traits\SettingsAccessTrait;
-    use \NuclearEngagement\PendingSettingsTrait;
+	/**
+	 * Maximum size (in bytes) for settings to be autoloaded.
+	 *
+	 * @since 1.0.0
+	 * @var int
+	 */
+	const MAX_AUTOLOAD_SIZE = 512000;
 
 
-    /**
-     * Get the singleton instance.
-     *
-     * @since 1.0.0
-     *
-     * @param array $defaults Optional. Default settings to use if not already set.
-     * @return self The singleton instance.
-     */
-    public static function get_instance( array $defaults = array() ): self {
-        if ( null === self::$instance ) {
-            self::$instance = new self( $defaults );
-        }
-        return self::$instance;
-    }
+	/**
+	 * Singleton instance.
+	 *
+	 * @since 1.0.0
+	 * @var SettingsRepository|null
+	 */
+	private static ?self $instance = null;
 
-    /**
-     * Private constructor - use get_instance() instead.
-     *
-     * @since 1.0.0
-     *
-     * @param array $defaults Optional. Default settings to use.
-     */
-    private function __construct( array $defaults = array() ) {
-        // Merge provided defaults with built-in defaults.
-        $this->defaults = wp_parse_args( $defaults, Defaults::nuclen_get_default_settings() );
-        $this->cache    = new SettingsCache();
-        $this->cache->register_hooks();
-    }
+	/**
+	 * Default settings values.
+	 *
+	 * @since 1.0.0
+	 * @var array
+	 */
+	private array $defaults = array();
 
-    /**
-     * Get the default values.
-     *
-     * @since 1.0.0
-     *
-     * @return array The default settings values.
-     */
-    public function get_defaults(): array {
-            return $this->defaults;
-    }
+	/**
+	 * Pending changes not yet saved.
+	 *
+	 * @since 1.0.0
+	 * @var array
+	 */
+	private array $pending = array();
+
+	/**
+	 * Cache handler.
+	 *
+	 * @since 1.0.0
+	 * @var SettingsCache
+	 */
+	private SettingsCache $cache;
+
+	use \NuclearEngagement\Traits\SettingsGettersTrait;
+	use \NuclearEngagement\Traits\SettingsPersistenceTrait;
+	use \NuclearEngagement\Traits\SettingsCacheTrait;
+	use \NuclearEngagement\Traits\SettingsAccessTrait;
+	use \NuclearEngagement\PendingSettingsTrait;
 
 
+	/**
+	 * Get the singleton instance.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @param array $defaults Optional. Default settings to use if not already set.
+	 * @return self The singleton instance.
+	 */
+	public static function get_instance( array $defaults = array() ): self {
+		if ( null === self::$instance ) {
+			self::$instance = new self( $defaults );
+		}
+		return self::$instance;
+	}
 
-    /**
-     * Reset singleton instance (for testing).
-     *
-     * @since 1.0.0
-     */
-    public static function reset_for_tests(): void {
-            self::$instance = null;
-        if ( function_exists( 'wp_cache_flush_group' ) ) {
-                wp_cache_flush_group( SettingsCache::CACHE_GROUP );
-        } else {
-                    wp_cache_flush();
-        }
-    }
+	/**
+	 * Private constructor - use get_instance() instead.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @param array $defaults Optional. Default settings to use.
+	 */
+	private function __construct( array $defaults = array() ) {
+		// Merge provided defaults with built-in defaults.
+		$this->defaults = wp_parse_args( $defaults, Defaults::nuclen_get_default_settings() );
+		$this->cache    = new SettingsCache();
+		$this->cache->register_hooks();
+	}
+
+	/**
+	 * Get the default values.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @return array The default settings values.
+	 */
+	public function get_defaults(): array {
+			return $this->defaults;
+	}
+
+
+
+	/**
+	 * Reset singleton instance (for testing).
+	 *
+	 * @since 1.0.0
+	 */
+	public static function reset_for_tests(): void {
+			self::$instance = null;
+		if ( function_exists( 'wp_cache_flush_group' ) ) {
+				wp_cache_flush_group( SettingsCache::CACHE_GROUP );
+		} else {
+					wp_cache_flush();
+		}
+	}
 }

--- a/nuclear-engagement/inc/Core/SettingsSanitizer.php
+++ b/nuclear-engagement/inc/Core/SettingsSanitizer.php
@@ -15,7 +15,7 @@ namespace NuclearEngagement\Core;
 
 // If this file is called directly, abort.
 if ( ! defined( 'ABSPATH' ) ) {
-    exit;
+	exit;
 }
 
 /**
@@ -27,153 +27,153 @@ if ( ! defined( 'ABSPATH' ) ) {
  * @since 1.0.0
  */
 final class SettingsSanitizer {
-    /**
-     * Sanitization rules for settings.
-     *
-     * Maps setting keys to their respective sanitization callbacks.
-     *
-     * @since 1.0.0
-     * @var array<string, callable|string>
-    private const SANITIZATION_RULES = array(
-        'api_key'                              => 'sanitize_text_field',
-        'theme'                              => 'sanitize_text_field',
-        'font_size'                          => 'absint',
-        'font_color'                            => 'sanitize_hex_color',
-        'bg_color'                            => 'sanitize_hex_color',
-        'border_color'                        => 'sanitize_hex_color',
-        'border_style'                        => 'sanitize_text_field',
-        'border_width'                        => 'absint',
-        'quiz_title'                            => 'sanitize_text_field',
-        'summary_title'                      => 'sanitize_text_field',
-        'toc_title'                          => 'sanitize_text_field',
-        'quiz_label_retake_test'                => 'sanitize_text_field',
-        'quiz_label_your_score'              => 'sanitize_text_field',
-        'quiz_label_perfect'                    => 'sanitize_text_field',
-        'quiz_label_well_done'                => 'sanitize_text_field',
-        'quiz_label_retake_prompt'            => 'sanitize_text_field',
-        'quiz_label_correct'                    => 'sanitize_text_field',
-        'quiz_label_your_answer'                => 'sanitize_text_field',
-        'show_attribution'                    => 'rest_sanitize_boolean',
-        'display_summary'                      => 'sanitize_text_field',
-        'display_quiz'                        => 'sanitize_text_field',
-        'display_toc'                          => 'sanitize_text_field',
-        'connected'                          => 'rest_sanitize_boolean',
-        'wp_app_pass_created'                  => 'rest_sanitize_boolean',
-        'wp_app_pass_uuid'                    => 'sanitize_text_field',
-        'plugin_password'                      => 'sanitize_text_field',
-        'delete_settings_on_uninstall'        => 'rest_sanitize_boolean',
-        'delete_generated_content_on_uninstall' => 'rest_sanitize_boolean',
-        'delete_optin_data_on_uninstall'        => 'rest_sanitize_boolean',
-        'delete_log_file_on_uninstall'        => 'rest_sanitize_boolean',
-        'delete_custom_css_on_uninstall'        => 'rest_sanitize_boolean',
-        'toc_heading_levels'                    => array( self::class, 'sanitize_heading_levels' ),
-        'generation_post_types'              => array( self::class, 'sanitize_post_types' ),
-    );
+	/**
+	 * Sanitization rules for settings.
+	 *
+	 * Maps setting keys to their respective sanitization callbacks.
+	 *
+	 * @since 1.0.0
+	 * @var array<string, callable|string>
+	private const SANITIZATION_RULES = array(
+		'api_key'                              => 'sanitize_text_field',
+		'theme'                              => 'sanitize_text_field',
+		'font_size'                          => 'absint',
+		'font_color'                            => 'sanitize_hex_color',
+		'bg_color'                            => 'sanitize_hex_color',
+		'border_color'                        => 'sanitize_hex_color',
+		'border_style'                        => 'sanitize_text_field',
+		'border_width'                        => 'absint',
+		'quiz_title'                            => 'sanitize_text_field',
+		'summary_title'                      => 'sanitize_text_field',
+		'toc_title'                          => 'sanitize_text_field',
+		'quiz_label_retake_test'                => 'sanitize_text_field',
+		'quiz_label_your_score'              => 'sanitize_text_field',
+		'quiz_label_perfect'                    => 'sanitize_text_field',
+		'quiz_label_well_done'                => 'sanitize_text_field',
+		'quiz_label_retake_prompt'            => 'sanitize_text_field',
+		'quiz_label_correct'                    => 'sanitize_text_field',
+		'quiz_label_your_answer'                => 'sanitize_text_field',
+		'show_attribution'                    => 'rest_sanitize_boolean',
+		'display_summary'                      => 'sanitize_text_field',
+		'display_quiz'                        => 'sanitize_text_field',
+		'display_toc'                          => 'sanitize_text_field',
+		'connected'                          => 'rest_sanitize_boolean',
+		'wp_app_pass_created'                  => 'rest_sanitize_boolean',
+		'wp_app_pass_uuid'                    => 'sanitize_text_field',
+		'plugin_password'                      => 'sanitize_text_field',
+		'delete_settings_on_uninstall'        => 'rest_sanitize_boolean',
+		'delete_generated_content_on_uninstall' => 'rest_sanitize_boolean',
+		'delete_optin_data_on_uninstall'        => 'rest_sanitize_boolean',
+		'delete_log_file_on_uninstall'        => 'rest_sanitize_boolean',
+		'delete_custom_css_on_uninstall'        => 'rest_sanitize_boolean',
+		'toc_heading_levels'                    => array( self::class, 'sanitize_heading_levels' ),
+		'generation_post_types'              => array( self::class, 'sanitize_post_types' ),
+	);
 
-    /**
-     * Sanitize an array of settings values.
-     *
-     * @since 1.0.0
-     *
-     * @param array $settings Raw settings array to sanitize.
-     * @return array Sanitized settings array.
-     */
-    public static function sanitize_settings( array $settings ): array {
-        $sanitized = array();
-        foreach ( $settings as $key => $value ) {
-            if ( ! is_string( $key ) ) {
-                continue;
-            }
-            $sanitized[ $key ] = self::sanitize_setting( $key, $value );
-        }
-        return $sanitized;
-    }
+	/**
+	 * Sanitize an array of settings values.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @param array $settings Raw settings array to sanitize.
+	 * @return array Sanitized settings array.
+	 */
+	public static function sanitize_settings( array $settings ): array {
+		$sanitized = array();
+		foreach ( $settings as $key => $value ) {
+			if ( ! is_string( $key ) ) {
+				continue;
+			}
+			$sanitized[ $key ] = self::sanitize_setting( $key, $value );
+		}
+		return $sanitized;
+	}
 
-    /**
-     * Sanitize a single setting value.
-     *
-     * @since 1.0.0
-     *
-     * @param string $key   Setting key to identify the sanitization rule.
-     * @param mixed  $value Setting value to sanitize.
-     * @return mixed Sanitized value.
-     */
-    public static function sanitize_setting( string $key, $value ) {
-        if ( isset( self::SANITIZATION_RULES[ $key ] ) ) {
-            $rule = self::SANITIZATION_RULES[ $key ];
-            return is_callable( $rule ) ? call_user_func( $rule, $value ) : $value;
-        }
+	/**
+	 * Sanitize a single setting value.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @param string $key   Setting key to identify the sanitization rule.
+	 * @param mixed  $value Setting value to sanitize.
+	 * @return mixed Sanitized value.
+	 */
+	public static function sanitize_setting( string $key, $value ) {
+		if ( isset( self::SANITIZATION_RULES[ $key ] ) ) {
+			$rule = self::SANITIZATION_RULES[ $key ];
+			return is_callable( $rule ) ? call_user_func( $rule, $value ) : $value;
+		}
 
-        if ( is_array( $value ) ) {
-            return self::sanitize_array( $value );
-        }
+		if ( is_array( $value ) ) {
+			return self::sanitize_array( $value );
+		}
 
-        if ( is_bool( $value ) ) {
-            return (bool) $value;
-        }
+		if ( is_bool( $value ) ) {
+			return (bool) $value;
+		}
 
-        if ( is_numeric( $value ) ) {
-            return is_float( $value ) ? (float) $value : (int) $value;
-        }
+		if ( is_numeric( $value ) ) {
+			return is_float( $value ) ? (float) $value : (int) $value;
+		}
 
-        return sanitize_text_field( (string) $value );
-    }
+		return sanitize_text_field( (string) $value );
+	}
 
-    /**
-     * Recursively sanitize an array of values.
-     *
-     * @since 1.0.0
-     * @access private
-     *
-     * @param array $values Values to sanitize.
-     * @return array Sanitized values with all strings properly escaped.
-     */
-    private static function sanitize_array( array $values ): array {
-        return array_map(
-            function ( $value ) {
-                if ( is_array( $value ) ) {
-                        return self::sanitize_array( $value );
-                }
-                return is_string( $value ) ? sanitize_text_field( $value ) : $value;
-            },
-            $values
-        );
-    }
+	/**
+	 * Recursively sanitize an array of values.
+	 *
+	 * @since 1.0.0
+	 * @access private
+	 *
+	 * @param array $values Values to sanitize.
+	 * @return array Sanitized values with all strings properly escaped.
+	 */
+	private static function sanitize_array( array $values ): array {
+		return array_map(
+			function ( $value ) {
+				if ( is_array( $value ) ) {
+						return self::sanitize_array( $value );
+				}
+				return is_string( $value ) ? sanitize_text_field( $value ) : $value;
+			},
+			$values
+		);
+	}
 
-    /**
-     * Sanitize heading levels array.
-     *
-     * @since 1.0.0
-     *
-     * @param mixed $value Raw value to sanitize as heading levels.
-     * @return array<int> Sanitized array of heading levels (1-6).
-     */
-    public static function sanitize_heading_levels( $value ): array {
-        if ( ! is_array( $value ) ) {
-            return array( 2, 3, 4, 5, 6 );
-        }
-        return array_values(
-            array_filter(
-                array_map( 'absint', $value ),
-                function ( $level ) {
-                    return $level >= 1 && $level <= 6;
-                }
-            )
-        );
-    }
+	/**
+	 * Sanitize heading levels array.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @param mixed $value Raw value to sanitize as heading levels.
+	 * @return array<int> Sanitized array of heading levels (1-6).
+	 */
+	public static function sanitize_heading_levels( $value ): array {
+		if ( ! is_array( $value ) ) {
+			return array( 2, 3, 4, 5, 6 );
+		}
+		return array_values(
+			array_filter(
+				array_map( 'absint', $value ),
+				function ( $level ) {
+					return $level >= 1 && $level <= 6;
+				}
+			)
+		);
+	}
 
-    /**
-     * Sanitize post types array.
-     *
-     * @since 1.0.0
-     *
-     * @param mixed $value Raw value to sanitize as post types.
-     * @return array<int,string> Sanitized array of valid post type slugs.
-     */
-    public static function sanitize_post_types( $value ): array {
-        if ( ! is_array( $value ) ) {
-            return array( 'post' );
-        }
-        return array_values( array_filter( array_map( 'sanitize_key', $value ), 'post_type_exists' ) );
-    }
+	/**
+	 * Sanitize post types array.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @param mixed $value Raw value to sanitize as post types.
+	 * @return array<int,string> Sanitized array of valid post type slugs.
+	 */
+	public static function sanitize_post_types( $value ): array {
+		if ( ! is_array( $value ) ) {
+			return array( 'post' );
+		}
+		return array_values( array_filter( array_map( 'sanitize_key', $value ), 'post_type_exists' ) );
+	}
 }

--- a/nuclear-engagement/inc/Core/Themes.php
+++ b/nuclear-engagement/inc/Core/Themes.php
@@ -11,49 +11,49 @@ declare(strict_types=1);
 namespace NuclearEngagement\Core;
 
 if ( ! defined( 'ABSPATH' ) ) {
-    exit;
+	exit;
 }
 
 /**
  * Central theme definitions to avoid duplication.
  */
 final class ThemeRegistry {
-        /**
-         * Map of registered theme names to CSS files.
-         *
-         * @var array<string,string>
-         */
-    private static array $themes = array(
-        'bright' => 'nuclen-theme-bright.css',
-        'dark'   => 'nuclen-theme-dark.css',
-    );
+		/**
+		 * Map of registered theme names to CSS files.
+		 *
+		 * @var array<string,string>
+		 */
+	private static array $themes = array(
+		'bright' => 'nuclen-theme-bright.css',
+		'dark'   => 'nuclen-theme-dark.css',
+	);
 
-        /**
-         * Register a theme stylesheet.
-         *
-         * @param string $name      Theme slug.
-         * @param string $stylesheet Stylesheet filename.
-         */
-    public static function register( string $name, string $stylesheet ): void {
-            self::$themes[ $name ] = $stylesheet;
-    }
+		/**
+		 * Register a theme stylesheet.
+		 *
+		 * @param string $name      Theme slug.
+		 * @param string $stylesheet Stylesheet filename.
+		 */
+	public static function register( string $name, string $stylesheet ): void {
+			self::$themes[ $name ] = $stylesheet;
+	}
 
-        /**
-         * Retrieve the registered themes.
-         *
-         * @return array<string,string> Map of theme names to stylesheets.
-         */
-    public static function get_themes(): array {
-            return self::$themes;
-    }
+		/**
+		 * Retrieve the registered themes.
+		 *
+		 * @return array<string,string> Map of theme names to stylesheets.
+		 */
+	public static function get_themes(): array {
+			return self::$themes;
+	}
 
-        /**
-         * Get the stylesheet for a theme name.
-         *
-         * @param string $name Theme slug.
-         * @return string|null Stylesheet filename if registered.
-         */
-    public static function get( string $name ): ?string {
-            return self::$themes[ $name ] ?? null;
-    }
+		/**
+		 * Get the stylesheet for a theme name.
+		 *
+		 * @param string $name Theme slug.
+		 * @return string|null Stylesheet filename if registered.
+		 */
+	public static function get( string $name ): ?string {
+			return self::$themes[ $name ] ?? null;
+	}
 }

--- a/nuclear-engagement/inc/Core/index.php
+++ b/nuclear-engagement/inc/Core/index.php
@@ -1,5 +1,5 @@
 <?php
 declare(strict_types=1);
 if ( ! defined( 'ABSPATH' ) ) {
-    exit;
+	exit;
 } // Silence is golden

--- a/nuclear-engagement/inc/Helpers/SettingsHelper.php
+++ b/nuclear-engagement/inc/Helpers/SettingsHelper.php
@@ -12,7 +12,7 @@ namespace NuclearEngagement\Helpers;
 use NuclearEngagement\Core\SettingsRepository;
 
 if ( ! defined( 'ABSPATH' ) ) {
-    exit;
+	exit;
 }
 
 /**
@@ -20,59 +20,59 @@ if ( ! defined( 'ABSPATH' ) ) {
  */
 final class SettingsHelper {
 
-    /** Singleton repository instance */
-    private static ?SettingsRepository $repo = null;
+	/** Singleton repository instance */
+	private static ?SettingsRepository $repo = null;
 
-    /**
-     * Retrieve the settings repository instance.
-     */
-    private static function repo(): SettingsRepository {
-        if ( null === self::$repo ) {
-            self::$repo = SettingsRepository::get_instance();
-        }
-        return self::$repo;
-    }
+	/**
+	 * Retrieve the settings repository instance.
+	 */
+	private static function repo(): SettingsRepository {
+		if ( null === self::$repo ) {
+			self::$repo = SettingsRepository::get_instance();
+		}
+		return self::$repo;
+	}
 
-    /**
-     * Get any setting or all settings if no key provided.
-     *
-     * @param string|null $key     Setting key or null for all.
-     * @param mixed       $default Default value.
-     * @return mixed
-     */
-    public static function get( ?string $key = null, $default = null ) {
-        $repository = self::repo();
-        if ( null === $key ) {
-            return $repository->all();
-        }
-        return $repository->get( $key, $default );
-    }
+	/**
+	 * Get any setting or all settings if no key provided.
+	 *
+	 * @param string|null $key     Setting key or null for all.
+	 * @param mixed       $default Default value.
+	 * @return mixed
+	 */
+	public static function get( ?string $key = null, $default = null ) {
+		$repository = self::repo();
+		if ( null === $key ) {
+			return $repository->all();
+		}
+		return $repository->get( $key, $default );
+	}
 
-    /**
-     * Get a boolean setting.
-     */
-    public static function get_bool( string $key, bool $default = false ): bool {
-        return self::repo()->get_bool( $key, $default );
-    }
+	/**
+	 * Get a boolean setting.
+	 */
+	public static function get_bool( string $key, bool $default = false ): bool {
+		return self::repo()->get_bool( $key, $default );
+	}
 
-    /**
-     * Get an integer setting.
-     */
-    public static function get_int( string $key, int $default = 0 ): int {
-        return self::repo()->get_int( $key, $default );
-    }
+	/**
+	 * Get an integer setting.
+	 */
+	public static function get_int( string $key, int $default = 0 ): int {
+		return self::repo()->get_int( $key, $default );
+	}
 
-    /**
-     * Get a string setting.
-     */
-    public static function get_string( string $key, string $default = '' ): string {
-        return self::repo()->get_string( $key, $default );
-    }
+	/**
+	 * Get a string setting.
+	 */
+	public static function get_string( string $key, string $default = '' ): string {
+		return self::repo()->get_string( $key, $default );
+	}
 
-    /**
-     * Get an array setting.
-     */
-    public static function get_array( string $key, array $default = array() ): array {
-        return self::repo()->get_array( $key, $default );
-    }
+	/**
+	 * Get an array setting.
+	 */
+	public static function get_array( string $key, array $default = array() ): array {
+		return self::repo()->get_array( $key, $default );
+	}
 }

--- a/nuclear-engagement/inc/Helpers/settings-functions.php
+++ b/nuclear-engagement/inc/Helpers/settings-functions.php
@@ -12,33 +12,33 @@ namespace {
 use NuclearEngagement\Helpers\SettingsHelper;
 
 if ( ! function_exists( 'nuclen_settings' ) ) {
-    function nuclen_settings( ?string $key = null, $default = null ) {
-        return SettingsHelper::get( $key, $default );
-    }
+	function nuclen_settings( ?string $key = null, $default = null ) {
+		return SettingsHelper::get( $key, $default );
+	}
 }
 
 if ( ! function_exists( 'nuclen_settings_bool' ) ) {
-    function nuclen_settings_bool( string $key, bool $default = false ): bool {
-        return SettingsHelper::get_bool( $key, $default );
-    }
+	function nuclen_settings_bool( string $key, bool $default = false ): bool {
+		return SettingsHelper::get_bool( $key, $default );
+	}
 }
 
 if ( ! function_exists( 'nuclen_settings_int' ) ) {
-    function nuclen_settings_int( string $key, int $default = 0 ): int {
-        return SettingsHelper::get_int( $key, $default );
-    }
+	function nuclen_settings_int( string $key, int $default = 0 ): int {
+		return SettingsHelper::get_int( $key, $default );
+	}
 }
 
 if ( ! function_exists( 'nuclen_settings_string' ) ) {
-    function nuclen_settings_string( string $key, string $default = '' ): string {
-        return SettingsHelper::get_string( $key, $default );
-    }
+	function nuclen_settings_string( string $key, string $default = '' ): string {
+		return SettingsHelper::get_string( $key, $default );
+	}
 }
 
 if ( ! function_exists( 'nuclen_settings_array' ) ) {
-    function nuclen_settings_array( string $key, array $default = array() ): array {
-        return SettingsHelper::get_array( $key, $default );
-    }
+	function nuclen_settings_array( string $key, array $default = array() ): array {
+		return SettingsHelper::get_array( $key, $default );
+	}
 }
 
 }

--- a/nuclear-engagement/inc/Modules/Quiz/loader.php
+++ b/nuclear-engagement/inc/Modules/Quiz/loader.php
@@ -12,7 +12,7 @@ declare(strict_types=1);
 namespace NuclearEngagement\Modules\Quiz;
 
 if ( ! defined( 'ABSPATH' ) ) {
-        exit;
+		exit;
 }
 
 use NuclearEngagement\Core\SettingsRepository;
@@ -25,7 +25,7 @@ use NuclearEngagement\Core\Container;
  * ------------------------------------------------------------------
 */
 if ( ! defined( 'NUCLEN_QUIZ_DIR' ) ) {
-        define( 'NUCLEN_QUIZ_DIR', __DIR__ . '/' );
+		define( 'NUCLEN_QUIZ_DIR', __DIR__ . '/' );
 }
 
 /*
@@ -43,21 +43,21 @@ require_once NUCLEN_QUIZ_DIR . 'Quiz_Shortcode.php';
  * ------------------------------------------------------------------
 */
 add_action(
-        'plugins_loaded',
-        static function () {
-                $settings = SettingsRepository::get_instance();
-                $service  = new Quiz_Service();
+		'plugins_loaded',
+		static function () {
+				$settings = SettingsRepository::get_instance();
+				$service  = new Quiz_Service();
 
-                if ( is_admin() ) {
-                        ( new Quiz_Admin( $settings, $service ) )->register_hooks();
-                } else {
-                        $front = new FrontClass(
-                                'nuclear-engagement',
-                                defined( 'NUCLEN_PLUGIN_VERSION' ) ? NUCLEN_PLUGIN_VERSION : '1.0.0',
-                                $settings,
-                                new Container()
-                        );
-                        ( new Quiz_Shortcode( $settings, $front, $service ) )->register();
-                }
-        }
+				if ( is_admin() ) {
+						( new Quiz_Admin( $settings, $service ) )->register_hooks();
+				} else {
+						$front = new FrontClass(
+								'nuclear-engagement',
+								defined( 'NUCLEN_PLUGIN_VERSION' ) ? NUCLEN_PLUGIN_VERSION : '1.0.0',
+								$settings,
+								new Container()
+						);
+						( new Quiz_Shortcode( $settings, $front, $service ) )->register();
+				}
+		}
 );

--- a/nuclear-engagement/inc/Modules/Summary/Summary_Service.php
+++ b/nuclear-engagement/inc/Modules/Summary/Summary_Service.php
@@ -9,10 +9,10 @@ declare(strict_types=1);
 namespace NuclearEngagement\Modules\Summary;
 
 if ( ! defined( 'ABSPATH' ) ) {
-    exit;
+	exit;
 }
 
 final class Summary_Service {
-    public const META_KEY      = 'nuclen-summary-data';
-    public const PROTECTED_KEY = 'nuclen_summary_protected';
+	public const META_KEY      = 'nuclen-summary-data';
+	public const PROTECTED_KEY = 'nuclen_summary_protected';
 }

--- a/nuclear-engagement/inc/Modules/Summary/includes/Nuclen_Summary_Metabox.php
+++ b/nuclear-engagement/inc/Modules/Summary/includes/Nuclen_Summary_Metabox.php
@@ -58,7 +58,7 @@ final class Nuclen_Summary_Metabox {
 	 * ---------------------------------------------------------------------- */
 
 	public function nuclen_render_summary_data_meta_box( $post ) {
-                $summary_data = get_post_meta( $post->ID, Summary_Service::META_KEY, true );
+				$summary_data = get_post_meta( $post->ID, Summary_Service::META_KEY, true );
 		if ( ! empty( $summary_data ) ) {
 			$summary_data = maybe_unserialize( $summary_data );
 		} else {
@@ -74,7 +74,7 @@ final class Nuclen_Summary_Metabox {
 		$summary = $summary_data['summary'] ?? '';
 		$date    = $summary_data['date'] ?? '';
 
-                $summary_protected = get_post_meta( $post->ID, Summary_Service::PROTECTED_KEY, true );
+				$summary_protected = get_post_meta( $post->ID, Summary_Service::PROTECTED_KEY, true );
 
 				require NUCLEN_PLUGIN_DIR . 'templates/admin/summary-metabox.php';
 	}
@@ -109,7 +109,7 @@ final class Nuclen_Summary_Metabox {
 		);
 
 		/* ---- Save to DB --------------------------------------------------- */
-                $updated = update_post_meta( $post_id, Summary_Service::META_KEY, $formatted );
+				$updated = update_post_meta( $post_id, Summary_Service::META_KEY, $formatted );
 		if ( false === $updated ) {
 			\NuclearEngagement\Services\LoggingService::log( 'Failed to update summary data for post ' . $post_id );
 			\NuclearEngagement\Services\LoggingService::notify_admin( 'Failed to update summary data for post ' . $post_id );
@@ -141,14 +141,14 @@ final class Nuclen_Summary_Metabox {
 		}
 
 		/* ---- Protected flag ---------------------------------------------- */
-                if ( isset( $_POST[ Summary_Service::PROTECTED_KEY ] ) && $_POST[ Summary_Service::PROTECTED_KEY ] === '1' ) {
-                        $updated_prot = update_post_meta( $post_id, Summary_Service::PROTECTED_KEY, 1 );
-                        if ( false === $updated_prot ) {
-                                \NuclearEngagement\Services\LoggingService::log( 'Failed to update summary protected flag for post ' . $post_id );
-                                \NuclearEngagement\Services\LoggingService::notify_admin( 'Failed to update summary protected flag for post ' . $post_id );
-                        }
-                } else {
-                        delete_post_meta( $post_id, Summary_Service::PROTECTED_KEY );
-                }
+				if ( isset( $_POST[ Summary_Service::PROTECTED_KEY ] ) && $_POST[ Summary_Service::PROTECTED_KEY ] === '1' ) {
+						$updated_prot = update_post_meta( $post_id, Summary_Service::PROTECTED_KEY, 1 );
+						if ( false === $updated_prot ) {
+								\NuclearEngagement\Services\LoggingService::log( 'Failed to update summary protected flag for post ' . $post_id );
+								\NuclearEngagement\Services\LoggingService::notify_admin( 'Failed to update summary protected flag for post ' . $post_id );
+						}
+				} else {
+						delete_post_meta( $post_id, Summary_Service::PROTECTED_KEY );
+				}
 	}
 }

--- a/nuclear-engagement/inc/Modules/Summary/includes/Nuclen_Summary_Shortcode.php
+++ b/nuclear-engagement/inc/Modules/Summary/includes/Nuclen_Summary_Shortcode.php
@@ -42,10 +42,10 @@ final class Nuclen_Summary_Shortcode {
 		return $html;
 	}
 
-        private function getSummaryData() {
-                $post_id = get_the_ID();
-                return get_post_meta( $post_id, Summary_Service::META_KEY, true );
-        }
+		private function getSummaryData() {
+				$post_id = get_the_ID();
+				return get_post_meta( $post_id, Summary_Service::META_KEY, true );
+		}
 
 	private function isValidSummaryData( $summary_data ): bool {
 		return ! empty( $summary_data ) && ! empty( trim( $summary_data['summary'] ?? '' ) );

--- a/nuclear-engagement/inc/OptinData.php
+++ b/nuclear-engagement/inc/OptinData.php
@@ -81,15 +81,15 @@ class OptinData {
 		$table   = self::table_name();
 
 		$sql = "
-            CREATE TABLE {$table} (
-                id            BIGINT(20) UNSIGNED NOT NULL AUTO_INCREMENT,
-                submitted_at  DATETIME            NOT NULL,
-                url           TEXT                NOT NULL,
-                name          TEXT                NOT NULL,
-                email         VARCHAR(255)        NOT NULL,
-                PRIMARY KEY  (id),
-                KEY email (email)
-            ) {$charset};";
+			CREATE TABLE {$table} (
+				id            BIGINT(20) UNSIGNED NOT NULL AUTO_INCREMENT,
+				submitted_at  DATETIME            NOT NULL,
+				url           TEXT                NOT NULL,
+				name          TEXT                NOT NULL,
+				email         VARCHAR(255)        NOT NULL,
+				PRIMARY KEY  (id),
+				KEY email (email)
+			) {$charset};";
 
 		require_once ABSPATH . 'wp-admin/includes/upgrade.php';
 		$result = dbDelta( $sql );
@@ -176,7 +176,7 @@ class OptinData {
 	 * ------------------------------------------------------------------- */
 	public static function handle_export(): void {
 
-       $service = new \NuclearEngagement\Services\OptinExportService();
-       $service->stream_csv();
+	   $service = new \NuclearEngagement\Services\OptinExportService();
+	   $service->stream_csv();
 	}
 }

--- a/nuclear-engagement/inc/Requests/ContentRequest.php
+++ b/nuclear-engagement/inc/Requests/ContentRequest.php
@@ -11,50 +11,50 @@ declare(strict_types=1);
 namespace NuclearEngagement\Requests;
 
 if ( ! defined( 'ABSPATH' ) ) {
-    exit;
+	exit;
 }
 
 /**
  * Data transfer object for content receive requests
  */
 class ContentRequest {
-    /**
-     * @var string Workflow type (quiz|summary)
-     */
-    public string $workflow = '';
+	/**
+	 * @var string Workflow type (quiz|summary)
+	 */
+	public string $workflow = '';
 
-    /**
-     * @var array Results data from remote API
-     */
-    public array $results = array();
+	/**
+	 * @var array Results data from remote API
+	 */
+	public array $results = array();
 
-    /**
-     * Create from JSON data
-     *
-     * @param array $data JSON data
-     * @return self
-     * @throws \InvalidArgumentException On validation errors
-     */
-    public static function fromJson( array $data ): self {
-        $request = new self();
+	/**
+	 * Create from JSON data
+	 *
+	 * @param array $data JSON data
+	 * @return self
+	 * @throws \InvalidArgumentException On validation errors
+	 */
+	public static function fromJson( array $data ): self {
+		$request = new self();
 
-        if ( empty( $data['workflow'] ) ) {
-            throw new \InvalidArgumentException( 'No workflow found in request' );
-        }
+		if ( empty( $data['workflow'] ) ) {
+			throw new \InvalidArgumentException( 'No workflow found in request' );
+		}
 
-        if ( empty( $data['results'] ) || ! is_array( $data['results'] ) ) {
-            throw new \InvalidArgumentException( 'No results data found in request' );
-        }
+		if ( empty( $data['results'] ) || ! is_array( $data['results'] ) ) {
+			throw new \InvalidArgumentException( 'No results data found in request' );
+		}
 
-        $request->workflow = sanitize_text_field( $data['workflow'] );
+		$request->workflow = sanitize_text_field( $data['workflow'] );
 
-        // Validate workflow
-        if ( ! in_array( $request->workflow, array( 'quiz', 'summary' ), true ) ) {
-            throw new \InvalidArgumentException( 'Invalid workflow type: ' . $request->workflow );
-        }
+		// Validate workflow
+		if ( ! in_array( $request->workflow, array( 'quiz', 'summary' ), true ) ) {
+			throw new \InvalidArgumentException( 'Invalid workflow type: ' . $request->workflow );
+		}
 
-        $request->results = $data['results'];
+		$request->results = $data['results'];
 
-        return $request;
-    }
+		return $request;
+	}
 }

--- a/nuclear-engagement/inc/Requests/GenerateRequest.php
+++ b/nuclear-engagement/inc/Requests/GenerateRequest.php
@@ -11,129 +11,129 @@ declare(strict_types=1);
 namespace NuclearEngagement\Requests;
 
 if ( ! defined( 'ABSPATH' ) ) {
-    exit;
+	exit;
 }
 
 /**
  * Data transfer object for generation requests
  */
 class GenerateRequest {
-    /**
-     * @var array Post IDs to generate content for
-     */
-    public array $postIds = array();
+	/**
+	 * @var array Post IDs to generate content for
+	 */
+	public array $postIds = array();
 
-    /**
-     * @var string Workflow type (quiz|summary)
-     */
-    public string $workflowType = '';
+	/**
+	 * @var string Workflow type (quiz|summary)
+	 */
+	public string $workflowType = '';
 
-    /**
-     * @var string Summary format (paragraph|bullet_list)
-     */
-    public string $summaryFormat = 'paragraph';
+	/**
+	 * @var string Summary format (paragraph|bullet_list)
+	 */
+	public string $summaryFormat = 'paragraph';
 
-    /**
-     * @var int Summary length in words
-     */
-    public int $summaryLength = NUCLEN_SUMMARY_LENGTH_DEFAULT;
+	/**
+	 * @var int Summary length in words
+	 */
+	public int $summaryLength = NUCLEN_SUMMARY_LENGTH_DEFAULT;
 
-    /**
-     * @var int Number of summary items
-     */
-    public int $summaryItems = NUCLEN_SUMMARY_ITEMS_DEFAULT;
+	/**
+	 * @var int Number of summary items
+	 */
+	public int $summaryItems = NUCLEN_SUMMARY_ITEMS_DEFAULT;
 
-    /**
-     * @var string Generation ID for tracking
-     */
-    public string $generationId = '';
+	/**
+	 * @var string Generation ID for tracking
+	 */
+	public string $generationId = '';
 
-    /**
-     * @var string Post status filter
-     */
-    public string $postStatus = 'any';
+	/**
+	 * @var string Post status filter
+	 */
+	public string $postStatus = 'any';
 
-    /**
-     * @var string Post type filter
-     */
-    public string $postType = 'post';
+	/**
+	 * @var string Post type filter
+	 */
+	public string $postType = 'post';
 
-    /**
-     * Create from POST data
-     *
-     * @param array $post POST data
-     * @return self
-     * @throws \InvalidArgumentException On validation errors
-     */
-    public static function fromPost( array $post ): self {
-        $request = new self();
+	/**
+	 * Create from POST data
+	 *
+	 * @param array $post POST data
+	 * @return self
+	 * @throws \InvalidArgumentException On validation errors
+	 */
+	public static function fromPost( array $post ): self {
+		$request = new self();
 
-        // Parse the payload
-        $payload = array();
-        if ( ! empty( $post['payload'] ) ) {
-            $payload = json_decode( wp_unslash( $post['payload'] ), true );
-            if ( json_last_error() !== JSON_ERROR_NONE ) {
-                throw new \InvalidArgumentException( 'Invalid JSON payload: ' . json_last_error_msg() );
-            }
-        }
+		// Parse the payload
+		$payload = array();
+		if ( ! empty( $post['payload'] ) ) {
+			$payload = json_decode( wp_unslash( $post['payload'] ), true );
+			if ( json_last_error() !== JSON_ERROR_NONE ) {
+				throw new \InvalidArgumentException( 'Invalid JSON payload: ' . json_last_error_msg() );
+			}
+		}
 
-        // Extract and validate post IDs
-        $postIdsJson      = $payload['nuclen_selected_post_ids'] ?? '';
-        $request->postIds = json_decode( $postIdsJson, true ) ?: array();
+		// Extract and validate post IDs
+		$postIdsJson      = $payload['nuclen_selected_post_ids'] ?? '';
+		$request->postIds = json_decode( $postIdsJson, true ) ?: array();
 
-        if ( empty( $request->postIds ) || ! is_array( $request->postIds ) ) {
-            throw new \InvalidArgumentException( 'No valid posts selected' );
-        }
+		if ( empty( $request->postIds ) || ! is_array( $request->postIds ) ) {
+			throw new \InvalidArgumentException( 'No valid posts selected' );
+		}
 
-        // Sanitize post IDs
-        $request->postIds = array_map( 'intval', $request->postIds );
-        $request->postIds = array_filter(
-            $request->postIds,
-            function ( $id ) {
-                return $id > 0;
-            }
-        );
+		// Sanitize post IDs
+		$request->postIds = array_map( 'intval', $request->postIds );
+		$request->postIds = array_filter(
+			$request->postIds,
+			function ( $id ) {
+				return $id > 0;
+			}
+		);
 
-        if ( empty( $request->postIds ) ) {
-            throw new \InvalidArgumentException( 'No valid post IDs after sanitization' );
-        }
+		if ( empty( $request->postIds ) ) {
+			throw new \InvalidArgumentException( 'No valid post IDs after sanitization' );
+		}
 
-        // Map other fields
-        $request->postStatus   = sanitize_text_field( $payload['nuclen_selected_post_status'] ?? 'any' );
-        $request->postType     = sanitize_text_field( $payload['nuclen_selected_post_type'] ?? 'post' );
-        $request->workflowType = sanitize_text_field( $payload['nuclen_selected_generate_workflow'] ?? '' );
+		// Map other fields
+		$request->postStatus   = sanitize_text_field( $payload['nuclen_selected_post_status'] ?? 'any' );
+		$request->postType     = sanitize_text_field( $payload['nuclen_selected_post_type'] ?? 'post' );
+		$request->workflowType = sanitize_text_field( $payload['nuclen_selected_generate_workflow'] ?? '' );
 
-        // Validate workflow type
-        if ( ! in_array( $request->workflowType, array( 'quiz', 'summary' ), true ) ) {
-            throw new \InvalidArgumentException( 'Invalid workflow type: ' . $request->workflowType );
-        }
+		// Validate workflow type
+		if ( ! in_array( $request->workflowType, array( 'quiz', 'summary' ), true ) ) {
+			throw new \InvalidArgumentException( 'Invalid workflow type: ' . $request->workflowType );
+		}
 
-        // Summary specific fields
-        $request->summaryFormat = sanitize_text_field( $payload['nuclen_selected_summary_format'] ?? 'paragraph' );
-        if ( ! in_array( $request->summaryFormat, array( 'paragraph', 'bullet_list' ), true ) ) {
-            $request->summaryFormat = 'paragraph';
-        }
+		// Summary specific fields
+		$request->summaryFormat = sanitize_text_field( $payload['nuclen_selected_summary_format'] ?? 'paragraph' );
+		if ( ! in_array( $request->summaryFormat, array( 'paragraph', 'bullet_list' ), true ) ) {
+			$request->summaryFormat = 'paragraph';
+		}
 
-        $request->summaryLength = max(
-            NUCLEN_SUMMARY_LENGTH_MIN,
-            min(
-                NUCLEN_SUMMARY_LENGTH_MAX,
-                (int) ( $payload['nuclen_selected_summary_length'] ?? NUCLEN_SUMMARY_LENGTH_DEFAULT )
-            )
-        );
-        $request->summaryItems  = max(
-            NUCLEN_SUMMARY_ITEMS_MIN,
-            min(
-                NUCLEN_SUMMARY_ITEMS_MAX,
-                (int) ( $payload['nuclen_selected_summary_number_of_items'] ?? NUCLEN_SUMMARY_ITEMS_DEFAULT )
-            )
-        );
+		$request->summaryLength = max(
+			NUCLEN_SUMMARY_LENGTH_MIN,
+			min(
+				NUCLEN_SUMMARY_LENGTH_MAX,
+				(int) ( $payload['nuclen_selected_summary_length'] ?? NUCLEN_SUMMARY_LENGTH_DEFAULT )
+			)
+		);
+		$request->summaryItems  = max(
+			NUCLEN_SUMMARY_ITEMS_MIN,
+			min(
+				NUCLEN_SUMMARY_ITEMS_MAX,
+				(int) ( $payload['nuclen_selected_summary_number_of_items'] ?? NUCLEN_SUMMARY_ITEMS_DEFAULT )
+			)
+		);
 
-        // Generation ID
-        $request->generationId = ! empty( $payload['generation_id'] )
-            ? sanitize_text_field( $payload['generation_id'] )
-            : 'gen_' . uniqid( 'manual_', true );
+		// Generation ID
+		$request->generationId = ! empty( $payload['generation_id'] )
+			? sanitize_text_field( $payload['generation_id'] )
+			: 'gen_' . uniqid( 'manual_', true );
 
-        return $request;
-    }
+		return $request;
+	}
 }

--- a/nuclear-engagement/inc/Requests/PostsCountRequest.php
+++ b/nuclear-engagement/inc/Requests/PostsCountRequest.php
@@ -11,40 +11,40 @@ declare(strict_types=1);
 namespace NuclearEngagement\Requests;
 
 if ( ! defined( 'ABSPATH' ) ) {
-    exit;
+	exit;
 }
 
 /**
  * Data transfer object for posts count requests
  */
 class PostsCountRequest {
-    public string $postStatus        = 'any';
-    public int $categoryId           = 0;
-    public int $authorId             = 0;
-    public string $postType          = '';
-    public string $workflow          = '';
-    public bool $allowRegenerate     = false;
-    public bool $regenerateProtected = false;
+	public string $postStatus        = 'any';
+	public int $categoryId           = 0;
+	public int $authorId             = 0;
+	public string $postType          = '';
+	public string $workflow          = '';
+	public bool $allowRegenerate     = false;
+	public bool $regenerateProtected = false;
 
-    /**
-     * Create from POST data
-     *
-     * @param array $post POST data
-     * @return self
-     */
-    public static function fromPost( array $post ): self {
-        $request = new self();
+	/**
+	 * Create from POST data
+	 *
+	 * @param array $post POST data
+	 * @return self
+	 */
+	public static function fromPost( array $post ): self {
+		$request = new self();
 
-        $unslashed = wp_unslash( $post );
+		$unslashed = wp_unslash( $post );
 
-        $request->postStatus          = sanitize_text_field( $unslashed['nuclen_post_status'] ?? 'any' );
-        $request->categoryId          = absint( $unslashed['nuclen_category'] ?? 0 );
-        $request->authorId            = absint( $unslashed['nuclen_author'] ?? 0 );
-        $request->postType            = sanitize_text_field( $unslashed['nuclen_post_type'] ?? '' );
-        $request->workflow            = sanitize_text_field( $unslashed['nuclen_generate_workflow'] ?? '' );
-        $request->allowRegenerate     = (bool) absint( $unslashed['nuclen_allow_regenerate_data'] ?? 0 );
-        $request->regenerateProtected = (bool) absint( $unslashed['nuclen_regenerate_protected_data'] ?? 0 );
+		$request->postStatus          = sanitize_text_field( $unslashed['nuclen_post_status'] ?? 'any' );
+		$request->categoryId          = absint( $unslashed['nuclen_category'] ?? 0 );
+		$request->authorId            = absint( $unslashed['nuclen_author'] ?? 0 );
+		$request->postType            = sanitize_text_field( $unslashed['nuclen_post_type'] ?? '' );
+		$request->workflow            = sanitize_text_field( $unslashed['nuclen_generate_workflow'] ?? '' );
+		$request->allowRegenerate     = (bool) absint( $unslashed['nuclen_allow_regenerate_data'] ?? 0 );
+		$request->regenerateProtected = (bool) absint( $unslashed['nuclen_regenerate_protected_data'] ?? 0 );
 
-        return $request;
-    }
+		return $request;
+	}
 }

--- a/nuclear-engagement/inc/Requests/UpdatesRequest.php
+++ b/nuclear-engagement/inc/Requests/UpdatesRequest.php
@@ -11,29 +11,29 @@ declare(strict_types=1);
 namespace NuclearEngagement\Requests;
 
 if ( ! defined( 'ABSPATH' ) ) {
-    exit;
+	exit;
 }
 
 /**
  * Data transfer object for update polling requests
  */
 class UpdatesRequest {
-    /**
-     * @var string Generation ID to check
-     */
-    public string $generationId = '';
+	/**
+	 * @var string Generation ID to check
+	 */
+	public string $generationId = '';
 
-    /**
-     * Create from POST data
-     *
-     * @param array $post POST data
-     * @return self
-     */
-    public static function fromPost( array $post ): self {
-        $request               = new self();
-        $request->generationId = isset( $post['generation_id'] )
-            ? sanitize_text_field( wp_unslash( $post['generation_id'] ) )
-            : '';
-        return $request;
-    }
+	/**
+	 * Create from POST data
+	 *
+	 * @param array $post POST data
+	 * @return self
+	 */
+	public static function fromPost( array $post ): self {
+		$request               = new self();
+		$request->generationId = isset( $post['generation_id'] )
+			? sanitize_text_field( wp_unslash( $post['generation_id'] ) )
+			: '';
+		return $request;
+	}
 }

--- a/nuclear-engagement/inc/Responses/GenerationResponse.php
+++ b/nuclear-engagement/inc/Responses/GenerationResponse.php
@@ -11,67 +11,67 @@ declare(strict_types=1);
 namespace NuclearEngagement\Responses;
 
 if ( ! defined( 'ABSPATH' ) ) {
-    exit;
+	exit;
 }
 
 /**
  * Response object for generation requests
  */
 class GenerationResponse {
-    /**
-     * @var string Generation ID for tracking
-     */
-    public string $generationId;
+	/**
+	 * @var string Generation ID for tracking
+	 */
+	public string $generationId;
 
-    /**
-     * @var array Generated results
-     */
-    public array $results = array();
+	/**
+	 * @var array Generated results
+	 */
+	public array $results = array();
 
-    /**
-     * @var bool Success status
-     */
-    public bool $success = true;
+	/**
+	 * @var bool Success status
+	 */
+	public bool $success = true;
 
-    /**
-     * @var string|null Error message if any
-     */
-    public ?string $error = null;
+	/**
+	 * @var string|null Error message if any
+	 */
+	public ?string $error = null;
 
-    /**
-     * @var string|null Error code if any
-     */
-    public ?string $errorCode = null;
+	/**
+	 * @var string|null Error code if any
+	 */
+	public ?string $errorCode = null;
 
-    /**
-     * @var int|null HTTP status code from remote API
-     */
-    public ?int $statusCode = null;
+	/**
+	 * @var int|null HTTP status code from remote API
+	 */
+	public ?int $statusCode = null;
 
-    /**
-     * Convert to array for JSON response
-     *
-     * @return array
-     */
-    public function toArray(): array {
-        $data = array(
-            'generation_id' => $this->generationId,
-            'results'       => $this->results,
-            'success'       => $this->success,
-        );
+	/**
+	 * Convert to array for JSON response
+	 *
+	 * @return array
+	 */
+	public function toArray(): array {
+		$data = array(
+			'generation_id' => $this->generationId,
+			'results'       => $this->results,
+			'success'       => $this->success,
+		);
 
-        if ( $this->error !== null ) {
-            $data['error'] = $this->error;
-        }
+		if ( $this->error !== null ) {
+			$data['error'] = $this->error;
+		}
 
-        if ( $this->errorCode !== null ) {
-            $data['error_code'] = $this->errorCode;
-        }
+		if ( $this->errorCode !== null ) {
+			$data['error_code'] = $this->errorCode;
+		}
 
-        if ( $this->statusCode !== null ) {
-            $data['status_code'] = $this->statusCode;
-        }
+		if ( $this->statusCode !== null ) {
+			$data['status_code'] = $this->statusCode;
+		}
 
-        return $data;
-    }
+		return $data;
+	}
 }

--- a/nuclear-engagement/inc/Responses/UpdatesResponse.php
+++ b/nuclear-engagement/inc/Responses/UpdatesResponse.php
@@ -11,7 +11,7 @@ declare(strict_types=1);
 namespace NuclearEngagement\Responses;
 
 if ( ! defined( 'ABSPATH' ) ) {
-    exit;
+	exit;
 }
 
 /**
@@ -19,45 +19,45 @@ if ( ! defined( 'ABSPATH' ) ) {
  */
 class UpdatesResponse {
 
-    public bool $success          = true;
-    public ?int $processed        = null;
-    public ?int $total            = null;
-    public ?array $results        = null;
-    public ?string $workflow      = null; // NEW
-    public ?int $remainingCredits = null;
-    public ?string $message       = null;
-    public ?int $statusCode       = null;
+	public bool $success          = true;
+	public ?int $processed        = null;
+	public ?int $total            = null;
+	public ?array $results        = null;
+	public ?string $workflow      = null; // NEW
+	public ?int $remainingCredits = null;
+	public ?string $message       = null;
+	public ?int $statusCode       = null;
 
-    /**
-     * Convert to array for JSON response.
-     *
-     * @return array
-     */
-    public function toArray(): array {
-        $data = array( 'success' => $this->success );
+	/**
+	 * Convert to array for JSON response.
+	 *
+	 * @return array
+	 */
+	public function toArray(): array {
+		$data = array( 'success' => $this->success );
 
-        if ( null !== $this->processed ) {
-            $data['processed'] = $this->processed;
-        }
-        if ( null !== $this->total ) {
-            $data['total'] = $this->total;
-        }
-        if ( null !== $this->results ) {
-            $data['results'] = $this->results;
-        }
-        if ( null !== $this->workflow ) {
-            $data['workflow'] = $this->workflow;
-        }
-        if ( null !== $this->remainingCredits ) {
-            $data['remaining_credits'] = $this->remainingCredits;
-        }
-        if ( null !== $this->message ) {
-            $data['message'] = $this->message;
-        }
-        if ( null !== $this->statusCode ) {
-            $data['status_code'] = $this->statusCode;
-        }
+		if ( null !== $this->processed ) {
+			$data['processed'] = $this->processed;
+		}
+		if ( null !== $this->total ) {
+			$data['total'] = $this->total;
+		}
+		if ( null !== $this->results ) {
+			$data['results'] = $this->results;
+		}
+		if ( null !== $this->workflow ) {
+			$data['workflow'] = $this->workflow;
+		}
+		if ( null !== $this->remainingCredits ) {
+			$data['remaining_credits'] = $this->remainingCredits;
+		}
+		if ( null !== $this->message ) {
+			$data['message'] = $this->message;
+		}
+		if ( null !== $this->statusCode ) {
+			$data['status_code'] = $this->statusCode;
+		}
 
-        return $data;
-    }
+		return $data;
+	}
 }

--- a/nuclear-engagement/inc/Services/AdminNoticeService.php
+++ b/nuclear-engagement/inc/Services/AdminNoticeService.php
@@ -7,26 +7,26 @@ declare(strict_types=1);
 namespace NuclearEngagement\Services;
 
 if ( ! defined( 'ABSPATH' ) ) {
-    exit;
+	exit;
 }
 
 class AdminNoticeService {
-    /**
-     * @var array<string>
-     */
-    private array $messages = array();
+	/**
+	 * @var array<string>
+	 */
+	private array $messages = array();
 
-    public function add( string $message ): void {
-        $this->messages[] = $message;
-        if ( count( $this->messages ) === 1 ) {
-            add_action( 'admin_notices', array( $this, 'render' ) );
-        }
-    }
+	public function add( string $message ): void {
+		$this->messages[] = $message;
+		if ( count( $this->messages ) === 1 ) {
+			add_action( 'admin_notices', array( $this, 'render' ) );
+		}
+	}
 
-    public function render(): void {
-        foreach ( $this->messages as $msg ) {
-            echo '<div class="notice notice-error"><p>' . esc_html( $msg ) . '</p></div>';
-        }
-        $this->messages = array();
-    }
+	public function render(): void {
+		foreach ( $this->messages as $msg ) {
+			echo '<div class="notice notice-error"><p>' . esc_html( $msg ) . '</p></div>';
+		}
+		$this->messages = array();
+	}
 }

--- a/nuclear-engagement/inc/Services/ApiException.php
+++ b/nuclear-engagement/inc/Services/ApiException.php
@@ -9,18 +9,18 @@ declare(strict_types=1);
 namespace NuclearEngagement\Services;
 
 if ( ! defined( 'ABSPATH' ) ) {
-    exit;
+	exit;
 }
 
 class ApiException extends \RuntimeException {
-    private ?string $errorCode;
+	private ?string $errorCode;
 
-    public function __construct( string $message, int $code = 500, ?string $errorCode = null ) {
-        parent::__construct( $message, $code );
-        $this->errorCode = $errorCode;
-    }
+	public function __construct( string $message, int $code = 500, ?string $errorCode = null ) {
+		parent::__construct( $message, $code );
+		$this->errorCode = $errorCode;
+	}
 
-    public function getErrorCode(): ?string {
-        return $this->errorCode;
-    }
+	public function getErrorCode(): ?string {
+		return $this->errorCode;
+	}
 }

--- a/nuclear-engagement/inc/Services/AutoGenerationQueue.php
+++ b/nuclear-engagement/inc/Services/AutoGenerationQueue.php
@@ -9,144 +9,144 @@ declare(strict_types=1);
 namespace NuclearEngagement\Services;
 
 if ( ! defined( 'ABSPATH' ) ) {
-    exit;
+	exit;
 }
 
 class AutoGenerationQueue {
-    /** Option name storing the queued post IDs. */
-    private const QUEUE_OPTION = 'nuclen_autogen_queue';
+	/** Option name storing the queued post IDs. */
+	private const QUEUE_OPTION = 'nuclen_autogen_queue';
 
-    /** Maximum number of posts to send in one batch. */
-    private const BATCH_SIZE = 5;
+	/** Maximum number of posts to send in one batch. */
+	private const BATCH_SIZE = 5;
 
 
-    private RemoteApiService $remote_api;
-    private ContentStorageService $content_storage;
-    private PostDataFetcher $fetcher;
+	private RemoteApiService $remote_api;
+	private ContentStorageService $content_storage;
+	private PostDataFetcher $fetcher;
 
-    public function __construct( RemoteApiService $remote_api, ContentStorageService $content_storage, ?PostDataFetcher $fetcher = null ) {
-        $this->remote_api      = $remote_api;
-        $this->content_storage = $content_storage;
-        $this->fetcher         = $fetcher ?: new PostDataFetcher();
-    }
+	public function __construct( RemoteApiService $remote_api, ContentStorageService $content_storage, ?PostDataFetcher $fetcher = null ) {
+		$this->remote_api      = $remote_api;
+		$this->content_storage = $content_storage;
+		$this->fetcher         = $fetcher ?: new PostDataFetcher();
+	}
 
-    /**
-     * Add a post to the pending generation queue and schedule processing.
-     */
-    public function queue_post( int $post_id, string $workflow_type ): void {
-        $queue = get_option( self::QUEUE_OPTION, array() );
-        if ( ! isset( $queue[ $workflow_type ] ) ) {
-            $queue[ $workflow_type ] = array();
-        }
-        if ( ! in_array( $post_id, $queue[ $workflow_type ], true ) ) {
-            $queue[ $workflow_type ][] = $post_id;
-            update_option( self::QUEUE_OPTION, $queue, 'no' );
-        }
-        if ( ! wp_next_scheduled( AutoGenerationService::QUEUE_HOOK ) ) {
-            $scheduled = wp_schedule_single_event( time(), AutoGenerationService::QUEUE_HOOK, array() );
-            if ( false === $scheduled ) {
-                \NuclearEngagement\Services\LoggingService::log( 'Failed to schedule event ' . AutoGenerationService::QUEUE_HOOK );
-                \NuclearEngagement\Services\LoggingService::notify_admin(
-                    sprintf( __( 'Failed to schedule event %s', 'nuclear-engagement' ), AutoGenerationService::QUEUE_HOOK )
-                );
-            }
-        }
-    }
+	/**
+	 * Add a post to the pending generation queue and schedule processing.
+	 */
+	public function queue_post( int $post_id, string $workflow_type ): void {
+		$queue = get_option( self::QUEUE_OPTION, array() );
+		if ( ! isset( $queue[ $workflow_type ] ) ) {
+			$queue[ $workflow_type ] = array();
+		}
+		if ( ! in_array( $post_id, $queue[ $workflow_type ], true ) ) {
+			$queue[ $workflow_type ][] = $post_id;
+			update_option( self::QUEUE_OPTION, $queue, 'no' );
+		}
+		if ( ! wp_next_scheduled( AutoGenerationService::QUEUE_HOOK ) ) {
+			$scheduled = wp_schedule_single_event( time(), AutoGenerationService::QUEUE_HOOK, array() );
+			if ( false === $scheduled ) {
+				\NuclearEngagement\Services\LoggingService::log( 'Failed to schedule event ' . AutoGenerationService::QUEUE_HOOK );
+				\NuclearEngagement\Services\LoggingService::notify_admin(
+					sprintf( __( 'Failed to schedule event %s', 'nuclear-engagement' ), AutoGenerationService::QUEUE_HOOK )
+				);
+			}
+		}
+	}
 
-    /**
-     * Process queued posts in batches.
-     */
-    public function process_queue(): void {
-        $queue = get_option( self::QUEUE_OPTION, array() );
-        if ( empty( $queue ) ) {
-            return;
-        }
+	/**
+	 * Process queued posts in batches.
+	 */
+	public function process_queue(): void {
+		$queue = get_option( self::QUEUE_OPTION, array() );
+		if ( empty( $queue ) ) {
+			return;
+		}
 
-        $generations = get_option( 'nuclen_active_generations', array() );
+		$generations = get_option( 'nuclen_active_generations', array() );
 
-        foreach ( $queue as $workflow_type => $ids ) {
-            $ids = array_map( 'absint', $ids );
-            while ( ! empty( $ids ) ) {
-                $batch     = array_splice( $ids, 0, self::BATCH_SIZE );
-                $post_data = array();
+		foreach ( $queue as $workflow_type => $ids ) {
+			$ids = array_map( 'absint', $ids );
+			while ( ! empty( $ids ) ) {
+				$batch     = array_splice( $ids, 0, self::BATCH_SIZE );
+				$post_data = array();
 
-                $posts = $this->fetcher->fetch( $batch );
+				$posts = $this->fetcher->fetch( $batch );
 
-                foreach ( $posts as $post ) {
-                    $pid         = (int) $post->ID;
-                    $post_data[] = array(
-                        'id'      => $pid,
-                        'title'   => $post->post_title,
-                        'content' => wp_strip_all_tags( $post->post_content ),
-                    );
-                }
+				foreach ( $posts as $post ) {
+					$pid         = (int) $post->ID;
+					$post_data[] = array(
+						'id'      => $pid,
+						'title'   => $post->post_title,
+						'content' => wp_strip_all_tags( $post->post_content ),
+					);
+				}
 
-                if ( empty( $post_data ) ) {
-                    continue;
-                }
+				if ( empty( $post_data ) ) {
+					continue;
+				}
 
-                $workflow = array(
-                    'type'                    => $workflow_type,
-                    'summary_format'          => 'paragraph',
-                    'summary_length'          => NUCLEN_SUMMARY_LENGTH_DEFAULT,
-                    'summary_number_of_items' => NUCLEN_SUMMARY_ITEMS_DEFAULT,
-                );
+				$workflow = array(
+					'type'                    => $workflow_type,
+					'summary_format'          => 'paragraph',
+					'summary_length'          => NUCLEN_SUMMARY_LENGTH_DEFAULT,
+					'summary_number_of_items' => NUCLEN_SUMMARY_ITEMS_DEFAULT,
+				);
 
-                $generation_id = 'gen_' . uniqid( 'auto_', true );
+				$generation_id = 'gen_' . uniqid( 'auto_', true );
 
-                try {
-                    $this->remote_api->send_posts_to_generate(
-                        array(
-                            'posts'         => $post_data,
-                            'workflow'      => $workflow,
-                            'generation_id' => $generation_id,
-                        )
-                    );
-                } catch ( \Throwable $e ) {
-                    \NuclearEngagement\Services\LoggingService::log( 'Failed to start generation: ' . $e->getMessage() );
-                    \NuclearEngagement\Services\LoggingService::notify_admin( 'Auto-generation failed: ' . $e->getMessage() );
-                    continue;
-                }
+				try {
+					$this->remote_api->send_posts_to_generate(
+						array(
+							'posts'         => $post_data,
+							'workflow'      => $workflow,
+							'generation_id' => $generation_id,
+						)
+					);
+				} catch ( \Throwable $e ) {
+					\NuclearEngagement\Services\LoggingService::log( 'Failed to start generation: ' . $e->getMessage() );
+					\NuclearEngagement\Services\LoggingService::notify_admin( 'Auto-generation failed: ' . $e->getMessage() );
+					continue;
+				}
 
-                $next_poll                     = time() + NUCLEN_INITIAL_POLL_DELAY + mt_rand( 1, 5 );
-                $generations[ $generation_id ] = array(
-                    'started_at'    => current_time( 'mysql' ),
-                    'post_ids'      => $batch,
-                    'next_poll'     => $next_poll,
-                    'attempt'       => 1,
-                    'workflow_type' => $workflow_type,
-                );
+				$next_poll                     = time() + NUCLEN_INITIAL_POLL_DELAY + mt_rand( 1, 5 );
+				$generations[ $generation_id ] = array(
+					'started_at'    => current_time( 'mysql' ),
+					'post_ids'      => $batch,
+					'next_poll'     => $next_poll,
+					'attempt'       => 1,
+					'workflow_type' => $workflow_type,
+				);
 
-                $scheduled = wp_schedule_single_event( $next_poll, 'nuclen_poll_generation', array( $generation_id, $workflow_type, $batch, 1 ) );
-                if ( false === $scheduled ) {
-                    \NuclearEngagement\Services\LoggingService::log( 'Failed to schedule event nuclen_poll_generation for generation ' . $generation_id );
-                    \NuclearEngagement\Services\LoggingService::notify_admin(
-                        sprintf( __( 'Failed to schedule event nuclen_poll_generation for generation %s', 'nuclear-engagement' ), $generation_id )
-                    );
-                }
-            }
-            $queue[ $workflow_type ] = $ids;
-        }
+				$scheduled = wp_schedule_single_event( $next_poll, 'nuclen_poll_generation', array( $generation_id, $workflow_type, $batch, 1 ) );
+				if ( false === $scheduled ) {
+					\NuclearEngagement\Services\LoggingService::log( 'Failed to schedule event nuclen_poll_generation for generation ' . $generation_id );
+					\NuclearEngagement\Services\LoggingService::notify_admin(
+						sprintf( __( 'Failed to schedule event nuclen_poll_generation for generation %s', 'nuclear-engagement' ), $generation_id )
+					);
+				}
+			}
+			$queue[ $workflow_type ] = $ids;
+		}
 
-        update_option( 'nuclen_active_generations', $generations, 'no' );
+		update_option( 'nuclen_active_generations', $generations, 'no' );
 
-        foreach ( $queue as $type => $ids ) {
-            if ( empty( $ids ) ) {
-                unset( $queue[ $type ] );
-            }
-        }
+		foreach ( $queue as $type => $ids ) {
+			if ( empty( $ids ) ) {
+				unset( $queue[ $type ] );
+			}
+		}
 
-        if ( empty( $queue ) ) {
-            delete_option( self::QUEUE_OPTION );
-        } else {
-            update_option( self::QUEUE_OPTION, $queue, 'no' );
-            $scheduled = wp_schedule_single_event( time() + 1, AutoGenerationService::QUEUE_HOOK, array() );
-            if ( false === $scheduled ) {
-                \NuclearEngagement\Services\LoggingService::log( 'Failed to schedule event ' . AutoGenerationService::QUEUE_HOOK );
-                \NuclearEngagement\Services\LoggingService::notify_admin(
-                    sprintf( __( 'Failed to schedule event %s', 'nuclear-engagement' ), AutoGenerationService::QUEUE_HOOK )
-                );
-            }
-        }
-    }
+		if ( empty( $queue ) ) {
+			delete_option( self::QUEUE_OPTION );
+		} else {
+			update_option( self::QUEUE_OPTION, $queue, 'no' );
+			$scheduled = wp_schedule_single_event( time() + 1, AutoGenerationService::QUEUE_HOOK, array() );
+			if ( false === $scheduled ) {
+				\NuclearEngagement\Services\LoggingService::log( 'Failed to schedule event ' . AutoGenerationService::QUEUE_HOOK );
+				\NuclearEngagement\Services\LoggingService::notify_admin(
+					sprintf( __( 'Failed to schedule event %s', 'nuclear-engagement' ), AutoGenerationService::QUEUE_HOOK )
+				);
+			}
+		}
+	}
 }

--- a/nuclear-engagement/inc/Services/AutoGenerationScheduler.php
+++ b/nuclear-engagement/inc/Services/AutoGenerationScheduler.php
@@ -9,29 +9,29 @@ declare(strict_types=1);
 namespace NuclearEngagement\Services;
 
 if ( ! defined( 'ABSPATH' ) ) {
-    exit;
+	exit;
 }
 
 class AutoGenerationScheduler {
-    private GenerationPoller $poller;
+	private GenerationPoller $poller;
 
-    public function __construct( GenerationPoller $poller ) {
-        $this->poller = $poller;
-    }
+	public function __construct( GenerationPoller $poller ) {
+		$this->poller = $poller;
+	}
 
-    public function register_hooks(): void {
-        $this->poller->register_hooks();
-    }
+	public function register_hooks(): void {
+		$this->poller->register_hooks();
+	}
 
-    /**
-     * Poll for generation updates.
-     *
-     * @param string $generation_id Generation ID
-     * @param string $workflow_type Type of workflow
-     * @param array  $post_ids      Post IDs
-     * @param int    $attempt       Current attempt number
-     */
-    public function poll_generation( string $generation_id, string $workflow_type, array $post_ids, int $attempt ): void {
-        $this->poller->poll_generation( $generation_id, $workflow_type, $post_ids, $attempt );
-    }
+	/**
+	 * Poll for generation updates.
+	 *
+	 * @param string $generation_id Generation ID
+	 * @param string $workflow_type Type of workflow
+	 * @param array  $post_ids      Post IDs
+	 * @param int    $attempt       Current attempt number
+	 */
+	public function poll_generation( string $generation_id, string $workflow_type, array $post_ids, int $attempt ): void {
+		$this->poller->poll_generation( $generation_id, $workflow_type, $post_ids, $attempt );
+	}
 }

--- a/nuclear-engagement/inc/Services/AutoGenerationService.php
+++ b/nuclear-engagement/inc/Services/AutoGenerationService.php
@@ -15,129 +15,129 @@ use NuclearEngagement\Services\GenerationPoller;
 use NuclearEngagement\Services\PublishGenerationHandler;
 
 if ( ! defined( 'ABSPATH' ) ) {
-    exit;
+	exit;
 }
 
 class AutoGenerationService {
-        /** Cron hook used to start a generation task. */
-    public const START_HOOK = 'nuclen_start_generation';
+		/** Cron hook used to start a generation task. */
+	public const START_HOOK = 'nuclen_start_generation';
 
-        /** Cron hook for processing the queued posts. */
-    public const QUEUE_HOOK = 'nuclen_process_autogen_queue';
-
-
-
-    /**
-     * @var SettingsRepository
-     */
-    private $settings_repository;
+		/** Cron hook for processing the queued posts. */
+	public const QUEUE_HOOK = 'nuclen_process_autogen_queue';
 
 
-    private AutoGenerationQueue $queue;
 
-    private AutoGenerationScheduler $scheduler;
-
-
-    /**
-     * @var PublishGenerationHandler
-     */
-    private PublishGenerationHandler $publish_handler;
-
-    /**
-     * Constructor
-     *
-     * @param SettingsRepository      $settings_repository
-     * @param AutoGenerationQueue     $queue
-     * @param AutoGenerationScheduler $scheduler
-     */
-    public function __construct(
-        SettingsRepository $settings_repository,
-        AutoGenerationQueue $queue,
-        AutoGenerationScheduler $scheduler,
-        PublishGenerationHandler $publish_handler
-    ) {
-                $this->settings_repository = $settings_repository;
-                $this->queue               = $queue;
-                $this->scheduler           = $scheduler;
-                $this->publish_handler     = $publish_handler;
-    }
-
-    /**
-     * Register WordPress hooks
-     */
-    public function register_hooks(): void {
-            $this->scheduler->register_hooks();
-
-            add_action(
-                self::START_HOOK,
-                array( $this, 'run_generation' ),
-                10,
-                2 // post_id, workflow_type
-            );
-
-            add_action( self::QUEUE_HOOK, array( $this, 'process_queue' ) );
-
-        $this->publish_handler->register_hooks();
-    }
-
-    /**
-     * Handle post publish transition
-     *
-     * @param string   $new_status New post status
-     * @param string   $old_status Old post status
-     * @param \WP_Post $post Post object
-     */
-    public function handle_post_publish( $new_status, $old_status, $post ): void {
-        $this->publish_handler->handle_post_publish( $new_status, $old_status, $post );
-    }
-
-    /**
-     * Generate content for a single post
-     *
-     * @param int    $post_id Post ID
-     * @param string $workflow_type Type of content to generate (quiz/summary)
-     */
-    public function generate_single( int $post_id, string $workflow_type ): void {
-        $this->queue->queue_post( $post_id, $workflow_type );
-    }
-
-    /**
-     * Process queued posts in batches.
-     */
-    public function process_queue(): void {
-        $this->queue->process_queue();
-    }
+	/**
+	 * @var SettingsRepository
+	 */
+	private $settings_repository;
 
 
-    /**
-     * Poll for generation updates
-     *
-     * @param string $generation_id Generation ID
-     * @param string $workflow_type Type of workflow (quiz/summary)
-     * @param array  $post_ids List of post IDs
-     * @param int    $attempt  Current attempt number
-     */
-    public function poll_generation( string $generation_id, string $workflow_type, array $post_ids, int $attempt ): void {
-        $this->scheduler->poll_generation( $generation_id, $workflow_type, $post_ids, $attempt );
-    }
+	private AutoGenerationQueue $queue;
 
-    /**
-     * Cron callback to start a generation task for a post.
-     *
-     * @param int    $post_id       Post ID
-     * @param string $workflow_type Type of content to generate
-     */
-    public function run_generation( int $post_id, string $workflow_type ): void {
-        $this->generate_single( $post_id, $workflow_type );
-    }
+	private AutoGenerationScheduler $scheduler;
 
-    /**
-     * Generate content for a single post (public alias for backward compatibility)
-     *
-     * @param int    $post_id Post ID
-     * @param string $workflow_type Type of content to generate (quiz/summary)
-     */
-    public function generateSingle( int $post_id, string $workflow_type ): void {
-        $this->generate_single( $post_id, $workflow_type );
-    }
+
+	/**
+	 * @var PublishGenerationHandler
+	 */
+	private PublishGenerationHandler $publish_handler;
+
+	/**
+	 * Constructor
+	 *
+	 * @param SettingsRepository      $settings_repository
+	 * @param AutoGenerationQueue     $queue
+	 * @param AutoGenerationScheduler $scheduler
+	 */
+	public function __construct(
+		SettingsRepository $settings_repository,
+		AutoGenerationQueue $queue,
+		AutoGenerationScheduler $scheduler,
+		PublishGenerationHandler $publish_handler
+	) {
+				$this->settings_repository = $settings_repository;
+				$this->queue               = $queue;
+				$this->scheduler           = $scheduler;
+				$this->publish_handler     = $publish_handler;
+	}
+
+	/**
+	 * Register WordPress hooks
+	 */
+	public function register_hooks(): void {
+			$this->scheduler->register_hooks();
+
+			add_action(
+				self::START_HOOK,
+				array( $this, 'run_generation' ),
+				10,
+				2 // post_id, workflow_type
+			);
+
+			add_action( self::QUEUE_HOOK, array( $this, 'process_queue' ) );
+
+		$this->publish_handler->register_hooks();
+	}
+
+	/**
+	 * Handle post publish transition
+	 *
+	 * @param string   $new_status New post status
+	 * @param string   $old_status Old post status
+	 * @param \WP_Post $post Post object
+	 */
+	public function handle_post_publish( $new_status, $old_status, $post ): void {
+		$this->publish_handler->handle_post_publish( $new_status, $old_status, $post );
+	}
+
+	/**
+	 * Generate content for a single post
+	 *
+	 * @param int    $post_id Post ID
+	 * @param string $workflow_type Type of content to generate (quiz/summary)
+	 */
+	public function generate_single( int $post_id, string $workflow_type ): void {
+		$this->queue->queue_post( $post_id, $workflow_type );
+	}
+
+	/**
+	 * Process queued posts in batches.
+	 */
+	public function process_queue(): void {
+		$this->queue->process_queue();
+	}
+
+
+	/**
+	 * Poll for generation updates
+	 *
+	 * @param string $generation_id Generation ID
+	 * @param string $workflow_type Type of workflow (quiz/summary)
+	 * @param array  $post_ids List of post IDs
+	 * @param int    $attempt  Current attempt number
+	 */
+	public function poll_generation( string $generation_id, string $workflow_type, array $post_ids, int $attempt ): void {
+		$this->scheduler->poll_generation( $generation_id, $workflow_type, $post_ids, $attempt );
+	}
+
+	/**
+	 * Cron callback to start a generation task for a post.
+	 *
+	 * @param int    $post_id       Post ID
+	 * @param string $workflow_type Type of content to generate
+	 */
+	public function run_generation( int $post_id, string $workflow_type ): void {
+		$this->generate_single( $post_id, $workflow_type );
+	}
+
+	/**
+	 * Generate content for a single post (public alias for backward compatibility)
+	 *
+	 * @param int    $post_id Post ID
+	 * @param string $workflow_type Type of content to generate (quiz/summary)
+	 */
+	public function generateSingle( int $post_id, string $workflow_type ): void {
+		$this->generate_single( $post_id, $workflow_type );
+	}
 }

--- a/nuclear-engagement/inc/Services/ContentStorageService.php
+++ b/nuclear-engagement/inc/Services/ContentStorageService.php
@@ -15,205 +15,205 @@ use NuclearEngagement\Utils\Utils;
 use NuclearEngagement\Modules\Summary\Summary_Service;
 
 if ( ! defined( 'ABSPATH' ) ) {
-    exit;
+	exit;
 }
 
 /**
  * Service for storing generated content
  */
 class ContentStorageService {
-    /**
-     * @var SettingsRepository
-     */
-    private SettingsRepository $settings;
+	/**
+	 * @var SettingsRepository
+	 */
+	private SettingsRepository $settings;
 
-    /**
-     * @var Utils
-     */
-    private Utils $utils;
+	/**
+	 * @var Utils
+	 */
+	private Utils $utils;
 
-    /**
-     * Constructor
-     *
-     * @param SettingsRepository $settings
-     */
-    public function __construct( SettingsRepository $settings ) {
-        $this->settings = $settings;
-        $this->utils    = new Utils();
-    }
+	/**
+	 * Constructor
+	 *
+	 * @param SettingsRepository $settings
+	 */
+	public function __construct( SettingsRepository $settings ) {
+		$this->settings = $settings;
+		$this->utils    = new Utils();
+	}
 
-    /**
-     * Store generation results
-     *
-         * @param array  $results
-         * @param string $workflowType
-         *
-         * @return array<int, mixed> Status for each post ID
-         */
-        public function storeResults( array $results, string $workflowType ): array {
-                $updateLastModified = $this->settings->get_bool( 'update_last_modified', false );
-                $dateNow            = current_time( 'mysql' );
+	/**
+	 * Store generation results
+	 *
+		 * @param array  $results
+		 * @param string $workflowType
+		 *
+		 * @return array<int, mixed> Status for each post ID
+		 */
+		public function storeResults( array $results, string $workflowType ): array {
+				$updateLastModified = $this->settings->get_bool( 'update_last_modified', false );
+				$dateNow            = current_time( 'mysql' );
 
-                $statuses = array();
+				$statuses = array();
 
-        foreach ( $results as $postIdString => $data ) {
-            $postId = (int) $postIdString;
+		foreach ( $results as $postIdString => $data ) {
+			$postId = (int) $postIdString;
 
-            // Ensure date is set
-            if ( empty( $data['date'] ) ) {
-                $data['date'] = $dateNow;
-            }
+			// Ensure date is set
+			if ( empty( $data['date'] ) ) {
+				$data['date'] = $dateNow;
+			}
 
-                        try {
-                                if ( $workflowType === 'quiz' ) {
-                                        $this->storeQuizData( $postId, $data );
-                                } else {
-                                        $this->storeSummaryData( $postId, $data );
-                                }
+						try {
+								if ( $workflowType === 'quiz' ) {
+										$this->storeQuizData( $postId, $data );
+								} else {
+										$this->storeSummaryData( $postId, $data );
+								}
 
-                                // Update post modified time if enabled
-                                if ( $updateLastModified ) {
-                                        $this->updatePostModifiedTime( $postId );
-                                } else {
-                                        clean_post_cache( $postId );
-                                }
+								// Update post modified time if enabled
+								if ( $updateLastModified ) {
+										$this->updatePostModifiedTime( $postId );
+								} else {
+										clean_post_cache( $postId );
+								}
 
-                                \NuclearEngagement\Services\LoggingService::log( "Stored {$workflowType} data for post {$postId}" );
+								\NuclearEngagement\Services\LoggingService::log( "Stored {$workflowType} data for post {$postId}" );
 
-                                $statuses[ $postId ] = true;
+								$statuses[ $postId ] = true;
 
-                        } catch ( \Throwable $e ) {
-                                \NuclearEngagement\Services\LoggingService::log_exception( $e );
-                                $statuses[ $postId ] = $e->getMessage();
-                        }
-                }
+						} catch ( \Throwable $e ) {
+								\NuclearEngagement\Services\LoggingService::log_exception( $e );
+								$statuses[ $postId ] = $e->getMessage();
+						}
+				}
 
-                return $statuses;
-        }
+				return $statuses;
+		}
 
-    /**
-     * Store quiz data
-     *
-     * @param int   $postId
-     * @param array $data
-     * @throws \InvalidArgumentException On invalid data
-     */
-    public function storeQuizData( int $postId, array $data ): void {
-        if ( empty( $data['questions'] ) || ! is_array( $data['questions'] ) ) {
-                throw new \InvalidArgumentException( "Invalid quiz data for post {$postId}" );
-        }
+	/**
+	 * Store quiz data
+	 *
+	 * @param int   $postId
+	 * @param array $data
+	 * @throws \InvalidArgumentException On invalid data
+	 */
+	public function storeQuizData( int $postId, array $data ): void {
+		if ( empty( $data['questions'] ) || ! is_array( $data['questions'] ) ) {
+				throw new \InvalidArgumentException( "Invalid quiz data for post {$postId}" );
+		}
 
-            $maxAnswers = $this->settings->get_int( 'answers_per_question', 4 );
-            $questions  = array();
+			$maxAnswers = $this->settings->get_int( 'answers_per_question', 4 );
+			$questions  = array();
 
-        foreach ( $data['questions'] as $question ) {
-            if ( ! is_array( $question ) ) {
-                    continue;
-            }
+		foreach ( $data['questions'] as $question ) {
+			if ( ! is_array( $question ) ) {
+					continue;
+			}
 
-                $qText   = trim( (string) ( $question['question'] ?? '' ) );
-                $answers = isset( $question['answers'] ) && is_array( $question['answers'] )
-                        ? array_map( 'trim', $question['answers'] )
-                        : array();
-                $answers = array_filter(
-                    $answers,
-                    static function ( $a ) {
-                            return $a !== '';
-                    }
-                );
+				$qText   = trim( (string) ( $question['question'] ?? '' ) );
+				$answers = isset( $question['answers'] ) && is_array( $question['answers'] )
+						? array_map( 'trim', $question['answers'] )
+						: array();
+				$answers = array_filter(
+					$answers,
+					static function ( $a ) {
+							return $a !== '';
+					}
+				);
 
-            if ( $qText === '' || empty( $answers ) ) {
-                continue;
-            }
+			if ( $qText === '' || empty( $answers ) ) {
+				continue;
+			}
 
-                $questions[] = array(
-                    'question'    => sanitize_text_field( $qText ),
-                    'answers'     => array_map( 'sanitize_text_field', array_slice( $answers, 0, $maxAnswers ) ),
-                    'explanation' => sanitize_text_field( (string) ( $question['explanation'] ?? '' ) ),
-                );
-        }
+				$questions[] = array(
+					'question'    => sanitize_text_field( $qText ),
+					'answers'     => array_map( 'sanitize_text_field', array_slice( $answers, 0, $maxAnswers ) ),
+					'explanation' => sanitize_text_field( (string) ( $question['explanation'] ?? '' ) ),
+				);
+		}
 
-        if ( empty( $questions ) ) {
-                throw new \InvalidArgumentException( "Invalid quiz data for post {$postId}" );
-        }
+		if ( empty( $questions ) ) {
+				throw new \InvalidArgumentException( "Invalid quiz data for post {$postId}" );
+		}
 
-            $formatted = array(
-                'questions' => $questions,
-                'date'      => $data['date'] ?? current_time( 'mysql' ),
-            );
+			$formatted = array(
+				'questions' => $questions,
+				'date'      => $data['date'] ?? current_time( 'mysql' ),
+			);
 
-            if ( ! update_post_meta( $postId, 'nuclen-quiz-data', $formatted ) ) {
-                    throw new \RuntimeException( "Failed to update quiz data for post {$postId}" );
-            }
-    }
+			if ( ! update_post_meta( $postId, 'nuclen-quiz-data', $formatted ) ) {
+					throw new \RuntimeException( "Failed to update quiz data for post {$postId}" );
+			}
+	}
 
-    /**
-     * Store summary data
-     *
-     * @param int   $postId
-     * @param array $data
-     * @throws \InvalidArgumentException On invalid data
-     */
-    public function storeSummaryData( int $postId, array $data ): void {
-        if ( ! isset( $data['summary'] ) || ! is_string( $data['summary'] ) ) {
-            // Legacy support for 'content' key
-            if ( isset( $data['content'] ) && is_string( $data['content'] ) ) {
-                $data['summary'] = $data['content'];
-            } else {
-                throw new \InvalidArgumentException( "Invalid summary data for post {$postId}" );
-            }
-        }
+	/**
+	 * Store summary data
+	 *
+	 * @param int   $postId
+	 * @param array $data
+	 * @throws \InvalidArgumentException On invalid data
+	 */
+	public function storeSummaryData( int $postId, array $data ): void {
+		if ( ! isset( $data['summary'] ) || ! is_string( $data['summary'] ) ) {
+			// Legacy support for 'content' key
+			if ( isset( $data['content'] ) && is_string( $data['content'] ) ) {
+				$data['summary'] = $data['content'];
+			} else {
+				throw new \InvalidArgumentException( "Invalid summary data for post {$postId}" );
+			}
+		}
 
-        $allowedHtml = array(
-            'a'      => array(
-                'href'   => array(),
-                'title'  => array(),
-                'target' => array(),
-            ),
-            'br'     => array(),
-            'em'     => array(),
-            'strong' => array(),
-            'p'      => array(),
-            'ul'     => array(),
-            'ol'     => array(),
-            'li'     => array(),
-            'h1'     => array(),
-            'h2'     => array(),
-            'h3'     => array(),
-            'h4'     => array(),
-            'div'    => array( 'class' => array() ),
-            'span'   => array( 'class' => array() ),
-        );
+		$allowedHtml = array(
+			'a'      => array(
+				'href'   => array(),
+				'title'  => array(),
+				'target' => array(),
+			),
+			'br'     => array(),
+			'em'     => array(),
+			'strong' => array(),
+			'p'      => array(),
+			'ul'     => array(),
+			'ol'     => array(),
+			'li'     => array(),
+			'h1'     => array(),
+			'h2'     => array(),
+			'h3'     => array(),
+			'h4'     => array(),
+			'div'    => array( 'class' => array() ),
+			'span'   => array( 'class' => array() ),
+		);
 
-        $formatted = array(
-            'summary' => wp_kses( $data['summary'], $allowedHtml ),
-            'date'    => $data['date'] ?? current_time( 'mysql' ),
-        );
+		$formatted = array(
+			'summary' => wp_kses( $data['summary'], $allowedHtml ),
+			'date'    => $data['date'] ?? current_time( 'mysql' ),
+		);
 
-        if ( ! update_post_meta( $postId, Summary_Service::META_KEY, $formatted ) ) {
-            throw new \RuntimeException( "Failed to update summary data for post {$postId}" );
-        }
-    }
+		if ( ! update_post_meta( $postId, Summary_Service::META_KEY, $formatted ) ) {
+			throw new \RuntimeException( "Failed to update summary data for post {$postId}" );
+		}
+	}
 
-    /**
-     * Update post modified time
-     *
-     * @param int $postId
-     */
-    private function updatePostModifiedTime( int $postId ): void {
-        $time   = current_time( 'mysql' );
-        $result = wp_update_post(
-            array(
-                'ID'                => $postId,
-                'post_modified'     => $time,
-                'post_modified_gmt' => get_gmt_from_date( $time ),
-            )
-        );
+	/**
+	 * Update post modified time
+	 *
+	 * @param int $postId
+	 */
+	private function updatePostModifiedTime( int $postId ): void {
+		$time   = current_time( 'mysql' );
+		$result = wp_update_post(
+			array(
+				'ID'                => $postId,
+				'post_modified'     => $time,
+				'post_modified_gmt' => get_gmt_from_date( $time ),
+			)
+		);
 
-        if ( is_wp_error( $result ) ) {
-            \NuclearEngagement\Services\LoggingService::log( "Failed to update modified time for post {$postId}: " . $result->get_error_message() );
-        }
+		if ( is_wp_error( $result ) ) {
+			\NuclearEngagement\Services\LoggingService::log( "Failed to update modified time for post {$postId}: " . $result->get_error_message() );
+		}
 
-        clean_post_cache( $postId );
-    }
+		clean_post_cache( $postId );
+	}
 }

--- a/nuclear-engagement/inc/Services/DashboardDataService.php
+++ b/nuclear-engagement/inc/Services/DashboardDataService.php
@@ -13,182 +13,182 @@ namespace NuclearEngagement\Services;
 use NuclearEngagement\Modules\Summary\Summary_Service;
 
 if ( ! defined( 'ABSPATH' ) ) {
-    exit;
+	exit;
 }
 
 /**
  * Service for fetching dashboard data.
  */
 class DashboardDataService {
-    /** Cache group for dashboard queries. */
-    private const CACHE_GROUP = 'nuclen_dashboard';
+	/** Cache group for dashboard queries. */
+	private const CACHE_GROUP = 'nuclen_dashboard';
 
-    /** Cache lifetime in seconds. */
-    private const CACHE_TTL = 10 * MINUTE_IN_SECONDS; // 10 minutes.
+	/** Cache lifetime in seconds. */
+	private const CACHE_TTL = 10 * MINUTE_IN_SECONDS; // 10 minutes.
 
-    /** Option name storing cache version. */
-    private const VERSION_OPTION = 'nuclen_dashboard_version';
+	/** Option name storing cache version. */
+	private const VERSION_OPTION = 'nuclen_dashboard_version';
 
-    /**
-     * Get current cache version.
-     */
-    private function get_cache_version(): int {
-        return (int) get_option( self::VERSION_OPTION, 1 );
-    }
+	/**
+	 * Get current cache version.
+	 */
+	private function get_cache_version(): int {
+		return (int) get_option( self::VERSION_OPTION, 1 );
+	}
 
-    /**
-     * Clear cached dashboard query results.
-     */
-    public static function clear_cache(): void {
-        $version = (int) get_option( self::VERSION_OPTION, 1 );
-        update_option( self::VERSION_OPTION, $version + 1, false );
+	/**
+	 * Clear cached dashboard query results.
+	 */
+	public static function clear_cache(): void {
+		$version = (int) get_option( self::VERSION_OPTION, 1 );
+		update_option( self::VERSION_OPTION, $version + 1, false );
 
-        if ( function_exists( 'wp_cache_flush_group' ) ) {
-            wp_cache_flush_group( self::CACHE_GROUP );
-        } else {
-            wp_cache_flush();
-        }
-    }
-    /**
-     * Run a grouped count query (status, post type, author, etc.).
-     *
-     * @param string $group_by   Column to group by (prefixed, e.g. "p.post_status").
-     * @param string $meta_key   Meta key to test for existence (quiz/summary).
-     * @param array  $post_types Allowed post types.
-     * @param array  $statuses   Allowed post statuses.
-     * @return array             Rows of counts.
-     */
-    public function get_group_counts( string $group_by, string $meta_key, array $post_types, array $statuses ): array {
-        global $wpdb;
+		if ( function_exists( 'wp_cache_flush_group' ) ) {
+			wp_cache_flush_group( self::CACHE_GROUP );
+		} else {
+			wp_cache_flush();
+		}
+	}
+	/**
+	 * Run a grouped count query (status, post type, author, etc.).
+	 *
+	 * @param string $group_by   Column to group by (prefixed, e.g. "p.post_status").
+	 * @param string $meta_key   Meta key to test for existence (quiz/summary).
+	 * @param array  $post_types Allowed post types.
+	 * @param array  $statuses   Allowed post statuses.
+	 * @return array             Rows of counts.
+	 */
+	public function get_group_counts( string $group_by, string $meta_key, array $post_types, array $statuses ): array {
+		global $wpdb;
 
-        $post_types = array_map( 'sanitize_key', $post_types );
-        $statuses   = array_map( 'sanitize_key', $statuses );
+		$post_types = array_map( 'sanitize_key', $post_types );
+		$statuses   = array_map( 'sanitize_key', $statuses );
 
-        $cache_key = md5( wp_json_encode( array( 'grp', $group_by, $meta_key, $post_types, $statuses, $this->get_cache_version(), get_current_blog_id() ) ) );
-        $transient = 'nuclen_dash_' . $cache_key;
-        $found     = false;
-        $cached    = wp_cache_get( $cache_key, self::CACHE_GROUP, false, $found );
-        if ( ! $found ) {
-            $cached = get_transient( $transient );
-        }
+		$cache_key = md5( wp_json_encode( array( 'grp', $group_by, $meta_key, $post_types, $statuses, $this->get_cache_version(), get_current_blog_id() ) ) );
+		$transient = 'nuclen_dash_' . $cache_key;
+		$found     = false;
+		$cached    = wp_cache_get( $cache_key, self::CACHE_GROUP, false, $found );
+		if ( ! $found ) {
+			$cached = get_transient( $transient );
+		}
 
-        if ( is_array( $cached ) ) {
-            return $cached;
-        }
+		if ( is_array( $cached ) ) {
+			return $cached;
+		}
 
-        $placeholders_pt = implode( ',', array_fill( 0, count( $post_types ), '%s' ) );
-        $placeholders_st = implode( ',', array_fill( 0, count( $statuses ), '%s' ) );
+		$placeholders_pt = implode( ',', array_fill( 0, count( $post_types ), '%s' ) );
+		$placeholders_st = implode( ',', array_fill( 0, count( $statuses ), '%s' ) );
 
-        $sql = $wpdb->prepare(
-            "SELECT $group_by AS g,
-                   CASE WHEN pm.meta_id IS NULL THEN 'without' ELSE 'with' END AS w,
-                   COUNT(*) AS c
-            FROM {$wpdb->posts} p
-            LEFT JOIN {$wpdb->postmeta} pm
-              ON pm.post_id = p.ID
-             AND pm.meta_key = %s
-            WHERE p.post_type IN ($placeholders_pt)
-              AND p.post_status IN ($placeholders_st)
-            GROUP BY $group_by, w",
-            array_merge( array( $meta_key ), $post_types, $statuses )
-        );
+		$sql = $wpdb->prepare(
+			"SELECT $group_by AS g,
+				   CASE WHEN pm.meta_id IS NULL THEN 'without' ELSE 'with' END AS w,
+				   COUNT(*) AS c
+			FROM {$wpdb->posts} p
+			LEFT JOIN {$wpdb->postmeta} pm
+			  ON pm.post_id = p.ID
+			 AND pm.meta_key = %s
+			WHERE p.post_type IN ($placeholders_pt)
+			  AND p.post_status IN ($placeholders_st)
+			GROUP BY $group_by, w",
+			array_merge( array( $meta_key ), $post_types, $statuses )
+		);
 
-        $rows = $wpdb->get_results( $sql, ARRAY_A );
+		$rows = $wpdb->get_results( $sql, ARRAY_A );
 
-        if ( ! empty( $wpdb->last_error ) ) {
-            LoggingService::log( 'Dashboard query error: ' . $wpdb->last_error );
-            return array();
-        }
+		if ( ! empty( $wpdb->last_error ) ) {
+			LoggingService::log( 'Dashboard query error: ' . $wpdb->last_error );
+			return array();
+		}
 
-        wp_cache_set( $cache_key, $rows, self::CACHE_GROUP, self::CACHE_TTL );
-        set_transient( $transient, $rows, self::CACHE_TTL );
+		wp_cache_set( $cache_key, $rows, self::CACHE_GROUP, self::CACHE_TTL );
+		set_transient( $transient, $rows, self::CACHE_TTL );
 
-        return $rows;
-    }
+		return $rows;
+	}
 
-    /**
-     * Run a grouped count query for both quiz and summary meta in one go.
-     *
-     * @param string $group_by   Column to group by.
-     * @param array  $post_types Allowed post types.
-     * @param array  $statuses   Allowed post statuses.
-     * @return array             Rows with counts for quiz and summary.
-     */
-    public function get_dual_counts( string $group_by, array $post_types, array $statuses ): array {
-        global $wpdb;
+	/**
+	 * Run a grouped count query for both quiz and summary meta in one go.
+	 *
+	 * @param string $group_by   Column to group by.
+	 * @param array  $post_types Allowed post types.
+	 * @param array  $statuses   Allowed post statuses.
+	 * @return array             Rows with counts for quiz and summary.
+	 */
+	public function get_dual_counts( string $group_by, array $post_types, array $statuses ): array {
+		global $wpdb;
 
-        $post_types = array_map( 'sanitize_key', $post_types );
-        $statuses   = array_map( 'sanitize_key', $statuses );
+		$post_types = array_map( 'sanitize_key', $post_types );
+		$statuses   = array_map( 'sanitize_key', $statuses );
 
-        $cache_key = md5( wp_json_encode( array( 'dual', $group_by, $post_types, $statuses, $this->get_cache_version(), get_current_blog_id() ) ) );
-        $transient = 'nuclen_dash_' . $cache_key;
-        $found     = false;
-        $cached    = wp_cache_get( $cache_key, self::CACHE_GROUP, false, $found );
-        if ( ! $found ) {
-            $cached = get_transient( $transient );
-        }
+		$cache_key = md5( wp_json_encode( array( 'dual', $group_by, $post_types, $statuses, $this->get_cache_version(), get_current_blog_id() ) ) );
+		$transient = 'nuclen_dash_' . $cache_key;
+		$found     = false;
+		$cached    = wp_cache_get( $cache_key, self::CACHE_GROUP, false, $found );
+		if ( ! $found ) {
+			$cached = get_transient( $transient );
+		}
 
-        if ( is_array( $cached ) ) {
-            return $cached;
-        }
+		if ( is_array( $cached ) ) {
+			return $cached;
+		}
 
-        $placeholders_pt = implode( ',', array_fill( 0, count( $post_types ), '%s' ) );
-        $placeholders_st = implode( ',', array_fill( 0, count( $statuses ), '%s' ) );
+		$placeholders_pt = implode( ',', array_fill( 0, count( $post_types ), '%s' ) );
+		$placeholders_st = implode( ',', array_fill( 0, count( $statuses ), '%s' ) );
 
-        $sql = $wpdb->prepare(
-            "SELECT $group_by AS g,
-                   SUM(CASE WHEN pm_q.meta_id IS NULL THEN 0 ELSE 1 END) AS quiz_with,
-                   SUM(CASE WHEN pm_q.meta_id IS NULL THEN 1 ELSE 0 END) AS quiz_without,
-                   SUM(CASE WHEN pm_s.meta_id IS NULL THEN 0 ELSE 1 END) AS summary_with,
-                   SUM(CASE WHEN pm_s.meta_id IS NULL THEN 1 ELSE 0 END) AS summary_without
-            FROM {$wpdb->posts} p
-            LEFT JOIN {$wpdb->postmeta} pm_q ON pm_q.post_id = p.ID AND pm_q.meta_key = 'nuclen-quiz-data'
-            LEFT JOIN {$wpdb->postmeta} pm_s ON pm_s.post_id = p.ID AND pm_s.meta_key = '" . Summary_Service::META_KEY . "'
-            WHERE p.post_type IN ($placeholders_pt)
-              AND p.post_status IN ($placeholders_st)
-            GROUP BY $group_by",
-            array_merge( $post_types, $statuses )
-        );
+		$sql = $wpdb->prepare(
+			"SELECT $group_by AS g,
+				   SUM(CASE WHEN pm_q.meta_id IS NULL THEN 0 ELSE 1 END) AS quiz_with,
+				   SUM(CASE WHEN pm_q.meta_id IS NULL THEN 1 ELSE 0 END) AS quiz_without,
+				   SUM(CASE WHEN pm_s.meta_id IS NULL THEN 0 ELSE 1 END) AS summary_with,
+				   SUM(CASE WHEN pm_s.meta_id IS NULL THEN 1 ELSE 0 END) AS summary_without
+			FROM {$wpdb->posts} p
+			LEFT JOIN {$wpdb->postmeta} pm_q ON pm_q.post_id = p.ID AND pm_q.meta_key = 'nuclen-quiz-data'
+			LEFT JOIN {$wpdb->postmeta} pm_s ON pm_s.post_id = p.ID AND pm_s.meta_key = '" . Summary_Service::META_KEY . "'
+			WHERE p.post_type IN ($placeholders_pt)
+			  AND p.post_status IN ($placeholders_st)
+			GROUP BY $group_by",
+			array_merge( $post_types, $statuses )
+		);
 
-        $rows = $wpdb->get_results( $sql, ARRAY_A );
+		$rows = $wpdb->get_results( $sql, ARRAY_A );
 
-        if ( ! empty( $wpdb->last_error ) ) {
-            LoggingService::log( 'Dashboard query error: ' . $wpdb->last_error );
-            return array();
-        }
+		if ( ! empty( $wpdb->last_error ) ) {
+			LoggingService::log( 'Dashboard query error: ' . $wpdb->last_error );
+			return array();
+		}
 
-        wp_cache_set( $cache_key, $rows, self::CACHE_GROUP, self::CACHE_TTL );
-        set_transient( $transient, $rows, self::CACHE_TTL );
+		wp_cache_set( $cache_key, $rows, self::CACHE_GROUP, self::CACHE_TTL );
+		set_transient( $transient, $rows, self::CACHE_TTL );
 
-        return $rows;
-    }
+		return $rows;
+	}
 
-    /**
-     * Retrieve any scheduled generation tasks.
-     *
-     * @return array List of scheduled tasks.
-     */
-    public function get_scheduled_generations(): array {
-        $active_generations = get_option( 'nuclen_active_generations', array() );
-        $scheduled_tasks    = array();
-        $date_format        = get_option( 'date_format' );
-        $time_format        = get_option( 'time_format' );
+	/**
+	 * Retrieve any scheduled generation tasks.
+	 *
+	 * @return array List of scheduled tasks.
+	 */
+	public function get_scheduled_generations(): array {
+		$active_generations = get_option( 'nuclen_active_generations', array() );
+		$scheduled_tasks    = array();
+		$date_format        = get_option( 'date_format' );
+		$time_format        = get_option( 'time_format' );
 
-        foreach ( $active_generations as $gen_id => $info ) {
-            $post_id   = (int) ( $info['post_ids'][0] ?? 0 );
-            $title     = $post_id ? get_the_title( $post_id ) : $gen_id;
-            $next_poll = isset( $info['next_poll'] )
-                ? date_i18n( $date_format . ' ' . $time_format, (int) $info['next_poll'] )
-                : '';
+		foreach ( $active_generations as $gen_id => $info ) {
+			$post_id   = (int) ( $info['post_ids'][0] ?? 0 );
+			$title     = $post_id ? get_the_title( $post_id ) : $gen_id;
+			$next_poll = isset( $info['next_poll'] )
+				? date_i18n( $date_format . ' ' . $time_format, (int) $info['next_poll'] )
+				: '';
 
-            $scheduled_tasks[] = array(
-                'post_title'    => $title,
-                'workflow_type' => $info['workflow_type'] ?? '',
-                'attempt'       => (int) ( $info['attempt'] ?? 1 ),
-                'next_poll'     => $next_poll,
-            );
-        }
+			$scheduled_tasks[] = array(
+				'post_title'    => $title,
+				'workflow_type' => $info['workflow_type'] ?? '',
+				'attempt'       => (int) ( $info['attempt'] ?? 1 ),
+				'next_poll'     => $next_poll,
+			);
+		}
 
-        return $scheduled_tasks;
-    }
+		return $scheduled_tasks;
+	}
 }

--- a/nuclear-engagement/inc/Services/GenerationPoller.php
+++ b/nuclear-engagement/inc/Services/GenerationPoller.php
@@ -14,149 +14,149 @@ use NuclearEngagement\Services\ContentStorageService;
 use NuclearEngagement\Services\ApiException;
 
 if ( ! defined( 'ABSPATH' ) ) {
-    exit;
+	exit;
 }
 
 class GenerationPoller {
-    /**
-     * @var SettingsRepository
-     */
-    private SettingsRepository $settings_repository;
+	/**
+	 * @var SettingsRepository
+	 */
+	private SettingsRepository $settings_repository;
 
-    /**
-     * @var RemoteApiService
-     */
-    private RemoteApiService $remote_api;
+	/**
+	 * @var RemoteApiService
+	 */
+	private RemoteApiService $remote_api;
 
-    /**
-     * @var ContentStorageService
-     */
-    private ContentStorageService $content_storage;
+	/**
+	 * @var ContentStorageService
+	 */
+	private ContentStorageService $content_storage;
 
-    public function __construct(
-        SettingsRepository $settings_repository,
-        RemoteApiService $remote_api,
-        ContentStorageService $content_storage
-    ) {
-        $this->settings_repository = $settings_repository;
-        $this->remote_api          = $remote_api;
-        $this->content_storage     = $content_storage;
-    }
+	public function __construct(
+		SettingsRepository $settings_repository,
+		RemoteApiService $remote_api,
+		ContentStorageService $content_storage
+	) {
+		$this->settings_repository = $settings_repository;
+		$this->remote_api          = $remote_api;
+		$this->content_storage     = $content_storage;
+	}
 
-    /**
-     * Register WordPress hook for polling events.
-     */
-    public function register_hooks(): void {
-        add_action(
-            'nuclen_poll_generation',
-            array( $this, 'poll_generation' ),
-            10,
-            4 // generation_id, workflow_type, post_ids, attempt
-        );
-    }
+	/**
+	 * Register WordPress hook for polling events.
+	 */
+	public function register_hooks(): void {
+		add_action(
+			'nuclen_poll_generation',
+			array( $this, 'poll_generation' ),
+			10,
+			4 // generation_id, workflow_type, post_ids, attempt
+		);
+	}
 
-    /**
-     * Poll for generation updates.
-     *
-     * @param string $generation_id Generation ID
-     * @param string $workflow_type  Type of workflow (quiz/summary)
-     * @param array  $post_ids      List of post IDs in this batch
-     * @param int    $attempt       Current attempt number
-     */
-    public function poll_generation( string $generation_id, string $workflow_type, array $post_ids, int $attempt ): void {
-            $max_attempts = NUCLEN_MAX_POLL_ATTEMPTS;
-            $retry_delay  = NUCLEN_POLL_RETRY_DELAY * $attempt;
+	/**
+	 * Poll for generation updates.
+	 *
+	 * @param string $generation_id Generation ID
+	 * @param string $workflow_type  Type of workflow (quiz/summary)
+	 * @param array  $post_ids      List of post IDs in this batch
+	 * @param int    $attempt       Current attempt number
+	 */
+	public function poll_generation( string $generation_id, string $workflow_type, array $post_ids, int $attempt ): void {
+			$max_attempts = NUCLEN_MAX_POLL_ATTEMPTS;
+			$retry_delay  = NUCLEN_POLL_RETRY_DELAY * $attempt;
 
-        try {
-            $connected      = $this->settings_repository->get( 'connected', false );
-            $wp_app_created = $this->settings_repository->get( 'wp_app_pass_created', false );
-            if ( ! $connected || ! $wp_app_created ) {
-                return;
-            }
+		try {
+			$connected      = $this->settings_repository->get( 'connected', false );
+			$wp_app_created = $this->settings_repository->get( 'wp_app_pass_created', false );
+			if ( ! $connected || ! $wp_app_created ) {
+				return;
+			}
 
-            // fetch_updates() checks a short cache to avoid redundant requests.
-            $data = $this->remote_api->fetch_updates( $generation_id );
+			// fetch_updates() checks a short cache to avoid redundant requests.
+			$data = $this->remote_api->fetch_updates( $generation_id );
 
-                        if ( ! empty( $data['results'] ) && is_array( $data['results'] ) ) {
-                                $statuses = $this->content_storage->storeResults( $data['results'], $workflow_type );
-                                if ( array_filter( $statuses, static fn( $s ) => $s !== true ) ) {
-                                        \NuclearEngagement\Services\LoggingService::notify_admin(
-                                                sprintf( 'Failed to store results for generation %s', $generation_id )
-                                        );
-                                } else {
-                                        \NuclearEngagement\Services\LoggingService::log(
-                                                "Poll success for generation {$generation_id}"
-                                        );
-                                }
-                                $this->cleanup_generation( $generation_id );
-                                return;
-                        }
+						if ( ! empty( $data['results'] ) && is_array( $data['results'] ) ) {
+								$statuses = $this->content_storage->storeResults( $data['results'], $workflow_type );
+								if ( array_filter( $statuses, static fn( $s ) => $s !== true ) ) {
+										\NuclearEngagement\Services\LoggingService::notify_admin(
+												sprintf( 'Failed to store results for generation %s', $generation_id )
+										);
+								} else {
+										\NuclearEngagement\Services\LoggingService::log(
+												"Poll success for generation {$generation_id}"
+										);
+								}
+								$this->cleanup_generation( $generation_id );
+								return;
+						}
 
-            if ( isset( $data['success'] ) && $data['success'] === true ) {
-                                \NuclearEngagement\Services\LoggingService::log(
-                                    "Still processing generation {$generation_id}, attempt {$attempt}/{$max_attempts}"
-                                );
-            }
-        } catch ( ApiException $e ) {
-                                \NuclearEngagement\Services\LoggingService::log(
-                                    "Polling error for generation {$generation_id}: " . $e->getMessage()
-                                );
-            if ( $attempt >= $max_attempts ) {
-                $this->cleanup_generation( $generation_id );
-                return;
-            }
-        } catch ( \Throwable $e ) {
-                                \NuclearEngagement\Services\LoggingService::log(
-                                    "Polling error for generation {$generation_id}: " . $e->getMessage()
-                                );
-            if ( $attempt >= $max_attempts ) {
-                $this->cleanup_generation( $generation_id );
-                return;
-            }
-        }
+			if ( isset( $data['success'] ) && $data['success'] === true ) {
+								\NuclearEngagement\Services\LoggingService::log(
+									"Still processing generation {$generation_id}, attempt {$attempt}/{$max_attempts}"
+								);
+			}
+		} catch ( ApiException $e ) {
+								\NuclearEngagement\Services\LoggingService::log(
+									"Polling error for generation {$generation_id}: " . $e->getMessage()
+								);
+			if ( $attempt >= $max_attempts ) {
+				$this->cleanup_generation( $generation_id );
+				return;
+			}
+		} catch ( \Throwable $e ) {
+								\NuclearEngagement\Services\LoggingService::log(
+									"Polling error for generation {$generation_id}: " . $e->getMessage()
+								);
+			if ( $attempt >= $max_attempts ) {
+				$this->cleanup_generation( $generation_id );
+				return;
+			}
+		}
 
-        if ( $attempt < $max_attempts ) {
-                $event_args = array( $generation_id, $workflow_type, $post_ids, $attempt + 1 );
-                $scheduled  = wp_schedule_single_event(
-                    time() + $retry_delay,
-                    'nuclen_poll_generation',
-                    $event_args
-                );
-            if ( false === $scheduled ) {
-                \NuclearEngagement\Services\LoggingService::log(
-                    'Failed to schedule event nuclen_poll_generation for generation ' . $generation_id
-                );
-                \NuclearEngagement\Services\LoggingService::notify_admin(
-                    sprintf(
-                        __( 'Failed to schedule event nuclen_poll_generation for generation %s', 'nuclear-engagement' ),
-                        $generation_id
-                    )
-                );
-            }
-        } else {
-            \NuclearEngagement\Services\LoggingService::log(
-                "Polling aborted after {$max_attempts} attempts for generation {$generation_id}"
-            );
-            $this->cleanup_generation( $generation_id );
-        }
-    }
+		if ( $attempt < $max_attempts ) {
+				$event_args = array( $generation_id, $workflow_type, $post_ids, $attempt + 1 );
+				$scheduled  = wp_schedule_single_event(
+					time() + $retry_delay,
+					'nuclen_poll_generation',
+					$event_args
+				);
+			if ( false === $scheduled ) {
+				\NuclearEngagement\Services\LoggingService::log(
+					'Failed to schedule event nuclen_poll_generation for generation ' . $generation_id
+				);
+				\NuclearEngagement\Services\LoggingService::notify_admin(
+					sprintf(
+						__( 'Failed to schedule event nuclen_poll_generation for generation %s', 'nuclear-engagement' ),
+						$generation_id
+					)
+				);
+			}
+		} else {
+			\NuclearEngagement\Services\LoggingService::log(
+				"Polling aborted after {$max_attempts} attempts for generation {$generation_id}"
+			);
+			$this->cleanup_generation( $generation_id );
+		}
+	}
 
-    /**
-     * Remove a completed or failed generation from the tracking option.
-     *
-     * @param string $generation_id Generation ID to remove
-     */
-    private function cleanup_generation( string $generation_id ): void {
-        $generations = get_option( 'nuclen_active_generations', array() );
+	/**
+	 * Remove a completed or failed generation from the tracking option.
+	 *
+	 * @param string $generation_id Generation ID to remove
+	 */
+	private function cleanup_generation( string $generation_id ): void {
+		$generations = get_option( 'nuclen_active_generations', array() );
 
-        if ( ! isset( $generations[ $generation_id ] ) ) {
-            return;
-        }
+		if ( ! isset( $generations[ $generation_id ] ) ) {
+			return;
+		}
 
-        unset( $generations[ $generation_id ] );
+		unset( $generations[ $generation_id ] );
 
-        empty( $generations )
-            ? delete_option( 'nuclen_active_generations' )
-            : update_option( 'nuclen_active_generations', $generations, 'no' );
-    }
+		empty( $generations )
+			? delete_option( 'nuclen_active_generations' )
+			: update_option( 'nuclen_active_generations', $generations, 'no' );
+	}
 }

--- a/nuclear-engagement/inc/Services/GenerationService.php
+++ b/nuclear-engagement/inc/Services/GenerationService.php
@@ -19,230 +19,230 @@ use NuclearEngagement\Services\PostDataFetcher;
 use NuclearEngagement\Modules\Summary\Summary_Service;
 
 if ( ! defined( 'ABSPATH' ) ) {
-    exit;
+	exit;
 }
 
 /**
  * Service for handling content generation
  */
 class GenerationService {
-    /** Seconds to wait between polling events. */
-    private const DEFAULT_POLL_DELAY = 30;
+	/** Seconds to wait between polling events. */
+	private const DEFAULT_POLL_DELAY = 30;
 
-    private int $pollDelay = self::DEFAULT_POLL_DELAY;
-    /**
-     * @var SettingsRepository
-     */
-    private SettingsRepository $settings;
+	private int $pollDelay = self::DEFAULT_POLL_DELAY;
+	/**
+	 * @var SettingsRepository
+	 */
+	private SettingsRepository $settings;
 
-    /**
-     * @var RemoteApiService
-     */
-    private RemoteApiService $api;
+	/**
+	 * @var RemoteApiService
+	 */
+	private RemoteApiService $api;
 
-    /**
-     * @var ContentStorageService
-     */
-        private ContentStorageService $storage;
+	/**
+	 * @var ContentStorageService
+	 */
+		private ContentStorageService $storage;
 
-        /**
-         * @var PostDataFetcher
-         */
-        private PostDataFetcher $fetcher;
+		/**
+		 * @var PostDataFetcher
+		 */
+		private PostDataFetcher $fetcher;
 
-    /**
-     * @var Utils
-     */
-    private Utils $utils;
+	/**
+	 * @var Utils
+	 */
+	private Utils $utils;
 
-    /**
-     * Constructor
-     *
-     * @param SettingsRepository    $settings
-     * @param RemoteApiService      $api
-     * @param ContentStorageService $storage
-     */
-        public function __construct(
-                SettingsRepository $settings,
-                RemoteApiService $api,
-                ContentStorageService $storage,
-                ?PostDataFetcher $fetcher = null
-        ) {
-                $this->settings = $settings;
-                $this->api      = $api;
-                $this->storage  = $storage;
-                $this->fetcher  = $fetcher ?: new PostDataFetcher();
-                $this->utils    = new Utils();
-                if ( defined( 'NUCLEN_GENERATION_POLL_DELAY' ) ) {
-                        $this->pollDelay = (int) constant( 'NUCLEN_GENERATION_POLL_DELAY' );
-                }
-        }
+	/**
+	 * Constructor
+	 *
+	 * @param SettingsRepository    $settings
+	 * @param RemoteApiService      $api
+	 * @param ContentStorageService $storage
+	 */
+		public function __construct(
+				SettingsRepository $settings,
+				RemoteApiService $api,
+				ContentStorageService $storage,
+				?PostDataFetcher $fetcher = null
+		) {
+				$this->settings = $settings;
+				$this->api      = $api;
+				$this->storage  = $storage;
+				$this->fetcher  = $fetcher ?: new PostDataFetcher();
+				$this->utils    = new Utils();
+				if ( defined( 'NUCLEN_GENERATION_POLL_DELAY' ) ) {
+						$this->pollDelay = (int) constant( 'NUCLEN_GENERATION_POLL_DELAY' );
+				}
+		}
 
-    /**
-     * Generate content for multiple posts
-     *
-     * @param GenerateRequest $request
-     * @return GenerationResponse
-     * @throws \RuntimeException On API errors
-     */
-    public function generateContent( GenerateRequest $request ): GenerationResponse {
-        // Get posts data
-        $posts = $this->getPostsData( $request->postIds, $request->postType, $request->postStatus );
-        if ( empty( $posts ) ) {
-            throw new \RuntimeException( 'No matching posts found' );
-        }
+	/**
+	 * Generate content for multiple posts
+	 *
+	 * @param GenerateRequest $request
+	 * @return GenerationResponse
+	 * @throws \RuntimeException On API errors
+	 */
+	public function generateContent( GenerateRequest $request ): GenerationResponse {
+		// Get posts data
+		$posts = $this->getPostsData( $request->postIds, $request->postType, $request->postStatus );
+		if ( empty( $posts ) ) {
+			throw new \RuntimeException( 'No matching posts found' );
+		}
 
-        // Build workflow data
-        $workflow = array(
-            'type'                    => $request->workflowType,
-            'summary_format'          => $request->summaryFormat,
-            'summary_length'          => $request->summaryLength,
-            'summary_number_of_items' => $request->summaryItems,
-        );
+		// Build workflow data
+		$workflow = array(
+			'type'                    => $request->workflowType,
+			'summary_format'          => $request->summaryFormat,
+			'summary_length'          => $request->summaryLength,
+			'summary_number_of_items' => $request->summaryItems,
+		);
 
-        // Send to API
-        try {
-                $result = $this->api->send_posts_to_generate(
-                    array(
-                        'posts'         => $posts,
-                        'workflow'      => $workflow,
-                        'generation_id' => $request->generationId,
-                    )
-                );
-        } catch ( \Throwable $e ) {
-            \NuclearEngagement\Services\LoggingService::log_exception( $e );
-            $response               = new GenerationResponse();
-            $response->generationId = $request->generationId;
-            $response->success      = false;
-            $response->error        = $e->getMessage();
-            $code                   = $e->getCode();
-            $response->statusCode   = is_numeric( $code ) ? (int) $code : 0;
-            if ( $e instanceof ApiException ) {
-                $response->errorCode = $e->getErrorCode();
-            }
-            return $response;
-        }
+		// Send to API
+		try {
+				$result = $this->api->send_posts_to_generate(
+					array(
+						'posts'         => $posts,
+						'workflow'      => $workflow,
+						'generation_id' => $request->generationId,
+					)
+				);
+		} catch ( \Throwable $e ) {
+			\NuclearEngagement\Services\LoggingService::log_exception( $e );
+			$response               = new GenerationResponse();
+			$response->generationId = $request->generationId;
+			$response->success      = false;
+			$response->error        = $e->getMessage();
+			$code                   = $e->getCode();
+			$response->statusCode   = is_numeric( $code ) ? (int) $code : 0;
+			if ( $e instanceof ApiException ) {
+				$response->errorCode = $e->getErrorCode();
+			}
+			return $response;
+		}
 
-        // Create response
-        $response               = new GenerationResponse();
-        $response->generationId = $request->generationId;
+		// Create response
+		$response               = new GenerationResponse();
+		$response->generationId = $request->generationId;
 
-        // Process immediate results if any
-                if ( ! empty( $result['results'] ) && is_array( $result['results'] ) ) {
-                        $statuses = $this->storage->storeResults( $result['results'], $request->workflowType );
-                        if ( array_filter( $statuses, static fn( $s ) => $s !== true ) ) {
-                                $response->success    = false;
-                                $response->error      = 'Failed to store generated content';
-                                return $response;
-                        }
-                        $response->results = $result['results'];
-                }
+		// Process immediate results if any
+				if ( ! empty( $result['results'] ) && is_array( $result['results'] ) ) {
+						$statuses = $this->storage->storeResults( $result['results'], $request->workflowType );
+						if ( array_filter( $statuses, static fn( $s ) => $s !== true ) ) {
+								$response->success    = false;
+								$response->error      = 'Failed to store generated content';
+								return $response;
+						}
+						$response->results = $result['results'];
+				}
 
-        return $response;
-    }
+		return $response;
+	}
 
-    /**
-     * Generate content for a single post
-     *
-     * @param int    $postId
-     * @param string $workflowType
-     * @throws \InvalidArgumentException If post not found
-     */
-    public function generateSingle( int $postId, string $workflowType ): void {
-        $post = get_post( $postId );
-        if ( ! $post ) {
-            throw new \InvalidArgumentException( "Post {$postId} not found" );
-        }
+	/**
+	 * Generate content for a single post
+	 *
+	 * @param int    $postId
+	 * @param string $workflowType
+	 * @throws \InvalidArgumentException If post not found
+	 */
+	public function generateSingle( int $postId, string $workflowType ): void {
+		$post = get_post( $postId );
+		if ( ! $post ) {
+			throw new \InvalidArgumentException( "Post {$postId} not found" );
+		}
 
-        // Check if protected
-        if ( $this->isProtected( $postId, $workflowType ) ) {
-            \NuclearEngagement\Services\LoggingService::log( "Skipping protected {$workflowType} for post {$postId}" );
-            return;
-        }
+		// Check if protected
+		if ( $this->isProtected( $postId, $workflowType ) ) {
+			\NuclearEngagement\Services\LoggingService::log( "Skipping protected {$workflowType} for post {$postId}" );
+			return;
+		}
 
-        $request               = new GenerateRequest();
-        $request->postIds      = array( $postId );
-        $request->workflowType = $workflowType;
-        $request->generationId = 'auto_' . $postId . '_' . time();
-        $request->postType     = $post->post_type;
-        $request->postStatus   = $post->post_status;
+		$request               = new GenerateRequest();
+		$request->postIds      = array( $postId );
+		$request->workflowType = $workflowType;
+		$request->generationId = 'auto_' . $postId . '_' . time();
+		$request->postType     = $post->post_type;
+		$request->postStatus   = $post->post_status;
 
-        try {
-            $response = $this->generateContent( $request );
+		try {
+			$response = $this->generateContent( $request );
 
-            if ( ! $response->success ) {
-                throw new ApiException(
-                    $response->error ?? 'Generation failed',
-                    $response->statusCode ?? 0,
-                    $response->errorCode
-                );
-            }
+			if ( ! $response->success ) {
+				throw new ApiException(
+					$response->error ?? 'Generation failed',
+					$response->statusCode ?? 0,
+					$response->errorCode
+				);
+			}
 
-            // If no immediate results, schedule polling
-            if ( empty( $response->results ) ) {
-                    $scheduled = wp_schedule_single_event(
-                        time() + $this->pollDelay,
-                        'nuclen_poll_generation',
-                        array( $response->generationId, $workflowType, $postId, 1 )
-                    );
-                if ( false === $scheduled ) {
-                    \NuclearEngagement\Services\LoggingService::log(
-                        'Failed to schedule event nuclen_poll_generation for generation ' . $response->generationId
-                    );
-                }
-                    \NuclearEngagement\Services\LoggingService::log( "Scheduled polling for post {$postId}, generation {$response->generationId}" );
-            }
-        } catch ( \Throwable $e ) {
-            \NuclearEngagement\Services\LoggingService::log_exception( $e );
-            throw $e;
-        }
-    }
+			// If no immediate results, schedule polling
+			if ( empty( $response->results ) ) {
+					$scheduled = wp_schedule_single_event(
+						time() + $this->pollDelay,
+						'nuclen_poll_generation',
+						array( $response->generationId, $workflowType, $postId, 1 )
+					);
+				if ( false === $scheduled ) {
+					\NuclearEngagement\Services\LoggingService::log(
+						'Failed to schedule event nuclen_poll_generation for generation ' . $response->generationId
+					);
+				}
+					\NuclearEngagement\Services\LoggingService::log( "Scheduled polling for post {$postId}, generation {$response->generationId}" );
+			}
+		} catch ( \Throwable $e ) {
+			\NuclearEngagement\Services\LoggingService::log_exception( $e );
+			throw $e;
+		}
+	}
 
-    /**
-     * Get posts data for generation
-     *
-     * @param array  $postIds
-     * @param string $postType
-     * @param string $postStatus
-     * @return array
-     */
-        private function getPostsData( array $postIds, string $postType, string $postStatus ): array {
-                $data      = array();
-                $postsById = array();
+	/**
+	 * Get posts data for generation
+	 *
+	 * @param array  $postIds
+	 * @param string $postType
+	 * @param string $postStatus
+	 * @return array
+	 */
+		private function getPostsData( array $postIds, string $postType, string $postStatus ): array {
+				$data      = array();
+				$postsById = array();
 
-                $chunkSize = defined( 'NUCLEN_POST_FETCH_CHUNK' ) ? (int) constant( 'NUCLEN_POST_FETCH_CHUNK' ) : 200;
-                $chunks    = count( $postIds ) <= $chunkSize ? array( $postIds ) : array_chunk( $postIds, $chunkSize );
+				$chunkSize = defined( 'NUCLEN_POST_FETCH_CHUNK' ) ? (int) constant( 'NUCLEN_POST_FETCH_CHUNK' ) : 200;
+				$chunks    = count( $postIds ) <= $chunkSize ? array( $postIds ) : array_chunk( $postIds, $chunkSize );
 
-                foreach ( $chunks as $chunk ) {
-                        $posts = $this->fetcher->fetch( $chunk );
+				foreach ( $chunks as $chunk ) {
+						$posts = $this->fetcher->fetch( $chunk );
 
-                        foreach ( $posts as $post ) {
-                                $postsById[ (int) $post->ID ] = array(
-                                        'id'      => (int) $post->ID,
-                                        'title'   => $post->post_title,
-                                        'content' => wp_strip_all_tags( $post->post_content ),
-                                );
-                        }
-                }
+						foreach ( $posts as $post ) {
+								$postsById[ (int) $post->ID ] = array(
+										'id'      => (int) $post->ID,
+										'title'   => $post->post_title,
+										'content' => wp_strip_all_tags( $post->post_content ),
+								);
+						}
+				}
 
-        foreach ( $postIds as $id ) {
-            if ( isset( $postsById[ $id ] ) ) {
-                $data[] = $postsById[ $id ];
-            }
-        }
+		foreach ( $postIds as $id ) {
+			if ( isset( $postsById[ $id ] ) ) {
+				$data[] = $postsById[ $id ];
+			}
+		}
 
-        return $data;
-    }
+		return $data;
+	}
 
-    /**
-     * Check if content is protected from regeneration
-     *
-     * @param int    $postId
-     * @param string $workflowType
-     * @return bool
-     */
-    private function isProtected( int $postId, string $workflowType ): bool {
-        $metaKey = $workflowType === 'quiz' ? 'nuclen_quiz_protected' : Summary_Service::PROTECTED_KEY;
-        return (bool) get_post_meta( $postId, $metaKey, true );
-    }
+	/**
+	 * Check if content is protected from regeneration
+	 *
+	 * @param int    $postId
+	 * @param string $workflowType
+	 * @return bool
+	 */
+	private function isProtected( int $postId, string $workflowType ): bool {
+		$metaKey = $workflowType === 'quiz' ? 'nuclen_quiz_protected' : Summary_Service::PROTECTED_KEY;
+		return (bool) get_post_meta( $postId, $metaKey, true );
+	}
 }

--- a/nuclear-engagement/inc/Services/LoggingService.php
+++ b/nuclear-engagement/inc/Services/LoggingService.php
@@ -28,182 +28,182 @@ class LoggingService {
 	private bool $shutdown_registered = false;
 
 	public function __construct( AdminNoticeService $notices ) {
-	    $this->notices  = $notices;
-	    self::$instance = $this;
+		$this->notices  = $notices;
+		self::$instance = $this;
 	}
 
 	/** Retrieve the active instance. */
 	private static function instance(): self {
-	    if ( null === self::$instance ) {
-	        throw new \RuntimeException( 'LoggingService not initialized' );
-	    }
-	    return self::$instance;
+		if ( null === self::$instance ) {
+			throw new \RuntimeException( 'LoggingService not initialized' );
+		}
+		return self::$instance;
 	}
 
 	/** Forward static calls to the current instance. */
 	public static function __callStatic( string $name, array $arguments ) {
-	    $instance = self::instance();
-	    if ( ! method_exists( $instance, $name ) ) {
-	        throw new \BadMethodCallException( "Method {$name} does not exist" );
-	    }
-	    return $instance->$name( ...$arguments );
+		$instance = self::instance();
+		if ( ! method_exists( $instance, $name ) ) {
+			throw new \BadMethodCallException( "Method {$name} does not exist" );
+		}
+		return $instance->$name( ...$arguments );
 	}
 
 	/** Get directory, path and URL for the log file. */
 	public function get_log_file_info(): array {
-	    $upload_dir = wp_upload_dir();
+		$upload_dir = wp_upload_dir();
 
-	    if ( ! empty( $upload_dir['error'] ) ) {
-	        error_log( '[Nuclear Engagement] ' . $upload_dir['error'] );
-	        $this->add_admin_notice( 'Uploads directory unavailable. Using plugin directory for logs.' );
-	        $fallback_dir = rtrim( NUCLEN_PLUGIN_DIR, '/' ) . '/logs';
-	        return array(
-	            'dir'  => $fallback_dir,
-	            'path' => $fallback_dir . '/log.txt',
-	            'url'  => '',
-	        );
-	    }
+		if ( ! empty( $upload_dir['error'] ) ) {
+			error_log( '[Nuclear Engagement] ' . $upload_dir['error'] );
+			$this->add_admin_notice( 'Uploads directory unavailable. Using plugin directory for logs.' );
+			$fallback_dir = rtrim( NUCLEN_PLUGIN_DIR, '/' ) . '/logs';
+			return array(
+				'dir'  => $fallback_dir,
+				'path' => $fallback_dir . '/log.txt',
+				'url'  => '',
+			);
+		}
 
-	    $log_folder = $upload_dir['basedir'] . '/nuclear-engagement';
-	    $log_file   = $log_folder . '/log.txt';
-	    $log_url    = $upload_dir['baseurl'] . '/nuclear-engagement/log.txt';
+		$log_folder = $upload_dir['basedir'] . '/nuclear-engagement';
+		$log_file   = $log_folder . '/log.txt';
+		$log_url    = $upload_dir['baseurl'] . '/nuclear-engagement/log.txt';
 
-	    return array(
-	        'dir'  => $log_folder,
-	        'path' => $log_file,
-	        'url'  => $log_url,
-	    );
+		return array(
+			'dir'  => $log_folder,
+			'path' => $log_file,
+			'url'  => $log_url,
+		);
 	}
 
 	/** Store an admin notice and ensure the hook is registered. */
 	private function add_admin_notice( string $message ): void {
-	    $this->notices->add( $message );
+		$this->notices->add( $message );
 	}
 
 	/** Public helper to show an admin error notice. */
 	public function notify_admin( string $message ): void {
-	    $this->add_admin_notice( $message );
+		$this->add_admin_notice( $message );
 	}
 
 	/** Debug level logging, only when WP_DEBUG is true. */
 	public function debug( string $message ): void {
-	    if ( defined( 'WP_DEBUG' ) && WP_DEBUG ) {
-	        $this->log( '[DEBUG] ' . $message );
-	    }
+		if ( defined( 'WP_DEBUG' ) && WP_DEBUG ) {
+			$this->log( '[DEBUG] ' . $message );
+		}
 	}
 
 	/** Log an exception including file and line. */
 	public function log_exception( \Throwable $e ): void {
-	    $msg = $e->getMessage() . ' in ' . $e->getFile() . ':' . $e->getLine();
-	    if ( defined( 'WP_DEBUG' ) && WP_DEBUG ) {
-	        $trace_lines = explode( "\n", $e->getTraceAsString() );
-	        $trace       = implode( ' | ', array_slice( $trace_lines, 0, 3 ) );
-	        $msg        .= ' Stack trace: ' . $trace;
-	    }
-	    $this->log( $msg );
+		$msg = $e->getMessage() . ' in ' . $e->getFile() . ':' . $e->getLine();
+		if ( defined( 'WP_DEBUG' ) && WP_DEBUG ) {
+			$trace_lines = explode( "\n", $e->getTraceAsString() );
+			$trace       = implode( ' | ', array_slice( $trace_lines, 0, 3 ) );
+			$msg        .= ' Stack trace: ' . $trace;
+		}
+		$this->log( $msg );
 	}
 
 	/** Fallback when writing to the log fails. */
 	private function fallback( string $original, string $error ): void {
-	    $timestamp = gmdate( 'Y-m-d H:i:s' );
-	    error_log( "[Nuclear Engagement] [{$timestamp}] {$original} - {$error}" );
-	    $this->add_admin_notice( $error );
+		$timestamp = gmdate( 'Y-m-d H:i:s' );
+		error_log( "[Nuclear Engagement] [{$timestamp}] {$original} - {$error}" );
+		$this->add_admin_notice( $error );
 	}
 
 	/** Determine if logging should be buffered. */
 	private function use_buffer(): bool {
-	    $default = defined( 'NUCLEN_BUFFER_LOGS' ) ? (bool) NUCLEN_BUFFER_LOGS : true;
-	    return (bool) apply_filters( 'nuclen_enable_log_buffer', $default );
+		$default = defined( 'NUCLEN_BUFFER_LOGS' ) ? (bool) NUCLEN_BUFFER_LOGS : true;
+		return (bool) apply_filters( 'nuclen_enable_log_buffer', $default );
 	}
 
 	/** Flush buffered messages to the log file. */
 	public function flush(): void {
-	    if ( empty( $this->buffer ) ) {
-	        return;
-	    }
+		if ( empty( $this->buffer ) ) {
+			return;
+		}
 
-	    $this->write_messages( $this->buffer );
-	    $this->buffer = array();
+		$this->write_messages( $this->buffer );
+		$this->buffer = array();
 	}
 
 	/** Write one or more messages to the log. */
 	private function write_messages( array $messages ): void {
-	    $info       = $this->get_log_file_info();
-	    $log_folder = $info['dir'];
-	    $log_file   = $info['path'];
-	    $max_size   = defined( 'NUCLEN_LOG_FILE_MAX_SIZE' ) ? NUCLEN_LOG_FILE_MAX_SIZE : MB_IN_BYTES;
+		$info       = $this->get_log_file_info();
+		$log_folder = $info['dir'];
+		$log_file   = $info['path'];
+		$max_size   = defined( 'NUCLEN_LOG_FILE_MAX_SIZE' ) ? NUCLEN_LOG_FILE_MAX_SIZE : MB_IN_BYTES;
 
-	    if ( ! file_exists( $log_folder ) ) {
-	        if ( ! wp_mkdir_p( $log_folder ) ) {
-	            foreach ( $messages as $msg ) {
-	                $this->fallback( $msg, 'Failed to create log directory: ' . $log_folder );
-	            }
-	            return;
-	        }
-	    }
+		if ( ! file_exists( $log_folder ) ) {
+			if ( ! wp_mkdir_p( $log_folder ) ) {
+				foreach ( $messages as $msg ) {
+					$this->fallback( $msg, 'Failed to create log directory: ' . $log_folder );
+				}
+				return;
+			}
+		}
 
-	    if ( ! is_writable( $log_folder ) ) {
-	        foreach ( $messages as $msg ) {
-	            $this->fallback( $msg, 'Log directory not writable: ' . $log_folder );
-	        }
-	        return;
-	    }
+		if ( ! is_writable( $log_folder ) ) {
+			foreach ( $messages as $msg ) {
+				$this->fallback( $msg, 'Log directory not writable: ' . $log_folder );
+			}
+			return;
+		}
 
-	    if ( file_exists( $log_file ) && ! is_writable( $log_file ) ) {
-	        foreach ( $messages as $msg ) {
-	            $this->fallback( $msg, 'Log file not writable: ' . $log_file );
-	        }
-	        return;
-	    }
+		if ( file_exists( $log_file ) && ! is_writable( $log_file ) ) {
+			foreach ( $messages as $msg ) {
+				$this->fallback( $msg, 'Log file not writable: ' . $log_file );
+			}
+			return;
+		}
 
-	    if ( file_exists( $log_file ) && filesize( $log_file ) > $max_size ) {
-	        $timestamped = $log_folder . '/log-' . gmdate( 'Y-m-d-His' ) . '.txt';
-	        $renamed     = rename( $log_file, $timestamped );
-	        if ( ! $renamed ) {
-	            foreach ( $messages as $msg ) {
-	                $this->fallback( $msg, 'Failed to rotate log file: ' . $timestamped );
-	            }
-	        }
-	    }
+		if ( file_exists( $log_file ) && filesize( $log_file ) > $max_size ) {
+			$timestamped = $log_folder . '/log-' . gmdate( 'Y-m-d-His' ) . '.txt';
+			$renamed     = rename( $log_file, $timestamped );
+			if ( ! $renamed ) {
+				foreach ( $messages as $msg ) {
+					$this->fallback( $msg, 'Failed to rotate log file: ' . $timestamped );
+				}
+			}
+		}
 
-	    $data = '';
-	    if ( ! file_exists( $log_file ) ) {
-	        $timestamp = gmdate( 'Y-m-d H:i:s' );
-	        $data     .= "[{$timestamp}] Log file created\n";
-	    }
+		$data = '';
+		if ( ! file_exists( $log_file ) ) {
+			$timestamp = gmdate( 'Y-m-d H:i:s' );
+			$data     .= "[{$timestamp}] Log file created\n";
+		}
 
-	    foreach ( $messages as $msg ) {
-	        $timestamp = gmdate( 'Y-m-d H:i:s' );
-	        $data     .= "[{$timestamp}] {$msg}\n";
-	    }
+		foreach ( $messages as $msg ) {
+			$timestamp = gmdate( 'Y-m-d H:i:s' );
+			$data     .= "[{$timestamp}] {$msg}\n";
+		}
 
-	    if ( file_put_contents( $log_file, $data, FILE_APPEND | LOCK_EX ) === false ) {
-	        foreach ( $messages as $msg ) {
-	            $this->fallback( $msg, 'Failed to write to log file: ' . $log_file );
-	        }
-	    }
+		if ( file_put_contents( $log_file, $data, FILE_APPEND | LOCK_EX ) === false ) {
+			foreach ( $messages as $msg ) {
+				$this->fallback( $msg, 'Failed to write to log file: ' . $log_file );
+			}
+		}
 	}
 
 	/** Append a message to the plugin log file. */
 	public function log( string $message ): void {
-	    if ( $message === '' ) {
-	        return;
-	    }
+		if ( $message === '' ) {
+			return;
+		}
 
-	    $message = wp_strip_all_tags( $message );
-	    if ( strlen( $message ) > 1000 ) {
-	        $message = substr( $message, 0, 1000 ) . '...';
-	    }
+		$message = wp_strip_all_tags( $message );
+		if ( strlen( $message ) > 1000 ) {
+			$message = substr( $message, 0, 1000 ) . '...';
+		}
 
-	    if ( $this->use_buffer() ) {
-	        $this->buffer[] = $message;
-	        if ( ! $this->shutdown_registered ) {
-	            register_shutdown_function( array( self::class, 'flush' ) );
-	            $this->shutdown_registered = true;
-	        }
-	        return;
-	    }
+		if ( $this->use_buffer() ) {
+			$this->buffer[] = $message;
+			if ( ! $this->shutdown_registered ) {
+				register_shutdown_function( array( self::class, 'flush' ) );
+				$this->shutdown_registered = true;
+			}
+			return;
+		}
 
-	    $this->write_messages( array( $message ) );
+		$this->write_messages( array( $message ) );
 	}
 }

--- a/nuclear-engagement/inc/Services/OptinExportService.php
+++ b/nuclear-engagement/inc/Services/OptinExportService.php
@@ -20,65 +20,65 @@ class OptinExportService {
 	 * Stream the opt-in CSV file to the browser.
 	 */
 	public function stream_csv(): void {
-	    if ( ! current_user_can( 'manage_options' ) ) {
-	        wp_die( __( 'Insufficient permissions.', 'nuclear-engagement' ), 403 );
-	    }
+		if ( ! current_user_can( 'manage_options' ) ) {
+			wp_die( __( 'Insufficient permissions.', 'nuclear-engagement' ), 403 );
+		}
 
-	    $nonce = $_REQUEST['_wpnonce'] ?? '';
-	    if ( ! wp_verify_nonce( $nonce, 'nuclen_export_optin' ) ) {
-	        wp_die( __( 'Invalid nonce.', 'nuclear-engagement' ), 400 );
-	    }
+		$nonce = $_REQUEST['_wpnonce'] ?? '';
+		if ( ! wp_verify_nonce( $nonce, 'nuclen_export_optin' ) ) {
+			wp_die( __( 'Invalid nonce.', 'nuclear-engagement' ), 400 );
+		}
 
-	    global $wpdb;
+		global $wpdb;
 
-	    if ( ob_get_length() ) {
-	        ob_end_clean();
-	    }
-	    nocache_headers();
-	    header( 'Content-Type: text/csv; charset=utf-8' );
-	    header( 'Content-Disposition: attachment; filename=nuclen_optins_' . gmdate( 'Y-m-d' ) . '.csv' );
+		if ( ob_get_length() ) {
+			ob_end_clean();
+		}
+		nocache_headers();
+		header( 'Content-Type: text/csv; charset=utf-8' );
+		header( 'Content-Disposition: attachment; filename=nuclen_optins_' . gmdate( 'Y-m-d' ) . '.csv' );
 
-	    $out = fopen( 'php://output', 'w' );
-	    if ( false === $out ) {
-	        LoggingService::log( 'Failed to open output stream for CSV export' );
-	        wp_die( __( 'Unable to generate export.', 'nuclear-engagement' ), 500 );
-	    }
+		$out = fopen( 'php://output', 'w' );
+		if ( false === $out ) {
+			LoggingService::log( 'Failed to open output stream for CSV export' );
+			wp_die( __( 'Unable to generate export.', 'nuclear-engagement' ), 500 );
+		}
 
-	    if ( false === fputcsv( $out, array( 'datetime', 'url', 'name', 'email' ) ) ) {
-	        LoggingService::log( 'Failed writing CSV header' );
-	    }
+		if ( false === fputcsv( $out, array( 'datetime', 'url', 'name', 'email' ) ) ) {
+			LoggingService::log( 'Failed writing CSV header' );
+		}
 
-	    $limit  = 500;
-	    $offset = 0;
-	    do {
-	        $rows = $wpdb->get_results(
-	            $wpdb->prepare(
-	                "SELECT submitted_at AS datetime,
-	                    url,
-	                    name,
-	                    email
-	                FROM " . OptinData::table_name() . "
-	                ORDER BY submitted_at DESC
-	                LIMIT %d OFFSET %d",
-	                $limit,
-	                $offset
-	            ),
-	            ARRAY_A
-	        );
+		$limit  = 500;
+		$offset = 0;
+		do {
+			$rows = $wpdb->get_results(
+				$wpdb->prepare(
+					"SELECT submitted_at AS datetime,
+						url,
+						name,
+						email
+					FROM " . OptinData::table_name() . "
+					ORDER BY submitted_at DESC
+					LIMIT %d OFFSET %d",
+					$limit,
+					$offset
+				),
+				ARRAY_A
+			);
 
-	        foreach ( $rows as $r ) {
-	            $r['name']  = OptinData::escape_csv_field( $r['name'] );
-	            $r['email'] = OptinData::escape_csv_field( $r['email'] );
-	            $r['url']   = OptinData::escape_csv_field( $r['url'] );
-	            if ( false === fputcsv( $out, $r ) ) {
-	                LoggingService::log( 'Failed writing CSV row' );
-	            }
-	        }
+			foreach ( $rows as $r ) {
+				$r['name']  = OptinData::escape_csv_field( $r['name'] );
+				$r['email'] = OptinData::escape_csv_field( $r['email'] );
+				$r['url']   = OptinData::escape_csv_field( $r['url'] );
+				if ( false === fputcsv( $out, $r ) ) {
+					LoggingService::log( 'Failed writing CSV row' );
+				}
+			}
 
-	        $offset += $limit;
-	    } while ( count( $rows ) === $limit );
+			$offset += $limit;
+		} while ( count( $rows ) === $limit );
 
-	    fclose( $out );
-	    exit;
+		fclose( $out );
+		exit;
 	}
 }

--- a/nuclear-engagement/inc/Services/PointerService.php
+++ b/nuclear-engagement/inc/Services/PointerService.php
@@ -11,49 +11,49 @@ declare(strict_types=1);
 namespace NuclearEngagement\Services;
 
 if ( ! defined( 'ABSPATH' ) ) {
-    exit;
+	exit;
 }
 
 /**
  * Service for managing admin pointers
  */
 class PointerService {
-    /**
-     * Dismiss a pointer for a user
-     *
-     * @param string $pointerId
-     * @param int    $userId
-     * @throws \InvalidArgumentException On empty pointer ID
-     */
-    public function dismissPointer( string $pointerId, int $userId ): void {
-        if ( empty( $pointerId ) ) {
-            throw new \InvalidArgumentException( 'No pointer ID provided' );
-        }
+	/**
+	 * Dismiss a pointer for a user
+	 *
+	 * @param string $pointerId
+	 * @param int    $userId
+	 * @throws \InvalidArgumentException On empty pointer ID
+	 */
+	public function dismissPointer( string $pointerId, int $userId ): void {
+		if ( empty( $pointerId ) ) {
+			throw new \InvalidArgumentException( 'No pointer ID provided' );
+		}
 
-        update_user_meta( $userId, 'nuclen_pointer_dismissed_' . $pointerId, true );
-    }
+		update_user_meta( $userId, 'nuclen_pointer_dismissed_' . $pointerId, true );
+	}
 
-    /**
-     * Get undismissed pointers for a user
-     *
-     * @param array $pointers All pointers
-     * @param int   $userId
-     * @return array Undismissed pointers
-     */
-    public function getUndismissedPointers( array $pointers, int $userId ): array {
-        $undismissed = array();
+	/**
+	 * Get undismissed pointers for a user
+	 *
+	 * @param array $pointers All pointers
+	 * @param int   $userId
+	 * @return array Undismissed pointers
+	 */
+	public function getUndismissedPointers( array $pointers, int $userId ): array {
+		$undismissed = array();
 
-        foreach ( $pointers as $pointer ) {
-            if ( ! isset( $pointer['id'] ) ) {
-                continue;
-            }
+		foreach ( $pointers as $pointer ) {
+			if ( ! isset( $pointer['id'] ) ) {
+				continue;
+			}
 
-            $dismissed = get_user_meta( $userId, 'nuclen_pointer_dismissed_' . $pointer['id'], true );
-            if ( ! $dismissed ) {
-                $undismissed[] = $pointer;
-            }
-        }
+			$dismissed = get_user_meta( $userId, 'nuclen_pointer_dismissed_' . $pointer['id'], true );
+			if ( ! $dismissed ) {
+				$undismissed[] = $pointer;
+			}
+		}
 
-        return $undismissed;
-    }
+		return $undismissed;
+	}
 }

--- a/nuclear-engagement/inc/Services/PostDataFetcher.php
+++ b/nuclear-engagement/inc/Services/PostDataFetcher.php
@@ -13,92 +13,92 @@ namespace NuclearEngagement\Services;
 use NuclearEngagement\Modules\Summary\Summary_Service;
 
 if ( ! defined( 'ABSPATH' ) ) {
-    exit;
+	exit;
 }
 
 /**
  * Fetches post data for batches using $wpdb.
  */
 class PostDataFetcher {
-       /** Cache group for post fetch results. */
-       private const CACHE_GROUP = 'nuclen_post_fetch';
+	   /** Cache group for post fetch results. */
+	   private const CACHE_GROUP = 'nuclen_post_fetch';
 
-       /** Short cache lifetime in seconds. */
-       private const CACHE_TTL = 30;
+	   /** Short cache lifetime in seconds. */
+	   private const CACHE_TTL = 30;
 
-       /**
-        * Register hooks to clear cached entries when posts change.
-        */
-       public static function register_hooks(): void {
-               $cb = array( self::class, 'clear_cache' );
-               foreach ( array( 'save_post', 'deleted_post', 'clean_post_cache', 'switch_blog' ) as $hook ) {
-                       add_action( $hook, $cb );
-               }
-       }
+	   /**
+		* Register hooks to clear cached entries when posts change.
+		*/
+	   public static function register_hooks(): void {
+			   $cb = array( self::class, 'clear_cache' );
+			   foreach ( array( 'save_post', 'deleted_post', 'clean_post_cache', 'switch_blog' ) as $hook ) {
+					   add_action( $hook, $cb );
+			   }
+	   }
 
-       /**
-        * Flush the cached post data.
-        */
-       public static function clear_cache(): void {
-               if ( function_exists( 'wp_cache_flush_group' ) ) {
-                       wp_cache_flush_group( self::CACHE_GROUP );
-               } else {
-                       wp_cache_flush();
-               }
-       }
-    /**
-     * Retrieve post rows for the given IDs.
-     *
-     * Posts are filtered to published status and exclude those
-     * with quiz or summary protection meta set.
-     *
-     * @param array $ids Post IDs.
-     * @return array Rows from the posts table.
-     */
-       public function fetch( array $ids ): array {
-               global $wpdb;
+	   /**
+		* Flush the cached post data.
+		*/
+	   public static function clear_cache(): void {
+			   if ( function_exists( 'wp_cache_flush_group' ) ) {
+					   wp_cache_flush_group( self::CACHE_GROUP );
+			   } else {
+					   wp_cache_flush();
+			   }
+	   }
+	/**
+	 * Retrieve post rows for the given IDs.
+	 *
+	 * Posts are filtered to published status and exclude those
+	 * with quiz or summary protection meta set.
+	 *
+	 * @param array $ids Post IDs.
+	 * @return array Rows from the posts table.
+	 */
+	   public function fetch( array $ids ): array {
+			   global $wpdb;
 
-               if ( empty( $ids ) ) {
-                       return array();
-               }
+			   if ( empty( $ids ) ) {
+					   return array();
+			   }
 
-               $ids          = array_map( 'absint', $ids );
-               $cache_key    = md5( implode( ',', $ids ) . '|' . get_current_blog_id() );
-               $found        = false;
-               $cached       = wp_cache_get( $cache_key, self::CACHE_GROUP, false, $found );
-               if ( $found && is_array( $cached ) ) {
-                       return $cached;
-               }
+			   $ids          = array_map( 'absint', $ids );
+			   $cache_key    = md5( implode( ',', $ids ) . '|' . get_current_blog_id() );
+			   $found        = false;
+			   $cached       = wp_cache_get( $cache_key, self::CACHE_GROUP, false, $found );
+			   if ( $found && is_array( $cached ) ) {
+					   return $cached;
+			   }
 
-               $placeholders = implode( ',', array_fill( 0, count( $ids ), '%d' ) );
-               $order_ids    = implode( ',', $ids );
+			   $placeholders = implode( ',', array_fill( 0, count( $ids ), '%d' ) );
+			   $order_ids    = implode( ',', $ids );
 
-        $sql = $wpdb->prepare(
-            "SELECT p.ID, p.post_title, p.post_content
-             FROM {$wpdb->posts} p
-             LEFT JOIN {$wpdb->postmeta} pmq
-               ON pmq.post_id = p.ID
-              AND pmq.meta_key = %s
-             LEFT JOIN {$wpdb->postmeta} pms
-               ON pms.post_id = p.ID
-              AND pms.meta_key = %s
-             WHERE p.ID IN ($placeholders)
-               AND p.post_status = 'publish'
-               AND pmq.meta_id IS NULL
-               AND pms.meta_id IS NULL
-             ORDER BY FIELD(p.ID, $order_ids)",
-            array_merge( array( 'nuclen_quiz_protected', Summary_Service::PROTECTED_KEY ), $ids )
-        );
+		$sql = $wpdb->prepare(
+			"SELECT p.ID, p.post_title, p.post_content
+			 FROM {$wpdb->posts} p
+			 LEFT JOIN {$wpdb->postmeta} pmq
+			   ON pmq.post_id = p.ID
+			  AND pmq.meta_key = %s
+			 LEFT JOIN {$wpdb->postmeta} pms
+			   ON pms.post_id = p.ID
+			  AND pms.meta_key = %s
+			 WHERE p.ID IN ($placeholders)
+			   AND p.post_status = 'publish'
+			   AND pmq.meta_id IS NULL
+			   AND pms.meta_id IS NULL
+			 ORDER BY FIELD(p.ID, $order_ids)",
+			array_merge( array( 'nuclen_quiz_protected', Summary_Service::PROTECTED_KEY ), $ids )
+		);
 
-               $rows = $wpdb->get_results( $sql );
+			   $rows = $wpdb->get_results( $sql );
 
-               if ( ! empty( $wpdb->last_error ) ) {
-                       LoggingService::log( 'Post fetch error: ' . $wpdb->last_error );
-                       return array();
-               }
+			   if ( ! empty( $wpdb->last_error ) ) {
+					   LoggingService::log( 'Post fetch error: ' . $wpdb->last_error );
+					   return array();
+			   }
 
-               wp_cache_set( $cache_key, $rows, self::CACHE_GROUP, self::CACHE_TTL );
+			   wp_cache_set( $cache_key, $rows, self::CACHE_GROUP, self::CACHE_TTL );
 
-               return $rows;
-       }
+			   return $rows;
+	   }
 }

--- a/nuclear-engagement/inc/Services/PostsQueryService.php
+++ b/nuclear-engagement/inc/Services/PostsQueryService.php
@@ -15,282 +15,282 @@ use NuclearEngagement\Services\LoggingService;
 use NuclearEngagement\Modules\Summary\Summary_Service;
 
 if ( ! defined( 'ABSPATH' ) ) {
-    exit;
+	exit;
 }
 
 /**
  * Service for querying posts
  */
 class PostsQueryService {
-        /** Cache group for query results. */
-    private const CACHE_GROUP = 'nuclen_posts_query';
+		/** Cache group for query results. */
+	private const CACHE_GROUP = 'nuclen_posts_query';
 
-        /** Cache lifetime in seconds. */
-    private const CACHE_TTL = 10 * MINUTE_IN_SECONDS; // 10 minutes.
+		/** Cache lifetime in seconds. */
+	private const CACHE_TTL = 10 * MINUTE_IN_SECONDS; // 10 minutes.
 
-        /** Option name storing cache version. */
-    private const VERSION_OPTION = 'nuclen_posts_query_version';
+		/** Option name storing cache version. */
+	private const VERSION_OPTION = 'nuclen_posts_query_version';
 
-        /**
-         * Register hooks to invalidate caches when posts or terms change.
-         */
-    public static function register_hooks(): void {
-            $cb = array( self::class, 'clear_cache' );
+		/**
+		 * Register hooks to invalidate caches when posts or terms change.
+		 */
+	public static function register_hooks(): void {
+			$cb = array( self::class, 'clear_cache' );
 
-        foreach ( array(
-            'save_post',
-            'delete_post',
-            'deleted_post',
-            'trashed_post',
-            'untrashed_post',
-            'transition_post_status',
-            'clean_post_cache',
-        ) as $hook ) {
-                add_action( $hook, $cb );
-        }
+		foreach ( array(
+			'save_post',
+			'delete_post',
+			'deleted_post',
+			'trashed_post',
+			'untrashed_post',
+			'transition_post_status',
+			'clean_post_cache',
+		) as $hook ) {
+				add_action( $hook, $cb );
+		}
 
-        foreach ( array( 'added_post_meta', 'updated_post_meta', 'deleted_post_meta' ) as $hook ) {
-                add_action( $hook, $cb );
-        }
+		foreach ( array( 'added_post_meta', 'updated_post_meta', 'deleted_post_meta' ) as $hook ) {
+				add_action( $hook, $cb );
+		}
 
-        foreach ( array(
-            'create_term',
-            'created_term',
-            'edit_term',
-            'edited_term',
-            'delete_term',
-            'deleted_term',
-            'set_object_terms',
-            'added_term_relationship',
-            'deleted_term_relationships',
-            'edited_terms',
-        ) as $hook ) {
-                add_action( $hook, $cb );
-        }
+		foreach ( array(
+			'create_term',
+			'created_term',
+			'edit_term',
+			'edited_term',
+			'delete_term',
+			'deleted_term',
+			'set_object_terms',
+			'added_term_relationship',
+			'deleted_term_relationships',
+			'edited_terms',
+		) as $hook ) {
+				add_action( $hook, $cb );
+		}
 
-            add_action( 'switch_blog', $cb );
-    }
+			add_action( 'switch_blog', $cb );
+	}
 
-        /**
-         * Clear all cached query results.
-         */
-    public static function clear_cache(): void {
-            $version = (int) get_option( self::VERSION_OPTION, 1 );
-            update_option( self::VERSION_OPTION, $version + 1, false );
+		/**
+		 * Clear all cached query results.
+		 */
+	public static function clear_cache(): void {
+			$version = (int) get_option( self::VERSION_OPTION, 1 );
+			update_option( self::VERSION_OPTION, $version + 1, false );
 
-        if ( function_exists( 'wp_cache_flush_group' ) ) {
-                wp_cache_flush_group( self::CACHE_GROUP );
-        } else {
-                wp_cache_flush();
-        }
-    }
+		if ( function_exists( 'wp_cache_flush_group' ) ) {
+				wp_cache_flush_group( self::CACHE_GROUP );
+		} else {
+				wp_cache_flush();
+		}
+	}
 
-        /**
-         * Get current cache version.
-         */
-    private function get_cache_version(): int {
-            return (int) get_option( self::VERSION_OPTION, 1 );
-    }
+		/**
+		 * Get current cache version.
+		 */
+	private function get_cache_version(): int {
+			return (int) get_option( self::VERSION_OPTION, 1 );
+	}
 
-        /**
-         * Generate a cache key for the given request.
-         */
-    private function getCacheKey( PostsCountRequest $request ): string {
-            $data = array(
-                $request->postType,
-                $request->postStatus,
-                $request->categoryId,
-                $request->authorId,
-                $request->allowRegenerate ? 1 : 0,
-                $request->regenerateProtected ? 1 : 0,
-                $request->workflow,
-                $this->get_cache_version(),
-                get_current_blog_id(),
-            );
+		/**
+		 * Generate a cache key for the given request.
+		 */
+	private function getCacheKey( PostsCountRequest $request ): string {
+			$data = array(
+				$request->postType,
+				$request->postStatus,
+				$request->categoryId,
+				$request->authorId,
+				$request->allowRegenerate ? 1 : 0,
+				$request->regenerateProtected ? 1 : 0,
+				$request->workflow,
+				$this->get_cache_version(),
+				get_current_blog_id(),
+			);
 
-            return md5( wp_json_encode( $data ) );
-    }
+			return md5( wp_json_encode( $data ) );
+	}
 
-    /**
-     * Build query args from request
-     *
-     * @param PostsCountRequest $request
-     * @return array
-     */
-    public function buildQueryArgs( PostsCountRequest $request ): array {
-        $metaQuery = array( 'relation' => 'AND' );
+	/**
+	 * Build query args from request
+	 *
+	 * @param PostsCountRequest $request
+	 * @return array
+	 */
+	public function buildQueryArgs( PostsCountRequest $request ): array {
+		$metaQuery = array( 'relation' => 'AND' );
 
-        $queryArgs = array(
-            'post_type'      => $request->postType,
-            'posts_per_page' => -1,
-            'post_status'    => $request->postStatus,
-            'fields'         => 'ids',
-        );
+		$queryArgs = array(
+			'post_type'      => $request->postType,
+			'posts_per_page' => -1,
+			'post_status'    => $request->postStatus,
+			'fields'         => 'ids',
+		);
 
-        if ( $request->categoryId ) {
-            $queryArgs['cat'] = $request->categoryId;
-        }
+		if ( $request->categoryId ) {
+			$queryArgs['cat'] = $request->categoryId;
+		}
 
-        if ( $request->authorId ) {
-            $queryArgs['author'] = $request->authorId;
-        }
+		if ( $request->authorId ) {
+			$queryArgs['author'] = $request->authorId;
+		}
 
-        // Skip existing data if not allowing regeneration
-        if ( ! $request->allowRegenerate ) {
-            $metaKey     = $request->workflow === 'quiz' ? 'nuclen-quiz-data' : Summary_Service::META_KEY;
-            $metaQuery[] = array(
-                'key'     => $metaKey,
-                'compare' => 'NOT EXISTS',
-            );
-        }
+		// Skip existing data if not allowing regeneration
+		if ( ! $request->allowRegenerate ) {
+			$metaKey     = $request->workflow === 'quiz' ? 'nuclen-quiz-data' : Summary_Service::META_KEY;
+			$metaQuery[] = array(
+				'key'     => $metaKey,
+				'compare' => 'NOT EXISTS',
+			);
+		}
 
-        // Skip protected data if not allowed
-        if ( ! $request->regenerateProtected ) {
-            $protectedKey = $request->workflow === 'quiz' ? 'nuclen_quiz_protected' : Summary_Service::PROTECTED_KEY;
-            $metaQuery[]  = array(
-                'relation' => 'OR',
-                array(
-                    'key'     => $protectedKey,
-                    'compare' => 'NOT EXISTS',
-                ),
-                array(
-                    'key'     => $protectedKey,
-                    'value'   => '1',
-                    'compare' => '!=',
-                ),
-            );
-        }
+		// Skip protected data if not allowed
+		if ( ! $request->regenerateProtected ) {
+			$protectedKey = $request->workflow === 'quiz' ? 'nuclen_quiz_protected' : Summary_Service::PROTECTED_KEY;
+			$metaQuery[]  = array(
+				'relation' => 'OR',
+				array(
+					'key'     => $protectedKey,
+					'compare' => 'NOT EXISTS',
+				),
+				array(
+					'key'     => $protectedKey,
+					'value'   => '1',
+					'compare' => '!=',
+				),
+			);
+		}
 
-        // Only add meta_query if we have conditions
-        if ( count( $metaQuery ) > 1 ) {
-            $queryArgs['meta_query'] = $metaQuery;
-        }
+		// Only add meta_query if we have conditions
+		if ( count( $metaQuery ) > 1 ) {
+			$queryArgs['meta_query'] = $metaQuery;
+		}
 
-        // Disable caching for performance during counts
-        $queryArgs['update_post_meta_cache'] = false;
-        $queryArgs['update_post_term_cache'] = false;
-        $queryArgs['cache_results']          = false;
+		// Disable caching for performance during counts
+		$queryArgs['update_post_meta_cache'] = false;
+		$queryArgs['update_post_term_cache'] = false;
+		$queryArgs['cache_results']          = false;
 
-        return $queryArgs;
-    }
+		return $queryArgs;
+	}
 
-    /**
-     * Build SQL JOIN and WHERE clauses for a posts count query.
-     *
-     * @param PostsCountRequest $request
-     * @return string
-     */
-    private function build_sql_clauses( PostsCountRequest $request ): string {
-        global $wpdb;
+	/**
+	 * Build SQL JOIN and WHERE clauses for a posts count query.
+	 *
+	 * @param PostsCountRequest $request
+	 * @return string
+	 */
+	private function build_sql_clauses( PostsCountRequest $request ): string {
+		global $wpdb;
 
-        $joins  = array();
-        $wheres = array();
+		$joins  = array();
+		$wheres = array();
 
-        $wheres[] = $wpdb->prepare( 'p.post_type = %s', $request->postType );
+		$wheres[] = $wpdb->prepare( 'p.post_type = %s', $request->postType );
 
-        if ( 'any' !== $request->postStatus ) {
-            $wheres[] = $wpdb->prepare( 'p.post_status = %s', $request->postStatus );
-        }
+		if ( 'any' !== $request->postStatus ) {
+			$wheres[] = $wpdb->prepare( 'p.post_status = %s', $request->postStatus );
+		}
 
-        if ( $request->authorId ) {
-            $wheres[] = $wpdb->prepare( 'p.post_author = %d', $request->authorId );
-        }
+		if ( $request->authorId ) {
+			$wheres[] = $wpdb->prepare( 'p.post_author = %d', $request->authorId );
+		}
 
-        if ( $request->categoryId ) {
-            $joins[]  = "JOIN {$wpdb->term_relationships} tr ON tr.object_id = p.ID";
-            $joins[]  = "JOIN {$wpdb->term_taxonomy} tt ON tt.term_taxonomy_id = tr.term_taxonomy_id AND tt.taxonomy = 'category'";
-            $wheres[] = $wpdb->prepare( 'tt.term_id = %d', $request->categoryId );
-        }
+		if ( $request->categoryId ) {
+			$joins[]  = "JOIN {$wpdb->term_relationships} tr ON tr.object_id = p.ID";
+			$joins[]  = "JOIN {$wpdb->term_taxonomy} tt ON tt.term_taxonomy_id = tr.term_taxonomy_id AND tt.taxonomy = 'category'";
+			$wheres[] = $wpdb->prepare( 'tt.term_id = %d', $request->categoryId );
+		}
 
-        if ( ! $request->allowRegenerate ) {
-            $meta_key = $request->workflow === 'quiz' ? 'nuclen-quiz-data' : Summary_Service::META_KEY;
-            $joins[]  = $wpdb->prepare( "LEFT JOIN {$wpdb->postmeta} pm_exist ON pm_exist.post_id = p.ID AND pm_exist.meta_key = %s", $meta_key );
-            $wheres[] = 'pm_exist.meta_id IS NULL';
-        }
+		if ( ! $request->allowRegenerate ) {
+			$meta_key = $request->workflow === 'quiz' ? 'nuclen-quiz-data' : Summary_Service::META_KEY;
+			$joins[]  = $wpdb->prepare( "LEFT JOIN {$wpdb->postmeta} pm_exist ON pm_exist.post_id = p.ID AND pm_exist.meta_key = %s", $meta_key );
+			$wheres[] = 'pm_exist.meta_id IS NULL';
+		}
 
-        if ( ! $request->regenerateProtected ) {
-            $prot_key = $request->workflow === 'quiz' ? 'nuclen_quiz_protected' : Summary_Service::PROTECTED_KEY;
-            $joins[]  = $wpdb->prepare( "LEFT JOIN {$wpdb->postmeta} pm_prot ON pm_prot.post_id = p.ID AND pm_prot.meta_key = %s", $prot_key );
-            $wheres[] = "(pm_prot.meta_id IS NULL OR pm_prot.meta_value != '1')";
-        }
+		if ( ! $request->regenerateProtected ) {
+			$prot_key = $request->workflow === 'quiz' ? 'nuclen_quiz_protected' : Summary_Service::PROTECTED_KEY;
+			$joins[]  = $wpdb->prepare( "LEFT JOIN {$wpdb->postmeta} pm_prot ON pm_prot.post_id = p.ID AND pm_prot.meta_key = %s", $prot_key );
+			$wheres[] = "(pm_prot.meta_id IS NULL OR pm_prot.meta_value != '1')";
+		}
 
-        $sql = "FROM {$wpdb->posts} p " . implode( ' ', $joins );
-        if ( $wheres ) {
-            $sql .= ' WHERE ' . implode( ' AND ', $wheres );
-        }
+		$sql = "FROM {$wpdb->posts} p " . implode( ' ', $joins );
+		if ( $wheres ) {
+			$sql .= ' WHERE ' . implode( ' AND ', $wheres );
+		}
 
-        return $sql;
-    }
+		return $sql;
+	}
 
-    /**
-     * Execute the COUNT query for posts.
-     *
-     * @param string $sql
-     * @return int
-     */
-    private function execute_count_query( string $sql ): int {
-        global $wpdb;
+	/**
+	 * Execute the COUNT query for posts.
+	 *
+	 * @param string $sql
+	 * @return int
+	 */
+	private function execute_count_query( string $sql ): int {
+		global $wpdb;
 
-        $count = (int) $wpdb->get_var( "SELECT COUNT(DISTINCT p.ID) $sql" );
+		$count = (int) $wpdb->get_var( "SELECT COUNT(DISTINCT p.ID) $sql" );
 
-        if ( $wpdb->last_error ) {
-            LoggingService::log( 'Posts query error: ' . $wpdb->last_error );
-        }
+		if ( $wpdb->last_error ) {
+			LoggingService::log( 'Posts query error: ' . $wpdb->last_error );
+		}
 
-        return $count;
-    }
+		return $count;
+	}
 
-    /**
-     * Get posts count and IDs
-     *
-     * @param PostsCountRequest $request
-     * @return array
-     */
-    public function getPostsCount( PostsCountRequest $request ): array {
-            $cache_key     = $this->getCacheKey( $request );
-            $transient_key = 'nuclen_pq_' . $cache_key;
-            $found         = false;
-            $cached        = wp_cache_get( $cache_key, self::CACHE_GROUP, false, $found );
-        if ( ! $found ) {
-                $cached = get_transient( $transient_key );
-        }
+	/**
+	 * Get posts count and IDs
+	 *
+	 * @param PostsCountRequest $request
+	 * @return array
+	 */
+	public function getPostsCount( PostsCountRequest $request ): array {
+			$cache_key     = $this->getCacheKey( $request );
+			$transient_key = 'nuclen_pq_' . $cache_key;
+			$found         = false;
+			$cached        = wp_cache_get( $cache_key, self::CACHE_GROUP, false, $found );
+		if ( ! $found ) {
+				$cached = get_transient( $transient_key );
+		}
 
-        if ( is_array( $cached ) ) {
-                    return $cached;
-        }
+		if ( is_array( $cached ) ) {
+					return $cached;
+		}
 
-        global $wpdb;
+		global $wpdb;
 
-        $sql   = $this->build_sql_clauses( $request );
-        $count = $this->execute_count_query( $sql );
+		$sql   = $this->build_sql_clauses( $request );
+		$count = $this->execute_count_query( $sql );
 
-                $post_ids = array();
-                $limit    = 1000;
-                $offset   = 0;
+				$post_ids = array();
+				$limit    = 1000;
+				$offset   = 0;
 
-        do {
-                $query    = $wpdb->prepare(
-                    "SELECT DISTINCT p.ID $sql ORDER BY p.ID ASC LIMIT %d OFFSET %d",
-                    $limit,
-                    $offset
-                );
-                $batch    = $wpdb->get_col( $query );
-                $post_ids = array_merge( $post_ids, $batch );
-                $offset  += $limit;
-        } while ( count( $batch ) === $limit );
+		do {
+				$query    = $wpdb->prepare(
+					"SELECT DISTINCT p.ID $sql ORDER BY p.ID ASC LIMIT %d OFFSET %d",
+					$limit,
+					$offset
+				);
+				$batch    = $wpdb->get_col( $query );
+				$post_ids = array_merge( $post_ids, $batch );
+				$offset  += $limit;
+		} while ( count( $batch ) === $limit );
 
-        if ( $wpdb->last_error ) {
-                LoggingService::log( 'Posts query error: ' . $wpdb->last_error );
-        }
+		if ( $wpdb->last_error ) {
+				LoggingService::log( 'Posts query error: ' . $wpdb->last_error );
+		}
 
-                $result = array(
-                    'count'    => $count,
-                    'post_ids' => $post_ids,
-                );
+				$result = array(
+					'count'    => $count,
+					'post_ids' => $post_ids,
+				);
 
-                wp_cache_set( $cache_key, $result, self::CACHE_GROUP, self::CACHE_TTL );
-                set_transient( $transient_key, $result, self::CACHE_TTL );
+				wp_cache_set( $cache_key, $result, self::CACHE_GROUP, self::CACHE_TTL );
+				set_transient( $transient_key, $result, self::CACHE_TTL );
 
-                return $result;
-    }
+				return $result;
+	}
 }

--- a/nuclear-engagement/inc/Services/PublishGenerationHandler.php
+++ b/nuclear-engagement/inc/Services/PublishGenerationHandler.php
@@ -16,91 +16,91 @@ use NuclearEngagement\Core\SettingsRepository;
 use NuclearEngagement\Modules\Summary\Summary_Service;
 
 if ( ! defined( 'ABSPATH' ) ) {
-        exit;
+		exit;
 }
 
 /**
  * Handles generation events when a post is published.
  */
 class PublishGenerationHandler {
-    /**
-     * @var SettingsRepository
-     */
-    private SettingsRepository $settings_repository;
+	/**
+	 * @var SettingsRepository
+	 */
+	private SettingsRepository $settings_repository;
 
-        /**
-         * Constructor.
-         *
-         * @param SettingsRepository $settings_repository Repository of plugin settings.
-         */
-    public function __construct( SettingsRepository $settings_repository ) {
-            $this->settings_repository = $settings_repository;
-    }
+		/**
+		 * Constructor.
+		 *
+		 * @param SettingsRepository $settings_repository Repository of plugin settings.
+		 */
+	public function __construct( SettingsRepository $settings_repository ) {
+			$this->settings_repository = $settings_repository;
+	}
 
-    /**
-     * Register the publish transition hook.
-     */
-    public function register_hooks(): void {
-        add_action( 'transition_post_status', array( $this, 'handle_post_publish' ), 10, 3 );
-    }
+	/**
+	 * Register the publish transition hook.
+	 */
+	public function register_hooks(): void {
+		add_action( 'transition_post_status', array( $this, 'handle_post_publish' ), 10, 3 );
+	}
 
-        /**
-         * Handle post publish transition.
-         *
-         * @param string   $new_status New post status.
-         * @param string   $old_status Old post status.
-         * @param \WP_Post $post    Post object.
-         */
-    public function handle_post_publish( $new_status, $old_status, $post ): void {
-        if ( 'publish' === $old_status || 'publish' !== $new_status ) {
-                return;
-        }
+		/**
+		 * Handle post publish transition.
+		 *
+		 * @param string   $new_status New post status.
+		 * @param string   $old_status Old post status.
+		 * @param \WP_Post $post    Post object.
+		 */
+	public function handle_post_publish( $new_status, $old_status, $post ): void {
+		if ( 'publish' === $old_status || 'publish' !== $new_status ) {
+				return;
+		}
 
-            // Prevent unauthorized users from triggering generation.
-        if ( ! wp_doing_cron() && ! current_user_can( 'publish_post', $post->ID ) ) {
-                    return;
-        }
+			// Prevent unauthorized users from triggering generation.
+		if ( ! wp_doing_cron() && ! current_user_can( 'publish_post', $post->ID ) ) {
+					return;
+		}
 
-                $allowed_post_types = $this->settings_repository->get( 'generation_post_types', array( 'post' ) );
-        if ( ! in_array( $post->post_type, (array) $allowed_post_types, true ) ) {
-            return;
-        }
+				$allowed_post_types = $this->settings_repository->get( 'generation_post_types', array( 'post' ) );
+		if ( ! in_array( $post->post_type, (array) $allowed_post_types, true ) ) {
+			return;
+		}
 
-                $gen_quiz    = (bool) $this->settings_repository->get( 'auto_generate_quiz_on_publish', false );
-                $gen_summary = (bool) $this->settings_repository->get( 'auto_generate_summary_on_publish', false );
+				$gen_quiz    = (bool) $this->settings_repository->get( 'auto_generate_quiz_on_publish', false );
+				$gen_summary = (bool) $this->settings_repository->get( 'auto_generate_summary_on_publish', false );
 
-        if ( ! $gen_quiz && ! $gen_summary ) {
-            return;
-        }
+		if ( ! $gen_quiz && ! $gen_summary ) {
+			return;
+		}
 
-        if ( $gen_quiz ) {
-            $protected = get_post_meta( $post->ID, 'nuclen_quiz_protected', true );
-            if ( ! $protected ) {
-                $args = array( $post->ID, 'quiz' );
-                if ( ! wp_next_scheduled( AutoGenerationService::START_HOOK, $args ) ) {
-                        $scheduled = wp_schedule_single_event( time(), AutoGenerationService::START_HOOK, $args );
-                    if ( false === $scheduled ) {
-                                        \NuclearEngagement\Services\LoggingService::log(
-                                            'Failed to schedule event ' . AutoGenerationService::START_HOOK
-                                        );
-                    }
-                }
-            }
-        }
+		if ( $gen_quiz ) {
+			$protected = get_post_meta( $post->ID, 'nuclen_quiz_protected', true );
+			if ( ! $protected ) {
+				$args = array( $post->ID, 'quiz' );
+				if ( ! wp_next_scheduled( AutoGenerationService::START_HOOK, $args ) ) {
+						$scheduled = wp_schedule_single_event( time(), AutoGenerationService::START_HOOK, $args );
+					if ( false === $scheduled ) {
+										\NuclearEngagement\Services\LoggingService::log(
+											'Failed to schedule event ' . AutoGenerationService::START_HOOK
+										);
+					}
+				}
+			}
+		}
 
-        if ( $gen_summary ) {
-            $protected = get_post_meta( $post->ID, Summary_Service::PROTECTED_KEY, true );
-            if ( ! $protected ) {
-                $args = array( $post->ID, 'summary' );
-                if ( ! wp_next_scheduled( AutoGenerationService::START_HOOK, $args ) ) {
-                        $scheduled = wp_schedule_single_event( time(), AutoGenerationService::START_HOOK, $args );
-                    if ( false === $scheduled ) {
-                                        \NuclearEngagement\Services\LoggingService::log(
-                                            'Failed to schedule event ' . AutoGenerationService::START_HOOK
-                                        );
-                    }
-                }
-            }
-        }
-    }
+		if ( $gen_summary ) {
+			$protected = get_post_meta( $post->ID, Summary_Service::PROTECTED_KEY, true );
+			if ( ! $protected ) {
+				$args = array( $post->ID, 'summary' );
+				if ( ! wp_next_scheduled( AutoGenerationService::START_HOOK, $args ) ) {
+						$scheduled = wp_schedule_single_event( time(), AutoGenerationService::START_HOOK, $args );
+					if ( false === $scheduled ) {
+										\NuclearEngagement\Services\LoggingService::log(
+											'Failed to schedule event ' . AutoGenerationService::START_HOOK
+										);
+					}
+				}
+			}
+		}
+	}
 }

--- a/nuclear-engagement/inc/Services/RemoteApiService.php
+++ b/nuclear-engagement/inc/Services/RemoteApiService.php
@@ -20,7 +20,7 @@ use NuclearEngagement\Services\Remote\RemoteRequest;
 use NuclearEngagement\Services\Remote\ApiResponseHandler;
 
 if ( ! defined( 'ABSPATH' ) ) {
-    exit;
+	exit;
 }
 
 /**
@@ -28,114 +28,114 @@ if ( ! defined( 'ABSPATH' ) ) {
  */
 class RemoteApiService {
 
-    /** Cache group for API responses. */
-    private const CACHE_GROUP = 'nuclen_remote';
+	/** Cache group for API responses. */
+	private const CACHE_GROUP = 'nuclen_remote';
 
-    /** Short cache lifetime for update polling. */
-    private const CACHE_TTL = 60; // 60 seconds
+	/** Short cache lifetime for update polling. */
+	private const CACHE_TTL = 60; // 60 seconds
 
-    /**
-     * @var SettingsRepository
-     */
-    private SettingsRepository $settings;
+	/**
+	 * @var SettingsRepository
+	 */
+	private SettingsRepository $settings;
 
 
-    private RemoteRequest $request;
+	private RemoteRequest $request;
 
-    private ApiResponseHandler $handler;
+	private ApiResponseHandler $handler;
 
-    /**
-     * Constructor
-     *
-     * @param SettingsRepository $settings
-     */
-    public function __construct( SettingsRepository $settings, RemoteRequest $request, ApiResponseHandler $handler ) {
-        $this->settings = $settings;
-        $this->request  = $request;
-        $this->handler  = $handler;
-    }
+	/**
+	 * Constructor
+	 *
+	 * @param SettingsRepository $settings
+	 */
+	public function __construct( SettingsRepository $settings, RemoteRequest $request, ApiResponseHandler $handler ) {
+		$this->settings = $settings;
+		$this->request  = $request;
+		$this->handler  = $handler;
+	}
 
-    /**
-     * Send posts to remote API for content generation
-     *
-     * @param array $data Data to send.
-     * @return array Response data on success
-     * @throws \RuntimeException On API errors
-     */
-    public function send_posts_to_generate( array $data ): array {
-        $api_key       = $this->settings->get_string( 'api_key', '' );
-        $generation_id = $data['generation_id'] ?? '';
+	/**
+	 * Send posts to remote API for content generation
+	 *
+	 * @param array $data Data to send.
+	 * @return array Response data on success
+	 * @throws \RuntimeException On API errors
+	 */
+	public function send_posts_to_generate( array $data ): array {
+		$api_key       = $this->settings->get_string( 'api_key', '' );
+		$generation_id = $data['generation_id'] ?? '';
 
-        if ( empty( $api_key ) ) {
-            throw new \RuntimeException( 'API key not configured' );
-        }
+		if ( empty( $api_key ) ) {
+			throw new \RuntimeException( 'API key not configured' );
+		}
 
-        $cache_key = 'nuclen_update_' . $generation_id;
-        $found     = false;
-        $cached    = wp_cache_get( $cache_key, self::CACHE_GROUP, false, $found );
-        if ( ! $found ) {
-            $cached = get_transient( $cache_key );
-        }
+		$cache_key = 'nuclen_update_' . $generation_id;
+		$found     = false;
+		$cached    = wp_cache_get( $cache_key, self::CACHE_GROUP, false, $found );
+		if ( ! $found ) {
+			$cached = get_transient( $cache_key );
+		}
 
-        if ( is_array( $cached ) ) {
-            return $cached;
-        }
+		if ( is_array( $cached ) ) {
+			return $cached;
+		}
 
-        $payload = array(
-            'generation_id' => $generation_id,
-            'api_key'       => $api_key,
-            'siteUrl'       => get_site_url(),
-            'posts'         => array_values(
-                array_filter(
-                    $data['posts'] ?? array(),
-                    function ( $p ) {
-                        return ! empty( $p['id'] ) && ! empty( $p['title'] ) && ! empty( $p['content'] );
-                    }
-                )
-            ),
-            'workflow'      => $data['workflow'] ?? array(),
-        );
+		$payload = array(
+			'generation_id' => $generation_id,
+			'api_key'       => $api_key,
+			'siteUrl'       => get_site_url(),
+			'posts'         => array_values(
+				array_filter(
+					$data['posts'] ?? array(),
+					function ( $p ) {
+						return ! empty( $p['id'] ) && ! empty( $p['title'] ) && ! empty( $p['content'] );
+					}
+				)
+			),
+			'workflow'      => $data['workflow'] ?? array(),
+		);
 
-        \NuclearEngagement\Services\LoggingService::log( 'Sending generation request: ' . $generation_id ); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
+		\NuclearEngagement\Services\LoggingService::log( 'Sending generation request: ' . $generation_id ); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
 
-        $response = $this->request->post( '/process-posts', $payload, $api_key );
+		$response = $this->request->post( '/process-posts', $payload, $api_key );
 
-        return $this->handler->handle( $response );
-    }
+		return $this->handler->handle( $response );
+	}
 
-    /**
-     * Fetch generation updates from remote API
-     *
-     * @param string $generation_id Generation identifier.
-     * @return array API response data.
-     * @throws \RuntimeException On API errors
-     */
-    public function fetch_updates( string $generation_id ): array {
-        $api_key = $this->settings->get_string( 'api_key', '' );
+	/**
+	 * Fetch generation updates from remote API
+	 *
+	 * @param string $generation_id Generation identifier.
+	 * @return array API response data.
+	 * @throws \RuntimeException On API errors
+	 */
+	public function fetch_updates( string $generation_id ): array {
+		$api_key = $this->settings->get_string( 'api_key', '' );
 
-        if ( empty( $api_key ) ) {
-            throw new \RuntimeException( 'API key not configured' );
-        }
+		if ( empty( $api_key ) ) {
+			throw new \RuntimeException( 'API key not configured' );
+		}
 
-        $payload = array(
-            'siteUrl'       => get_site_url(),
-            'generation_id' => $generation_id,
-        );
+		$payload = array(
+			'siteUrl'       => get_site_url(),
+			'generation_id' => $generation_id,
+		);
 
-        if ( empty( $generation_id ) ) {
-            \NuclearEngagement\Services\LoggingService::log( 'Fetching credits only (no generation_id)' ); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
-        } else {
-            \NuclearEngagement\Services\LoggingService::log( "Fetching updates for generation: {$generation_id}" ); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
-        }
+		if ( empty( $generation_id ) ) {
+			\NuclearEngagement\Services\LoggingService::log( 'Fetching credits only (no generation_id)' ); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
+		} else {
+			\NuclearEngagement\Services\LoggingService::log( "Fetching updates for generation: {$generation_id}" ); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
+		}
 
-        $response = $this->request->post( '/updates', $payload, $api_key );
+		$response = $this->request->post( '/updates', $payload, $api_key );
 
-        $data = $this->handler->handle( $response );
+		$data = $this->handler->handle( $response );
 
-        $cache_key = 'nuclen_update_' . $generation_id;
-        wp_cache_set( $cache_key, $data, self::CACHE_GROUP, self::CACHE_TTL );
-        set_transient( $cache_key, $data, self::CACHE_TTL );
+		$cache_key = 'nuclen_update_' . $generation_id;
+		wp_cache_set( $cache_key, $data, self::CACHE_GROUP, self::CACHE_TTL );
+		set_transient( $cache_key, $data, self::CACHE_TTL );
 
-        return $data;
-    }
+		return $data;
+	}
 }

--- a/nuclear-engagement/inc/Services/SetupService.php
+++ b/nuclear-engagement/inc/Services/SetupService.php
@@ -18,7 +18,7 @@ use NuclearEngagement\Services\Remote\RemoteRequest;
 
 // If this file is called directly, abort.
 if ( ! defined( 'ABSPATH' ) ) {
-    exit;
+	exit;
 }
 
 /**
@@ -31,118 +31,118 @@ if ( ! defined( 'ABSPATH' ) ) {
  */
 class SetupService {
 
-    /**
-     * Default timeout for API requests in seconds.
-     *
-     * @since 1.0.0
-     * @var int
-     */
-    private const DEFAULT_TIMEOUT = 30;
+	/**
+	 * Default timeout for API requests in seconds.
+	 *
+	 * @since 1.0.0
+	 * @var int
+	 */
+	private const DEFAULT_TIMEOUT = 30;
 
-    /**
-     * Utilities instance.
-     *
-     * @since 1.0.0
-     * @var Utils
-     */
-    private Utils $utils;
+	/**
+	 * Utilities instance.
+	 *
+	 * @since 1.0.0
+	 * @var Utils
+	 */
+	private Utils $utils;
 
-    /**
-     * Constructor.
-     *
-     * @since 1.0.0
-     */
-    public function __construct() {
-        $this->utils = new Utils();
-    }
+	/**
+	 * Constructor.
+	 *
+	 * @since 1.0.0
+	 */
+	public function __construct() {
+		$this->utils = new Utils();
+	}
 
-    /**
-     * Validate the provided API key with the SaaS.
-     *
-     * @since 1.0.0
-     *
-     * @param string $api_key API key to validate.
-     * @return bool Whether the key is valid.
-     */
-    public function validate_api_key( string $api_key ): bool {
-        if ( '' === $api_key ) {
-            return false;
-        }
+	/**
+	 * Validate the provided API key with the SaaS.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @param string $api_key API key to validate.
+	 * @return bool Whether the key is valid.
+	 */
+	public function validate_api_key( string $api_key ): bool {
+		if ( '' === $api_key ) {
+			return false;
+		}
 
-        $timeout = defined( 'NUCLEN_API_TIMEOUT' ) ? NUCLEN_API_TIMEOUT : self::DEFAULT_TIMEOUT;
+		$timeout = defined( 'NUCLEN_API_TIMEOUT' ) ? NUCLEN_API_TIMEOUT : self::DEFAULT_TIMEOUT;
 
-        $response = wp_remote_post(
-            RemoteRequest::API_BASE . '/check-api-key',
-            array(
-                'method'             => 'POST',
-                'headers'            => array( 'Content-Type' => 'application/json' ),
-                'body'               => wp_json_encode( array( 'appApiKey' => $api_key ) ),
-                'timeout'            => $timeout,
-                'reject_unsafe_urls' => true,
-                'user-agent'         => 'NuclearEngagement/' . ( defined( 'NUCLEN_PLUGIN_VERSION' ) ? NUCLEN_PLUGIN_VERSION : '1.0.0' ),
-            )
-        );
+		$response = wp_remote_post(
+			RemoteRequest::API_BASE . '/check-api-key',
+			array(
+				'method'             => 'POST',
+				'headers'            => array( 'Content-Type' => 'application/json' ),
+				'body'               => wp_json_encode( array( 'appApiKey' => $api_key ) ),
+				'timeout'            => $timeout,
+				'reject_unsafe_urls' => true,
+				'user-agent'         => 'NuclearEngagement/' . ( defined( 'NUCLEN_PLUGIN_VERSION' ) ? NUCLEN_PLUGIN_VERSION : '1.0.0' ),
+			)
+		);
 
-        if ( is_wp_error( $response ) ) {
-            LoggingService::log( 'API-key validation error: ' . $response->get_error_message() );
-            LoggingService::notify_admin( 'Failed to validate API key.' );
-            return false;
-        }
+		if ( is_wp_error( $response ) ) {
+			LoggingService::log( 'API-key validation error: ' . $response->get_error_message() );
+			LoggingService::notify_admin( 'Failed to validate API key.' );
+			return false;
+		}
 
-        $code = wp_remote_retrieve_response_code( $response );
-        $body = wp_remote_retrieve_body( $response );
-        LoggingService::debug( 'API key validation response: ' . $body );
+		$code = wp_remote_retrieve_response_code( $response );
+		$body = wp_remote_retrieve_body( $response );
+		LoggingService::debug( 'API key validation response: ' . $body );
 
-        if ( 200 !== $code ) {
-            LoggingService::log( 'Unexpected API-key validation response code: ' . $code . ', body: ' . $body );
-            LoggingService::notify_admin( 'Failed to validate API key.' );
-            return false;
-        }
+		if ( 200 !== $code ) {
+			LoggingService::log( 'Unexpected API-key validation response code: ' . $code . ', body: ' . $body );
+			LoggingService::notify_admin( 'Failed to validate API key.' );
+			return false;
+		}
 
-        return true;
-    }
+		return true;
+	}
 
-    /**
-     * Send the generated WordPress credentials to the SaaS.
-     *
-     * @since 1.0.0
-     *
-     * @param array $data Credential payload containing appApiKey and other credentials.
-     * @return bool True on success, false on failure.
-     */
-    public function send_app_password( array $data ): bool {
-        if ( empty( $data['appApiKey'] ) ) {
-            return false;
-        }
+	/**
+	 * Send the generated WordPress credentials to the SaaS.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @param array $data Credential payload containing appApiKey and other credentials.
+	 * @return bool True on success, false on failure.
+	 */
+	public function send_app_password( array $data ): bool {
+		if ( empty( $data['appApiKey'] ) ) {
+			return false;
+		}
 
-        $response = wp_remote_post(
-            RemoteRequest::API_BASE . '/store-wp-creds',
-            array(
-                'method'             => 'POST',
-                'headers'            => array( 'Content-Type' => 'application/json' ),
-                'body'               => wp_json_encode( $data ),
-                'timeout'            => NUCLEN_API_TIMEOUT,
-                'reject_unsafe_urls' => true,
-                'user-agent'         => 'NuclearEngagement/' . NUCLEN_PLUGIN_VERSION,
-            )
-        );
+		$response = wp_remote_post(
+			RemoteRequest::API_BASE . '/store-wp-creds',
+			array(
+				'method'             => 'POST',
+				'headers'            => array( 'Content-Type' => 'application/json' ),
+				'body'               => wp_json_encode( $data ),
+				'timeout'            => NUCLEN_API_TIMEOUT,
+				'reject_unsafe_urls' => true,
+				'user-agent'         => 'NuclearEngagement/' . NUCLEN_PLUGIN_VERSION,
+			)
+		);
 
-        if ( is_wp_error( $response ) ) {
-                \NuclearEngagement\Services\LoggingService::log( 'Error sending creds: ' . $response->get_error_message() );
-                \NuclearEngagement\Services\LoggingService::notify_admin( 'Failed to send WordPress credentials.' );
-                return false;
-        }
+		if ( is_wp_error( $response ) ) {
+				\NuclearEngagement\Services\LoggingService::log( 'Error sending creds: ' . $response->get_error_message() );
+				\NuclearEngagement\Services\LoggingService::notify_admin( 'Failed to send WordPress credentials.' );
+				return false;
+		}
 
-                $code = wp_remote_retrieve_response_code( $response );
-                $body = wp_remote_retrieve_body( $response );
-                \NuclearEngagement\Services\LoggingService::debug( 'Send creds response: ' . $body );
+				$code = wp_remote_retrieve_response_code( $response );
+				$body = wp_remote_retrieve_body( $response );
+				\NuclearEngagement\Services\LoggingService::debug( 'Send creds response: ' . $body );
 
-        if ( 200 !== $code ) {
-                \NuclearEngagement\Services\LoggingService::log( 'Unexpected creds response code: ' . $code . ', body: ' . $body );
-                \NuclearEngagement\Services\LoggingService::notify_admin( 'Failed to send WordPress credentials.' );
-                return false;
-        }
+		if ( 200 !== $code ) {
+				\NuclearEngagement\Services\LoggingService::log( 'Unexpected creds response code: ' . $code . ', body: ' . $body );
+				\NuclearEngagement\Services\LoggingService::notify_admin( 'Failed to send WordPress credentials.' );
+				return false;
+		}
 
-                return true;
-    }
+				return true;
+	}
 }

--- a/nuclear-engagement/inc/Services/VersionService.php
+++ b/nuclear-engagement/inc/Services/VersionService.php
@@ -17,7 +17,7 @@ use NuclearEngagement\Core\AssetVersions;
 
 // If this file is called directly, abort.
 if ( ! defined( 'ABSPATH' ) ) {
-    exit;
+	exit;
 }
 
 /**
@@ -30,33 +30,33 @@ if ( ! defined( 'ABSPATH' ) ) {
  */
 final class VersionService {
 
-    /**
-     * Retrieve a version string for the given asset key.
-     *
-     * @since 1.0.0
-     *
-     * @param string $key The unique identifier for the asset (e.g., 'admin-css', 'frontend-js').
-     * @return string The version string for the given asset key, or empty string if not found.
-     *
-     * @throws \InvalidArgumentException If the provided key is empty.
-     */
-    public function get( string $key ): string {
-        if ( '' === trim( $key ) ) {
-            throw new \InvalidArgumentException( 'Asset key cannot be empty.' );
-        }
+	/**
+	 * Retrieve a version string for the given asset key.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @param string $key The unique identifier for the asset (e.g., 'admin-css', 'frontend-js').
+	 * @return string The version string for the given asset key, or empty string if not found.
+	 *
+	 * @throws \InvalidArgumentException If the provided key is empty.
+	 */
+	public function get( string $key ): string {
+		if ( '' === trim( $key ) ) {
+			throw new \InvalidArgumentException( 'Asset key cannot be empty.' );
+		}
 
-        /**
-         * Filters the version string for a given asset.
-         *
-         * @since 1.0.0
-         *
-         * @param string $version The version string for the asset.
-         * @param string $key    The asset key being requested.
-         */
-        return (string) apply_filters(
-            'nuclen_asset_version',
-            AssetVersions::get( $key ),
-            $key
-        );
-    }
+		/**
+		 * Filters the version string for a given asset.
+		 *
+		 * @since 1.0.0
+		 *
+		 * @param string $version The version string for the asset.
+		 * @param string $key    The asset key being requested.
+		 */
+		return (string) apply_filters(
+			'nuclen_asset_version',
+			AssetVersions::get( $key ),
+			$key
+		);
+	}
 }

--- a/nuclear-engagement/inc/Traits/SettingsAccessTrait.php
+++ b/nuclear-engagement/inc/Traits/SettingsAccessTrait.php
@@ -15,7 +15,7 @@ namespace NuclearEngagement\Traits;
 
 // If this file is called directly, abort.
 if ( ! defined( 'ABSPATH' ) ) {
-    exit;
+	exit;
 }
 
 /**
@@ -27,124 +27,124 @@ if ( ! defined( 'ABSPATH' ) ) {
  */
 trait SettingsAccessTrait {
 
-    /**
-     * Get a string setting.
-     *
-     * @since 1.0.0
-     *
-     * @param string $key          Setting key.
-     * @param string $default_value Default value if setting doesn't exist. Default empty string.
-     * @return string Setting value.
-     */
-    public function get_string( string $key, string $default_value = '' ): string {
-            $value = $this->get( $key, $default_value );
-        return is_string( $value ) ? $value : (string) $value;
-    }
+	/**
+	 * Get a string setting.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @param string $key          Setting key.
+	 * @param string $default_value Default value if setting doesn't exist. Default empty string.
+	 * @return string Setting value.
+	 */
+	public function get_string( string $key, string $default_value = '' ): string {
+			$value = $this->get( $key, $default_value );
+		return is_string( $value ) ? $value : (string) $value;
+	}
 
-    /**
-     * Get an integer setting.
-     *
-     * @since 1.0.0
-     *
-     * @param string $key          Setting key.
-     * @param int    $default_value Default value if setting doesn't exist. Default 0.
-     * @return int Setting value.
-     */
-    public function get_int( string $key, int $default_value = 0 ): int {
-            $value = $this->get( $key, $default_value );
-            return is_numeric( $value ) ? (int) $value : $default_value;
-    }
+	/**
+	 * Get an integer setting.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @param string $key          Setting key.
+	 * @param int    $default_value Default value if setting doesn't exist. Default 0.
+	 * @return int Setting value.
+	 */
+	public function get_int( string $key, int $default_value = 0 ): int {
+			$value = $this->get( $key, $default_value );
+			return is_numeric( $value ) ? (int) $value : $default_value;
+	}
 
-    /**
-     * Get a boolean setting.
-     *
-     * @since 1.0.0
-     *
-     * @param string $key          Setting key.
-     * @param bool   $default_value Default value if setting doesn't exist. Default false.
-     * @return bool Setting value.
-     */
-    public function get_bool( string $key, bool $default_value = false ): bool {
-            return (bool) $this->get( $key, $default_value );
-    }
+	/**
+	 * Get a boolean setting.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @param string $key          Setting key.
+	 * @param bool   $default_value Default value if setting doesn't exist. Default false.
+	 * @return bool Setting value.
+	 */
+	public function get_bool( string $key, bool $default_value = false ): bool {
+			return (bool) $this->get( $key, $default_value );
+	}
 
-    /**
-     * Get an array setting.
-     *
-     * @since 1.0.0
-     *
-     * @param string $key          Setting key.
-     * @param array  $default_value Default value if setting doesn't exist. Default empty array.
-     * @return array Setting value.
-     */
-    public function get_array( string $key, array $default_value = array() ): array {
-            $value = $this->get( $key, $default_value );
-            return is_array( $value ) ? $value : $default_value;
-    }
+	/**
+	 * Get an array setting.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @param string $key          Setting key.
+	 * @param array  $default_value Default value if setting doesn't exist. Default empty array.
+	 * @return array Setting value.
+	 */
+	public function get_array( string $key, array $default_value = array() ): array {
+			$value = $this->get( $key, $default_value );
+			return is_array( $value ) ? $value : $default_value;
+	}
 
-    /**
-     * Set a setting value to be saved later.
-     *
-     * @since 1.0.0
-     *
-     * @param string $key   Setting key.
-     * @param mixed  $value Setting value.
-     * @return self
-     */
-    public function set( string $key, $value ): self {
-        $this->pending[ $key ] = $value;
-        return $this;
-    }
+	/**
+	 * Set a setting value to be saved later.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @param string $key   Setting key.
+	 * @param mixed  $value Setting value.
+	 * @return self
+	 */
+	public function set( string $key, $value ): self {
+		$this->pending[ $key ] = $value;
+		return $this;
+	}
 
-    /**
-     * Set a string setting.
-     *
-     * @since 1.0.0
-     *
-     * @param string $key   Setting key.
-     * @param string $value Setting value.
-     * @return self
-     */
-    public function set_string( string $key, string $value ): self {
-        return $this->set( $key, sanitize_text_field( $value ) );
-    }
+	/**
+	 * Set a string setting.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @param string $key   Setting key.
+	 * @param string $value Setting value.
+	 * @return self
+	 */
+	public function set_string( string $key, string $value ): self {
+		return $this->set( $key, sanitize_text_field( $value ) );
+	}
 
-    /**
-     * Set an integer setting.
-     *
-     * @since 1.0.0
-     *
-     * @param string $key   Setting key.
-     * @param int    $value Setting value.
-     * @return self
-     */
-    public function set_int( string $key, int $value ): self {
-        return $this->set( $key, (int) $value );
-    }
+	/**
+	 * Set an integer setting.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @param string $key   Setting key.
+	 * @param int    $value Setting value.
+	 * @return self
+	 */
+	public function set_int( string $key, int $value ): self {
+		return $this->set( $key, (int) $value );
+	}
 
-    /**
-     * Set a boolean setting.
-     *
-     * @since 1.0.0
-     *
-     * @param string $key   Setting key.
-     * @param bool   $value Setting value.
-     * @return self
-     */
-    public function set_bool( string $key, bool $value ): self {
-        return $this->set( $key, (bool) $value );
-    }
+	/**
+	 * Set a boolean setting.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @param string $key   Setting key.
+	 * @param bool   $value Setting value.
+	 * @return self
+	 */
+	public function set_bool( string $key, bool $value ): self {
+		return $this->set( $key, (bool) $value );
+	}
 
-    /**
-     * Set an array setting.
-     *
-     * @since 1.0.0
-     *
-     * @param string $key   Setting key.
-     * @param array  $value Setting value.
-     * @return self
-     */
-    public function set_array( string $key, array $value ): self {
-        return $this->set( $key, SettingsSanitizer::sanitize_setting( $key, $value ) );
-    }
+	/**
+	 * Set an array setting.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @param string $key   Setting key.
+	 * @param array  $value Setting value.
+	 * @return self
+	 */
+	public function set_array( string $key, array $value ): self {
+		return $this->set( $key, SettingsSanitizer::sanitize_setting( $key, $value ) );
+	}
 }

--- a/nuclear-engagement/inc/Traits/SettingsCacheTrait.php
+++ b/nuclear-engagement/inc/Traits/SettingsCacheTrait.php
@@ -15,50 +15,50 @@ namespace NuclearEngagement\Traits;
 
 // If this file is called directly, abort.
 if ( ! defined( 'ABSPATH' ) ) {
-    exit;
+	exit;
 }
 
 trait SettingsCacheTrait {
-    /**
-     * Invalidate the settings cache.
-     *
-     * @since 1.0.0
-     */
-    public function invalidate_cache(): void {
-        $this->cache->invalidate_cache();
-    }
+	/**
+	 * Invalidate the settings cache.
+	 *
+	 * @since 1.0.0
+	 */
+	public function invalidate_cache(): void {
+		$this->cache->invalidate_cache();
+	}
 
-    /**
-     * Handle option updates to invalidate cache.
-     *
-     * @since 1.0.0
-     *
-     * @param string $option    The option name being updated.
-     * @param mixed  $old_value The old option value.
-     * @param mixed  $value     The new option value.
-     */
-    public function maybe_invalidate_cache( $option, $old_value, $value ): void {
-        unset( $old_value, $value );
-        $this->cache->maybe_invalidate_cache( $option );
-    }
+	/**
+	 * Handle option updates to invalidate cache.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @param string $option    The option name being updated.
+	 * @param mixed  $old_value The old option value.
+	 * @param mixed  $value     The new option value.
+	 */
+	public function maybe_invalidate_cache( $option, $old_value, $value ): void {
+		unset( $old_value, $value );
+		$this->cache->maybe_invalidate_cache( $option );
+	}
 
-    /**
-     * Handle option deletion to invalidate cache.
-     *
-     * @since 1.0.0
-     *
-     * @param string $option The option name being deleted.
-     */
-    public function maybe_invalidate_cache_on_delete( $option ): void {
-        $this->cache->maybe_invalidate_cache( $option );
-    }
+	/**
+	 * Handle option deletion to invalidate cache.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @param string $option The option name being deleted.
+	 */
+	public function maybe_invalidate_cache_on_delete( $option ): void {
+		$this->cache->maybe_invalidate_cache( $option );
+	}
 
-    /**
-     * Clear all cached data (for testing).
-     *
-     * @since 1.0.0
-     */
-    public function clear_cache(): void {
-        $this->cache->clear();
-    }
+	/**
+	 * Clear all cached data (for testing).
+	 *
+	 * @since 1.0.0
+	 */
+	public function clear_cache(): void {
+		$this->cache->clear();
+	}
 }

--- a/nuclear-engagement/inc/Traits/SettingsGettersTrait.php
+++ b/nuclear-engagement/inc/Traits/SettingsGettersTrait.php
@@ -15,78 +15,78 @@ namespace NuclearEngagement\Traits;
 
 // If this file is called directly, abort.
 if ( ! defined( 'ABSPATH' ) ) {
-    exit;
+	exit;
 }
 
 trait SettingsGettersTrait {
-    /**
-     * Get all settings with defaults merged in.
-     *
-     * @since 1.0.0
-     *
-     * @return array The complete settings array with defaults merged in.
-     */
-    public function all(): array {
-        $cached = $this->cache->get();
-        if ( null !== $cached ) {
-            return $cached;
-        }
+	/**
+	 * Get all settings with defaults merged in.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @return array The complete settings array with defaults merged in.
+	 */
+	public function all(): array {
+		$cached = $this->cache->get();
+		if ( null !== $cached ) {
+			return $cached;
+		}
 
-        // Not in cache, fetch from database.
-        $saved    = get_option( self::OPTION, array() );
-        $settings = wp_parse_args(
-            is_array( $saved ) ? $saved : array(),
-            $this->defaults
-        );
+		// Not in cache, fetch from database.
+		$saved    = get_option( self::OPTION, array() );
+		$settings = wp_parse_args(
+			is_array( $saved ) ? $saved : array(),
+			$this->defaults
+		);
 
-        // Store in cache.
-        $this->cache->set( $settings );
+		// Store in cache.
+		$this->cache->set( $settings );
 
-        return $settings;
-    }
+		return $settings;
+	}
 
-    /**
-     * Get all settings from database (bypasses cache).
-     *
-     * @since 1.0.0
-     *
-     * @return array The complete settings array.
-     */
-    public function get_all(): array {
-        return $this->all();
-    }
+	/**
+	 * Get all settings from database (bypasses cache).
+	 *
+	 * @since 1.0.0
+	 *
+	 * @return array The complete settings array.
+	 */
+	public function get_all(): array {
+		return $this->all();
+	}
 
-    /**
-     * Get a specific setting by key.
-     *
-     * @since 1.0.0
-     *
-     * @param string $key      The setting key to retrieve.
-     * @param mixed  $fallback Optional. Fallback value if the setting doesn't exist.
-     * @return mixed The setting value, or fallback if not found.
-     */
-    public function get( string $key, $fallback = null ) {
-        $all   = $this->all();
-        $value = $all[ $key ] ?? $fallback;
+	/**
+	 * Get a specific setting by key.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @param string $key      The setting key to retrieve.
+	 * @param mixed  $fallback Optional. Fallback value if the setting doesn't exist.
+	 * @return mixed The setting value, or fallback if not found.
+	 */
+	public function get( string $key, $fallback = null ) {
+		$all   = $this->all();
+		$value = $all[ $key ] ?? $fallback;
 
-        // Allow filtering of individual settings.
-        if ( 1 === func_num_args() ) {
-            $value = apply_filters( "nuclen_setting_{$key}", $value, $key );
-        }
+		// Allow filtering of individual settings.
+		if ( 1 === func_num_args() ) {
+			$value = apply_filters( "nuclen_setting_{$key}", $value, $key );
+		}
 
-        return $value;
-    }
+		return $value;
+	}
 
-    /**
-     * Check if a setting exists.
-     *
-     * @since 1.0.0
-     *
-     * @param string $key The setting key to check.
-     * @return bool True if the setting exists, false otherwise.
-     */
-    public function has( string $key ): bool {
-        $all = $this->all();
-        return array_key_exists( $key, $all );
-    }
+	/**
+	 * Check if a setting exists.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @param string $key The setting key to check.
+	 * @return bool True if the setting exists, false otherwise.
+	 */
+	public function has( string $key ): bool {
+		$all = $this->all();
+		return array_key_exists( $key, $all );
+	}
 }

--- a/nuclear-engagement/inc/Traits/SettingsPersistenceTrait.php
+++ b/nuclear-engagement/inc/Traits/SettingsPersistenceTrait.php
@@ -17,65 +17,65 @@ use NuclearEngagement\Core\SettingsSanitizer;
 
 // If this file is called directly, abort.
 if ( ! defined( 'ABSPATH' ) ) {
-    exit;
+	exit;
 }
 
 trait SettingsPersistenceTrait {
-    /**
-     * Save pending settings to database.
-     *
-     * @since 1.0.0
-     *
-     * @return bool True if settings were saved, false otherwise.
-     */
-    public function save(): bool {
-        if ( empty( $this->pending ) ) {
-            return false;
-        }
+	/**
+	 * Save pending settings to database.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @return bool True if settings were saved, false otherwise.
+	 */
+	public function save(): bool {
+		if ( empty( $this->pending ) ) {
+			return false;
+		}
 
-        $current   = $this->all();
-        $sanitized = SettingsSanitizer::sanitize_settings( $this->pending );
-        $merged    = wp_parse_args( $sanitized, $current );
+		$current   = $this->all();
+		$sanitized = SettingsSanitizer::sanitize_settings( $this->pending );
+		$merged    = wp_parse_args( $sanitized, $current );
 
-        // Clear pending settings.
-        $this->pending = array();
+		// Clear pending settings.
+		$this->pending = array();
 
-        // Invalidate cache before save.
-        $this->invalidate_cache();
+		// Invalidate cache before save.
+		$this->invalidate_cache();
 
-        // Only update if settings have changed.
-        if ( $merged !== $current ) {
-            $autoload = $this->should_autoload( $merged );
-            $result   = update_option( self::OPTION, $merged, $autoload ? 'yes' : 'no' );
+		// Only update if settings have changed.
+		if ( $merged !== $current ) {
+			$autoload = $this->should_autoload( $merged );
+			$result   = update_option( self::OPTION, $merged, $autoload ? 'yes' : 'no' );
 
-            // Also update legacy option for backward compatibility.
-            if ( $result && false !== get_option( 'nuclear_engagement_setup' ) ) {
-                $legacy_data = array(
-                    'api_key'             => $merged['api_key'] ?? '',
-                    'connected'           => $merged['connected'] ?? false,
-                    'wp_app_pass_created' => $merged['wp_app_pass_created'] ?? false,
-                    'wp_app_pass_uuid'    => $merged['wp_app_pass_uuid'] ?? '',
-                    'plugin_password'     => $merged['plugin_password'] ?? '',
-                );
-                update_option( 'nuclear_engagement_setup', $legacy_data );
-            }
+			// Also update legacy option for backward compatibility.
+			if ( $result && false !== get_option( 'nuclear_engagement_setup' ) ) {
+				$legacy_data = array(
+					'api_key'             => $merged['api_key'] ?? '',
+					'connected'           => $merged['connected'] ?? false,
+					'wp_app_pass_created' => $merged['wp_app_pass_created'] ?? false,
+					'wp_app_pass_uuid'    => $merged['wp_app_pass_uuid'] ?? '',
+					'plugin_password'     => $merged['plugin_password'] ?? '',
+				);
+				update_option( 'nuclear_engagement_setup', $legacy_data );
+			}
 
-            return $result;
-        }
+			return $result;
+		}
 
-        return false;
-    }
+		return false;
+	}
 
-    /**
-     * Determine if settings should be autoloaded.
-     *
-     * @since 1.0.0
-     *
-     * @param array $settings The settings array to check.
-     * @return bool True if settings should be autoloaded, false otherwise.
-     */
-    private function should_autoload( array $settings ): bool {
-        $size = strlen( wp_json_encode( $settings ) );
-        return $size <= self::MAX_AUTOLOAD_SIZE;
-    }
+	/**
+	 * Determine if settings should be autoloaded.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @param array $settings The settings array to check.
+	 * @return bool True if settings should be autoloaded, false otherwise.
+	 */
+	private function should_autoload( array $settings ): bool {
+		$size = strlen( wp_json_encode( $settings ) );
+		return $size <= self::MAX_AUTOLOAD_SIZE;
+	}
 }

--- a/nuclear-engagement/inc/Utils/Utils.php
+++ b/nuclear-engagement/inc/Utils/Utils.php
@@ -15,7 +15,7 @@ declare(strict_types=1);
 namespace NuclearEngagement\Utils;
 
 if ( ! defined( 'ABSPATH' ) ) {
-    exit;
+	exit;
 }
 
 /**
@@ -23,64 +23,64 @@ if ( ! defined( 'ABSPATH' ) ) {
  */
 class Utils {
 
-    /**
-     * Output a standard page header used across admin screens.
-     *
-     * @return void
-     */
-    public function display_nuclen_page_header(): void {
-        $image_url = plugin_dir_url( __DIR__ ) . 'assets/nuclear-engagement-logo.webp';
-        if ( ! filter_var( $image_url, FILTER_VALIDATE_URL ) ) {
-            return;
-        }
-        $image_html = '<img height="40" width="40" src="' . esc_url( $image_url ) . '" alt="' . esc_attr__( 'Nuclear Engagement Logo', 'nuclear-engagement' ) . '" />';
-        echo '<div id="nuclen-page-header">
-                ' . wp_kses_post( $image_html ) . '
-                <p><b>' . esc_html__( 'NUCLEAR ENGAGEMENT', 'nuclear-engagement' ) . '</b></p>
-        </div>';
-    }
+	/**
+	 * Output a standard page header used across admin screens.
+	 *
+	 * @return void
+	 */
+	public function display_nuclen_page_header(): void {
+		$image_url = plugin_dir_url( __DIR__ ) . 'assets/nuclear-engagement-logo.webp';
+		if ( ! filter_var( $image_url, FILTER_VALIDATE_URL ) ) {
+			return;
+		}
+		$image_html = '<img height="40" width="40" src="' . esc_url( $image_url ) . '" alt="' . esc_attr__( 'Nuclear Engagement Logo', 'nuclear-engagement' ) . '" />';
+		echo '<div id="nuclen-page-header">
+				' . wp_kses_post( $image_html ) . '
+				<p><b>' . esc_html__( 'NUCLEAR ENGAGEMENT', 'nuclear-engagement' ) . '</b></p>
+		</div>';
+	}
 
-    /**
-     * Retrieve paths and URLs for the custom CSS file.
-     *
-     * @return array<string,string> Information about the custom CSS file.
-     */
-    public static function nuclen_get_custom_css_info(): array {
-        $upload_dir = wp_upload_dir();
-        if ( ! empty( $upload_dir['error'] ) ) {
-            \NuclearEngagement\Services\LoggingService::log( 'wp_upload_dir error: ' . $upload_dir['error'] );
-            \NuclearEngagement\Services\LoggingService::notify_admin( 'Uploads directory unavailable.' );
-            return array();
-        }
+	/**
+	 * Retrieve paths and URLs for the custom CSS file.
+	 *
+	 * @return array<string,string> Information about the custom CSS file.
+	 */
+	public static function nuclen_get_custom_css_info(): array {
+		$upload_dir = wp_upload_dir();
+		if ( ! empty( $upload_dir['error'] ) ) {
+			\NuclearEngagement\Services\LoggingService::log( 'wp_upload_dir error: ' . $upload_dir['error'] );
+			\NuclearEngagement\Services\LoggingService::notify_admin( 'Uploads directory unavailable.' );
+			return array();
+		}
 
-        $custom_dir = $upload_dir['basedir'] . '/nuclear-engagement';
+		$custom_dir = $upload_dir['basedir'] . '/nuclear-engagement';
 
-        if ( ! file_exists( $custom_dir ) ) {
-            if ( ! wp_mkdir_p( $custom_dir ) ) {
-                \NuclearEngagement\Services\LoggingService::log( 'Failed creating custom CSS directory: ' . $custom_dir );
-                \NuclearEngagement\Services\LoggingService::notify_admin( 'Failed creating custom CSS directory.' );
-                return array();
-            }
-        }
+		if ( ! file_exists( $custom_dir ) ) {
+			if ( ! wp_mkdir_p( $custom_dir ) ) {
+				\NuclearEngagement\Services\LoggingService::log( 'Failed creating custom CSS directory: ' . $custom_dir );
+				\NuclearEngagement\Services\LoggingService::notify_admin( 'Failed creating custom CSS directory.' );
+				return array();
+			}
+		}
 
-        $base_css_file_name = 'nuclen-theme-custom.css';
-        $custom_css_path    = $custom_dir . '/' . $base_css_file_name;
+		$base_css_file_name = 'nuclen-theme-custom.css';
+		$custom_css_path    = $custom_dir . '/' . $base_css_file_name;
 
-        // Get the stored version hash or generate a new one if the file exists.
-        $version = get_option( 'nuclen_custom_css_version', '' );
-        if ( '' === $version && file_exists( $custom_css_path ) ) {
-            $file_mtime = filemtime( $custom_css_path );
-            $file_hash  = md5_file( $custom_css_path );
-            $version    = $file_mtime . '-' . substr( $file_hash, 0, 8 );
-        }
+		// Get the stored version hash or generate a new one if the file exists.
+		$version = get_option( 'nuclen_custom_css_version', '' );
+		if ( '' === $version && file_exists( $custom_css_path ) ) {
+			$file_mtime = filemtime( $custom_css_path );
+			$file_hash  = md5_file( $custom_css_path );
+			$version    = $file_mtime . '-' . substr( $file_hash, 0, 8 );
+		}
 
-        $custom_css_url = $upload_dir['baseurl'] . '/nuclear-engagement/' . $base_css_file_name . '?v=' . $version;
+		$custom_css_url = $upload_dir['baseurl'] . '/nuclear-engagement/' . $base_css_file_name . '?v=' . $version;
 
-        return array(
-            'dir'       => $custom_dir,
-            'file_name' => $base_css_file_name,
-            'path'      => $custom_css_path,
-            'url'       => $custom_css_url,
-        );
-    }
+		return array(
+			'dir'       => $custom_dir,
+			'file_name' => $base_css_file_name,
+			'path'      => $custom_css_path,
+			'url'       => $custom_css_url,
+		);
+	}
 }

--- a/nuclear-engagement/templates/admin/dashboard/inventory.php
+++ b/nuclear-engagement/templates/admin/dashboard/inventory.php
@@ -39,11 +39,11 @@ if ( ! defined( 'ABSPATH' ) ) {
 		<div class="nuclen-row">
 			<div class="nuclen-col">
 				<h3><?php esc_html_e( 'Quizzes', 'nuclear-engagement' ); ?></h3>
-                <?php echo $this->nuclen_render_dashboard_stats_table( $by_status_quiz ); // phpcs:ignore ?>
+				<?php echo $this->nuclen_render_dashboard_stats_table( $by_status_quiz ); // phpcs:ignore ?>
 			</div>
 			<div class="nuclen-col">
 				<h3><?php esc_html_e( 'Summaries', 'nuclear-engagement' ); ?></h3>
-                <?php echo $this->nuclen_render_dashboard_stats_table( $by_status_summary ); // phpcs:ignore ?>
+				<?php echo $this->nuclen_render_dashboard_stats_table( $by_status_summary ); // phpcs:ignore ?>
 			</div>
 		</div>
 	</div>
@@ -53,11 +53,11 @@ if ( ! defined( 'ABSPATH' ) ) {
 		<div class="nuclen-row">
 			<div class="nuclen-col">
 				<h3><?php esc_html_e( 'Quizzes', 'nuclear-engagement' ); ?></h3>
-                <?php echo $this->nuclen_render_dashboard_stats_table( $by_category_quiz ); // phpcs:ignore ?>
+				<?php echo $this->nuclen_render_dashboard_stats_table( $by_category_quiz ); // phpcs:ignore ?>
 			</div>
 			<div class="nuclen-col">
 				<h3><?php esc_html_e( 'Summaries', 'nuclear-engagement' ); ?></h3>
-                <?php echo $this->nuclen_render_dashboard_stats_table( $by_category_summary ); // phpcs:ignore ?>
+				<?php echo $this->nuclen_render_dashboard_stats_table( $by_category_summary ); // phpcs:ignore ?>
 			</div>
 		</div>
 	</div>
@@ -67,11 +67,11 @@ if ( ! defined( 'ABSPATH' ) ) {
 		<div class="nuclen-row">
 			<div class="nuclen-col">
 				<h3><?php esc_html_e( 'Quizzes', 'nuclear-engagement' ); ?></h3>
-                <?php echo $this->nuclen_render_dashboard_stats_table( $by_author_quiz ); // phpcs:ignore ?>
+				<?php echo $this->nuclen_render_dashboard_stats_table( $by_author_quiz ); // phpcs:ignore ?>
 			</div>
 			<div class="nuclen-col">
 				<h3><?php esc_html_e( 'Summaries', 'nuclear-engagement' ); ?></h3>
-                <?php echo $this->nuclen_render_dashboard_stats_table( $by_author_summary ); // phpcs:ignore ?>
+				<?php echo $this->nuclen_render_dashboard_stats_table( $by_author_summary ); // phpcs:ignore ?>
 			</div>
 		</div>
 	</div>
@@ -81,11 +81,11 @@ if ( ! defined( 'ABSPATH' ) ) {
 		<div class="nuclen-row">
 			<div class="nuclen-col">
 				<h3><?php esc_html_e( 'Quizzes', 'nuclear-engagement' ); ?></h3>
-                <?php echo $this->nuclen_render_dashboard_stats_table( $by_post_type_quiz ); // phpcs:ignore ?>
+				<?php echo $this->nuclen_render_dashboard_stats_table( $by_post_type_quiz ); // phpcs:ignore ?>
 			</div>
 			<div class="nuclen-col">
 				<h3><?php esc_html_e( 'Summaries', 'nuclear-engagement' ); ?></h3>
-                <?php echo $this->nuclen_render_dashboard_stats_table( $by_post_type_summary ); // phpcs:ignore ?>
+				<?php echo $this->nuclen_render_dashboard_stats_table( $by_post_type_summary ); // phpcs:ignore ?>
 			</div>
 		</div>
 	</div>

--- a/nuclear-engagement/templates/admin/summary-metabox.php
+++ b/nuclear-engagement/templates/admin/summary-metabox.php
@@ -1,6 +1,6 @@
 <?php
 if ( ! defined( 'ABSPATH' ) ) {
-        exit;
+		exit;
 }
 
 use NuclearEngagement\Modules\Summary\Summary_Service;
@@ -8,7 +8,7 @@ use NuclearEngagement\Modules\Summary\Summary_Service;
 wp_nonce_field( 'nuclen_summary_data_nonce', 'nuclen_summary_data_nonce' );
 ?>
 <div><label>
-        <input type="checkbox" name="<?php echo esc_attr( Summary_Service::PROTECTED_KEY ); ?>" value="1" <?php checked( $summary_protected, 1 ); ?> />
+		<input type="checkbox" name="<?php echo esc_attr( Summary_Service::PROTECTED_KEY ); ?>" value="1" <?php checked( $summary_protected, 1 ); ?> />
 	<?php esc_html_e( 'Protected?', 'nuclear-engagement' ); ?>
 	<span nuclen-tooltip="<?php esc_attr_e( 'Tick this box and save post to prevent overwriting during bulk generation.', 'nuclear-engagement' ); ?>">🛈</span>
 </label></div>

--- a/nuclear-engagement/uninstall.php
+++ b/nuclear-engagement/uninstall.php
@@ -64,15 +64,15 @@ $delete_css       = ! empty( $settings['delete_custom_css_on_uninstall'] );
 
 // Delete generated content from post meta if requested.
 if ( $delete_generated ) {
-                                $meta_keys = array(
-                                        'nuclen-quiz-data',
-                                        \NuclearEngagement\Modules\Summary\Summary_Service::META_KEY,
-                                        'nuclen_quiz_protected',
-                                        \NuclearEngagement\Modules\Summary\Summary_Service::PROTECTED_KEY,
-                                );
-                                foreach ( $meta_keys as $mk ) {
-                                                delete_post_meta_by_key( $mk );
-                                }
+								$meta_keys = array(
+										'nuclen-quiz-data',
+										\NuclearEngagement\Modules\Summary\Summary_Service::META_KEY,
+										'nuclen_quiz_protected',
+										\NuclearEngagement\Modules\Summary\Summary_Service::PROTECTED_KEY,
+								);
+								foreach ( $meta_keys as $mk ) {
+												delete_post_meta_by_key( $mk );
+								}
 }
 
 // Delete plugin settings if requested.
@@ -92,7 +92,7 @@ if ( $delete_log ) {
 
 // Remove custom theme file if requested.
 if ( $delete_css ) {
-                                $info = \NuclearEngagement\Utils\Utils::nuclen_get_custom_css_info();
+								$info = \NuclearEngagement\Utils\Utils::nuclen_get_custom_css_info();
 	if ( ! empty( $info ) && file_exists( $info['path'] ) ) {
 					wp_delete_file( $info['path'] );
 	}

--- a/phpcs.xml
+++ b/phpcs.xml
@@ -3,6 +3,7 @@
     <rule ref="WordPress">
         <exclude name="WordPress.Files.FileName" />
     </rule>
+    <rule ref="Generic.WhiteSpace.DisallowSpaceIndent" />
 
     <exclude-pattern>vendor/*</exclude-pattern>
     <exclude-pattern>node_modules/*</exclude-pattern>

--- a/src/admin/ts/blocks/nuclen-editor-blocks.ts
+++ b/src/admin/ts/blocks/nuclen-editor-blocks.ts
@@ -1,30 +1,30 @@
 (function(){
-  interface WPGlobal {
-    blocks?: { registerBlockType: (...args: unknown[]) => void };
-    element?: { createElement: (...args: unknown[]) => unknown };
-    i18n?: { __: (...args: unknown[]) => string };
-  }
-  const wp = window.wp as WPGlobal;
-  if (!wp || !wp.blocks || !wp.element || !wp.i18n) {
-    return;
-  }
-  const { registerBlockType } = wp.blocks;
-  const { createElement } = wp.element;
-  const { __ } = wp.i18n;
-  registerBlockType('nuclear-engagement/quiz', {
-    apiVersion: 2,
-    title: __('Quiz', 'nuclear-engagement'),
-    icon: 'editor-help',
-    category: 'widgets',
-    edit: () => createElement('p', null, __('Quiz will render on the front-end.', 'nuclear-engagement')),
-    save: () => null,
-  });
-  registerBlockType('nuclear-engagement/summary', {
-    apiVersion: 2,
-    title: __('Summary', 'nuclear-engagement'),
-    icon: 'excerpt-view',
-    category: 'widgets',
-    edit: () => createElement('p', null, __('Summary will render on the front-end.', 'nuclear-engagement')),
-    save: () => null,
-  });
+	interface WPGlobal {
+	blocks?: { registerBlockType: (...args: unknown[]) => void };
+	element?: { createElement: (...args: unknown[]) => unknown };
+	i18n?: { __: (...args: unknown[]) => string };
+	}
+	const wp = window.wp as WPGlobal;
+	if (!wp || !wp.blocks || !wp.element || !wp.i18n) {
+	return;
+	}
+	const { registerBlockType } = wp.blocks;
+	const { createElement } = wp.element;
+	const { __ } = wp.i18n;
+	registerBlockType('nuclear-engagement/quiz', {
+	apiVersion: 2,
+	title: __('Quiz', 'nuclear-engagement'),
+	icon: 'editor-help',
+	category: 'widgets',
+	edit: () => createElement('p', null, __('Quiz will render on the front-end.', 'nuclear-engagement')),
+	save: () => null,
+	});
+	registerBlockType('nuclear-engagement/summary', {
+	apiVersion: 2,
+	title: __('Summary', 'nuclear-engagement'),
+	icon: 'excerpt-view',
+	category: 'widgets',
+	edit: () => createElement('p', null, __('Summary will render on the front-end.', 'nuclear-engagement')),
+	save: () => null,
+	});
 })();

--- a/src/admin/ts/generate/elements.ts
+++ b/src/admin/ts/generate/elements.ts
@@ -1,37 +1,37 @@
 export interface GeneratePageElements {
-  step1: HTMLDivElement | null;
-  step2: HTMLDivElement | null;
-  updatesSection: HTMLDivElement | null;
-  updatesContent: HTMLDivElement | null;
-  restartBtn: HTMLButtonElement | null;
-  getPostsBtn: HTMLButtonElement | null;
-  goBackBtn: HTMLButtonElement | null;
-  generateForm: HTMLFormElement | null;
-  submitBtn: HTMLButtonElement | null;
-  postsCountEl: HTMLSpanElement | null;
-  stepBar1: HTMLElement | null;
-  stepBar2: HTMLElement | null;
-  stepBar3: HTMLElement | null;
-  stepBar4: HTMLElement | null;
-  creditsInfoEl: HTMLParagraphElement | null;
+	step1: HTMLDivElement | null;
+	step2: HTMLDivElement | null;
+	updatesSection: HTMLDivElement | null;
+	updatesContent: HTMLDivElement | null;
+	restartBtn: HTMLButtonElement | null;
+	getPostsBtn: HTMLButtonElement | null;
+	goBackBtn: HTMLButtonElement | null;
+	generateForm: HTMLFormElement | null;
+	submitBtn: HTMLButtonElement | null;
+	postsCountEl: HTMLSpanElement | null;
+	stepBar1: HTMLElement | null;
+	stepBar2: HTMLElement | null;
+	stepBar3: HTMLElement | null;
+	stepBar4: HTMLElement | null;
+	creditsInfoEl: HTMLParagraphElement | null;
 }
 
 export function getGeneratePageElements(): GeneratePageElements {
-  return {
-    step1: document.getElementById('nuclen-step-1') as HTMLDivElement | null,
-    step2: document.getElementById('nuclen-step-2') as HTMLDivElement | null,
-    updatesSection: document.getElementById('nuclen-updates-section') as HTMLDivElement | null,
-    updatesContent: document.getElementById('nuclen-updates-content') as HTMLDivElement | null,
-    restartBtn: document.getElementById('nuclen-restart-btn') as HTMLButtonElement | null,
-    getPostsBtn: document.getElementById('nuclen-get-posts-btn') as HTMLButtonElement | null,
-    goBackBtn: document.getElementById('nuclen-go-back-btn') as HTMLButtonElement | null,
-    generateForm: document.getElementById('nuclen-generate-form') as HTMLFormElement | null,
-    submitBtn: document.getElementById('nuclen-submit-btn') as HTMLButtonElement | null,
-    postsCountEl: document.getElementById('nuclen-posts-count') as HTMLSpanElement | null,
-    stepBar1: document.getElementById('nuclen-step-bar-1'),
-    stepBar2: document.getElementById('nuclen-step-bar-2'),
-    stepBar3: document.getElementById('nuclen-step-bar-3'),
-    stepBar4: document.getElementById('nuclen-step-bar-4'),
-    creditsInfoEl: document.getElementById('nuclen-credits-info') as HTMLParagraphElement | null,
-  };
+	return {
+	step1: document.getElementById('nuclen-step-1') as HTMLDivElement | null,
+	step2: document.getElementById('nuclen-step-2') as HTMLDivElement | null,
+	updatesSection: document.getElementById('nuclen-updates-section') as HTMLDivElement | null,
+	updatesContent: document.getElementById('nuclen-updates-content') as HTMLDivElement | null,
+	restartBtn: document.getElementById('nuclen-restart-btn') as HTMLButtonElement | null,
+	getPostsBtn: document.getElementById('nuclen-get-posts-btn') as HTMLButtonElement | null,
+	goBackBtn: document.getElementById('nuclen-go-back-btn') as HTMLButtonElement | null,
+	generateForm: document.getElementById('nuclen-generate-form') as HTMLFormElement | null,
+	submitBtn: document.getElementById('nuclen-submit-btn') as HTMLButtonElement | null,
+	postsCountEl: document.getElementById('nuclen-posts-count') as HTMLSpanElement | null,
+	stepBar1: document.getElementById('nuclen-step-bar-1'),
+	stepBar2: document.getElementById('nuclen-step-bar-2'),
+	stepBar3: document.getElementById('nuclen-step-bar-3'),
+	stepBar4: document.getElementById('nuclen-step-bar-4'),
+	creditsInfoEl: document.getElementById('nuclen-credits-info') as HTMLParagraphElement | null,
+	};
 }

--- a/src/admin/ts/generate/filters.ts
+++ b/src/admin/ts/generate/filters.ts
@@ -1,79 +1,79 @@
 export interface NuclenFilterValues {
-  postStatus: string;
-  category: string;
-  author: string;
-  postType: string;
-  workflow: string;
-  allowRegenerate: boolean;
-  regenerateProtected: boolean;
-  summaryFormat: string;
-  summaryLength: string;
-  summaryNumberOfItems: string;
+	postStatus: string;
+	category: string;
+	author: string;
+	postType: string;
+	workflow: string;
+	allowRegenerate: boolean;
+	regenerateProtected: boolean;
+	summaryFormat: string;
+	summaryLength: string;
+	summaryNumberOfItems: string;
 }
 
 export function nuclenCollectFilters(): NuclenFilterValues {
-  const postStatusEl = document.getElementById('nuclen_post_status') as HTMLSelectElement | null;
-  const categoryEl = document.getElementById('nuclen_category') as HTMLSelectElement | null;
-  const authorEl = document.getElementById('nuclen_author') as HTMLSelectElement | null;
-  const postTypeEl = document.getElementById('nuclen_post_type') as HTMLSelectElement | null;
-  const workflowEl = document.getElementById('nuclen_generate_workflow') as HTMLSelectElement | null;
-  const allowRegenEl = document.getElementById('nuclen_allow_regenerate_data') as HTMLInputElement | null;
-  const protectRegenEl = document.getElementById('nuclen_regenerate_protected_data') as HTMLInputElement | null;
-  const summaryFormatEl = document.getElementById('nuclen_summary_format') as HTMLSelectElement | null;
-  const summaryLengthEl = document.getElementById('nuclen_summary_length') as HTMLSelectElement | null;
-  const summaryNumberEl = document.getElementById('nuclen_summary_number_of_items') as HTMLSelectElement | null;
-  return {
-    postStatus: postStatusEl ? postStatusEl.value : '',
-    category: categoryEl ? categoryEl.value : '',
-    author: authorEl ? authorEl.value : '',
-    postType: postTypeEl ? postTypeEl.value : '',
-    workflow: workflowEl ? workflowEl.value : '',
-    allowRegenerate: !!allowRegenEl && allowRegenEl.checked,
-    regenerateProtected: !!protectRegenEl && protectRegenEl.checked,
-    summaryFormat: summaryFormatEl ? summaryFormatEl.value : '',
-    summaryLength: summaryLengthEl ? summaryLengthEl.value : '',
-    summaryNumberOfItems: summaryNumberEl ? summaryNumberEl.value : '',
-  };
+	const postStatusEl = document.getElementById('nuclen_post_status') as HTMLSelectElement | null;
+	const categoryEl = document.getElementById('nuclen_category') as HTMLSelectElement | null;
+	const authorEl = document.getElementById('nuclen_author') as HTMLSelectElement | null;
+	const postTypeEl = document.getElementById('nuclen_post_type') as HTMLSelectElement | null;
+	const workflowEl = document.getElementById('nuclen_generate_workflow') as HTMLSelectElement | null;
+	const allowRegenEl = document.getElementById('nuclen_allow_regenerate_data') as HTMLInputElement | null;
+	const protectRegenEl = document.getElementById('nuclen_regenerate_protected_data') as HTMLInputElement | null;
+	const summaryFormatEl = document.getElementById('nuclen_summary_format') as HTMLSelectElement | null;
+	const summaryLengthEl = document.getElementById('nuclen_summary_length') as HTMLSelectElement | null;
+	const summaryNumberEl = document.getElementById('nuclen_summary_number_of_items') as HTMLSelectElement | null;
+	return {
+	postStatus: postStatusEl ? postStatusEl.value : '',
+	category: categoryEl ? categoryEl.value : '',
+	author: authorEl ? authorEl.value : '',
+	postType: postTypeEl ? postTypeEl.value : '',
+	workflow: workflowEl ? workflowEl.value : '',
+	allowRegenerate: !!allowRegenEl && allowRegenEl.checked,
+	regenerateProtected: !!protectRegenEl && protectRegenEl.checked,
+	summaryFormat: summaryFormatEl ? summaryFormatEl.value : '',
+	summaryLength: summaryLengthEl ? summaryLengthEl.value : '',
+	summaryNumberOfItems: summaryNumberEl ? summaryNumberEl.value : '',
+	};
 }
 
 export function nuclenAppendFilters(formData: FormData, filters: NuclenFilterValues): void {
-  formData.append('nuclen_post_status', filters.postStatus);
-  formData.append('nuclen_category', filters.category);
-  formData.append('nuclen_author', filters.author);
-  formData.append('nuclen_post_type', filters.postType);
-  formData.append('nuclen_generate_workflow', filters.workflow);
-  formData.append('nuclen_allow_regenerate_data', filters.allowRegenerate ? '1' : '0');
-  formData.append('nuclen_regenerate_protected_data', filters.regenerateProtected ? '1' : '0');
-  formData.append('nuclen_summary_format', filters.summaryFormat);
-  formData.append('nuclen_summary_length', filters.summaryLength);
-  formData.append('nuclen_summary_number_of_items', filters.summaryNumberOfItems);
+	formData.append('nuclen_post_status', filters.postStatus);
+	formData.append('nuclen_category', filters.category);
+	formData.append('nuclen_author', filters.author);
+	formData.append('nuclen_post_type', filters.postType);
+	formData.append('nuclen_generate_workflow', filters.workflow);
+	formData.append('nuclen_allow_regenerate_data', filters.allowRegenerate ? '1' : '0');
+	formData.append('nuclen_regenerate_protected_data', filters.regenerateProtected ? '1' : '0');
+	formData.append('nuclen_summary_format', filters.summaryFormat);
+	formData.append('nuclen_summary_length', filters.summaryLength);
+	formData.append('nuclen_summary_number_of_items', filters.summaryNumberOfItems);
 }
 
 export function nuclenStoreFilters(filters: NuclenFilterValues): void {
-  const selectedWorkflowEl = document.getElementById('nuclen_selected_generate_workflow') as HTMLInputElement | null;
-  const selectedSummaryFormatEl = document.getElementById('nuclen_selected_summary_format') as HTMLInputElement | null;
-  const selectedSummaryLengthEl = document.getElementById('nuclen_selected_summary_length') as HTMLInputElement | null;
-  const selectedSummaryNumberEl = document.getElementById('nuclen_selected_summary_number_of_items') as HTMLInputElement | null;
-  const selectedPostStatusEl = document.getElementById('nuclen_selected_post_status') as HTMLInputElement | null;
-  const selectedPostTypeEl = document.getElementById('nuclen_selected_post_type') as HTMLInputElement | null;
+	const selectedWorkflowEl = document.getElementById('nuclen_selected_generate_workflow') as HTMLInputElement | null;
+	const selectedSummaryFormatEl = document.getElementById('nuclen_selected_summary_format') as HTMLInputElement | null;
+	const selectedSummaryLengthEl = document.getElementById('nuclen_selected_summary_length') as HTMLInputElement | null;
+	const selectedSummaryNumberEl = document.getElementById('nuclen_selected_summary_number_of_items') as HTMLInputElement | null;
+	const selectedPostStatusEl = document.getElementById('nuclen_selected_post_status') as HTMLInputElement | null;
+	const selectedPostTypeEl = document.getElementById('nuclen_selected_post_type') as HTMLInputElement | null;
 
-  if (selectedWorkflowEl) {
-    selectedWorkflowEl.value = filters.workflow;
-  }
-  if (selectedSummaryFormatEl) {
-    selectedSummaryFormatEl.value = filters.summaryFormat;
-  }
-  if (selectedSummaryLengthEl) {
-    selectedSummaryLengthEl.value = filters.summaryLength;
-  }
-  if (selectedSummaryNumberEl) {
-    selectedSummaryNumberEl.value = filters.summaryNumberOfItems;
-  }
-  if (selectedPostStatusEl) {
-    selectedPostStatusEl.value = filters.postStatus;
-  }
-  if (selectedPostTypeEl) {
-    selectedPostTypeEl.value = filters.postType;
-  }
+	if (selectedWorkflowEl) {
+	selectedWorkflowEl.value = filters.workflow;
+	}
+	if (selectedSummaryFormatEl) {
+	selectedSummaryFormatEl.value = filters.summaryFormat;
+	}
+	if (selectedSummaryLengthEl) {
+	selectedSummaryLengthEl.value = filters.summaryLength;
+	}
+	if (selectedSummaryNumberEl) {
+	selectedSummaryNumberEl.value = filters.summaryNumberOfItems;
+	}
+	if (selectedPostStatusEl) {
+	selectedPostStatusEl.value = filters.postStatus;
+	}
+	if (selectedPostTypeEl) {
+	selectedPostTypeEl.value = filters.postType;
+	}
 }
 

--- a/src/admin/ts/generate/generate-page-handlers.ts
+++ b/src/admin/ts/generate/generate-page-handlers.ts
@@ -4,21 +4,21 @@ import { initStep2 } from './step2';
 import { initGoBack, initRestart, initSummaryToggle } from './navigation';
 
 export function initGeneratePage(): void {
-  const elements = getGeneratePageElements();
+	const elements = getGeneratePageElements();
 
-  // Initial UI setup
-  elements.step1 && elements.step1.classList.remove('nuclen-hidden');
-  elements.step2 && elements.step2.classList.add('nuclen-hidden');
-  elements.updatesSection && elements.updatesSection.classList.add('nuclen-hidden');
-  elements.restartBtn && elements.restartBtn.classList.add('nuclen-hidden');
-  elements.stepBar1 && elements.stepBar1.classList.add('ne-step-bar__step--current');
-  elements.stepBar2 && elements.stepBar2.classList.add('ne-step-bar__step--todo');
-  elements.stepBar3 && elements.stepBar3.classList.add('ne-step-bar__step--todo');
-  elements.stepBar4 && elements.stepBar4.classList.add('ne-step-bar__step--todo');
+	// Initial UI setup
+	elements.step1 && elements.step1.classList.remove('nuclen-hidden');
+	elements.step2 && elements.step2.classList.add('nuclen-hidden');
+	elements.updatesSection && elements.updatesSection.classList.add('nuclen-hidden');
+	elements.restartBtn && elements.restartBtn.classList.add('nuclen-hidden');
+	elements.stepBar1 && elements.stepBar1.classList.add('ne-step-bar__step--current');
+	elements.stepBar2 && elements.stepBar2.classList.add('ne-step-bar__step--todo');
+	elements.stepBar3 && elements.stepBar3.classList.add('ne-step-bar__step--todo');
+	elements.stepBar4 && elements.stepBar4.classList.add('ne-step-bar__step--todo');
 
-  initStep1(elements);
-  initStep2(elements);
-  initGoBack(elements);
-  initRestart(elements);
-  initSummaryToggle();
+	initStep1(elements);
+	initStep2(elements);
+	initGoBack(elements);
+	initRestart(elements);
+	initSummaryToggle();
 }

--- a/src/admin/ts/generate/generate-page-utils.ts
+++ b/src/admin/ts/generate/generate-page-utils.ts
@@ -1,97 +1,97 @@
 export function nuclenShowElement(el: HTMLElement | null): void {
-  if (!el) return;
-  el.classList.remove('nuclen-hidden');
+	if (!el) return;
+	el.classList.remove('nuclen-hidden');
 }
 
 export function nuclenHideElement(el: HTMLElement | null): void {
-  if (!el) return;
-  el.classList.add('nuclen-hidden');
+	if (!el) return;
+	el.classList.add('nuclen-hidden');
 }
 
 export function nuclenUpdateProgressBarStep(stepEl: HTMLElement | null, state: string): void {
-  if (!stepEl) return;
-  stepEl.classList.remove(
-    'ne-step-bar__step--todo',
-    'ne-step-bar__step--current',
-    'ne-step-bar__step--done',
-    'ne-step-bar__step--failed'
-  );
-  stepEl.classList.add(`ne-step-bar__step--${state}`);
+	if (!stepEl) return;
+	stepEl.classList.remove(
+	'ne-step-bar__step--todo',
+	'ne-step-bar__step--current',
+	'ne-step-bar__step--done',
+	'ne-step-bar__step--failed'
+	);
+	stepEl.classList.add(`ne-step-bar__step--${state}`);
 }
 
 /**
  * Fetch remaining credits from the SaaS.
  */
 interface CreditsResponse {
-  success: boolean;
-  message?: string;
-  data: {
-    remaining_credits?: number;
-    message?: string;
-    [key: string]: unknown;
-  };
+	success: boolean;
+	message?: string;
+	data: {
+	remaining_credits?: number;
+	message?: string;
+	[key: string]: unknown;
+	};
 }
 
 export async function nuclenCheckCreditsAjax(): Promise<number> {
-  if (!window.nuclenAjax || !window.nuclenAjax.ajax_url) {
-    throw new Error('Missing nuclenAjax configuration (ajax_url).');
-  }
-  if (!window.nuclenAjax.fetch_action) {
-    throw new Error('Missing fetch_action in nuclenAjax configuration.');
-  }
-  const formData = new FormData();
-  formData.append('action', window.nuclenAjax.fetch_action);
-  if (window.nuclenAjax.nonce) {
-    formData.append('security', window.nuclenAjax.nonce);
-  }
-  const result = await nuclenFetchWithRetry<CreditsResponse>(
-    window.nuclenAjax.ajax_url,
-    {
-      method: 'POST',
-      body: formData,
-      credentials: 'same-origin',
-    }
-  );
-  if (!result.ok) {
-    throw new Error(result.error || `HTTP ${result.status}`);
-  }
-  const data = result.data as CreditsResponse;
-  if (!data.success) {
-    throw new Error(data.message || data.data?.message || 'Failed to fetch credits from SaaS');
-  }
-  if (typeof data.data.remaining_credits === 'number') {
-    return data.data.remaining_credits;
-  }
-  throw new Error("No 'remaining_credits' in response");
+	if (!window.nuclenAjax || !window.nuclenAjax.ajax_url) {
+	throw new Error('Missing nuclenAjax configuration (ajax_url).');
+	}
+	if (!window.nuclenAjax.fetch_action) {
+	throw new Error('Missing fetch_action in nuclenAjax configuration.');
+	}
+	const formData = new FormData();
+	formData.append('action', window.nuclenAjax.fetch_action);
+	if (window.nuclenAjax.nonce) {
+	formData.append('security', window.nuclenAjax.nonce);
+	}
+	const result = await nuclenFetchWithRetry<CreditsResponse>(
+	window.nuclenAjax.ajax_url,
+	{
+		method: 'POST',
+		body: formData,
+		credentials: 'same-origin',
+	}
+	);
+	if (!result.ok) {
+	throw new Error(result.error || `HTTP ${result.status}`);
+	}
+	const data = result.data as CreditsResponse;
+	if (!data.success) {
+	throw new Error(data.message || data.data?.message || 'Failed to fetch credits from SaaS');
+	}
+	if (typeof data.data.remaining_credits === 'number') {
+	return data.data.remaining_credits;
+	}
+	throw new Error("No 'remaining_credits' in response");
 }
 
 /**
  * Toggle summary settings visibility.
  */
 export function nuclenToggleSummaryFields(): void {
-  const generateTypeEl = document.getElementById('nuclen_generate_workflow') as HTMLSelectElement | null;
-  const summarySettingsEl = document.getElementById('nuclen-summary-settings') as HTMLDivElement | null;
-  const summaryParagraphOptions = document.getElementById('nuclen-summary-paragraph-options') as HTMLDivElement | null;
-  const summaryBulletOptions = document.getElementById('nuclen-summary-bullet-options') as HTMLDivElement | null;
-  const summaryFormatEl = document.getElementById('nuclen_summary_format') as HTMLSelectElement | null;
+	const generateTypeEl = document.getElementById('nuclen_generate_workflow') as HTMLSelectElement | null;
+	const summarySettingsEl = document.getElementById('nuclen-summary-settings') as HTMLDivElement | null;
+	const summaryParagraphOptions = document.getElementById('nuclen-summary-paragraph-options') as HTMLDivElement | null;
+	const summaryBulletOptions = document.getElementById('nuclen-summary-bullet-options') as HTMLDivElement | null;
+	const summaryFormatEl = document.getElementById('nuclen_summary_format') as HTMLSelectElement | null;
 
-  if (!generateTypeEl || !summarySettingsEl || !summaryParagraphOptions || !summaryBulletOptions || !summaryFormatEl) {
-    return;
-  }
-  if (generateTypeEl.value === 'summary') {
-    summarySettingsEl.classList.remove('nuclen-hidden');
-    if (summaryFormatEl.value === 'paragraph') {
-      summaryParagraphOptions.classList.remove('nuclen-hidden');
-      summaryBulletOptions.classList.add('nuclen-hidden');
-    } else {
-      summaryParagraphOptions.classList.add('nuclen-hidden');
-      summaryBulletOptions.classList.remove('nuclen-hidden');
-    }
-  } else {
-    summarySettingsEl.classList.add('nuclen-hidden');
-    summaryParagraphOptions.classList.add('nuclen-hidden');
-    summaryBulletOptions.classList.add('nuclen-hidden');
-  }
+	if (!generateTypeEl || !summarySettingsEl || !summaryParagraphOptions || !summaryBulletOptions || !summaryFormatEl) {
+	return;
+	}
+	if (generateTypeEl.value === 'summary') {
+	summarySettingsEl.classList.remove('nuclen-hidden');
+	if (summaryFormatEl.value === 'paragraph') {
+		summaryParagraphOptions.classList.remove('nuclen-hidden');
+		summaryBulletOptions.classList.add('nuclen-hidden');
+	} else {
+		summaryParagraphOptions.classList.add('nuclen-hidden');
+		summaryBulletOptions.classList.remove('nuclen-hidden');
+	}
+	} else {
+	summarySettingsEl.classList.add('nuclen-hidden');
+	summaryParagraphOptions.classList.add('nuclen-hidden');
+	summaryBulletOptions.classList.add('nuclen-hidden');
+	}
 }
 
 import { nuclenFetchWithRetry } from '../nuclen-admin-generate';

--- a/src/admin/ts/generate/navigation.ts
+++ b/src/admin/ts/generate/navigation.ts
@@ -1,49 +1,49 @@
 import {
-  nuclenShowElement,
-  nuclenHideElement,
-  nuclenUpdateProgressBarStep,
-  nuclenToggleSummaryFields,
+	nuclenShowElement,
+	nuclenHideElement,
+	nuclenUpdateProgressBarStep,
+	nuclenToggleSummaryFields,
 } from './generate-page-utils';
 import type { GeneratePageElements } from './elements';
 
 export function initGoBack(elements: GeneratePageElements): void {
-  elements.goBackBtn?.addEventListener('click', () => {
-    nuclenHideElement(elements.step2);
-    nuclenShowElement(elements.step1);
-    if (elements.postsCountEl) {
-      elements.postsCountEl.innerText = '';
-    }
-    if (elements.creditsInfoEl) {
-      elements.creditsInfoEl.textContent = '';
-    }
-    nuclenUpdateProgressBarStep(elements.stepBar1, 'current');
-    nuclenUpdateProgressBarStep(elements.stepBar2, 'todo');
-  });
+	elements.goBackBtn?.addEventListener('click', () => {
+	nuclenHideElement(elements.step2);
+	nuclenShowElement(elements.step1);
+	if (elements.postsCountEl) {
+		elements.postsCountEl.innerText = '';
+	}
+	if (elements.creditsInfoEl) {
+		elements.creditsInfoEl.textContent = '';
+	}
+	nuclenUpdateProgressBarStep(elements.stepBar1, 'current');
+	nuclenUpdateProgressBarStep(elements.stepBar2, 'todo');
+	});
 }
 
 export function initRestart(elements: GeneratePageElements): void {
-  elements.restartBtn?.addEventListener('click', () => {
-    nuclenHideElement(elements.updatesSection);
-    nuclenHideElement(elements.restartBtn);
-    nuclenHideElement(elements.step2);
-    if (elements.postsCountEl) {
-      elements.postsCountEl.innerText = '';
-    }
-    if (elements.creditsInfoEl) {
-      elements.creditsInfoEl.textContent = '';
-    }
-    nuclenShowElement(elements.step1);
-    nuclenUpdateProgressBarStep(elements.stepBar1, 'current');
-    nuclenUpdateProgressBarStep(elements.stepBar2, 'todo');
-    nuclenUpdateProgressBarStep(elements.stepBar3, 'todo');
-    nuclenUpdateProgressBarStep(elements.stepBar4, 'todo');
-  });
+	elements.restartBtn?.addEventListener('click', () => {
+	nuclenHideElement(elements.updatesSection);
+	nuclenHideElement(elements.restartBtn);
+	nuclenHideElement(elements.step2);
+	if (elements.postsCountEl) {
+		elements.postsCountEl.innerText = '';
+	}
+	if (elements.creditsInfoEl) {
+		elements.creditsInfoEl.textContent = '';
+	}
+	nuclenShowElement(elements.step1);
+	nuclenUpdateProgressBarStep(elements.stepBar1, 'current');
+	nuclenUpdateProgressBarStep(elements.stepBar2, 'todo');
+	nuclenUpdateProgressBarStep(elements.stepBar3, 'todo');
+	nuclenUpdateProgressBarStep(elements.stepBar4, 'todo');
+	});
 }
 
 export function initSummaryToggle(): void {
-  nuclenToggleSummaryFields();
-  const generateTypeEl = document.getElementById('nuclen_generate_workflow') as HTMLSelectElement | null;
-  const summaryFormatEl = document.getElementById('nuclen_summary_format') as HTMLSelectElement | null;
-  generateTypeEl?.addEventListener('change', nuclenToggleSummaryFields);
-  summaryFormatEl?.addEventListener('change', nuclenToggleSummaryFields);
+	nuclenToggleSummaryFields();
+	const generateTypeEl = document.getElementById('nuclen_generate_workflow') as HTMLSelectElement | null;
+	const summaryFormatEl = document.getElementById('nuclen_summary_format') as HTMLSelectElement | null;
+	generateTypeEl?.addEventListener('change', nuclenToggleSummaryFields);
+	summaryFormatEl?.addEventListener('change', nuclenToggleSummaryFields);
 }

--- a/src/admin/ts/generate/step1.ts
+++ b/src/admin/ts/generate/step1.ts
@@ -1,128 +1,128 @@
 import { nuclenFetchWithRetry } from '../nuclen-admin-generate';
 import {
-  nuclenShowElement,
-  nuclenHideElement,
-  nuclenUpdateProgressBarStep,
-  nuclenCheckCreditsAjax,
+	nuclenShowElement,
+	nuclenHideElement,
+	nuclenUpdateProgressBarStep,
+	nuclenCheckCreditsAjax,
 } from './generate-page-utils';
 import type { GeneratePageElements } from './elements';
 import {
-  nuclenCollectFilters,
-  nuclenAppendFilters,
-  nuclenStoreFilters,
-  type NuclenFilterValues,
+	nuclenCollectFilters,
+	nuclenAppendFilters,
+	nuclenStoreFilters,
+	type NuclenFilterValues,
 } from './filters';
 import { displayError } from '../utils/displayError';
 import * as logger from '../utils/logger';
 
 interface PostsCountResponse {
-  success: boolean;
-  message?: string;
-  data: {
-    count: number;
-    post_ids: string[];
-    message?: string;
-    [key: string]: unknown;
-  };
+	success: boolean;
+	message?: string;
+	data: {
+	count: number;
+	post_ids: string[];
+	message?: string;
+	[key: string]: unknown;
+	};
 }
 
 export function initStep1(elements: GeneratePageElements): void {
-  elements.getPostsBtn?.addEventListener('click', async () => {
-    if (!window.nuclenAjax || !window.nuclenAjax.ajax_url) {
-      displayError('Error: Ajax is not configured properly. Please check the plugin settings.');
-      return;
-    }
-    if (elements.postsCountEl) {
-      elements.postsCountEl.innerText = 'Loading posts...';
-    }
+	elements.getPostsBtn?.addEventListener('click', async () => {
+	if (!window.nuclenAjax || !window.nuclenAjax.ajax_url) {
+		displayError('Error: Ajax is not configured properly. Please check the plugin settings.');
+		return;
+	}
+	if (elements.postsCountEl) {
+		elements.postsCountEl.innerText = 'Loading posts...';
+	}
 
-    const formData = new FormData();
-    formData.append('action', 'nuclen_get_posts_count');
-    if (window.nuclenAjax?.nonce) {
-      formData.append('security', window.nuclenAjax.nonce);
-    }
-    const filters: NuclenFilterValues = nuclenCollectFilters();
-    nuclenAppendFilters(formData, filters);
+	const formData = new FormData();
+	formData.append('action', 'nuclen_get_posts_count');
+	if (window.nuclenAjax?.nonce) {
+		formData.append('security', window.nuclenAjax.nonce);
+	}
+	const filters: NuclenFilterValues = nuclenCollectFilters();
+	nuclenAppendFilters(formData, filters);
 
-    const result = await nuclenFetchWithRetry<PostsCountResponse>(
-      window.nuclenAjax.ajax_url || '',
-      {
-        method: 'POST',
-        body: formData,
-        credentials: 'same-origin',
-      }
-    );
-    if (!result.ok) {
-      logger.error('Error retrieving post count:', result.error);
-      if (elements.postsCountEl) {
-        elements.postsCountEl.innerText = 'Error retrieving post count.';
-      }
-      return;
-    }
-    const data = result.data as PostsCountResponse;
-    if (!data.success) {
-      if (elements.postsCountEl) {
-        elements.postsCountEl.innerText = 'Error retrieving post count.';
-      }
-      const errMsg = data.message || data.data?.message;
-      if (errMsg) {
-        if (errMsg.includes('Invalid API key')) {
-          displayError('Your Gold Code (API key) is invalid. Please create a new one on the NE app and enter it on the plugin Setup page.');
-        } else if (errMsg.includes('Invalid WP App Password')) {
-          displayError('Your WP App Password is invalid. Please go to the plugin Setup page and re-generate it.');
-        } else {
-          displayError(errMsg);
-        }
-      }
-      return;
-    }
-    const count = data.data.count as number;
-    const foundPosts = data.data.post_ids;
-    const selectedPostIdsEl = document.getElementById('nuclen_selected_post_ids') as HTMLInputElement | null;
-    if (selectedPostIdsEl) {
-      selectedPostIdsEl.value = JSON.stringify(foundPosts);
-    }
-    nuclenStoreFilters(filters);
-    nuclenHideElement(elements.step1);
-    nuclenShowElement(elements.step2);
-    nuclenUpdateProgressBarStep(elements.stepBar1, 'done');
-    nuclenUpdateProgressBarStep(elements.stepBar2, 'current');
-    if (count === 0) {
-      if (elements.postsCountEl) {
-        elements.postsCountEl.innerText = 'No posts found with these filters.';
-      }
-      if (elements.submitBtn) {
-        nuclenHideElement(elements.submitBtn);
-      }
-      return;
-    }
-    if (elements.postsCountEl) {
-      elements.postsCountEl.innerText = `Number of posts to process: ${count}`;
-    }
-    try {
-      const remainingCredits = await nuclenCheckCreditsAjax();
-      const neededCredits = count;
-      if (elements.creditsInfoEl) {
-        elements.creditsInfoEl.textContent = `This will consume ${neededCredits} credit(s). You have ${remainingCredits} left.`;
-      }
-      if (remainingCredits < neededCredits) {
-        displayError('Not enough credits. Please top up or reduce the number of posts.');
-        if (elements.submitBtn) {
-          elements.submitBtn.disabled = true;
-        }
-      } else if (elements.submitBtn) {
-        nuclenShowElement(elements.submitBtn);
-        elements.submitBtn.disabled = false;
-      }
-    } catch (err: unknown) {
-      logger.error('Error fetching remaining credits:', err);
-      const message = err instanceof Error ? err.message : 'Unknown error';
-      if (elements.creditsInfoEl) {
-        elements.creditsInfoEl.textContent = `Unable to retrieve your credits: ${message}`;
-      }
-      if (elements.submitBtn) {
-        elements.submitBtn.disabled = false;
-      }
-    }
-    });
-  }
+	const result = await nuclenFetchWithRetry<PostsCountResponse>(
+		window.nuclenAjax.ajax_url || '',
+		{
+		method: 'POST',
+		body: formData,
+		credentials: 'same-origin',
+		}
+	);
+	if (!result.ok) {
+		logger.error('Error retrieving post count:', result.error);
+		if (elements.postsCountEl) {
+		elements.postsCountEl.innerText = 'Error retrieving post count.';
+		}
+		return;
+	}
+	const data = result.data as PostsCountResponse;
+	if (!data.success) {
+		if (elements.postsCountEl) {
+		elements.postsCountEl.innerText = 'Error retrieving post count.';
+		}
+		const errMsg = data.message || data.data?.message;
+		if (errMsg) {
+		if (errMsg.includes('Invalid API key')) {
+			displayError('Your Gold Code (API key) is invalid. Please create a new one on the NE app and enter it on the plugin Setup page.');
+		} else if (errMsg.includes('Invalid WP App Password')) {
+			displayError('Your WP App Password is invalid. Please go to the plugin Setup page and re-generate it.');
+		} else {
+			displayError(errMsg);
+		}
+		}
+		return;
+	}
+	const count = data.data.count as number;
+	const foundPosts = data.data.post_ids;
+	const selectedPostIdsEl = document.getElementById('nuclen_selected_post_ids') as HTMLInputElement | null;
+	if (selectedPostIdsEl) {
+		selectedPostIdsEl.value = JSON.stringify(foundPosts);
+	}
+	nuclenStoreFilters(filters);
+	nuclenHideElement(elements.step1);
+	nuclenShowElement(elements.step2);
+	nuclenUpdateProgressBarStep(elements.stepBar1, 'done');
+	nuclenUpdateProgressBarStep(elements.stepBar2, 'current');
+	if (count === 0) {
+		if (elements.postsCountEl) {
+		elements.postsCountEl.innerText = 'No posts found with these filters.';
+		}
+		if (elements.submitBtn) {
+		nuclenHideElement(elements.submitBtn);
+		}
+		return;
+	}
+	if (elements.postsCountEl) {
+		elements.postsCountEl.innerText = `Number of posts to process: ${count}`;
+	}
+	try {
+		const remainingCredits = await nuclenCheckCreditsAjax();
+		const neededCredits = count;
+		if (elements.creditsInfoEl) {
+		elements.creditsInfoEl.textContent = `This will consume ${neededCredits} credit(s). You have ${remainingCredits} left.`;
+		}
+		if (remainingCredits < neededCredits) {
+		displayError('Not enough credits. Please top up or reduce the number of posts.');
+		if (elements.submitBtn) {
+			elements.submitBtn.disabled = true;
+		}
+		} else if (elements.submitBtn) {
+		nuclenShowElement(elements.submitBtn);
+		elements.submitBtn.disabled = false;
+		}
+	} catch (err: unknown) {
+		logger.error('Error fetching remaining credits:', err);
+		const message = err instanceof Error ? err.message : 'Unknown error';
+		if (elements.creditsInfoEl) {
+		elements.creditsInfoEl.textContent = `Unable to retrieve your credits: ${message}`;
+		}
+		if (elements.submitBtn) {
+		elements.submitBtn.disabled = false;
+		}
+	}
+	});
+	}

--- a/src/admin/ts/generate/step2.ts
+++ b/src/admin/ts/generate/step2.ts
@@ -1,108 +1,108 @@
 import {
-  NuclenStartGeneration,
-  NuclenPollAndPullUpdates,
+	NuclenStartGeneration,
+	NuclenPollAndPullUpdates,
 } from '../nuclen-admin-generate';
 import type {
-  StartGenerationResponse,
-  PollingUpdateData,
+	StartGenerationResponse,
+	PollingUpdateData,
 } from '../generation/api';
 import {
-  nuclenShowElement,
-  nuclenHideElement,
-  nuclenUpdateProgressBarStep,
+	nuclenShowElement,
+	nuclenHideElement,
+	nuclenUpdateProgressBarStep,
 } from './generate-page-utils';
 import type { GeneratePageElements } from './elements';
 import {
-  nuclenAlertApiError,
-  nuclenStoreGenerationResults,
+	nuclenAlertApiError,
+	nuclenStoreGenerationResults,
 } from '../generation/results';
 import { displayError } from '../utils/displayError';
 import * as logger from '../utils/logger';
 
 export function initStep2(elements: GeneratePageElements): void {
-  elements.generateForm?.addEventListener('submit', async (event) => {
-    event.preventDefault();
-    if (!window.nuclenAdminVars || !window.nuclenAdminVars.ajax_url) {
-      displayError('Error: WP Ajax config not found. Please check the plugin settings.');
-      return;
-    }
-    nuclenUpdateProgressBarStep(elements.stepBar2, 'done');
-    nuclenUpdateProgressBarStep(elements.stepBar3, 'current');
-    nuclenShowElement(elements.updatesSection);
-    if (elements.updatesContent) {
-      elements.updatesContent.innerText = 'Processing posts... Do NOT leave this page until the process is complete.';
-    }
-    nuclenHideElement(elements.step2);
-    if (elements.submitBtn) {
-      elements.submitBtn.disabled = true;
-    }
-    try {
-      const formDataObj = Object.fromEntries(new FormData(elements.generateForm!).entries());
-      const startResp: StartGenerationResponse = await NuclenStartGeneration(
-        formDataObj
-      );
-      const generationId =
-        startResp.data?.generation_id || startResp.generation_id || 'gen_' + Math.random().toString(36).substring(2);
-      NuclenPollAndPullUpdates({
-        intervalMs: 5000,
-        generationId,
-        onProgress: (processed, total) => {
-          const safeProcessed = processed === undefined ? 0 : processed;
-          const safeTotal = total === undefined ? '' : total;
-          if (elements.updatesContent) {
-            elements.updatesContent.innerText = `Processed ${safeProcessed} of ${safeTotal} posts so far...`;
-          }
-        },
-        onComplete: async ({ failCount, finalReport, results, workflow }: PollingUpdateData) => {
-          nuclenUpdateProgressBarStep(elements.stepBar3, 'done');
-          nuclenUpdateProgressBarStep(elements.stepBar4, 'current');
-          if (results && typeof results === 'object') {
-            try {
-              const { ok, data } = await nuclenStoreGenerationResults(workflow, results);
-              const respData = data as Record<string, unknown>;
-              if (ok && !('code' in respData)) {
-                logger.log('Bulk content stored in WP meta successfully:', respData);
-              } else {
-                logger.error('Error storing bulk content in WP meta:', respData);
-              }
-            } catch (err) {
-              logger.error('Error storing bulk content in WP meta:', err);
-            }
-          }
-          if (elements.updatesContent) {
-            if (failCount && finalReport) {
-              elements.updatesContent.innerText = `Some posts failed. ${finalReport.message || ''}`;
-              nuclenUpdateProgressBarStep(elements.stepBar4, 'failed');
-            } else {
-              elements.updatesContent.innerText = 'All posts processed successfully! Your content has been saved.';
-              nuclenUpdateProgressBarStep(elements.stepBar4, 'done');
-            }
-          }
-          if (elements.submitBtn) {
-            elements.submitBtn.disabled = false;
-          }
-          nuclenShowElement(elements.restartBtn);
-        },
-        onError: (errMsg: string) => {
-          nuclenUpdateProgressBarStep(elements.stepBar3, 'failed');
-          nuclenAlertApiError(errMsg);
-          if (elements.updatesContent) {
-            elements.updatesContent.innerText = `Error: ${errMsg}`;
-          }
-          if (elements.submitBtn) {
-            elements.submitBtn.disabled = false;
-          }
-          nuclenShowElement(elements.restartBtn);
-        },
-      });
-    } catch (error: unknown) {
-      nuclenUpdateProgressBarStep(elements.stepBar3, 'failed');
-      const message = error instanceof Error ? error.message : 'Unknown error';
-      nuclenAlertApiError(message);
-      if (elements.submitBtn) {
-        elements.submitBtn.disabled = false;
-      }
-      nuclenShowElement(elements.restartBtn);
-    }
-  });
+	elements.generateForm?.addEventListener('submit', async (event) => {
+	event.preventDefault();
+	if (!window.nuclenAdminVars || !window.nuclenAdminVars.ajax_url) {
+		displayError('Error: WP Ajax config not found. Please check the plugin settings.');
+		return;
+	}
+	nuclenUpdateProgressBarStep(elements.stepBar2, 'done');
+	nuclenUpdateProgressBarStep(elements.stepBar3, 'current');
+	nuclenShowElement(elements.updatesSection);
+	if (elements.updatesContent) {
+		elements.updatesContent.innerText = 'Processing posts... Do NOT leave this page until the process is complete.';
+	}
+	nuclenHideElement(elements.step2);
+	if (elements.submitBtn) {
+		elements.submitBtn.disabled = true;
+	}
+	try {
+		const formDataObj = Object.fromEntries(new FormData(elements.generateForm!).entries());
+		const startResp: StartGenerationResponse = await NuclenStartGeneration(
+		formDataObj
+		);
+		const generationId =
+		startResp.data?.generation_id || startResp.generation_id || 'gen_' + Math.random().toString(36).substring(2);
+		NuclenPollAndPullUpdates({
+		intervalMs: 5000,
+		generationId,
+		onProgress: (processed, total) => {
+			const safeProcessed = processed === undefined ? 0 : processed;
+			const safeTotal = total === undefined ? '' : total;
+			if (elements.updatesContent) {
+			elements.updatesContent.innerText = `Processed ${safeProcessed} of ${safeTotal} posts so far...`;
+			}
+		},
+		onComplete: async ({ failCount, finalReport, results, workflow }: PollingUpdateData) => {
+			nuclenUpdateProgressBarStep(elements.stepBar3, 'done');
+			nuclenUpdateProgressBarStep(elements.stepBar4, 'current');
+			if (results && typeof results === 'object') {
+			try {
+				const { ok, data } = await nuclenStoreGenerationResults(workflow, results);
+				const respData = data as Record<string, unknown>;
+				if (ok && !('code' in respData)) {
+				logger.log('Bulk content stored in WP meta successfully:', respData);
+				} else {
+				logger.error('Error storing bulk content in WP meta:', respData);
+				}
+			} catch (err) {
+				logger.error('Error storing bulk content in WP meta:', err);
+			}
+			}
+			if (elements.updatesContent) {
+			if (failCount && finalReport) {
+				elements.updatesContent.innerText = `Some posts failed. ${finalReport.message || ''}`;
+				nuclenUpdateProgressBarStep(elements.stepBar4, 'failed');
+			} else {
+				elements.updatesContent.innerText = 'All posts processed successfully! Your content has been saved.';
+				nuclenUpdateProgressBarStep(elements.stepBar4, 'done');
+			}
+			}
+			if (elements.submitBtn) {
+			elements.submitBtn.disabled = false;
+			}
+			nuclenShowElement(elements.restartBtn);
+		},
+		onError: (errMsg: string) => {
+			nuclenUpdateProgressBarStep(elements.stepBar3, 'failed');
+			nuclenAlertApiError(errMsg);
+			if (elements.updatesContent) {
+			elements.updatesContent.innerText = `Error: ${errMsg}`;
+			}
+			if (elements.submitBtn) {
+			elements.submitBtn.disabled = false;
+			}
+			nuclenShowElement(elements.restartBtn);
+		},
+		});
+	} catch (error: unknown) {
+		nuclenUpdateProgressBarStep(elements.stepBar3, 'failed');
+		const message = error instanceof Error ? error.message : 'Unknown error';
+		nuclenAlertApiError(message);
+		if (elements.submitBtn) {
+		elements.submitBtn.disabled = false;
+		}
+		nuclenShowElement(elements.restartBtn);
+	}
+	});
 }

--- a/src/admin/ts/generation/api.ts
+++ b/src/admin/ts/generation/api.ts
@@ -1,163 +1,163 @@
 import * as logger from '../utils/logger';
 
 export interface NuclenFetchResult<T> {
-  ok: boolean;
-  status: number;
-  data: T | null;
-  error?: string;
+	ok: boolean;
+	status: number;
+	data: T | null;
+	error?: string;
 }
 
 export async function nuclenFetchWithRetry<T = unknown>(
-  url: string,
-  options: RequestInit,
-  retries = 3,
-  initialDelayMs = 500
+	url: string,
+	options: RequestInit,
+	retries = 3,
+	initialDelayMs = 500
 ): Promise<NuclenFetchResult<T>> {
-  let attempt = 0;
-  let delay = initialDelayMs;
-  let lastError: Error | undefined;
+	let attempt = 0;
+	let delay = initialDelayMs;
+	let lastError: Error | undefined;
 
-  while (attempt <= retries) {
-    try {
-      const response = await fetch(url, options);
-      const { status, ok } = response;
-      const bodyText = await response.text().catch(() => '');
-      let data: T | null = null;
-      if (bodyText) {
-        try {
-          data = JSON.parse(bodyText) as T;
-        } catch {
-          // body is not JSON
-        }
-      }
+	while (attempt <= retries) {
+	try {
+		const response = await fetch(url, options);
+		const { status, ok } = response;
+		const bodyText = await response.text().catch(() => '');
+		let data: T | null = null;
+		if (bodyText) {
+		try {
+			data = JSON.parse(bodyText) as T;
+		} catch {
+			// body is not JSON
+		}
+		}
 
-      if (ok) {
-        return { ok: true, status, data };
-      }
+		if (ok) {
+		return { ok: true, status, data };
+		}
 
-      return { ok: false, status, data, error: bodyText };
-    } catch (error: unknown) {
-      lastError = error as Error;
-      if (attempt === retries) {
-        break;
-      }
+		return { ok: false, status, data, error: bodyText };
+	} catch (error: unknown) {
+		lastError = error as Error;
+		if (attempt === retries) {
+		break;
+		}
 
-      logger.warn(
-        `Retrying request to ${url} with method ${options.method || 'GET'} (${retries - attempt} attempts left). Error: ${lastError.message}`,
-        lastError
-      );
-      await new Promise((resolve) => setTimeout(resolve, delay));
-      delay *= 2;
-    }
-    attempt += 1;
-  }
+		logger.warn(
+		`Retrying request to ${url} with method ${options.method || 'GET'} (${retries - attempt} attempts left). Error: ${lastError.message}`,
+		lastError
+		);
+		await new Promise((resolve) => setTimeout(resolve, delay));
+		delay *= 2;
+	}
+	attempt += 1;
+	}
 
-  logger.error(
-    `Max retries reached for ${url} with method ${options.method || 'GET'}:`,
-    lastError
-  );
-  throw lastError;
+	logger.error(
+	`Max retries reached for ${url} with method ${options.method || 'GET'}:`,
+	lastError
+	);
+	throw lastError;
 }
 
 export interface PollingUpdateData {
-  processed: number;
-  total: number;
-  successCount?: number;
-  failCount?: number;
-  finalReport?: { message?: string };
-  results?: Record<string, unknown>;
-  workflow: string;
+	processed: number;
+	total: number;
+	successCount?: number;
+	failCount?: number;
+	finalReport?: { message?: string };
+	results?: Record<string, unknown>;
+	workflow: string;
 }
 
 export interface PollingUpdateResponse {
-  success: boolean;
-  message?: string;
-  data: PollingUpdateData;
+	success: boolean;
+	message?: string;
+	data: PollingUpdateData;
 }
 
 export interface StartGenerationResponse {
-  success: boolean;
-  message?: string;
-  generation_id?: string;
-  data?: {
-    generation_id?: string;
-    [key: string]: unknown;
-  };
+	success: boolean;
+	message?: string;
+	generation_id?: string;
+	data?: {
+	generation_id?: string;
+	[key: string]: unknown;
+	};
 }
 
 export async function nuclenFetchUpdates(
-  generationId?: string
+	generationId?: string
 ): Promise<PollingUpdateResponse> {
-  if (!window.nuclenAjax || !window.nuclenAjax.ajax_url) {
-    throw new Error('Missing nuclenAjax configuration (ajax_url).');
-  }
-  if (!window.nuclenAjax.fetch_action) {
-    throw new Error('Missing fetch_action in nuclenAjax configuration.');
-  }
+	if (!window.nuclenAjax || !window.nuclenAjax.ajax_url) {
+	throw new Error('Missing nuclenAjax configuration (ajax_url).');
+	}
+	if (!window.nuclenAjax.fetch_action) {
+	throw new Error('Missing fetch_action in nuclenAjax configuration.');
+	}
 
-  const formData = new FormData();
-  formData.append('action', window.nuclenAjax.fetch_action);
+	const formData = new FormData();
+	formData.append('action', window.nuclenAjax.fetch_action);
 
-  if (window.nuclenAjax.nonce) {
-    formData.append('security', window.nuclenAjax.nonce);
-  }
+	if (window.nuclenAjax.nonce) {
+	formData.append('security', window.nuclenAjax.nonce);
+	}
 
-  if (generationId) {
-    formData.append('generation_id', generationId);
-  }
+	if (generationId) {
+	formData.append('generation_id', generationId);
+	}
 
-  const result = await nuclenFetchWithRetry<PollingUpdateResponse>(
-    window.nuclenAjax.ajax_url,
-    {
-      method: 'POST',
-      body: formData,
-      credentials: 'same-origin',
-    }
-  );
+	const result = await nuclenFetchWithRetry<PollingUpdateResponse>(
+	window.nuclenAjax.ajax_url,
+	{
+		method: 'POST',
+		body: formData,
+		credentials: 'same-origin',
+	}
+	);
 
-  if (!result.ok) {
-    throw new Error(result.error || `HTTP ${result.status}`);
-  }
+	if (!result.ok) {
+	throw new Error(result.error || `HTTP ${result.status}`);
+	}
 
-  return result.data as PollingUpdateResponse;
+	return result.data as PollingUpdateResponse;
 }
 
 export async function NuclenStartGeneration(
-  dataToSend: Record<string, unknown>
+	dataToSend: Record<string, unknown>
 ): Promise<StartGenerationResponse> {
-  if (!window.nuclenAdminVars || !window.nuclenAdminVars.ajax_url) {
-    throw new Error('Missing WP Ajax config (nuclenAdminVars.ajax_url).');
-  }
+	if (!window.nuclenAdminVars || !window.nuclenAdminVars.ajax_url) {
+	throw new Error('Missing WP Ajax config (nuclenAdminVars.ajax_url).');
+	}
 
-  const formData = new FormData();
-  formData.append('action', 'nuclen_trigger_generation');
-  formData.append('payload', JSON.stringify(dataToSend));
-  if (!window.nuclenAjax?.nonce) {
-    throw new Error('Missing security nonce.');
-  }
-  formData.append('security', window.nuclenAjax.nonce);
+	const formData = new FormData();
+	formData.append('action', 'nuclen_trigger_generation');
+	formData.append('payload', JSON.stringify(dataToSend));
+	if (!window.nuclenAjax?.nonce) {
+	throw new Error('Missing security nonce.');
+	}
+	formData.append('security', window.nuclenAjax.nonce);
 
-  const result = await nuclenFetchWithRetry<StartGenerationResponse>(
-    window.nuclenAdminVars.ajax_url,
-    {
-      method: 'POST',
-      body: formData,
-      credentials: 'same-origin',
-    }
-  );
+	const result = await nuclenFetchWithRetry<StartGenerationResponse>(
+	window.nuclenAdminVars.ajax_url,
+	{
+		method: 'POST',
+		body: formData,
+		credentials: 'same-origin',
+	}
+	);
 
-  if (!result.ok) {
-    throw new Error(result.error || `HTTP ${result.status}`);
-  }
+	if (!result.ok) {
+	throw new Error(result.error || `HTTP ${result.status}`);
+	}
 
-  const data = result.data as StartGenerationResponse;
-  if (!data?.success) {
-    const errMsg =
-      (data?.message as string) ||
-      (data?.data?.message as string) ||
-      'Generation start failed (unknown error).';
-    throw new Error(errMsg);
-  }
+	const data = result.data as StartGenerationResponse;
+	if (!data?.success) {
+	const errMsg =
+		(data?.message as string) ||
+		(data?.data?.message as string) ||
+		'Generation start failed (unknown error).';
+	throw new Error(errMsg);
+	}
 
-  return data;
+	return data;
 }

--- a/src/admin/ts/generation/polling.ts
+++ b/src/admin/ts/generation/polling.ts
@@ -2,54 +2,54 @@ import { nuclenFetchUpdates } from './api';
 import type { PollingUpdateData, PollingUpdateResponse } from './api';
 
 export function NuclenPollAndPullUpdates({
-  intervalMs = 5000,
-  generationId,
-  onProgress = (() => {}) as (processed: number, total: number) => void,
-  onComplete = () => {},
-  onError = () => {},
+	intervalMs = 5000,
+	generationId,
+	onProgress = (() => {}) as (processed: number, total: number) => void,
+	onComplete = () => {},
+	onError = () => {},
 }: {
-  intervalMs?: number;
-  generationId: string;
-  onProgress?: (processed: number, total: number) => void;
-  onComplete?: (finalData: PollingUpdateData) => void;
-  onError?: (errMsg: string) => void;
+	intervalMs?: number;
+	generationId: string;
+	onProgress?: (processed: number, total: number) => void;
+	onComplete?: (finalData: PollingUpdateData) => void;
+	onError?: (errMsg: string) => void;
 }) {
-  const pollInterval = setInterval(async () => {
-    try {
-      const pollResults: PollingUpdateResponse = await nuclenFetchUpdates(generationId);
-      if (!pollResults.success) {
-        const errMsg = pollResults.message || 'Polling error';
-        throw new Error(errMsg);
-      }
+	const pollInterval = setInterval(async () => {
+	try {
+		const pollResults: PollingUpdateResponse = await nuclenFetchUpdates(generationId);
+		if (!pollResults.success) {
+		const errMsg = pollResults.message || 'Polling error';
+		throw new Error(errMsg);
+		}
 
-      const {
-        processed,
-        total,
-        successCount = processed,
-        failCount,
-        finalReport,
-        results,
-        workflow,
-      } = pollResults.data;
+		const {
+		processed,
+		total,
+		successCount = processed,
+		failCount,
+		finalReport,
+		results,
+		workflow,
+		} = pollResults.data;
 
-      onProgress(processed, total);
+		onProgress(processed, total);
 
-      if (processed >= total) {
-        clearInterval(pollInterval);
-        onComplete({
-          processed,
-          total,
-          successCount,
-          failCount,
-          finalReport,
-          results,
-          workflow,
-        });
-      }
-    } catch (err: unknown) {
-      clearInterval(pollInterval);
-      const message = err instanceof Error ? err.message : 'Unknown error';
-      onError(message);
-    }
-  }, intervalMs);
+		if (processed >= total) {
+		clearInterval(pollInterval);
+		onComplete({
+			processed,
+			total,
+			successCount,
+			failCount,
+			finalReport,
+			results,
+			workflow,
+		});
+		}
+	} catch (err: unknown) {
+		clearInterval(pollInterval);
+		const message = err instanceof Error ? err.message : 'Unknown error';
+		onError(message);
+	}
+	}, intervalMs);
 }

--- a/src/admin/ts/generation/results.ts
+++ b/src/admin/ts/generation/results.ts
@@ -1,49 +1,49 @@
 export const REST_ENDPOINT =
-  window.nuclenAdminVars?.rest_receive_content ||
-  '/wp-json/nuclear-engagement/v1/receive-content';
+	window.nuclenAdminVars?.rest_receive_content ||
+	'/wp-json/nuclear-engagement/v1/receive-content';
 
 export const REST_NONCE = window.nuclenAdminVars?.rest_nonce || '';
 import { displayError } from '../utils/displayError';
 import * as logger from '../utils/logger';
 
 export function nuclenAlertApiError(errMsg: string): void {
-  const cleanMsg = errMsg.replace(/<[^>]+>/g, '');
-  if (cleanMsg.includes('Invalid API key')) {
-    displayError('Your API key is invalid. Please go to the Setup page and enter a new one.');
-  } else if (cleanMsg.includes('Invalid WP App Password')) {
-    displayError('Your WP App Password is invalid. Please re-generate it on the Setup page.');
-  } else if (cleanMsg.includes('Not enough credits')) {
-    displayError('Not enough credits. Please top up your account or reduce the number of posts.');
-  } else {
-    displayError(`Error: ${cleanMsg}`);
-  }
+	const cleanMsg = errMsg.replace(/<[^>]+>/g, '');
+	if (cleanMsg.includes('Invalid API key')) {
+	displayError('Your API key is invalid. Please go to the Setup page and enter a new one.');
+	} else if (cleanMsg.includes('Invalid WP App Password')) {
+	displayError('Your WP App Password is invalid. Please re-generate it on the Setup page.');
+	} else if (cleanMsg.includes('Not enough credits')) {
+	displayError('Not enough credits. Please top up your account or reduce the number of posts.');
+	} else {
+	displayError(`Error: ${cleanMsg}`);
+	}
 }
 
 export async function nuclenStoreGenerationResults(workflow: string, results: unknown) {
-  const payload = { workflow, results };
-  let resp: Response;
-  try {
-    resp = await fetch(REST_ENDPOINT, {
-      method: 'POST',
-      headers: {
-        'Content-Type': 'application/json',
-        'X-WP-Nonce': REST_NONCE,
-      },
-      credentials: 'include',
-      body: JSON.stringify(payload),
-    });
-  } catch (err) {
-    logger.error('Fetch failed in nuclenStoreGenerationResults:', err);
-    displayError('Network error');
-    return { ok: false, data: { message: 'Network error' } };
-  }
-  let data: unknown = null;
-  if (resp.ok) {
-    try {
-      data = await resp.json();
-    } catch (err) {
-      return { ok: false, data: { message: 'Invalid JSON' } };
-    }
-  }
-  return { ok: resp.ok, data };
+	const payload = { workflow, results };
+	let resp: Response;
+	try {
+	resp = await fetch(REST_ENDPOINT, {
+		method: 'POST',
+		headers: {
+		'Content-Type': 'application/json',
+		'X-WP-Nonce': REST_NONCE,
+		},
+		credentials: 'include',
+		body: JSON.stringify(payload),
+	});
+	} catch (err) {
+	logger.error('Fetch failed in nuclenStoreGenerationResults:', err);
+	displayError('Network error');
+	return { ok: false, data: { message: 'Network error' } };
+	}
+	let data: unknown = null;
+	if (resp.ok) {
+	try {
+		data = await resp.json();
+	} catch (err) {
+		return { ok: false, data: { message: 'Invalid JSON' } };
+	}
+	}
+	return { ok: resp.ok, data };
 }

--- a/src/admin/ts/nuclen-admin-generate.ts
+++ b/src/admin/ts/nuclen-admin-generate.ts
@@ -2,8 +2,8 @@
 // Keeps backward-compatible imports across the codebase.
 
 export {
-  nuclenFetchWithRetry,
-  nuclenFetchUpdates,
-  NuclenStartGeneration,
+	nuclenFetchWithRetry,
+	nuclenFetchUpdates,
+	NuclenStartGeneration,
 } from './generation/api';
 export { NuclenPollAndPullUpdates } from './generation/polling';

--- a/src/admin/ts/nuclen-admin-onboarding.ts
+++ b/src/admin/ts/nuclen-admin-onboarding.ts
@@ -5,142 +5,142 @@ import * as logger from './utils/logger';
 
 // 1) Declare the global shape of window.nePointerData.
 declare global {
-  interface Window {
-    nePointerData?: NuclenPointerData;
-  }
+	interface Window {
+	nePointerData?: NuclenPointerData;
+	}
 }
 
 // 2) Describe the structure of the pointer data
 export interface NuclenPointerData {
-  pointers: NuclenPointer[];
-  ajaxurl: string;
-  nonce?: string; // Add the nonce
+	pointers: NuclenPointer[];
+	ajaxurl: string;
+	nonce?: string; // Add the nonce
 }
 
 // 3) Each pointer has the properties your PHP code provides
 export interface NuclenPointer {
-  id: string;
-  target: string;
-  title: string;
-  content: string;
-  position: {
-    edge: 'top' | 'bottom' | 'left' | 'right';
-    align: 'top' | 'bottom' | 'left' | 'right' | 'center';
-  };
+	id: string;
+	target: string;
+	title: string;
+	content: string;
+	position: {
+	edge: 'top' | 'bottom' | 'left' | 'right';
+	align: 'top' | 'bottom' | 'left' | 'right' | 'center';
+	};
 }
 
 // Wrap our logic in an IIFE
 (function() {
-  // Wait for DOM ready
-  document.addEventListener('DOMContentLoaded', () => {
-    const pointerData = window.nePointerData;
+	// Wait for DOM ready
+	document.addEventListener('DOMContentLoaded', () => {
+	const pointerData = window.nePointerData;
 
-    // Check that pointerData exists and has pointers
-    if (!pointerData || !pointerData.pointers || pointerData.pointers.length === 0) {
-      return;
-    }
+	// Check that pointerData exists and has pointers
+	if (!pointerData || !pointerData.pointers || pointerData.pointers.length === 0) {
+		return;
+	}
 
-    let currentIndex = 0;
-    const pointers = pointerData.pointers;
-    const ajaxurl = pointerData.ajaxurl;
-    const nonce = pointerData.nonce; // We'll send this in our AJAX
+	let currentIndex = 0;
+	const pointers = pointerData.pointers;
+	const ajaxurl = pointerData.ajaxurl;
+	const nonce = pointerData.nonce; // We'll send this in our AJAX
 
-    function nuclenShowNextPointer() {
-      if (currentIndex >= pointers.length) {
-        return;
-      }
+	function nuclenShowNextPointer() {
+		if (currentIndex >= pointers.length) {
+		return;
+		}
 
-      const ptr = pointers[currentIndex];
-      const target = document.querySelector<HTMLElement>(ptr.target);
+		const ptr = pointers[currentIndex];
+		const target = document.querySelector<HTMLElement>(ptr.target);
 
-      if (!target) {
-        currentIndex++;
-        nuclenShowNextPointer();
-        return;
-      }
+		if (!target) {
+		currentIndex++;
+		nuclenShowNextPointer();
+		return;
+		}
 
-      const wrapper = document.createElement('div');
-      wrapper.className = `wp-pointer pointer-${ptr.position.edge}`;
-      wrapper.style.position = 'absolute';
-      wrapper.innerHTML = `
-        <div class="wp-pointer-content">
-          <h3>${ptr.title}</h3>
-          <p>${ptr.content}</p>
-          <a class="close" href="#">Dismiss</a>
-        </div>
-      `;
-      document.body.appendChild(wrapper);
+		const wrapper = document.createElement('div');
+		wrapper.className = `wp-pointer pointer-${ptr.position.edge}`;
+		wrapper.style.position = 'absolute';
+		wrapper.innerHTML = `
+		<div class="wp-pointer-content">
+			<h3>${ptr.title}</h3>
+			<p>${ptr.content}</p>
+			<a class="close" href="#">Dismiss</a>
+		</div>
+		`;
+		document.body.appendChild(wrapper);
 
-      const rect = target.getBoundingClientRect();
-      let top = window.scrollY + rect.top;
-      let left = window.scrollX + rect.left;
+		const rect = target.getBoundingClientRect();
+		let top = window.scrollY + rect.top;
+		let left = window.scrollX + rect.left;
 
-      switch (ptr.position.edge) {
-        case 'top':
-          top -= wrapper.offsetHeight;
-          break;
-        case 'bottom':
-          top += rect.height;
-          break;
-        case 'left':
-          left -= wrapper.offsetWidth;
-          break;
-        case 'right':
-          left += rect.width;
-          break;
-      }
+		switch (ptr.position.edge) {
+		case 'top':
+			top -= wrapper.offsetHeight;
+			break;
+		case 'bottom':
+			top += rect.height;
+			break;
+		case 'left':
+			left -= wrapper.offsetWidth;
+			break;
+		case 'right':
+			left += rect.width;
+			break;
+		}
 
-      if (ptr.position.align === 'center') {
-        if (ptr.position.edge === 'top' || ptr.position.edge === 'bottom') {
-          left += (rect.width - wrapper.offsetWidth) / 2;
-        } else {
-          top += (rect.height - wrapper.offsetHeight) / 2;
-        }
-      } else if (ptr.position.align === 'right' || ptr.position.align === 'bottom') {
-        if (ptr.position.edge === 'top' || ptr.position.edge === 'bottom') {
-          left += rect.width - wrapper.offsetWidth;
-        } else {
-          top += rect.height - wrapper.offsetHeight;
-        }
-      }
+		if (ptr.position.align === 'center') {
+		if (ptr.position.edge === 'top' || ptr.position.edge === 'bottom') {
+			left += (rect.width - wrapper.offsetWidth) / 2;
+		} else {
+			top += (rect.height - wrapper.offsetHeight) / 2;
+		}
+		} else if (ptr.position.align === 'right' || ptr.position.align === 'bottom') {
+		if (ptr.position.edge === 'top' || ptr.position.edge === 'bottom') {
+			left += rect.width - wrapper.offsetWidth;
+		} else {
+			top += rect.height - wrapper.offsetHeight;
+		}
+		}
 
-      wrapper.style.top = `${Math.max(top, 0)}px`;
-      wrapper.style.left = `${Math.max(left, 0)}px`;
+		wrapper.style.top = `${Math.max(top, 0)}px`;
+		wrapper.style.left = `${Math.max(left, 0)}px`;
 
-      const close = wrapper.querySelector<HTMLAnchorElement>('.close');
-      close?.addEventListener('click', async (e) => {
-        e.preventDefault();
+		const close = wrapper.querySelector<HTMLAnchorElement>('.close');
+		close?.addEventListener('click', async (e) => {
+		e.preventDefault();
 
-        const form = new URLSearchParams();
-        form.append('action', 'nuclen_dismiss_pointer');
-        form.append('pointer', ptr.id);
-        if (nonce) {
-          form.append('nonce', nonce);
-        }
+		const form = new URLSearchParams();
+		form.append('action', 'nuclen_dismiss_pointer');
+		form.append('pointer', ptr.id);
+		if (nonce) {
+			form.append('nonce', nonce);
+		}
 
-        try {
-          const result = await nuclenFetchWithRetry(ajaxurl, {
-            method: 'POST',
-            credentials: 'same-origin',
-            headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
-            body: form.toString(),
-          });
-          if (!result.ok) {
-            logger.error('Failed to dismiss pointer:', result.error);
-            displayError('Failed to dismiss pointer.');
-          }
-        } catch (err: unknown) {
-          logger.error('Error dismissing pointer:', err);
-          displayError('Network error while dismissing pointer.');
-        }
+		try {
+			const result = await nuclenFetchWithRetry(ajaxurl, {
+			method: 'POST',
+			credentials: 'same-origin',
+			headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+			body: form.toString(),
+			});
+			if (!result.ok) {
+			logger.error('Failed to dismiss pointer:', result.error);
+			displayError('Failed to dismiss pointer.');
+			}
+		} catch (err: unknown) {
+			logger.error('Error dismissing pointer:', err);
+			displayError('Network error while dismissing pointer.');
+		}
 
-        wrapper.remove();
-        currentIndex++;
-        nuclenShowNextPointer();
-      });
-    }
+		wrapper.remove();
+		currentIndex++;
+		nuclenShowNextPointer();
+		});
+	}
 
-    // Start the sequence
-    nuclenShowNextPointer();
-  });
+	// Start the sequence
+	nuclenShowNextPointer();
+	});
 })();

--- a/src/admin/ts/nuclen-admin-ui.ts
+++ b/src/admin/ts/nuclen-admin-ui.ts
@@ -1,58 +1,58 @@
 // admin/ts/nuclen-admin-ui.ts
 
 document.addEventListener("DOMContentLoaded", () => {
-    // Grab tab links as HTMLAnchorElements
-    const tabs = document.querySelectorAll<HTMLAnchorElement>(".nav-tab");
-    // Grab tab content sections as HTMLElements
-    const contents = document.querySelectorAll<HTMLElement>(".nuclen-tab-content");
+	// Grab tab links as HTMLAnchorElements
+	const tabs = document.querySelectorAll<HTMLAnchorElement>(".nav-tab");
+	// Grab tab content sections as HTMLElements
+	const contents = document.querySelectorAll<HTMLElement>(".nuclen-tab-content");
 
-    tabs.forEach((tab) => {
-      tab.addEventListener("click", (e) => {
-        e.preventDefault();
-        const target = tab.getAttribute("href");
-        if (!target) return; // If href is missing, bail
+	tabs.forEach((tab) => {
+		tab.addEventListener("click", (e) => {
+		e.preventDefault();
+		const target = tab.getAttribute("href");
+		if (!target) return; // If href is missing, bail
 
-        // Remove active class from all tabs, then add to the one that was clicked
-        tabs.forEach((t) => t.classList.remove("nav-tab-active"));
-        tab.classList.add("nav-tab-active");
+		// Remove active class from all tabs, then add to the one that was clicked
+		tabs.forEach((t) => t.classList.remove("nav-tab-active"));
+		tab.classList.add("nav-tab-active");
 
-        // Hide all tab contents, then show only the targeted one
-        contents.forEach((c) => {
-          c.style.display = "none";
-        });
-        const targetContent = document.querySelector<HTMLElement>(target);
-        if (targetContent) {
-          targetContent.style.display = "block";
-        }
-      });
-    });
+		// Hide all tab contents, then show only the targeted one
+		contents.forEach((c) => {
+			c.style.display = "none";
+		});
+		const targetContent = document.querySelector<HTMLElement>(target);
+		if (targetContent) {
+			targetContent.style.display = "block";
+		}
+		});
+	});
 
 
 
-    // Show/hide the custom theme section
-    const customThemeSection = document.getElementById("nuclen-custom-theme-section");
-    const themeRadios = document.querySelectorAll<HTMLInputElement>("input[name='nuclen_theme']");
+	// Show/hide the custom theme section
+	const customThemeSection = document.getElementById("nuclen-custom-theme-section");
+	const themeRadios = document.querySelectorAll<HTMLInputElement>("input[name='nuclen_theme']");
 
-    function nuclenUpdateCustomThemeVisibility() {
-      const checkedInput = document.querySelector<HTMLInputElement>("input[name='nuclen_theme']:checked");
-      // If either the input or the section is missing, do nothing
-      if (!checkedInput || !customThemeSection) {
-        return;
-      }
+	function nuclenUpdateCustomThemeVisibility() {
+		const checkedInput = document.querySelector<HTMLInputElement>("input[name='nuclen_theme']:checked");
+		// If either the input or the section is missing, do nothing
+		if (!checkedInput || !customThemeSection) {
+		return;
+		}
 
-      const selectedTheme = checkedInput.value;
-      if (selectedTheme === "custom") {
-        customThemeSection.classList.remove("nuclen-hidden");
-      } else {
-        customThemeSection.classList.add("nuclen-hidden");
-      }
-    }
+		const selectedTheme = checkedInput.value;
+		if (selectedTheme === "custom") {
+		customThemeSection.classList.remove("nuclen-hidden");
+		} else {
+		customThemeSection.classList.add("nuclen-hidden");
+		}
+	}
 
-    // Listen for theme radio changes
-    themeRadios.forEach((radio) => {
-      radio.addEventListener("change", nuclenUpdateCustomThemeVisibility);
-    });
+	// Listen for theme radio changes
+	themeRadios.forEach((radio) => {
+		radio.addEventListener("change", nuclenUpdateCustomThemeVisibility);
+	});
 
-    // Initial run on page load
-    nuclenUpdateCustomThemeVisibility();
-  });
+	// Initial run on page load
+	nuclenUpdateCustomThemeVisibility();
+	});

--- a/src/admin/ts/nuclen-globals.d.ts
+++ b/src/admin/ts/nuclen-globals.d.ts
@@ -2,20 +2,20 @@
 export {};
 
 declare global {
-  const wp: Record<string, unknown>;
-  interface Window {
-    nuclenAjax?: {
-      ajax_url?: string;
-      fetch_action?: string;
-      nonce?: string;
-    };
-    nuclenAdminVars?: {
-      ajax_url?: string;
-      security?: string;
-      rest_receive_content?: string;
-      rest_nonce?: string;
-    };
-    tinymce?: Record<string, unknown>;
-    wp?: Record<string, unknown>;
-  }
+	const wp: Record<string, unknown>;
+	interface Window {
+	nuclenAjax?: {
+		ajax_url?: string;
+		fetch_action?: string;
+		nonce?: string;
+	};
+	nuclenAdminVars?: {
+		ajax_url?: string;
+		security?: string;
+		rest_receive_content?: string;
+		rest_nonce?: string;
+	};
+	tinymce?: Record<string, unknown>;
+	wp?: Record<string, unknown>;
+	}
 }

--- a/src/admin/ts/single/single-generation-handlers.ts
+++ b/src/admin/ts/single/single-generation-handlers.ts
@@ -1,105 +1,105 @@
 import {
-  alertApiError,
-  populateQuizMetaBox,
-  populateSummaryMetaBox,
-  storeGenerationResults,
-  type PostResult,
+	alertApiError,
+	populateQuizMetaBox,
+	populateSummaryMetaBox,
+	storeGenerationResults,
+	type PostResult,
 } from './single-generation-utils';
 import {
-  NuclenStartGeneration,
-  NuclenPollAndPullUpdates,
+	NuclenStartGeneration,
+	NuclenPollAndPullUpdates,
 } from '../nuclen-admin-generate';
 import type { StartGenerationResponse, PollingUpdateData } from '../generation/api';
 import { displayError } from '../utils/displayError';
 import * as logger from '../utils/logger';
 
 export function initSingleGenerationButtons(): void {
-  document.addEventListener('click', async (event: MouseEvent) => {
-    const target = event.target;
-    if (!(target instanceof HTMLElement)) return;
-    if (!target.classList.contains('nuclen-generate-single')) return;
+	document.addEventListener('click', async (event: MouseEvent) => {
+	const target = event.target;
+	if (!(target instanceof HTMLElement)) return;
+	if (!target.classList.contains('nuclen-generate-single')) return;
 
-    const btn = target as HTMLButtonElement;
-    const postId = btn.dataset.postId;
-    const workflow = btn.dataset.workflow;
-    if (!postId || !workflow) {
-      displayError('Missing data attributes: postId or workflow not found.');
-      return;
-    }
+	const btn = target as HTMLButtonElement;
+	const postId = btn.dataset.postId;
+	const workflow = btn.dataset.workflow;
+	if (!postId || !workflow) {
+		displayError('Missing data attributes: postId or workflow not found.');
+		return;
+	}
 
-    btn.disabled = true;
-    btn.textContent = 'Generating...';
+	btn.disabled = true;
+	btn.textContent = 'Generating...';
 
-    try {
-      const startResp: StartGenerationResponse | {
-        ok: boolean;
-        status: number;
-        error?: string;
-        data?: { generation_id?: string; [key: string]: unknown };
-        generation_id?: string;
-      } = await NuclenStartGeneration({
-        nuclen_selected_post_ids: JSON.stringify([postId]),
-        nuclen_selected_generate_workflow: workflow,
-      });
+	try {
+		const startResp: StartGenerationResponse | {
+		ok: boolean;
+		status: number;
+		error?: string;
+		data?: { generation_id?: string; [key: string]: unknown };
+		generation_id?: string;
+		} = await NuclenStartGeneration({
+		nuclen_selected_post_ids: JSON.stringify([postId]),
+		nuclen_selected_generate_workflow: workflow,
+		});
 
-      if ('ok' in startResp && !startResp.ok) {
-        alertApiError((startResp as { error?: string }).error || 'Generation failed');
-        btn.textContent = 'Generate';
-        btn.disabled = false;
-        return;
-      }
+		if ('ok' in startResp && !startResp.ok) {
+		alertApiError((startResp as { error?: string }).error || 'Generation failed');
+		btn.textContent = 'Generate';
+		btn.disabled = false;
+		return;
+		}
 
-      const generationId =
-        startResp.data?.generation_id ||
-        startResp.generation_id ||
-        'gen_' + Math.random().toString(36).substring(2);
+		const generationId =
+		startResp.data?.generation_id ||
+		startResp.generation_id ||
+		'gen_' + Math.random().toString(36).substring(2);
 
-      NuclenPollAndPullUpdates({
-        intervalMs: 5000,
-        generationId,
-        onProgress() {
-          btn.textContent = 'Generating...';
-        },
-        async onComplete({ results, workflow: wf }: PollingUpdateData) {
-          if (results && typeof results === 'object') {
-            try {
-              const { ok, data } = await storeGenerationResults(wf, results);
-              const respData = data as Record<string, unknown>;
-              if (ok && !('code' in respData)) {
-                  const postResult = results[postId] as PostResult;
-                const finalDate = respData.finalDate && typeof respData.finalDate === 'string' ? (respData.finalDate as string) : undefined;
-                if (postResult) {
-                  if (wf === 'quiz') {
-                      populateQuizMetaBox(postResult, finalDate);
-                  } else if (wf === 'summary') {
-                      populateSummaryMetaBox(postResult, finalDate);
-                  }
-                }
-                btn.textContent = 'Stored!';
-              } else {
-                logger.error('Error storing single-generation results in WP:', respData);
-                btn.textContent = 'Generation failed!';
-              }
-            } catch (err) {
-              logger.error('Fetch error calling /receive-content endpoint:', err);
-              btn.textContent = 'Generation failed!';
-            }
-          } else {
-            btn.textContent = 'Done (no data)!';
-          }
-          btn.disabled = false;
-        },
-        onError(errMsg) {
-          alertApiError(errMsg);
-          btn.textContent = 'Generate';
-          btn.disabled = false;
-        },
-      });
-    } catch (err: unknown) {
-      const message = err instanceof Error ? err.message : 'Unknown error';
-      alertApiError(message);
-      btn.textContent = 'Generate';
-      btn.disabled = false;
-    }
-  });
+		NuclenPollAndPullUpdates({
+		intervalMs: 5000,
+		generationId,
+		onProgress() {
+			btn.textContent = 'Generating...';
+		},
+		async onComplete({ results, workflow: wf }: PollingUpdateData) {
+			if (results && typeof results === 'object') {
+			try {
+				const { ok, data } = await storeGenerationResults(wf, results);
+				const respData = data as Record<string, unknown>;
+				if (ok && !('code' in respData)) {
+					const postResult = results[postId] as PostResult;
+				const finalDate = respData.finalDate && typeof respData.finalDate === 'string' ? (respData.finalDate as string) : undefined;
+				if (postResult) {
+					if (wf === 'quiz') {
+						populateQuizMetaBox(postResult, finalDate);
+					} else if (wf === 'summary') {
+						populateSummaryMetaBox(postResult, finalDate);
+					}
+				}
+				btn.textContent = 'Stored!';
+				} else {
+				logger.error('Error storing single-generation results in WP:', respData);
+				btn.textContent = 'Generation failed!';
+				}
+			} catch (err) {
+				logger.error('Fetch error calling /receive-content endpoint:', err);
+				btn.textContent = 'Generation failed!';
+			}
+			} else {
+			btn.textContent = 'Done (no data)!';
+			}
+			btn.disabled = false;
+		},
+		onError(errMsg) {
+			alertApiError(errMsg);
+			btn.textContent = 'Generate';
+			btn.disabled = false;
+		},
+		});
+	} catch (err: unknown) {
+		const message = err instanceof Error ? err.message : 'Unknown error';
+		alertApiError(message);
+		btn.textContent = 'Generate';
+		btn.disabled = false;
+	}
+	});
 }

--- a/src/admin/ts/single/single-generation-utils.ts
+++ b/src/admin/ts/single/single-generation-utils.ts
@@ -1,97 +1,97 @@
 export {
-  nuclenAlertApiError as alertApiError,
-  nuclenStoreGenerationResults as storeGenerationResults,
+	nuclenAlertApiError as alertApiError,
+	nuclenStoreGenerationResults as storeGenerationResults,
 } from '../generation/results';
 
 export interface PostResult {
-  date?: string;
-  summary?: string;
-  questions?: Array<{
-    question?: string;
-    answers?: string[];
-    explanation?: string;
-  }>;
-  [key: string]: unknown;
+	date?: string;
+	summary?: string;
+	questions?: Array<{
+	question?: string;
+	answers?: string[];
+	explanation?: string;
+	}>;
+	[key: string]: unknown;
 }
 
 export function populateQuizMetaBox(
-  postResult: PostResult,
-  finalDate?: string
+	postResult: PostResult,
+	finalDate?: string
 ): void {
-  const { date, questions } = postResult;
-  const newDate = finalDate || date;
-  const dateField = document.querySelector<HTMLInputElement>('input[name="nuclen_quiz_data[date]"]');
-  if (dateField) {
-    dateField.readOnly = false;
-    dateField.value = newDate || '';
-    dateField.readOnly = true;
-  }
+	const { date, questions } = postResult;
+	const newDate = finalDate || date;
+	const dateField = document.querySelector<HTMLInputElement>('input[name="nuclen_quiz_data[date]"]');
+	if (dateField) {
+	dateField.readOnly = false;
+	dateField.value = newDate || '';
+	dateField.readOnly = true;
+	}
 
-  if (Array.isArray(questions)) {
-    questions.forEach((q, qIndex) => {
-      const questionSelector = `input[name="nuclen_quiz_data[questions][${qIndex}][question]"]`;
-      const questionInput = document.querySelector<HTMLInputElement>(questionSelector);
-      if (questionInput) {
-        questionInput.value = q.question || '';
-      }
+	if (Array.isArray(questions)) {
+	questions.forEach((q, qIndex) => {
+		const questionSelector = `input[name="nuclen_quiz_data[questions][${qIndex}][question]"]`;
+		const questionInput = document.querySelector<HTMLInputElement>(questionSelector);
+		if (questionInput) {
+		questionInput.value = q.question || '';
+		}
 
-      if (Array.isArray(q.answers)) {
-        q.answers.forEach((ans: string, aIndex: number) => {
-          const ansSelector = `input[name="nuclen_quiz_data[questions][${qIndex}][answers][${aIndex}]"]`;
-          const ansInput = document.querySelector<HTMLInputElement>(ansSelector);
-          if (ansInput) {
-            ansInput.value = ans;
-          }
-        });
-      }
+		if (Array.isArray(q.answers)) {
+		q.answers.forEach((ans: string, aIndex: number) => {
+			const ansSelector = `input[name="nuclen_quiz_data[questions][${qIndex}][answers][${aIndex}]"]`;
+			const ansInput = document.querySelector<HTMLInputElement>(ansSelector);
+			if (ansInput) {
+			ansInput.value = ans;
+			}
+		});
+		}
 
-      const explanationSelector = `textarea[name="nuclen_quiz_data[questions][${qIndex}][explanation]"]`;
-      const explanationTextarea = document.querySelector<HTMLTextAreaElement>(explanationSelector);
-      if (explanationTextarea) {
-        explanationTextarea.value = q.explanation || '';
-      }
-    });
-  }
+		const explanationSelector = `textarea[name="nuclen_quiz_data[questions][${qIndex}][explanation]"]`;
+		const explanationTextarea = document.querySelector<HTMLTextAreaElement>(explanationSelector);
+		if (explanationTextarea) {
+		explanationTextarea.value = q.explanation || '';
+		}
+	});
+	}
 }
 
 export function populateSummaryMetaBox(
-  postResult: PostResult,
-  finalDate?: string
+	postResult: PostResult,
+	finalDate?: string
 ): void {
-  const { date, summary } = postResult;
-  const newDate = finalDate || date;
-  const dateField = document.querySelector<HTMLInputElement>('input[name="nuclen_summary_data[date]"]');
-  if (dateField) {
-    dateField.readOnly = false;
-    dateField.value = newDate || '';
-    dateField.readOnly = true;
-  }
+	const { date, summary } = postResult;
+	const newDate = finalDate || date;
+	const dateField = document.querySelector<HTMLInputElement>('input[name="nuclen_summary_data[date]"]');
+	if (dateField) {
+	dateField.readOnly = false;
+	dateField.value = newDate || '';
+	dateField.readOnly = true;
+	}
 
-  if (typeof window.tinymce !== 'undefined') {
-    const tiny = window.tinymce as {
-      get?: (id: string) => {
-        setContent?: (html: string) => void;
-        save?: () => void;
-      };
-    };
-    let editor: { setContent?: (html: string) => void; save?: () => void } | undefined;
-    if (typeof tiny.get === 'function') {
-      editor = tiny.get('nuclen_summary_data_summary');
-    }
-    if (editor && typeof editor.setContent === 'function') {
-      editor.setContent(summary || '');
-      editor.save?.();
-    } else {
-      const summaryField = document.querySelector<HTMLTextAreaElement>('textarea[name="nuclen_summary_data[summary]"]');
-      if (summaryField) {
-        summaryField.value = summary || '';
-      }
-    }
-  } else {
-    const summaryField = document.querySelector<HTMLTextAreaElement>('textarea[name="nuclen_summary_data[summary]"]');
-    if (summaryField) {
-      summaryField.value = summary || '';
-    }
-  }
+	if (typeof window.tinymce !== 'undefined') {
+	const tiny = window.tinymce as {
+		get?: (id: string) => {
+		setContent?: (html: string) => void;
+		save?: () => void;
+		};
+	};
+	let editor: { setContent?: (html: string) => void; save?: () => void } | undefined;
+	if (typeof tiny.get === 'function') {
+		editor = tiny.get('nuclen_summary_data_summary');
+	}
+	if (editor && typeof editor.setContent === 'function') {
+		editor.setContent(summary || '');
+		editor.save?.();
+	} else {
+		const summaryField = document.querySelector<HTMLTextAreaElement>('textarea[name="nuclen_summary_data[summary]"]');
+		if (summaryField) {
+		summaryField.value = summary || '';
+		}
+	}
+	} else {
+	const summaryField = document.querySelector<HTMLTextAreaElement>('textarea[name="nuclen_summary_data[summary]"]');
+	if (summaryField) {
+		summaryField.value = summary || '';
+	}
+	}
 }
 

--- a/src/admin/ts/utils/api.ts
+++ b/src/admin/ts/utils/api.ts
@@ -1,20 +1,20 @@
 export async function apiRequest(url: string, options: RequestInit): Promise<Response> {
-  const allowedOrigins = ['https://app.nuclearengagement.com'];
-  const urlObj = new URL(url, window.location.origin);
-  if (!allowedOrigins.includes(urlObj.origin)) {
-    throw new Error('Invalid URL origin');
-  }
+	const allowedOrigins = ['https://app.nuclearengagement.com'];
+	const urlObj = new URL(url, window.location.origin);
+	if (!allowedOrigins.includes(urlObj.origin)) {
+	throw new Error('Invalid URL origin');
+	}
 
-  try {
-    const response = await fetch(url, options);
-    if (!response.ok) {
-      throw new Error(`HTTP ${response.status}`);
-    }
-    return response;
-  } catch (err: unknown) {
-    if (err instanceof Error) {
-      throw new Error(err.message || 'Network error');
-    }
-    throw new Error('Network error');
-  }
+	try {
+	const response = await fetch(url, options);
+	if (!response.ok) {
+		throw new Error(`HTTP ${response.status}`);
+	}
+	return response;
+	} catch (err: unknown) {
+	if (err instanceof Error) {
+		throw new Error(err.message || 'Network error');
+	}
+	throw new Error('Network error');
+	}
 }

--- a/src/admin/ts/utils/displayError.ts
+++ b/src/admin/ts/utils/displayError.ts
@@ -1,8 +1,8 @@
 export function displayError(message: string): void {
-  const toast = document.createElement('div');
-  toast.className = 'nuclen-error-toast';
-  toast.textContent = message;
-  document.body.appendChild(toast);
-  setTimeout(() => toast.remove(), 5000);
-  console.error(message);
+	const toast = document.createElement('div');
+	toast.className = 'nuclen-error-toast';
+	toast.textContent = message;
+	document.body.appendChild(toast);
+	setTimeout(() => toast.remove(), 5000);
+	console.error(message);
 }

--- a/src/admin/ts/utils/logger.ts
+++ b/src/admin/ts/utils/logger.ts
@@ -1,11 +1,11 @@
 export function log(...args: unknown[]): void {
-  console.log(...args);
+	console.log(...args);
 }
 
 export function warn(...args: unknown[]): void {
-  console.warn(...args);
+	console.warn(...args);
 }
 
 export function error(...args: unknown[]): void {
-  console.error(...args);
+	console.error(...args);
 }

--- a/src/front/ts/logger.ts
+++ b/src/front/ts/logger.ts
@@ -1,9 +1,9 @@
 export function log(...args: unknown[]): void {
-  console.log(...args);
+	console.log(...args);
 }
 export function warn(...args: unknown[]): void {
-  console.warn(...args);
+	console.warn(...args);
 }
 export function error(...args: unknown[]): void {
-  console.error(...args);
+	console.error(...args);
 }

--- a/src/front/ts/nuclen-front-global.ts
+++ b/src/front/ts/nuclen-front-global.ts
@@ -4,35 +4,35 @@
  * 1) Global Declarations
  *************************************************/
 declare global {
-  const postQuizData: Array<{
-    question: string;
-    answers: string[];
-    explanation: string;
-  }>;
+	const postQuizData: Array<{
+	question: string;
+	answers: string[];
+	explanation: string;
+	}>;
 
-  const NuclenOptinPosition: string;
-  const NuclenOptinMandatory: boolean;
-  const NuclenOptinPromptText: string;
-  const NuclenOptinButtonText: string;
+	const NuclenOptinPosition: string;
+	const NuclenOptinMandatory: boolean;
+	const NuclenOptinPromptText: string;
+	const NuclenOptinButtonText: string;
 
-  const NuclenCustomQuizHtmlAfter: string;
+	const NuclenCustomQuizHtmlAfter: string;
 
-  const NuclenOptinAjax: {
-    url: string;
-    nonce: string;
-  };
+	const NuclenOptinAjax: {
+	url: string;
+	nonce: string;
+	};
 
-  const NuclenStrings: {
-    retake_test: string;
-    your_score: string;
-    perfect: string;
-    well_done: string;
-    retake_prompt: string;
-    correct: string;
-    your_answer: string;
-  };
+	const NuclenStrings: {
+	retake_test: string;
+	your_score: string;
+	perfect: string;
+	well_done: string;
+	retake_prompt: string;
+	correct: string;
+	your_answer: string;
+	};
 
-  function gtag(...args: unknown[]): void;
+	function gtag(...args: unknown[]): void;
 }
 
 export {};

--- a/src/front/ts/nuclen-front-lazy.ts
+++ b/src/front/ts/nuclen-front-lazy.ts
@@ -12,78 +12,78 @@
  * 2a) Lazy-load container. Observes 'containerId' and triggers `initFunctionName` once visible.
  */
 window.NuclenLazyLoadComponent = function (
-  containerId: string,
-  initFunctionName: string | null = null,
+	containerId: string,
+	initFunctionName: string | null = null,
 ) {
-    const component = document.getElementById(containerId);
-    if (!component) return;
+	const component = document.getElementById(containerId);
+	if (!component) return;
 
-    const observer = new IntersectionObserver(
-      (entries) => {
-        entries.forEach((entry) => {
-          if (entry.isIntersecting) {
-            const win = window as unknown as Record<string, unknown>;
-            if (initFunctionName && typeof win[initFunctionName] === 'function') {
-              (win[initFunctionName] as () => void)();
-            }
-            observer.disconnect();
-          }
-        });
-      },
-      {
-        rootMargin: '0px 0px -200px 0px',
-        threshold: 0.1
-      }
-    );
+	const observer = new IntersectionObserver(
+		(entries) => {
+		entries.forEach((entry) => {
+			if (entry.isIntersecting) {
+			const win = window as unknown as Record<string, unknown>;
+			if (initFunctionName && typeof win[initFunctionName] === 'function') {
+				(win[initFunctionName] as () => void)();
+			}
+			observer.disconnect();
+			}
+		});
+		},
+		{
+		rootMargin: '0px 0px -200px 0px',
+		threshold: 0.1
+		}
+	);
 
-    observer.observe(component);
-  };
+	observer.observe(component);
+	};
 
-  /**
-   * 2b) Fire a GA event when a specific element is fully in view (threshold=1.0).
-   */
-  function nuclenInitIntersectionObserver(selector: string, gtagEventName: string) {
-    const target = document.querySelector(selector);
-    if (!target) return;
+	/**
+	 * 2b) Fire a GA event when a specific element is fully in view (threshold=1.0).
+	 */
+	function nuclenInitIntersectionObserver(selector: string, gtagEventName: string) {
+	const target = document.querySelector(selector);
+	if (!target) return;
 
-    const observer = new IntersectionObserver(
-      (entries, obs) => {
-        entries.forEach((entry) => {
-          // intersectionRatio === 1 means the element is fully in view
-          if (entry.isIntersecting && entry.intersectionRatio === 1) {
-            if (typeof gtag === 'function') {
-              gtag('event', gtagEventName);
-            }
-            // Stop observing after first event
-            obs.unobserve(entry.target);
-          }
-        });
-      },
-      {
-        root: null,
-        rootMargin: '0px',
-        threshold: 1.0 // require 100% of the element to be visible
-      }
-    );
+	const observer = new IntersectionObserver(
+		(entries, obs) => {
+		entries.forEach((entry) => {
+			// intersectionRatio === 1 means the element is fully in view
+			if (entry.isIntersecting && entry.intersectionRatio === 1) {
+			if (typeof gtag === 'function') {
+				gtag('event', gtagEventName);
+			}
+			// Stop observing after first event
+			obs.unobserve(entry.target);
+			}
+		});
+		},
+		{
+		root: null,
+		rootMargin: '0px',
+		threshold: 1.0 // require 100% of the element to be visible
+		}
+	);
 
-    observer.observe(target);
-  }
+	observer.observe(target);
+	}
 
-  /**
-   * 2c) Wait for #nuclen-quiz-container and #nuclen-summary-container in DOM, then attach GA observers.
-   */
-  const mutationObs = new MutationObserver((_mutations, obs) => {
-    const quizEl = document.getElementById('nuclen-quiz-container');
-    const summaryEl = document.getElementById('nuclen-summary-container');
-    if (quizEl && summaryEl) {
-      nuclenInitIntersectionObserver('#nuclen-summary-container', 'nuclen_summary_view');
-      nuclenInitIntersectionObserver('#nuclen-quiz-container', 'nuclen_quiz_view');
-      obs.disconnect(); // stop once attached
-    }
-  });
-  mutationObs.observe(document.body, { childList: true, subtree: true });
+	/**
+	 * 2c) Wait for #nuclen-quiz-container and #nuclen-summary-container in DOM, then attach GA observers.
+	 */
+	const mutationObs = new MutationObserver((_mutations, obs) => {
+	const quizEl = document.getElementById('nuclen-quiz-container');
+	const summaryEl = document.getElementById('nuclen-summary-container');
+	if (quizEl && summaryEl) {
+		nuclenInitIntersectionObserver('#nuclen-summary-container', 'nuclen_summary_view');
+		nuclenInitIntersectionObserver('#nuclen-quiz-container', 'nuclen_quiz_view');
+		obs.disconnect(); // stop once attached
+	}
+	});
+	mutationObs.observe(document.body, { childList: true, subtree: true });
 
-  /**
-   * 2d) Immediately call lazy-loading for the quiz container, telling it to run nuclearEngagementInitQuiz() once in view.
-   */
-  window.NuclenLazyLoadComponent('nuclen-quiz-container', 'nuclearEngagementInitQuiz');
+	/**
+	 * 2d) Immediately call lazy-loading for the quiz container, telling it to run nuclearEngagementInitQuiz() once in view.
+	 */
+	window.NuclenLazyLoadComponent('nuclen-quiz-container', 'nuclearEngagementInitQuiz');

--- a/src/front/ts/nuclen-globals.d.ts
+++ b/src/front/ts/nuclen-globals.d.ts
@@ -1,16 +1,16 @@
 export {};
 
 declare global {
-  interface Window {
-    NuclenOptinEnabled?: boolean;
-    NuclenOptinWebhook?: string;
-    NuclenOptinSuccessMessage?: string;
-    NuclenLazyLoadComponent?: (
-      containerId: string,
-      initFunctionName?: string | null
-    ) => void;
-    nuclearEngagementInitQuiz?: () => void;
-    nuclearEngagementShowQuizQuestionDetails?: (index: number) => void;
-    nuclearEngagementRetakeQuiz?: () => void;
-  }
+	interface Window {
+	NuclenOptinEnabled?: boolean;
+	NuclenOptinWebhook?: string;
+	NuclenOptinSuccessMessage?: string;
+	NuclenLazyLoadComponent?: (
+		containerId: string,
+		initFunctionName?: string | null
+	) => void;
+	nuclearEngagementInitQuiz?: () => void;
+	nuclearEngagementShowQuizQuestionDetails?: (index: number) => void;
+	nuclearEngagementRetakeQuiz?: () => void;
+	}
 }

--- a/src/front/ts/nuclen-quiz-main.ts
+++ b/src/front/ts/nuclen-quiz-main.ts
@@ -10,139 +10,139 @@
 // -----------------------------------------------------------------------------
 
 import type {
-  QuizQuestion,
-  OptinContext,
-  NuclenSettings as NuclenSettingsType,
+	QuizQuestion,
+	OptinContext,
+	NuclenSettings as NuclenSettingsType,
 } from './nuclen-quiz-types';
 import { escapeHtml } from './nuclen-quiz-utils';
 import {
-  QuizUIRefs,
-  QuizState,
-  renderFinal,
-  renderOptinBeforeResultsFlow,
+	QuizUIRefs,
+	QuizState,
+	renderFinal,
+	renderOptinBeforeResultsFlow,
 } from './nuclen-quiz-results';
 import * as logger from './logger';
 import { renderQuestion } from './nuclen-quiz-question';
 
-  /* Globals injected by wp_localize_script */
-  declare const postQuizData: QuizQuestion[];
-  declare const NuclenSettings: NuclenSettingsType;
+	/* Globals injected by wp_localize_script */
+	declare const postQuizData: QuizQuestion[];
+	declare const NuclenSettings: NuclenSettingsType;
 
-  declare const NuclenOptinPosition: string;
-  declare const NuclenOptinMandatory: boolean;
-  declare const NuclenOptinPromptText: string;
-  declare const NuclenOptinButtonText: string;
+	declare const NuclenOptinPosition: string;
+	declare const NuclenOptinMandatory: boolean;
+	declare const NuclenOptinPromptText: string;
+	declare const NuclenOptinButtonText: string;
 
-  declare const NuclenOptinAjax: { url: string; nonce: string };
+	declare const NuclenOptinAjax: { url: string; nonce: string };
 
-  declare function gtag(...args: unknown[]): void;
+	declare function gtag(...args: unknown[]): void;
 
-  /* ─────────────────────────────────────────────────────────────
-     Entry
-  ────────────────────────────────────────────────────────────── */
-  export function initQuiz(): void {
-    /* DOM refs (fail-fast if markup missing) */
-    const quizContainer  = document.getElementById('nuclen-quiz-container');
-    const qContainer     = document.getElementById('nuclen-quiz-question-container');
-    const aContainer     = document.getElementById('nuclen-quiz-answers-container');
-    const progBar        = document.getElementById('nuclen-quiz-progress-bar');
-    const finalContainer = document.getElementById('nuclen-quiz-final-result-container');
-    const nextBtn        = document.getElementById('nuclen-quiz-next-button');
-    const explContainer  = document.getElementById('nuclen-quiz-explanation-container');
-    if (
-      !quizContainer || !qContainer || !aContainer || !progBar ||
-      !finalContainer || !nextBtn || !explContainer
-    ) {
-      logger.warn('[NE] Quiz markup missing — init aborted.');
-      return;
-    }
+	/* ─────────────────────────────────────────────────────────────
+	 Entry
+	────────────────────────────────────────────────────────────── */
+	export function initQuiz(): void {
+	/* DOM refs (fail-fast if markup missing) */
+	const quizContainer  = document.getElementById('nuclen-quiz-container');
+	const qContainer     = document.getElementById('nuclen-quiz-question-container');
+	const aContainer     = document.getElementById('nuclen-quiz-answers-container');
+	const progBar        = document.getElementById('nuclen-quiz-progress-bar');
+	const finalContainer = document.getElementById('nuclen-quiz-final-result-container');
+	const nextBtn        = document.getElementById('nuclen-quiz-next-button');
+	const explContainer  = document.getElementById('nuclen-quiz-explanation-container');
+	if (
+		!quizContainer || !qContainer || !aContainer || !progBar ||
+		!finalContainer || !nextBtn || !explContainer
+	) {
+		logger.warn('[NE] Quiz markup missing — init aborted.');
+		return;
+	}
 
-    /* SETTINGS & OPT-IN CONTEXT */
-    const maxQuestions = NuclenSettings?.questions_per_quiz ?? 10;
-    const maxAnswers   = NuclenSettings?.answers_per_question ?? 4;
+	/* SETTINGS & OPT-IN CONTEXT */
+	const maxQuestions = NuclenSettings?.questions_per_quiz ?? 10;
+	const maxAnswers   = NuclenSettings?.answers_per_question ?? 4;
 
-    const optin: OptinContext = {
-      position: (NuclenOptinPosition as 'with_results' | 'before_results') ?? 'with_results',
-      mandatory: Boolean(NuclenOptinMandatory),
-      promptText: NuclenOptinPromptText,
-      submitLabel: NuclenOptinButtonText,
-      enabled: Boolean(window.NuclenOptinEnabled),
-      webhook: window.NuclenOptinWebhook ?? '',
-      ajaxUrl: NuclenOptinAjax?.url ?? '',
-      ajaxNonce: NuclenOptinAjax?.nonce ?? '',
-    };
+	const optin: OptinContext = {
+		position: (NuclenOptinPosition as 'with_results' | 'before_results') ?? 'with_results',
+		mandatory: Boolean(NuclenOptinMandatory),
+		promptText: NuclenOptinPromptText,
+		submitLabel: NuclenOptinButtonText,
+		enabled: Boolean(window.NuclenOptinEnabled),
+		webhook: window.NuclenOptinWebhook ?? '',
+		ajaxUrl: NuclenOptinAjax?.url ?? '',
+		ajaxNonce: NuclenOptinAjax?.nonce ?? '',
+	};
 
-    /* PREPARE QUESTIONS */
-    const questions: QuizQuestion[] = postQuizData
-      .filter((q) => q.question.trim() && q.answers[0]?.trim())
-      .slice(0, maxQuestions)
-      .map((q) => ({ ...q, answers: q.answers.slice(0, maxAnswers) }));
+	/* PREPARE QUESTIONS */
+	const questions: QuizQuestion[] = postQuizData
+		.filter((q) => q.question.trim() && q.answers[0]?.trim())
+		.slice(0, maxQuestions)
+		.map((q) => ({ ...q, answers: q.answers.slice(0, maxAnswers) }));
 
-    const ui: QuizUIRefs = {
-      qContainer: qContainer!,
-      aContainer: aContainer!,
-      explContainer: explContainer!,
-      nextBtn: nextBtn!,
-      finalContainer: finalContainer!,
-      progBar: progBar!,
-    };
+	const ui: QuizUIRefs = {
+		qContainer: qContainer!,
+		aContainer: aContainer!,
+		explContainer: explContainer!,
+		nextBtn: nextBtn!,
+		finalContainer: finalContainer!,
+		progBar: progBar!,
+	};
 
-    const state: QuizState = { currIdx: 0, score: 0, userAnswers: [] };
+	const state: QuizState = { currIdx: 0, score: 0, userAnswers: [] };
 
-    /* Start */
-    nextBtn.addEventListener('click', showNext);
-    renderQuestion(questions, state, ui, checkAnswer);
+	/* Start */
+	nextBtn.addEventListener('click', showNext);
+	renderQuestion(questions, state, ui, checkAnswer);
 
 
-    /* ───────────────────────────────────────────────────────────
-       Quiz flow helpers
-    ─────────────────────────────────────────────────────────── */
+	/* ───────────────────────────────────────────────────────────
+		 Quiz flow helpers
+	─────────────────────────────────────────────────────────── */
 
-    function checkAnswer(origIdx: number, shuffledIdx: number, correctIdx: number): void {
-      if (origIdx === 0) state.score++;
-      state.userAnswers.push(origIdx);
+	function checkAnswer(origIdx: number, shuffledIdx: number, correctIdx: number): void {
+		if (origIdx === 0) state.score++;
+		state.userAnswers.push(origIdx);
 
-      const btns = aContainer!.getElementsByTagName('button');
-      for (let i = 0; i < btns.length; i++) {
-        btns[i].classList.remove('nuclen-quiz-possible-answer');
-        if (i === correctIdx) {
-          btns[i].classList.add('nuclen-quiz-answer-correct', 'nuclen-quiz-pulse');
-        } else if (i === shuffledIdx) {
-          btns[i].classList.add('nuclen-quiz-answer-wrong');
-        } else {
-          btns[i].classList.add('nuclen-quiz-answer-not-selected');
-        }
-        btns[i].disabled = true;
-      }
+		const btns = aContainer!.getElementsByTagName('button');
+		for (let i = 0; i < btns.length; i++) {
+		btns[i].classList.remove('nuclen-quiz-possible-answer');
+		if (i === correctIdx) {
+			btns[i].classList.add('nuclen-quiz-answer-correct', 'nuclen-quiz-pulse');
+		} else if (i === shuffledIdx) {
+			btns[i].classList.add('nuclen-quiz-answer-wrong');
+		} else {
+			btns[i].classList.add('nuclen-quiz-answer-not-selected');
+		}
+		btns[i].disabled = true;
+		}
 
-      explContainer!.innerHTML = `<p>${escapeHtml(
-        questions[state.currIdx].explanation,
-      )}</p>`;
-      explContainer!.classList.remove('nuclen-quiz-hidden');
-      nextBtn!.classList.remove('nuclen-quiz-hidden');
+		explContainer!.innerHTML = `<p>${escapeHtml(
+		questions[state.currIdx].explanation,
+		)}</p>`;
+		explContainer!.classList.remove('nuclen-quiz-hidden');
+		nextBtn!.classList.remove('nuclen-quiz-hidden');
 
-      if (typeof gtag === 'function') {
-        if (state.currIdx === 0) gtag('event', 'nuclen_quiz_start');
-        gtag('event', 'nuclen_quiz_answer');
-      }
-    }
+		if (typeof gtag === 'function') {
+		if (state.currIdx === 0) gtag('event', 'nuclen_quiz_start');
+		gtag('event', 'nuclen_quiz_answer');
+		}
+	}
 
-    function showNext(): void {
-      state.currIdx++;
-      if (state.currIdx < questions.length) {
-        renderQuestion(questions, state, ui, checkAnswer);
-        return quizContainer!.scrollIntoView();
-      }
+	function showNext(): void {
+		state.currIdx++;
+		if (state.currIdx < questions.length) {
+		renderQuestion(questions, state, ui, checkAnswer);
+		return quizContainer!.scrollIntoView();
+		}
 
-      const finalCb = () =>
-        renderFinal(ui, optin, questions, state, () =>
-          renderQuestion(questions, state, ui, checkAnswer),
-        );
+		const finalCb = () =>
+		renderFinal(ui, optin, questions, state, () =>
+			renderQuestion(questions, state, ui, checkAnswer),
+		);
 
-      if (optin.enabled && optin.position === 'before_results') {
-        return renderOptinBeforeResultsFlow(ui, optin, finalCb);
-      }
-      finalCb();
-    }
+		if (optin.enabled && optin.position === 'before_results') {
+		return renderOptinBeforeResultsFlow(ui, optin, finalCb);
+		}
+		finalCb();
+	}
 
-  }
+	}

--- a/src/front/ts/nuclen-quiz-optin.ts
+++ b/src/front/ts/nuclen-quiz-optin.ts
@@ -6,68 +6,68 @@ import type { OptinContext } from './nuclen-quiz-types';
 import { isValidEmail, storeOptinLocally, submitToWebhook } from './nuclen-quiz-utils';
 
 export const buildOptinInlineHTML = (ctx: OptinContext): string => `
-  <div id="nuclen-optin-container" class="nuclen-optin-with-results">
-    <p class="nuclen-fg"><strong>${ctx.promptText}</strong></p>
-    <label for="nuclen-optin-name"  class="nuclen-fg">Name</label>
-    <input  type="text"  id="nuclen-optin-name">
-    <label for="nuclen-optin-email" class="nuclen-fg">Email</label>
-    <input  type="email" id="nuclen-optin-email" required>
-    <button type="button" id="nuclen-optin-submit">${ctx.submitLabel}</button>
-  </div>`;
+	<div id="nuclen-optin-container" class="nuclen-optin-with-results">
+	<p class="nuclen-fg"><strong>${ctx.promptText}</strong></p>
+	<label for="nuclen-optin-name"  class="nuclen-fg">Name</label>
+	<input  type="text"  id="nuclen-optin-name">
+	<label for="nuclen-optin-email" class="nuclen-fg">Email</label>
+	<input  type="email" id="nuclen-optin-email" required>
+	<button type="button" id="nuclen-optin-submit">${ctx.submitLabel}</button>
+	</div>`;
 
 export function mountOptinBeforeResults(
-  container: HTMLElement,
-  ctx: OptinContext,
-  onComplete: () => void,
-  onSkip: () => void
+	container: HTMLElement,
+	ctx: OptinContext,
+	onComplete: () => void,
+	onSkip: () => void
 ): void {
-  container.innerHTML = `
-    <div id="nuclen-optin-container">
-      <p class="nuclen-fg"><strong>${ctx.promptText}</strong></p>
-      <label for="nuclen-optin-name"  class="nuclen-fg">Name</label>
-      <input  type="text"  id="nuclen-optin-name">
-      <label for="nuclen-optin-email" class="nuclen-fg">Email *</label>
-      <input  type="email" id="nuclen-optin-email" required>
-      <div class="nuclen-optin-btn-row">
-        <button type="button" id="nuclen-optin-submit">${ctx.submitLabel}</button>
-      </div>
-      ${
-        ctx.mandatory
-          ? ''
-          : '<div class="nuclen-optin-skip"><a href="#" id="nuclen-optin-skip">Skip &amp; view results</a></div>'
-      }
-    </div>`;
+	container.innerHTML = `
+	<div id="nuclen-optin-container">
+		<p class="nuclen-fg"><strong>${ctx.promptText}</strong></p>
+		<label for="nuclen-optin-name"  class="nuclen-fg">Name</label>
+		<input  type="text"  id="nuclen-optin-name">
+		<label for="nuclen-optin-email" class="nuclen-fg">Email *</label>
+		<input  type="email" id="nuclen-optin-email" required>
+		<div class="nuclen-optin-btn-row">
+		<button type="button" id="nuclen-optin-submit">${ctx.submitLabel}</button>
+		</div>
+		${
+		ctx.mandatory
+			? ''
+			: '<div class="nuclen-optin-skip"><a href="#" id="nuclen-optin-skip">Skip &amp; view results</a></div>'
+		}
+	</div>`;
 
-  document.getElementById('nuclen-optin-submit')?.addEventListener('click', async () => {
-    const name  = (document.getElementById('nuclen-optin-name')  as HTMLInputElement).value.trim();
-    const email = (document.getElementById('nuclen-optin-email') as HTMLInputElement).value.trim();
-    if (!isValidEmail(email)) return alert('Please enter a valid email');
-    await storeOptinLocally(name, email, window.location.href, ctx);
-    try {
-      await submitToWebhook(name, email, ctx);
-      onComplete();
-    } catch {
-      alert('Network error – please try again later.');
-    }
-  });
+	document.getElementById('nuclen-optin-submit')?.addEventListener('click', async () => {
+	const name  = (document.getElementById('nuclen-optin-name')  as HTMLInputElement).value.trim();
+	const email = (document.getElementById('nuclen-optin-email') as HTMLInputElement).value.trim();
+	if (!isValidEmail(email)) return alert('Please enter a valid email');
+	await storeOptinLocally(name, email, window.location.href, ctx);
+	try {
+		await submitToWebhook(name, email, ctx);
+		onComplete();
+	} catch {
+		alert('Network error – please try again later.');
+	}
+	});
 
-  document.getElementById('nuclen-optin-skip')?.addEventListener('click', (e) => {
-    e.preventDefault();
-    onSkip();
-  });
+	document.getElementById('nuclen-optin-skip')?.addEventListener('click', (e) => {
+	e.preventDefault();
+	onSkip();
+	});
 }
 
 export function attachInlineOptinHandlers(ctx: OptinContext): void {
-  document.getElementById('nuclen-optin-submit')?.addEventListener('click', async () => {
-    const name  = (document.getElementById('nuclen-optin-name')  as HTMLInputElement).value.trim();
-    const email = (document.getElementById('nuclen-optin-email') as HTMLInputElement).value.trim();
-    if (!isValidEmail(email)) return alert('Please enter a valid email');
-    await storeOptinLocally(name, email, window.location.href, ctx);
-    try {
-      await submitToWebhook(name, email, ctx);
-    } catch {
-      alert('Unable to submit. Please try later.');
-    }
-  });
+	document.getElementById('nuclen-optin-submit')?.addEventListener('click', async () => {
+	const name  = (document.getElementById('nuclen-optin-name')  as HTMLInputElement).value.trim();
+	const email = (document.getElementById('nuclen-optin-email') as HTMLInputElement).value.trim();
+	if (!isValidEmail(email)) return alert('Please enter a valid email');
+	await storeOptinLocally(name, email, window.location.href, ctx);
+	try {
+		await submitToWebhook(name, email, ctx);
+	} catch {
+		alert('Unable to submit. Please try later.');
+	}
+	});
 }
 

--- a/src/front/ts/nuclen-quiz-progress.ts
+++ b/src/front/ts/nuclen-quiz-progress.ts
@@ -1,9 +1,9 @@
 // src/front/ts/nuclen-quiz-progress.ts
 
 export function updateProgress(
-  progBar: HTMLElement,
-  currIdx: number,
-  total: number,
+	progBar: HTMLElement,
+	currIdx: number,
+	total: number,
 ): void {
-  progBar.style.width = `${((currIdx + 1) / total) * 100}%`;
+	progBar.style.width = `${((currIdx + 1) / total) * 100}%`;
 }

--- a/src/front/ts/nuclen-quiz-question.ts
+++ b/src/front/ts/nuclen-quiz-question.ts
@@ -6,66 +6,66 @@ import type { QuizUIRefs, QuizState } from './nuclen-quiz-results';
 import { updateProgress } from './nuclen-quiz-progress';
 
 export function renderQuestion(
-  questions: QuizQuestion[],
-  state: QuizState,
-  ui: QuizUIRefs,
-  checkAnswer: (origIdx: number, shuffledIdx: number, correctIdx: number) => void,
+	questions: QuizQuestion[],
+	state: QuizState,
+	ui: QuizUIRefs,
+	checkAnswer: (origIdx: number, shuffledIdx: number, correctIdx: number) => void,
 ): void {
-  const { qContainer, aContainer, explContainer, nextBtn, progBar } = ui;
-  const q = questions[state.currIdx];
+	const { qContainer, aContainer, explContainer, nextBtn, progBar } = ui;
+	const q = questions[state.currIdx];
 
-  qContainer.innerHTML = `
-    <div id="nuclen-quiz-question-number" aria-live="polite" aria-atomic="true">
-      ${state.currIdx + 1}/${questions.length}
-    </div>
-    <div class="nuclen-quiz-title" role="heading" aria-level="2">${escapeHtml(q.question)}</div>`;
+	qContainer.innerHTML = `
+	<div id="nuclen-quiz-question-number" aria-live="polite" aria-atomic="true">
+		${state.currIdx + 1}/${questions.length}
+	</div>
+	<div class="nuclen-quiz-title" role="heading" aria-level="2">${escapeHtml(q.question)}</div>`;
 
-  const shuffled = shuffle(
-    q.answers.map((ans, idx) => ({ ans, idx })).filter((a) => a.ans.trim()),
-  );
+	const shuffled = shuffle(
+	q.answers.map((ans, idx) => ({ ans, idx })).filter((a) => a.ans.trim()),
+	);
 
-  aContainer.innerHTML = shuffled
-    .map(
-      (a, i) => `
-        <button
-          class="nuclen-quiz-answer-button nuclen-quiz-possible-answer"
-          data-orig-idx="${a.idx}"
-          tabindex="0"
-          aria-label="Answer ${i + 1}: ${escapeHtml(a.ans)}"
-        >${escapeHtml(a.ans)}</button>`,
-    )
-    .join('');
+	aContainer.innerHTML = shuffled
+	.map(
+		(a, i) => `
+		<button
+			class="nuclen-quiz-answer-button nuclen-quiz-possible-answer"
+			data-orig-idx="${a.idx}"
+			tabindex="0"
+			aria-label="Answer ${i + 1}: ${escapeHtml(a.ans)}"
+		>${escapeHtml(a.ans)}</button>`,
+	)
+	.join('');
 
-  const correctIdx = shuffled.findIndex((a) => a.idx === 0);
+	const correctIdx = shuffled.findIndex((a) => a.idx === 0);
 
-  /* reset */
-  explContainer.innerHTML = '';
-  explContainer.classList.add('nuclen-quiz-hidden');
-  nextBtn.classList.add('nuclen-quiz-hidden');
-  updateProgress(progBar, state.currIdx, questions.length);
+	/* reset */
+	explContainer.innerHTML = '';
+	explContainer.classList.add('nuclen-quiz-hidden');
+	nextBtn.classList.add('nuclen-quiz-hidden');
+	updateProgress(progBar, state.currIdx, questions.length);
 
-  /* one-shot answer handler */
-  const handler = (el: HTMLElement) => {
-    const origIdx = parseInt(el.getAttribute('data-orig-idx') || '0', 10);
-    checkAnswer(origIdx, shuffled.findIndex((a) => a.idx === origIdx), correctIdx);
-    aContainer.removeEventListener('click', clickListener);
-    aContainer.removeEventListener('keydown', keyListener);
-  };
+	/* one-shot answer handler */
+	const handler = (el: HTMLElement) => {
+	const origIdx = parseInt(el.getAttribute('data-orig-idx') || '0', 10);
+	checkAnswer(origIdx, shuffled.findIndex((a) => a.idx === origIdx), correctIdx);
+	aContainer.removeEventListener('click', clickListener);
+	aContainer.removeEventListener('keydown', keyListener);
+	};
 
-  const clickListener = (e: Event) => {
-    const el = e.target as HTMLElement;
-    if (!el.matches('button.nuclen-quiz-answer-button')) return;
-    handler(el);
-  };
-  const keyListener = (e: KeyboardEvent) => {
-    const el = e.target as HTMLElement;
-    if (!el.matches('button.nuclen-quiz-answer-button')) return;
-    if (e.key === 'Enter' || e.key === ' ') {
-      e.preventDefault();
-      handler(el);
-    }
-  };
+	const clickListener = (e: Event) => {
+	const el = e.target as HTMLElement;
+	if (!el.matches('button.nuclen-quiz-answer-button')) return;
+	handler(el);
+	};
+	const keyListener = (e: KeyboardEvent) => {
+	const el = e.target as HTMLElement;
+	if (!el.matches('button.nuclen-quiz-answer-button')) return;
+	if (e.key === 'Enter' || e.key === ' ') {
+		e.preventDefault();
+		handler(el);
+	}
+	};
 
-  aContainer.addEventListener('click', clickListener);
-  aContainer.addEventListener('keydown', keyListener);
+	aContainer.addEventListener('click', clickListener);
+	aContainer.addEventListener('keydown', keyListener);
 }

--- a/src/front/ts/nuclen-quiz-results.ts
+++ b/src/front/ts/nuclen-quiz-results.ts
@@ -3,153 +3,153 @@
 // -----------------------------------------------------------------------------
 import type { QuizQuestion, OptinContext } from './nuclen-quiz-types';
 import {
-  buildOptinInlineHTML,
-  mountOptinBeforeResults,
-  attachInlineOptinHandlers,
+	buildOptinInlineHTML,
+	mountOptinBeforeResults,
+	attachInlineOptinHandlers,
 } from './nuclen-quiz-optin';
 import { escapeHtml } from './nuclen-quiz-utils';
 
 // Globals injected by wp_localize_script
 declare const NuclenCustomQuizHtmlAfter: string;
 declare const NuclenStrings: {
-  retake_test: string;
-  your_score: string;
-  perfect: string;
-  well_done: string;
-  retake_prompt: string;
-  correct: string;
-  your_answer: string;
+	retake_test: string;
+	your_score: string;
+	perfect: string;
+	well_done: string;
+	retake_prompt: string;
+	correct: string;
+	your_answer: string;
 };
 
 declare function gtag(...args: unknown[]): void;
 
 declare global {
-  interface Window {
-    nuclearEngagementShowQuizQuestionDetails?: (idx: number) => void;
-    nuclearEngagementRetakeQuiz?: () => void;
-  }
+	interface Window {
+	nuclearEngagementShowQuizQuestionDetails?: (idx: number) => void;
+	nuclearEngagementRetakeQuiz?: () => void;
+	}
 }
 
 export interface QuizUIRefs {
-  qContainer: HTMLElement;
-  aContainer: HTMLElement;
-  explContainer: HTMLElement;
-  nextBtn: HTMLElement;
-  finalContainer: HTMLElement;
-  progBar: HTMLElement;
+	qContainer: HTMLElement;
+	aContainer: HTMLElement;
+	explContainer: HTMLElement;
+	nextBtn: HTMLElement;
+	finalContainer: HTMLElement;
+	progBar: HTMLElement;
 }
 
 export interface QuizState {
-  currIdx: number;
-  score: number;
-  userAnswers: number[];
+	currIdx: number;
+	score: number;
+	userAnswers: number[];
 }
 
 export function renderOptinBeforeResultsFlow(
-  ui: QuizUIRefs,
-  optin: OptinContext,
-  onFinal: () => void,
+	ui: QuizUIRefs,
+	optin: OptinContext,
+	onFinal: () => void,
 ): void {
-  const { qContainer, aContainer, explContainer, nextBtn, finalContainer } = ui;
-  qContainer.innerHTML = '';
-  aContainer.innerHTML = '';
-  explContainer.innerHTML = '';
-  nextBtn.classList.add('nuclen-quiz-hidden');
+	const { qContainer, aContainer, explContainer, nextBtn, finalContainer } = ui;
+	qContainer.innerHTML = '';
+	aContainer.innerHTML = '';
+	explContainer.innerHTML = '';
+	nextBtn.classList.add('nuclen-quiz-hidden');
 
-  mountOptinBeforeResults(finalContainer, optin, onFinal, onFinal);
+	mountOptinBeforeResults(finalContainer, optin, onFinal, onFinal);
 }
 
 export function renderFinal(
-  ui: QuizUIRefs,
-  optin: OptinContext,
-  questions: QuizQuestion[],
-  state: QuizState,
-  renderQuestion: () => void,
+	ui: QuizUIRefs,
+	optin: OptinContext,
+	questions: QuizQuestion[],
+	state: QuizState,
+	renderQuestion: () => void,
 ): void {
-  const { qContainer, aContainer, explContainer, nextBtn, finalContainer, progBar } = ui;
-  qContainer.innerHTML = '';
-  aContainer.innerHTML = '';
-  explContainer.innerHTML = '';
-  nextBtn.classList.add('nuclen-quiz-hidden');
-  finalContainer.classList.remove('nuclen-quiz-hidden');
+	const { qContainer, aContainer, explContainer, nextBtn, finalContainer, progBar } = ui;
+	qContainer.innerHTML = '';
+	aContainer.innerHTML = '';
+	explContainer.innerHTML = '';
+	nextBtn.classList.add('nuclen-quiz-hidden');
+	finalContainer.classList.remove('nuclen-quiz-hidden');
 
-  let html = '';
-  if (optin.enabled && optin.position === 'with_results') {
-    html += buildOptinInlineHTML(optin);
-  }
+	let html = '';
+	if (optin.enabled && optin.position === 'with_results') {
+	html += buildOptinInlineHTML(optin);
+	}
 
-  html += `
-    <div id="nuclen-quiz-results-title" class="nuclen-fg">${NuclenStrings.your_score}</div>
-    <div id="nuclen-quiz-results-score" class="nuclen-fg" aria-live="polite" aria-atomic="true">
-      ${state.score} / ${questions.length}
-    </div>`;
-  const comment =
-    state.score === questions.length
-      ? NuclenStrings.perfect
-      : state.score > questions.length / 2
-      ? NuclenStrings.well_done
-      : NuclenStrings.retake_prompt;
-  html += `<div id="nuclen-quiz-score-comment" aria-live="polite">${comment}</div>`;
+	html += `
+	<div id="nuclen-quiz-results-title" class="nuclen-fg">${NuclenStrings.your_score}</div>
+	<div id="nuclen-quiz-results-score" class="nuclen-fg" aria-live="polite" aria-atomic="true">
+		${state.score} / ${questions.length}
+	</div>`;
+	const comment =
+	state.score === questions.length
+		? NuclenStrings.perfect
+		: state.score > questions.length / 2
+		? NuclenStrings.well_done
+		: NuclenStrings.retake_prompt;
+	html += `<div id="nuclen-quiz-score-comment" aria-live="polite">${comment}</div>`;
 
-  html += '<div id="nuclen-quiz-result-tabs-container">';
-  questions.forEach((_, i) => {
-    html += `
-      <button class="nuclen-quiz-result-tab"
-              onclick="nuclearEngagementShowQuizQuestionDetails(${i})">${i + 1}</button>`;
-  });
-  html += '</div><div id="nuclen-quiz-result-details-container" class="nuclen-fg dashboard-box"></div>';
+	html += '<div id="nuclen-quiz-result-tabs-container">';
+	questions.forEach((_, i) => {
+	html += `
+		<button class="nuclen-quiz-result-tab"
+				onclick="nuclearEngagementShowQuizQuestionDetails(${i})">${i + 1}</button>`;
+	});
+	html += '</div><div id="nuclen-quiz-result-details-container" class="nuclen-fg dashboard-box"></div>';
 
-  if (NuclenCustomQuizHtmlAfter?.trim()) {
-    html += `
-      <div id="nuclen-quiz-end-message" class="nuclen-fg">
-        ${NuclenCustomQuizHtmlAfter}
-      </div>`;
-  }
+	if (NuclenCustomQuizHtmlAfter?.trim()) {
+	html += `
+		<div id="nuclen-quiz-end-message" class="nuclen-fg">
+		${NuclenCustomQuizHtmlAfter}
+		</div>`;
+	}
 
-  html += `
-    <button id="nuclen-quiz-retake-button"
-            onclick="nuclearEngagementRetakeQuiz()">${NuclenStrings.retake_test}</button>`;
+	html += `
+	<button id="nuclen-quiz-retake-button"
+			onclick="nuclearEngagementRetakeQuiz()">${NuclenStrings.retake_test}</button>`;
 
-  finalContainer.innerHTML = html;
-  finalContainer.setAttribute('aria-live', 'polite');
+	finalContainer.innerHTML = html;
+	finalContainer.setAttribute('aria-live', 'polite');
 
-  if (optin.enabled && optin.position === 'with_results') {
-    attachInlineOptinHandlers(optin);
-  }
+	if (optin.enabled && optin.position === 'with_results') {
+	attachInlineOptinHandlers(optin);
+	}
 
-  window.nuclearEngagementShowQuizQuestionDetails = (idx: number): void => {
-    const q = questions[idx];
-    const ua = state.userAnswers[idx];
-    (document.getElementById('nuclen-quiz-result-details-container') as HTMLElement).innerHTML = `
-      <p class="nuclen-quiz-detail-question">${escapeHtml(q.question)}</p>
-      <p class="nuclen-quiz-detail-correct"><strong>${NuclenStrings.correct}</strong> ${escapeHtml(q.answers[0])}</p>
-      ${
-        ua === 0
-          ? `<p class="nuclen-quiz-detail-chosen"><strong>${NuclenStrings.your_answer}</strong> ${escapeHtml(q.answers[0])} <span class="nuclen-quiz-checkmark">✔️</span></p>`
-          : `<p class="nuclen-quiz-detail-chosen"><strong>${NuclenStrings.your_answer}</strong> ${escapeHtml(q.answers[ua] ?? '[No data]')}</p>`
-      }
-      <p class="nuclen-quiz-detail-explanation">${escapeHtml(q.explanation)}</p>`;
-    Array.from(document.getElementsByClassName('nuclen-quiz-result-tab')).forEach((el) =>
-      el.classList.remove('nuclen-quiz-result-active-tab'),
-    );
-    document
-      .getElementsByClassName('nuclen-quiz-result-tab')[idx]?.classList.add(
-        'nuclen-quiz-result-active-tab',
-      );
-  };
-  window.nuclearEngagementShowQuizQuestionDetails(0);
+	window.nuclearEngagementShowQuizQuestionDetails = (idx: number): void => {
+	const q = questions[idx];
+	const ua = state.userAnswers[idx];
+	(document.getElementById('nuclen-quiz-result-details-container') as HTMLElement).innerHTML = `
+		<p class="nuclen-quiz-detail-question">${escapeHtml(q.question)}</p>
+		<p class="nuclen-quiz-detail-correct"><strong>${NuclenStrings.correct}</strong> ${escapeHtml(q.answers[0])}</p>
+		${
+		ua === 0
+			? `<p class="nuclen-quiz-detail-chosen"><strong>${NuclenStrings.your_answer}</strong> ${escapeHtml(q.answers[0])} <span class="nuclen-quiz-checkmark">✔️</span></p>`
+			: `<p class="nuclen-quiz-detail-chosen"><strong>${NuclenStrings.your_answer}</strong> ${escapeHtml(q.answers[ua] ?? '[No data]')}</p>`
+		}
+		<p class="nuclen-quiz-detail-explanation">${escapeHtml(q.explanation)}</p>`;
+	Array.from(document.getElementsByClassName('nuclen-quiz-result-tab')).forEach((el) =>
+		el.classList.remove('nuclen-quiz-result-active-tab'),
+	);
+	document
+		.getElementsByClassName('nuclen-quiz-result-tab')[idx]?.classList.add(
+		'nuclen-quiz-result-active-tab',
+		);
+	};
+	window.nuclearEngagementShowQuizQuestionDetails(0);
 
-  window.nuclearEngagementRetakeQuiz = (): void => {
-    state.currIdx = 0;
-    state.score = 0;
-    state.userAnswers.length = 0;
-    finalContainer.innerHTML = '';
-    finalContainer.classList.add('nuclen-quiz-hidden');
-    progBar.style.width = `${(1 / questions.length) * 100}%`;
-    renderQuestion();
-  };
+	window.nuclearEngagementRetakeQuiz = (): void => {
+	state.currIdx = 0;
+	state.score = 0;
+	state.userAnswers.length = 0;
+	finalContainer.innerHTML = '';
+	finalContainer.classList.add('nuclen-quiz-hidden');
+	progBar.style.width = `${(1 / questions.length) * 100}%`;
+	renderQuestion();
+	};
 
-  if (typeof gtag === 'function') {
-    gtag('event', 'nuclen_quiz_end');
-  }
+	if (typeof gtag === 'function') {
+	gtag('event', 'nuclen_quiz_end');
+	}
 }

--- a/src/front/ts/nuclen-quiz-types.ts
+++ b/src/front/ts/nuclen-quiz-types.ts
@@ -2,23 +2,23 @@
 // File: src/front/ts/nuclen-quiz-types.ts
 // -----------------------------------------------------------------------------
 export interface QuizQuestion {
-    question: string;
-    answers: string[];
-    explanation: string;
-  }
+	question: string;
+	answers: string[];
+	explanation: string;
+	}
 
-  export interface NuclenSettings {
-    questions_per_quiz: number;
-    answers_per_question: number;
-  }
+	export interface NuclenSettings {
+	questions_per_quiz: number;
+	answers_per_question: number;
+	}
 
-  export interface OptinContext {
-    position: 'with_results' | 'before_results';
-    mandatory: boolean;
-    promptText: string;
-    submitLabel: string;
-    enabled: boolean;
-    webhook: string;
-    ajaxUrl: string;
-    ajaxNonce: string;
-  }
+	export interface OptinContext {
+	position: 'with_results' | 'before_results';
+	mandatory: boolean;
+	promptText: string;
+	submitLabel: string;
+	enabled: boolean;
+	webhook: string;
+	ajaxUrl: string;
+	ajaxNonce: string;
+	}

--- a/src/front/ts/nuclen-quiz-utils.ts
+++ b/src/front/ts/nuclen-quiz-utils.ts
@@ -5,66 +5,66 @@ import type { OptinContext } from './nuclen-quiz-types';
 import * as logger from './logger';
 
 export function shuffle<T>(arr: T[]): T[] {
-  const a = [...arr];
-  for (let i = a.length - 1; i > 0; i--) {
-    const j = Math.floor(Math.random() * (i + 1));
-    [a[i], a[j]] = [a[j], a[i]];
-  }
-  return a;
+	const a = [...arr];
+	for (let i = a.length - 1; i > 0; i--) {
+	const j = Math.floor(Math.random() * (i + 1));
+	[a[i], a[j]] = [a[j], a[i]];
+	}
+	return a;
 }
 
 export const isValidEmail = (email: string): boolean => /.+@.+\..+/.test(email);
 
 export const escapeHtml = (str: string): string =>
-  str.replace(/[&<>"']/g, (c) =>
-    ({ '&': '&amp;', '<': '&lt;', '>': '&gt;', '"': '&quot;', "'": '&#039;' }[c] || c),
-  );
+	str.replace(/[&<>"']/g, (c) =>
+	({ '&': '&amp;', '<': '&lt;', '>': '&gt;', '"': '&quot;', "'": '&#039;' }[c] || c),
+	);
 
 export const storeOptinLocally = async (
-  name: string,
-  email: string,
-  url: string,
-  ctx: OptinContext
+	name: string,
+	email: string,
+	url: string,
+	ctx: OptinContext
 ): Promise<void> => {
-  if (!ctx.ajaxUrl || !ctx.ajaxNonce) return;
-  try {
-    const res = await fetch(ctx.ajaxUrl, {
-      method: 'POST',
-      headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
-      body: new URLSearchParams({
-        action: 'nuclen_save_optin',
-        nonce: ctx.ajaxNonce,
-        name,
-        email,
-        url,
-      }),
-    });
-    if (!res.ok) {
-      logger.error('[NE] Local opt-in failed', res.status);
-    }
-  } catch (err) {
-    logger.error('[NE] Local opt-in network error', err);
-  }
+	if (!ctx.ajaxUrl || !ctx.ajaxNonce) return;
+	try {
+	const res = await fetch(ctx.ajaxUrl, {
+		method: 'POST',
+		headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+		body: new URLSearchParams({
+		action: 'nuclen_save_optin',
+		nonce: ctx.ajaxNonce,
+		name,
+		email,
+		url,
+		}),
+	});
+	if (!res.ok) {
+		logger.error('[NE] Local opt-in failed', res.status);
+	}
+	} catch (err) {
+	logger.error('[NE] Local opt-in network error', err);
+	}
 };
 
 export const submitToWebhook = async (
-  name: string,
-  email: string,
-  ctx: OptinContext
+	name: string,
+	email: string,
+	ctx: OptinContext
 ): Promise<void> => {
-  if (!ctx.webhook) return;
-  try {
-    const res = await fetch(ctx.webhook, {
-      method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({ name, email }),
-    });
-    if (!res.ok) {
-      logger.error('[NE] Webhook responded with', res.status);
-      throw new Error(String(res.status));
-    }
-  } catch (err) {
-    logger.error('[NE] Webhook request error', err);
-    throw err;
-  }
+	if (!ctx.webhook) return;
+	try {
+	const res = await fetch(ctx.webhook, {
+		method: 'POST',
+		headers: { 'Content-Type': 'application/json' },
+		body: JSON.stringify({ name, email }),
+	});
+	if (!res.ok) {
+		logger.error('[NE] Webhook responded with', res.status);
+		throw new Error(String(res.status));
+	}
+	} catch (err) {
+	logger.error('[NE] Webhook request error', err);
+	throw err;
+	}
 };

--- a/src/modules/toc/ts/nuclen-toc-admin.ts
+++ b/src/modules/toc/ts/nuclen-toc-admin.ts
@@ -8,76 +8,76 @@
 declare const nuclenTocAdmin: { copy: string; done: string };
 
 const $ = (id: string): HTMLElement => {
-  const el = document.getElementById(id);
-  if (!el) {
-    throw new Error(`Missing element: ${id}`);
-  }
-  return el;
+	const el = document.getElementById(id);
+	if (!el) {
+	throw new Error(`Missing element: ${id}`);
+	}
+	return el;
 };
 
 const f = {
-  min: $('nuclen-min') as HTMLSelectElement,
-  max: $('nuclen-max') as HTMLSelectElement,
-  list: $('nuclen-list') as HTMLSelectElement,
-  title: $('nuclen-title') as HTMLInputElement,
-  tog: $('nuclen-tog') as HTMLInputElement,
-  col: $('nuclen-col') as HTMLInputElement,
-  smo: $('nuclen-smo') as HTMLInputElement,
-  hil: $('nuclen-hil') as HTMLInputElement,
-  off: $('nuclen-off') as HTMLInputElement,
+	min: $('nuclen-min') as HTMLSelectElement,
+	max: $('nuclen-max') as HTMLSelectElement,
+	list: $('nuclen-list') as HTMLSelectElement,
+	title: $('nuclen-title') as HTMLInputElement,
+	tog: $('nuclen-tog') as HTMLInputElement,
+	col: $('nuclen-col') as HTMLInputElement,
+	smo: $('nuclen-smo') as HTMLInputElement,
+	hil: $('nuclen-hil') as HTMLInputElement,
+	off: $('nuclen-off') as HTMLInputElement,
 };
 
 const out = $('nuclen-shortcode-preview');
 const btn = $('nuclen-copy');
 
 function build(): void {
-  let sc = '[simple_toc';
+	let sc = '[simple_toc';
 
-  if (f.min.value !== '2') {
-    sc += ` min_level="${f.min.value}"`;
-  }
-  if (f.max.value !== '6') {
-    sc += ` max_level="${f.max.value}"`;
-  }
-  if (f.list.value !== 'ul') {
-    sc += ` list="${f.list.value}"`;
-  }
+	if (f.min.value !== '2') {
+	sc += ` min_level="${f.min.value}"`;
+	}
+	if (f.max.value !== '6') {
+	sc += ` max_level="${f.max.value}"`;
+	}
+	if (f.list.value !== 'ul') {
+	sc += ` list="${f.list.value}"`;
+	}
 
-  const t = f.title.value.trim();
-  if (t) {
-    sc += ` title="${t.replace(/"/g, '&quot;')}"`;
-  }
+	const t = f.title.value.trim();
+	if (t) {
+	sc += ` title="${t.replace(/"/g, '&quot;')}"`;
+	}
 
-  if (!f.tog.checked) {
-    sc += ' toggle="false"';
-  }
-  if (f.col.checked) {
-    sc += ' collapsed="true"';
-  }
-  if (!f.smo.checked) {
-    sc += ' smooth="false"';
-  }
-  if (!f.hil.checked) {
-    sc += ' highlight="false"';
-  }
-  if (f.off.value !== '72') {
-    sc += ` offset="${f.off.value}"`;
-  }
+	if (!f.tog.checked) {
+	sc += ' toggle="false"';
+	}
+	if (f.col.checked) {
+	sc += ' collapsed="true"';
+	}
+	if (!f.smo.checked) {
+	sc += ' smooth="false"';
+	}
+	if (!f.hil.checked) {
+	sc += ' highlight="false"';
+	}
+	if (f.off.value !== '72') {
+	sc += ` offset="${f.off.value}"`;
+	}
 
-  sc += ']';
-  out.textContent = sc;
+	sc += ']';
+	out.textContent = sc;
 }
 
 Object.values(f).forEach((el) => {
-  el.addEventListener(el.type === 'checkbox' ? 'change' : 'input', build);
+	el.addEventListener(el.type === 'checkbox' ? 'change' : 'input', build);
 });
 build();
 
 btn.addEventListener('click', () => {
-  navigator.clipboard.writeText(out.textContent || '').then(() => {
-    btn.textContent = nuclenTocAdmin.done;
-    setTimeout(() => {
-      btn.textContent = nuclenTocAdmin.copy;
-    }, 2000);
-  });
+	navigator.clipboard.writeText(out.textContent || '').then(() => {
+	btn.textContent = nuclenTocAdmin.done;
+	setTimeout(() => {
+		btn.textContent = nuclenTocAdmin.copy;
+	}, 2000);
+	});
 });

--- a/src/modules/toc/ts/nuclen-toc-front.ts
+++ b/src/modules/toc/ts/nuclen-toc-front.ts
@@ -12,11 +12,11 @@ export { initStickyToc, initTocInteractions };
 
 // Boot
 if (document.readyState === 'loading') {
-  document.addEventListener('DOMContentLoaded', () => {
-    initStickyToc();
-    initTocInteractions();
-  });
+	document.addEventListener('DOMContentLoaded', () => {
+	initStickyToc();
+	initTocInteractions();
+	});
 } else {
-  initStickyToc();
-  initTocInteractions();
+	initStickyToc();
+	initTocInteractions();
 }

--- a/src/modules/toc/ts/sticky-toc.ts
+++ b/src/modules/toc/ts/sticky-toc.ts
@@ -4,129 +4,129 @@
  * Sticky Table of Contents behaviour.
  */
 export function initStickyToc(): void {
-  const wrappers = document.querySelectorAll<HTMLElement>('.nuclen-toc-sticky');
-  if (!wrappers.length) {
-    return;
-  }
+	const wrappers = document.querySelectorAll<HTMLElement>('.nuclen-toc-sticky');
+	if (!wrappers.length) {
+	return;
+	}
 
-  wrappers.forEach((wrapper) => {
-    const toc = wrapper.querySelector<HTMLElement>('.nuclen-toc');
-    if (!toc) {
-      return;
-    }
+	wrappers.forEach((wrapper) => {
+	const toc = wrapper.querySelector<HTMLElement>('.nuclen-toc');
+	if (!toc) {
+		return;
+	}
 
-    const headerOffset = parseInt(wrapper.dataset.offsetY || '20', 10);
-    const sideMargin = parseInt(wrapper.dataset.offsetX || '20', 10);
-    const showContent = wrapper.dataset.showContent;
-    if (showContent === 'false') {
-      toc.style.display = 'none';
-    }
+	const headerOffset = parseInt(wrapper.dataset.offsetY || '20', 10);
+	const sideMargin = parseInt(wrapper.dataset.offsetX || '20', 10);
+	const showContent = wrapper.dataset.showContent;
+	if (showContent === 'false') {
+		toc.style.display = 'none';
+	}
 
-    let rect = wrapper.getBoundingClientRect();
-    let originalTop = rect.top + window.pageYOffset;
-    let originalLeft = rect.left;
-    let originalWidth = rect.width;
-    let isStuck = false;
-    let raf: number | null = null;
+	let rect = wrapper.getBoundingClientRect();
+	let originalTop = rect.top + window.pageYOffset;
+	let originalLeft = rect.left;
+	let originalWidth = rect.width;
+	let isStuck = false;
+	let raf: number | null = null;
 
-    const dataMax = parseInt(wrapper.dataset.maxWidth || '0', 10); // 0 ⇒ unlimited.
+	const dataMax = parseInt(wrapper.dataset.maxWidth || '0', 10); // 0 ⇒ unlimited.
 
-    const ph = document.createElement('div');
-    ph.className = 'nuclen-toc-placeholder';
-    ph.style.height = `${rect.height}px`;
-    ph.style.width = `${rect.width}px`;
-    wrapper.insertAdjacentElement('afterend', ph);
-    ph.style.display = 'none';
+	const ph = document.createElement('div');
+	ph.className = 'nuclen-toc-placeholder';
+	ph.style.height = `${rect.height}px`;
+	ph.style.width = `${rect.width}px`;
+	wrapper.insertAdjacentElement('afterend', ph);
+	ph.style.display = 'none';
 
-    wrapper.style.transition = 'top 0.25s ease-out';
+	wrapper.style.transition = 'top 0.25s ease-out';
 
-    const calcLeft = (w: number): number => {
-      const container = document.querySelector<HTMLElement>(
-        '.entry-content, .post, .content-area, .site-main, main',
-      );
-      const contLeft = container ? container.getBoundingClientRect().left : originalLeft;
-      const min = sideMargin;
-      const max = window.innerWidth - w - sideMargin;
-      return Math.max(min, Math.min(contLeft, max));
-    };
-    const availHeight = (): number => window.innerHeight - headerOffset * 2;
+	const calcLeft = (w: number): number => {
+		const container = document.querySelector<HTMLElement>(
+		'.entry-content, .post, .content-area, .site-main, main',
+		);
+		const contLeft = container ? container.getBoundingClientRect().left : originalLeft;
+		const min = sideMargin;
+		const max = window.innerWidth - w - sideMargin;
+		return Math.max(min, Math.min(contLeft, max));
+	};
+	const availHeight = (): number => window.innerHeight - headerOffset * 2;
 
-    toc.style.position = 'relative';
-    toc.style.width = '100%';
+	toc.style.position = 'relative';
+	toc.style.width = '100%';
 
-    const setStuck = (stick: boolean): void => {
-      if (stick === isStuck) {
-        return;
-      }
-      isStuck = stick;
+	const setStuck = (stick: boolean): void => {
+		if (stick === isStuck) {
+		return;
+		}
+		isStuck = stick;
 
-      if (isStuck) {
-        const h = availHeight();
-        const w = dataMax > 0 ? Math.min(originalWidth, dataMax) : originalWidth;
+		if (isStuck) {
+		const h = availHeight();
+		const w = dataMax > 0 ? Math.min(originalWidth, dataMax) : originalWidth;
 
-        wrapper.classList.add('nuclen-toc-stuck');
-        wrapper.style.position = 'fixed';
-        wrapper.style.top = `${headerOffset}px`;
-        wrapper.style.left = `${calcLeft(w)}px`;
-        wrapper.style.width = `${w}px`;
-        wrapper.style.maxHeight = `${h}px`;
-        wrapper.style.overflow = 'visible';
+		wrapper.classList.add('nuclen-toc-stuck');
+		wrapper.style.position = 'fixed';
+		wrapper.style.top = `${headerOffset}px`;
+		wrapper.style.left = `${calcLeft(w)}px`;
+		wrapper.style.width = `${w}px`;
+		wrapper.style.maxHeight = `${h}px`;
+		wrapper.style.overflow = 'visible';
 
-        toc.style.maxHeight = `${h}px`;
-        toc.style.overflow = 'auto';
+		toc.style.maxHeight = `${h}px`;
+		toc.style.overflow = 'auto';
 
-        ph.style.display = 'block';
-        ph.style.width = `${w}px`;
-        ph.style.height = `${rect.height}px`;
-      } else {
-        wrapper.classList.remove('nuclen-toc-stuck');
-        wrapper.style.cssText = 'transition: top 0.25s ease-out;';
+		ph.style.display = 'block';
+		ph.style.width = `${w}px`;
+		ph.style.height = `${rect.height}px`;
+		} else {
+		wrapper.classList.remove('nuclen-toc-stuck');
+		wrapper.style.cssText = 'transition: top 0.25s ease-out;';
 
-        toc.style.maxHeight = '';
-        toc.style.overflow = '';
+		toc.style.maxHeight = '';
+		toc.style.overflow = '';
 
-        ph.style.display = 'none';
-      }
-    };
+		ph.style.display = 'none';
+		}
+	};
 
-    const onScroll = (): void => {
-      if (raf) {
-        return;
-      }
-      raf = window.requestAnimationFrame(() => {
-        raf = null;
-        const shouldStick = window.pageYOffset + headerOffset >= originalTop;
-        setStuck(shouldStick);
-      });
-    };
+	const onScroll = (): void => {
+		if (raf) {
+		return;
+		}
+		raf = window.requestAnimationFrame(() => {
+		raf = null;
+		const shouldStick = window.pageYOffset + headerOffset >= originalTop;
+		setStuck(shouldStick);
+		});
+	};
 
-    const onResize = (): void => {
-      if (raf) {
-        window.cancelAnimationFrame(raf);
-      }
-      raf = window.requestAnimationFrame(() => {
-        raf = null;
-        rect = wrapper.getBoundingClientRect();
-        originalLeft = rect.left;
-        originalWidth = rect.width;
+	const onResize = (): void => {
+		if (raf) {
+		window.cancelAnimationFrame(raf);
+		}
+		raf = window.requestAnimationFrame(() => {
+		raf = null;
+		rect = wrapper.getBoundingClientRect();
+		originalLeft = rect.left;
+		originalWidth = rect.width;
 
-        const w = dataMax > 0 ? Math.min(originalWidth, dataMax) : originalWidth;
+		const w = dataMax > 0 ? Math.min(originalWidth, dataMax) : originalWidth;
 
-        ph.style.width = `${w}px`;
-        ph.style.height = `${rect.height}px`;
+		ph.style.width = `${w}px`;
+		ph.style.height = `${rect.height}px`;
 
-        if (isStuck) {
-          const h = availHeight();
-          wrapper.style.left = `${calcLeft(w)}px`;
-          wrapper.style.width = `${w}px`;
-          wrapper.style.maxHeight = `${h}px`;
-          toc.style.maxHeight = `${h}px`;
-        }
-      });
-    };
+		if (isStuck) {
+			const h = availHeight();
+			wrapper.style.left = `${calcLeft(w)}px`;
+			wrapper.style.width = `${w}px`;
+			wrapper.style.maxHeight = `${h}px`;
+			toc.style.maxHeight = `${h}px`;
+		}
+		});
+	};
 
-    window.addEventListener('scroll', onScroll, { passive: true });
-    window.addEventListener('resize', onResize);
-    onScroll(); // initial determination.
-  });
+	window.addEventListener('scroll', onScroll, { passive: true });
+	window.addEventListener('resize', onResize);
+	onScroll(); // initial determination.
+	});
 }

--- a/src/modules/toc/ts/toc-interactions.ts
+++ b/src/modules/toc/ts/toc-interactions.ts
@@ -4,92 +4,92 @@
  * Handles TOC toggle buttons and scroll‑spy highlighting.
  */
 export function initTocInteractions(): void {
-  document.addEventListener('click', (e) => {
-    const btn = (e.target as HTMLElement).closest('.nuclen-toc-toggle');
-    if (!btn) {
-      return;
-    }
-    const navId = (btn as HTMLElement).getAttribute('aria-controls');
-    const nav = navId ? document.getElementById(navId) : null;
-    const expanded = (btn as HTMLElement).getAttribute('aria-expanded') === 'true';
-    (btn as HTMLElement).setAttribute('aria-expanded', expanded ? 'false' : 'true');
-    if (nav) {
-      nav.style.display = expanded ? 'none' : '';
-    }
-    // @ts-expect-error defined via wp_localize_script
-    const l10n = window.nuclenTocL10n as { show: string; hide: string };
-    (btn as HTMLElement).textContent = expanded ? l10n.show : l10n.hide;
-  });
+	document.addEventListener('click', (e) => {
+	const btn = (e.target as HTMLElement).closest('.nuclen-toc-toggle');
+	if (!btn) {
+		return;
+	}
+	const navId = (btn as HTMLElement).getAttribute('aria-controls');
+	const nav = navId ? document.getElementById(navId) : null;
+	const expanded = (btn as HTMLElement).getAttribute('aria-expanded') === 'true';
+	(btn as HTMLElement).setAttribute('aria-expanded', expanded ? 'false' : 'true');
+	if (nav) {
+		nav.style.display = expanded ? 'none' : '';
+	}
+	// @ts-expect-error defined via wp_localize_script
+	const l10n = window.nuclenTocL10n as { show: string; hide: string };
+	(btn as HTMLElement).textContent = expanded ? l10n.show : l10n.hide;
+	});
 
-  document.addEventListener('click', (e) => {
-    const link = (e.target as HTMLElement).closest('.nuclen-toc a');
-    const wrapper = link ? (link as HTMLElement).closest('.nuclen-toc-sticky') : null;
-    if (!link || !wrapper) {
-      return;
-    }
-    setTimeout(() => {
-      const btn = wrapper!.querySelector<HTMLElement>(
-        '.nuclen-toc-toggle[aria-expanded="true"]',
-      );
-      if (btn) {
-        btn.click();
-      }
-    }, 120);
-  });
+	document.addEventListener('click', (e) => {
+	const link = (e.target as HTMLElement).closest('.nuclen-toc a');
+	const wrapper = link ? (link as HTMLElement).closest('.nuclen-toc-sticky') : null;
+	if (!link || !wrapper) {
+		return;
+	}
+	setTimeout(() => {
+		const btn = wrapper!.querySelector<HTMLElement>(
+		'.nuclen-toc-toggle[aria-expanded="true"]',
+		);
+		if (btn) {
+		btn.click();
+		}
+	}, 120);
+	});
 
-  document.addEventListener('click', (e) => {
-    const stuck = document.querySelector<HTMLElement>(
-      '.nuclen-toc-sticky.nuclen-toc-stuck',
-    );
-    if (!stuck) {
-      return;
-    }
-    const target = e.target as HTMLElement;
-    if (!stuck.contains(target) && !target.closest('.nuclen-toc-toggle')) {
-      const btn = stuck.querySelector<HTMLElement>(
-        '.nuclen-toc-toggle[aria-expanded="true"]',
-      );
-      if (btn) {
-        btn.click();
-      }
-    }
-  });
+	document.addEventListener('click', (e) => {
+	const stuck = document.querySelector<HTMLElement>(
+		'.nuclen-toc-sticky.nuclen-toc-stuck',
+	);
+	if (!stuck) {
+		return;
+	}
+	const target = e.target as HTMLElement;
+	if (!stuck.contains(target) && !target.closest('.nuclen-toc-toggle')) {
+		const btn = stuck.querySelector<HTMLElement>(
+		'.nuclen-toc-toggle[aria-expanded="true"]',
+		);
+		if (btn) {
+		btn.click();
+		}
+	}
+	});
 
-  const navs = document.querySelectorAll<HTMLElement>(
-    '.nuclen-toc[data-highlight="true"]',
-  );
-  if (!navs.length || !('IntersectionObserver' in window)) {
-    return;
-  }
-  const ioOpts: IntersectionObserverInit = { rootMargin: '0px 0px -60%', threshold: 0 };
+	const navs = document.querySelectorAll<HTMLElement>(
+	'.nuclen-toc[data-highlight="true"]',
+	);
+	if (!navs.length || !('IntersectionObserver' in window)) {
+	return;
+	}
+	const ioOpts: IntersectionObserverInit = { rootMargin: '0px 0px -60%', threshold: 0 };
 
-  navs.forEach((nav) => {
-    const map = new Map<Element, HTMLAnchorElement>();
-    nav.querySelectorAll<HTMLAnchorElement>('a[href^="#"]').forEach((a) => {
-      const id = a.getAttribute('href')!.slice(1);
-      const tgt = id && document.getElementById(id);
-      if (tgt) map.set(tgt, a);
-    });
-    if (!map.size) {
-      return;
-    }
+	navs.forEach((nav) => {
+	const map = new Map<Element, HTMLAnchorElement>();
+	nav.querySelectorAll<HTMLAnchorElement>('a[href^="#"]').forEach((a) => {
+		const id = a.getAttribute('href')!.slice(1);
+		const tgt = id && document.getElementById(id);
+		if (tgt) map.set(tgt, a);
+	});
+	if (!map.size) {
+		return;
+	}
 
-    const io = new IntersectionObserver((entries) => {
-      entries.forEach((en) => {
-        const link = map.get(en.target);
-        if (!link) {
-          return;
-        }
-        if (en.isIntersecting) {
-          nav.querySelectorAll<HTMLAnchorElement>('a.is-active').forEach((el) => {
-            el.classList.remove('is-active');
-            el.removeAttribute('aria-current');
-          });
-          link.classList.add('is-active');
-          link.setAttribute('aria-current', 'location');
-        }
-      });
-    }, ioOpts);
-    map.forEach((_l, tgt) => io.observe(tgt));
-  });
+	const io = new IntersectionObserver((entries) => {
+		entries.forEach((en) => {
+		const link = map.get(en.target);
+		if (!link) {
+			return;
+		}
+		if (en.isIntersecting) {
+			nav.querySelectorAll<HTMLAnchorElement>('a.is-active').forEach((el) => {
+			el.classList.remove('is-active');
+			el.removeAttribute('aria-current');
+			});
+			link.classList.add('is-active');
+			link.setAttribute('aria-current', 'location');
+		}
+		});
+	}, ioOpts);
+	map.forEach((_l, tgt) => io.observe(tgt));
+	});
 }

--- a/tests/ActivatorDeactivatorTest.php
+++ b/tests/ActivatorDeactivatorTest.php
@@ -1,90 +1,90 @@
 <?php
 namespace {
-    use PHPUnit\Framework\TestCase;
-    use NuclearEngagement\Core\Activator;
-    use NuclearEngagement\Core\Deactivator;
-    use NuclearEngagement\Services\AutoGenerationService;
-    if (!defined('NUCLEN_PLUGIN_DIR')) {
-        define('NUCLEN_PLUGIN_DIR', dirname(__DIR__) . '/nuclear-engagement/');
-    }
-    if (!defined('NUCLEN_PLUGIN_VERSION')) { define('NUCLEN_PLUGIN_VERSION', '1.0'); }
-    if (!defined('NUCLEN_ASSET_VERSION')) { define('NUCLEN_ASSET_VERSION', 'dev'); }
-    if (!defined('NUCLEN_ACTIVATION_REDIRECT_TTL')) { define('NUCLEN_ACTIVATION_REDIRECT_TTL', 30); }
+	use PHPUnit\Framework\TestCase;
+	use NuclearEngagement\Core\Activator;
+	use NuclearEngagement\Core\Deactivator;
+	use NuclearEngagement\Services\AutoGenerationService;
+	if (!defined('NUCLEN_PLUGIN_DIR')) {
+		define('NUCLEN_PLUGIN_DIR', dirname(__DIR__) . '/nuclear-engagement/');
+	}
+	if (!defined('NUCLEN_PLUGIN_VERSION')) { define('NUCLEN_PLUGIN_VERSION', '1.0'); }
+	if (!defined('NUCLEN_ASSET_VERSION')) { define('NUCLEN_ASSET_VERSION', 'dev'); }
+	if (!defined('NUCLEN_ACTIVATION_REDIRECT_TTL')) { define('NUCLEN_ACTIVATION_REDIRECT_TTL', 30); }
 
-    // Globals used by stubs
-    $GLOBALS['transients'] = $GLOBALS['wp_options'] = $GLOBALS['wp_autoload'] = [];
-    $GLOBALS['update_option_calls'] = [];
-    $GLOBALS['cleared_hooks'] = [];
+	// Globals used by stubs
+	$GLOBALS['transients'] = $GLOBALS['wp_options'] = $GLOBALS['wp_autoload'] = [];
+	$GLOBALS['update_option_calls'] = [];
+	$GLOBALS['cleared_hooks'] = [];
 
-    // WordPress function stubs
-    if (!function_exists('set_transient')) {
-        function set_transient($key, $value, $ttl = 0) {
-            $GLOBALS['transients'][$key] = $value;
-        }
-    }
-    if (!function_exists('get_transient')) {
-        function get_transient($key) {
-            return $GLOBALS['transients'][$key] ?? false;
-        }
-    }
-    if (!function_exists('delete_transient')) {
-        function delete_transient($key) {
-            unset($GLOBALS['transients'][$key]);
-        }
-    }
-    if (!function_exists('update_option')) {
-        function update_option($name, $value, $autoload = 'yes') {
-            $GLOBALS['update_option_calls'][$name] = ($GLOBALS['update_option_calls'][$name] ?? 0) + 1;
-            $GLOBALS['wp_options'][$name] = $value;
-            $GLOBALS['wp_autoload'][$name] = $autoload;
-            return true;
-        }
-    }
-    if (!function_exists('get_option')) {
-        function get_option($name, $default = false) {
-            return $GLOBALS['wp_options'][$name] ?? $default;
-        }
-    }
-    if (!function_exists('delete_option')) {
-        function delete_option($name) {
-            unset($GLOBALS['wp_options'][$name]);
-            return true;
-        }
-    }
-    if (!function_exists('wp_clear_scheduled_hook')) {
-        function wp_clear_scheduled_hook($hook) {
-            $GLOBALS['cleared_hooks'][] = $hook;
-        }
-    }
+	// WordPress function stubs
+	if (!function_exists('set_transient')) {
+		function set_transient($key, $value, $ttl = 0) {
+			$GLOBALS['transients'][$key] = $value;
+		}
+	}
+	if (!function_exists('get_transient')) {
+		function get_transient($key) {
+			return $GLOBALS['transients'][$key] ?? false;
+		}
+	}
+	if (!function_exists('delete_transient')) {
+		function delete_transient($key) {
+			unset($GLOBALS['transients'][$key]);
+		}
+	}
+	if (!function_exists('update_option')) {
+		function update_option($name, $value, $autoload = 'yes') {
+			$GLOBALS['update_option_calls'][$name] = ($GLOBALS['update_option_calls'][$name] ?? 0) + 1;
+			$GLOBALS['wp_options'][$name] = $value;
+			$GLOBALS['wp_autoload'][$name] = $autoload;
+			return true;
+		}
+	}
+	if (!function_exists('get_option')) {
+		function get_option($name, $default = false) {
+			return $GLOBALS['wp_options'][$name] ?? $default;
+		}
+	}
+	if (!function_exists('delete_option')) {
+		function delete_option($name) {
+			unset($GLOBALS['wp_options'][$name]);
+			return true;
+		}
+	}
+	if (!function_exists('wp_clear_scheduled_hook')) {
+		function wp_clear_scheduled_hook($hook) {
+			$GLOBALS['cleared_hooks'][] = $hook;
+		}
+	}
 
-    // wpdb stub
-    class AD_WPDB {
-        public string $postmeta = 'wp_postmeta';
-        public string $prefix = 'wp_';
-        public array $queries = [];
-        public function prepare($query, ...$args) {
-            foreach ($args as $a) {
-                $query = preg_replace('/%s/', $a, $query, 1);
-            }
-            return $query;
-        }
-        public function get_var($sql) {
-            if (strpos($sql, 'SHOW TABLES') !== false) {
-                return $this->prefix . 'nuclen_optins';
-            }
-            return null;
-        }
-        public function query($sql) {
-            $this->queries[] = $sql;
-        }
-        public function get_charset_collate() { return ''; }
-    }
+	// wpdb stub
+	class AD_WPDB {
+		public string $postmeta = 'wp_postmeta';
+		public string $prefix = 'wp_';
+		public array $queries = [];
+		public function prepare($query, ...$args) {
+			foreach ($args as $a) {
+				$query = preg_replace('/%s/', $a, $query, 1);
+			}
+			return $query;
+		}
+		public function get_var($sql) {
+			if (strpos($sql, 'SHOW TABLES') !== false) {
+				return $this->prefix . 'nuclen_optins';
+			}
+			return null;
+		}
+		public function query($sql) {
+			$this->queries[] = $sql;
+		}
+		public function get_charset_collate() { return ''; }
+	}
 
-    require_once dirname(__DIR__) . '/nuclear-engagement/inc/Core/Defaults.php';
-    require_once dirname(__DIR__) . '/nuclear-engagement/inc/Core/SettingsRepository.php';
-    require_once dirname(__DIR__) . '/nuclear-engagement/inc/OptinData.php';
-    require_once dirname(__DIR__) . '/nuclear-engagement/inc/Core/AssetVersions.php';
-    require_once dirname(__DIR__) . '/nuclear-engagement/inc/Core/Activator.php';
+	require_once dirname(__DIR__) . '/nuclear-engagement/inc/Core/Defaults.php';
+	require_once dirname(__DIR__) . '/nuclear-engagement/inc/Core/SettingsRepository.php';
+	require_once dirname(__DIR__) . '/nuclear-engagement/inc/OptinData.php';
+	require_once dirname(__DIR__) . '/nuclear-engagement/inc/Core/AssetVersions.php';
+	require_once dirname(__DIR__) . '/nuclear-engagement/inc/Core/Activator.php';
 require_once dirname(__DIR__) . '/nuclear-engagement/inc/Core/Deactivator.php';
 }
 
@@ -92,37 +92,37 @@ namespace {
 use PHPUnit\Framework\TestCase;
 
 class ActivatorDeactivatorTest extends TestCase {
-    protected function setUp(): void {
-        global $wpdb, $wp_options, $wp_autoload, $transients, $update_option_calls, $cleared_hooks;
-        $wpdb = new AD_WPDB();
-        $wp_options = $wp_autoload = $transients = $update_option_calls = [];
-        $cleared_hooks = [];
-        \NuclearEngagement\Core\SettingsRepository::reset_for_tests();
-    }
+	protected function setUp(): void {
+		global $wpdb, $wp_options, $wp_autoload, $transients, $update_option_calls, $cleared_hooks;
+		$wpdb = new AD_WPDB();
+		$wp_options = $wp_autoload = $transients = $update_option_calls = [];
+		$cleared_hooks = [];
+		\NuclearEngagement\Core\SettingsRepository::reset_for_tests();
+	}
 
-    public function test_activation_creates_indexes_and_sets_options(): void {
-        global $wpdb, $wp_options, $transients, $update_option_calls;
-        Activator::nuclen_activate();
-        $this->assertTrue($transients['nuclen_plugin_activation_redirect']);
-        $this->assertArrayHasKey('nuclear_engagement_setup', $wp_options);
-        $this->assertSame(1, $update_option_calls['nuclear_engagement_setup'] ?? 0);
-        $this->assertCount(4, $wpdb->queries);
-        $this->assertStringContainsString('nuclen_quiz_data_idx', $wpdb->queries[0]);
-    }
+	public function test_activation_creates_indexes_and_sets_options(): void {
+		global $wpdb, $wp_options, $transients, $update_option_calls;
+		Activator::nuclen_activate();
+		$this->assertTrue($transients['nuclen_plugin_activation_redirect']);
+		$this->assertArrayHasKey('nuclear_engagement_setup', $wp_options);
+		$this->assertSame(1, $update_option_calls['nuclear_engagement_setup'] ?? 0);
+		$this->assertCount(4, $wpdb->queries);
+		$this->assertStringContainsString('nuclen_quiz_data_idx', $wpdb->queries[0]);
+	}
 
-    public function test_deactivation_clears_hooks_and_options(): void {
-        global $wp_options, $transients, $cleared_hooks;
-        $wp_options['nuclen_active_generations'] = ['x'];
-        $transients['nuclen_plugin_activation_redirect'] = true;
-        Deactivator::nuclen_deactivate();
-        $this->assertArrayNotHasKey('nuclen_active_generations', $wp_options);
-        $this->assertArrayNotHasKey('nuclen_plugin_activation_redirect', $transients);
-        $expected = [
-            AutoGenerationService::START_HOOK,
-            AutoGenerationService::QUEUE_HOOK,
-            'nuclen_poll_generation',
-        ];
-        $this->assertSame($expected, $cleared_hooks);
-    }
+	public function test_deactivation_clears_hooks_and_options(): void {
+		global $wp_options, $transients, $cleared_hooks;
+		$wp_options['nuclen_active_generations'] = ['x'];
+		$transients['nuclen_plugin_activation_redirect'] = true;
+		Deactivator::nuclen_deactivate();
+		$this->assertArrayNotHasKey('nuclen_active_generations', $wp_options);
+		$this->assertArrayNotHasKey('nuclen_plugin_activation_redirect', $transients);
+		$expected = [
+			AutoGenerationService::START_HOOK,
+			AutoGenerationService::QUEUE_HOOK,
+			'nuclen_poll_generation',
+		];
+		$this->assertSame($expected, $cleared_hooks);
+	}
 }
 }

--- a/tests/AdminNoticeServiceTest.php
+++ b/tests/AdminNoticeServiceTest.php
@@ -1,44 +1,44 @@
 <?php
 namespace NuclearEngagement\Services {
-    function add_action(...$args) {
-        $GLOBALS['ans_actions'][] = $args;
-    }
-    if (!function_exists('esc_html')) {
-        function esc_html($text) { return $text; }
-    }
+	function add_action(...$args) {
+		$GLOBALS['ans_actions'][] = $args;
+	}
+	if (!function_exists('esc_html')) {
+		function esc_html($text) { return $text; }
+	}
 }
 
 namespace {
-    use PHPUnit\Framework\TestCase;
-    use NuclearEngagement\Services\AdminNoticeService;
-    class AdminNoticeServiceTest extends TestCase {
-        protected function setUp(): void {
-            $GLOBALS['ans_actions'] = [];
-        }
+	use PHPUnit\Framework\TestCase;
+	use NuclearEngagement\Services\AdminNoticeService;
+	class AdminNoticeServiceTest extends TestCase {
+		protected function setUp(): void {
+			$GLOBALS['ans_actions'] = [];
+		}
 
-        public function test_add_hooks_into_admin_notices_once(): void {
-            $service = new AdminNoticeService();
-            $service->add('First');
-            $service->add('Second');
-            $this->assertCount(1, $GLOBALS['ans_actions']);
-            $this->assertSame('admin_notices', $GLOBALS['ans_actions'][0][0]);
-            $this->assertSame([$service, 'render'], $GLOBALS['ans_actions'][0][1]);
-        }
+		public function test_add_hooks_into_admin_notices_once(): void {
+			$service = new AdminNoticeService();
+			$service->add('First');
+			$service->add('Second');
+			$this->assertCount(1, $GLOBALS['ans_actions']);
+			$this->assertSame('admin_notices', $GLOBALS['ans_actions'][0][0]);
+			$this->assertSame([$service, 'render'], $GLOBALS['ans_actions'][0][1]);
+		}
 
-        public function test_render_outputs_notices_and_clears(): void {
-            $service = new AdminNoticeService();
-            $service->add('Hello');
-            ob_start();
-            $service->render();
-            $output = ob_get_clean();
-            $this->assertSame('<div class="notice notice-error"><p>Hello</p></div>', trim($output));
+		public function test_render_outputs_notices_and_clears(): void {
+			$service = new AdminNoticeService();
+			$service->add('Hello');
+			ob_start();
+			$service->render();
+			$output = ob_get_clean();
+			$this->assertSame('<div class="notice notice-error"><p>Hello</p></div>', trim($output));
 
-            $service->add('Again');
-            $this->assertCount(2, $GLOBALS['ans_actions']);
-            ob_start();
-            $service->render();
-            $second = ob_get_clean();
-            $this->assertSame('<div class="notice notice-error"><p>Again</p></div>', trim($second));
-        }
-    }
+			$service->add('Again');
+			$this->assertCount(2, $GLOBALS['ans_actions']);
+			ob_start();
+			$service->render();
+			$second = ob_get_clean();
+			$this->assertSame('<div class="notice notice-error"><p>Again</p></div>', trim($second));
+		}
+	}
 }

--- a/tests/AssetVersionsTest.php
+++ b/tests/AssetVersionsTest.php
@@ -1,98 +1,98 @@
 <?php
 namespace NuclearEngagement {
-    function time() {
-        return $GLOBALS['av_now'] ?? \time();
-    }
+	function time() {
+		return $GLOBALS['av_now'] ?? \time();
+	}
 }
 
 namespace {
-    use PHPUnit\Framework\TestCase;
-    use NuclearEngagement\Core\AssetVersions;
+	use PHPUnit\Framework\TestCase;
+	use NuclearEngagement\Core\AssetVersions;
 
-    class AssetVersionsTest extends TestCase {
-        private static string $dir;
+	class AssetVersionsTest extends TestCase {
+		private static string $dir;
 
-        public static function setUpBeforeClass(): void {
-            self::$dir = sys_get_temp_dir() . '/av_' . uniqid();
-            if (!defined('NUCLEN_PLUGIN_DIR')) {
-                define('NUCLEN_PLUGIN_DIR', self::$dir . '/');
-            }
-            if (!defined('NUCLEN_PLUGIN_VERSION')) {
-                define('NUCLEN_PLUGIN_VERSION', '1.0');
-            }
-            if (!defined('NUCLEN_ASSET_VERSION')) {
-                define('NUCLEN_ASSET_VERSION', 'default');
-            }
-            require_once dirname(__DIR__) . '/nuclear-engagement/inc/Core/AssetVersions.php';
-        }
+		public static function setUpBeforeClass(): void {
+			self::$dir = sys_get_temp_dir() . '/av_' . uniqid();
+			if (!defined('NUCLEN_PLUGIN_DIR')) {
+				define('NUCLEN_PLUGIN_DIR', self::$dir . '/');
+			}
+			if (!defined('NUCLEN_PLUGIN_VERSION')) {
+				define('NUCLEN_PLUGIN_VERSION', '1.0');
+			}
+			if (!defined('NUCLEN_ASSET_VERSION')) {
+				define('NUCLEN_ASSET_VERSION', 'default');
+			}
+			require_once dirname(__DIR__) . '/nuclear-engagement/inc/Core/AssetVersions.php';
+		}
 
-        protected function setUp(): void {
-            global $wp_options, $wp_autoload;
-            $wp_options = $wp_autoload = [];
-            $this->cleanDir(self::$dir);
-            $dirs = [
-                'admin/css',
-                'admin/js',
-                'front/css',
-                'front/js',
-                'inc/Modules/TOC/assets/css',
-                'inc/Modules/TOC/assets/js',
-            ];
-            foreach ($dirs as $d) {
-                @mkdir(self::$dir . '/' . $d, 0777, true);
-            }
-        }
+		protected function setUp(): void {
+			global $wp_options, $wp_autoload;
+			$wp_options = $wp_autoload = [];
+			$this->cleanDir(self::$dir);
+			$dirs = [
+				'admin/css',
+				'admin/js',
+				'front/css',
+				'front/js',
+				'inc/Modules/TOC/assets/css',
+				'inc/Modules/TOC/assets/js',
+			];
+			foreach ($dirs as $d) {
+				@mkdir(self::$dir . '/' . $d, 0777, true);
+			}
+		}
 
-        protected function tearDown(): void {
-            $this->cleanDir(self::$dir);
-            unset($GLOBALS['av_now']);
-        }
+		protected function tearDown(): void {
+			$this->cleanDir(self::$dir);
+			unset($GLOBALS['av_now']);
+		}
 
-        private function cleanDir(string $dir): void {
-            if (!is_dir($dir)) {
-                return;
-            }
-            $items = scandir($dir);
-            foreach ($items as $item) {
-                if ($item === '.' || $item === '..') {
-                    continue;
-                }
-                $path = $dir . '/' . $item;
-                if (is_dir($path)) {
-                    $this->cleanDir($path);
-                } else {
-                    @unlink($path);
-                }
-            }
-            @rmdir($dir);
-        }
+		private function cleanDir(string $dir): void {
+			if (!is_dir($dir)) {
+				return;
+			}
+			$items = scandir($dir);
+			foreach ($items as $item) {
+				if ($item === '.' || $item === '..') {
+					continue;
+				}
+				$path = $dir . '/' . $item;
+				if (is_dir($path)) {
+					$this->cleanDir($path);
+				} else {
+					@unlink($path);
+				}
+			}
+			@rmdir($dir);
+		}
 
-        public function test_get_returns_default_version_when_option_missing(): void {
-            $GLOBALS['av_now'] = 42;
-            $this->assertSame('default', AssetVersions::get('admin_css'));
-        }
+		public function test_get_returns_default_version_when_option_missing(): void {
+			$GLOBALS['av_now'] = 42;
+			$this->assertSame('default', AssetVersions::get('admin_css'));
+		}
 
-        public function test_update_versions_computes_versions_based_on_files(): void {
-            $file1 = self::$dir . '/admin/css/nuclen-admin.css';
-            $file2 = self::$dir . '/front/js/nuclen-front.js';
-            file_put_contents($file1, '');
-            file_put_contents($file2, '');
-            touch($file1, 123);
-            touch($file2, 456);
-            $GLOBALS['av_now'] = 999;
-            AssetVersions::update_versions();
-            $this->assertSame('123', AssetVersions::get('admin_css'));
-            $this->assertSame('456', AssetVersions::get('front_js'));
-            $this->assertSame('999', AssetVersions::get('front_css'));
-        }
+		public function test_update_versions_computes_versions_based_on_files(): void {
+			$file1 = self::$dir . '/admin/css/nuclen-admin.css';
+			$file2 = self::$dir . '/front/js/nuclen-front.js';
+			file_put_contents($file1, '');
+			file_put_contents($file2, '');
+			touch($file1, 123);
+			touch($file2, 456);
+			$GLOBALS['av_now'] = 999;
+			AssetVersions::update_versions();
+			$this->assertSame('123', AssetVersions::get('admin_css'));
+			$this->assertSame('456', AssetVersions::get('front_js'));
+			$this->assertSame('999', AssetVersions::get('front_css'));
+		}
 
-        public function test_init_updates_versions_when_version_changes(): void {
-            global $wp_options;
-            $wp_options['nuclen_asset_versions_build'] = 'old';
-            $GLOBALS['av_now'] = 5;
-            AssetVersions::init();
-            $this->assertSame('1.0', $wp_options['nuclen_asset_versions_build']);
-            $this->assertNotEmpty($wp_options['nuclen_asset_versions']);
-        }
-    }
+		public function test_init_updates_versions_when_version_changes(): void {
+			global $wp_options;
+			$wp_options['nuclen_asset_versions_build'] = 'old';
+			$GLOBALS['av_now'] = 5;
+			AssetVersions::init();
+			$this->assertSame('1.0', $wp_options['nuclen_asset_versions_build']);
+			$this->assertNotEmpty($wp_options['nuclen_asset_versions']);
+		}
+	}
 }

--- a/tests/AutoGenerationQueueTest.php
+++ b/tests/AutoGenerationQueueTest.php
@@ -5,117 +5,117 @@ use NuclearEngagement\Core\SettingsRepository;
 use NuclearEngagement\Modules\Summary\Summary_Service;
 
 class QueueDummyRemoteApiService {
-    public array $updates = [];
-    public $generateResponse = [];
-    public array $lastData = [];
-    public function send_posts_to_generate(array $data): array {
-        $this->lastData = $data;
-        return $this->generateResponse;
-    }
+	public array $updates = [];
+	public $generateResponse = [];
+	public array $lastData = [];
+	public function send_posts_to_generate(array $data): array {
+		$this->lastData = $data;
+		return $this->generateResponse;
+	}
 }
 
 class QueueDummyContentStorageService {
-    public array $stored = [];
-    public function storeResults(array $results, string $workflowType): array {
-        $this->stored[] = [$results, $workflowType];
-        return array_fill_keys(array_keys($results), true);
-    }
+	public array $stored = [];
+	public function storeResults(array $results, string $workflowType): array {
+		$this->stored[] = [$results, $workflowType];
+		return array_fill_keys(array_keys($results), true);
+	}
 }
 
 class Queue_WPDB {
-    public $posts = 'wp_posts';
-    public $postmeta = 'wp_postmeta';
-    public array $args = [];
-    public function prepare($sql, ...$args) {
-        $this->args = $args;
-        return $sql;
-    }
-    public function get_results($sql) {
-        $ids = array_slice($this->args, 2);
-        $rows = [];
-        foreach ($ids as $id) {
-            if (!isset($GLOBALS['wp_posts'][$id])) {
-                continue;
-            }
-            $p = $GLOBALS['wp_posts'][$id];
-            if ($p->post_status !== 'publish') {
-                continue;
-            }
-            if (!empty($GLOBALS['wp_meta'][$id]['nuclen_quiz_protected']) || !empty($GLOBALS['wp_meta'][$id][Summary_Service::PROTECTED_KEY])) {
-                continue;
-            }
-            $rows[] = (object) [
-                'ID' => $p->ID,
-                'post_title' => $p->post_title,
-                'post_content' => $p->post_content,
-            ];
-        }
-        return $rows;
-    }
+	public $posts = 'wp_posts';
+	public $postmeta = 'wp_postmeta';
+	public array $args = [];
+	public function prepare($sql, ...$args) {
+		$this->args = $args;
+		return $sql;
+	}
+	public function get_results($sql) {
+		$ids = array_slice($this->args, 2);
+		$rows = [];
+		foreach ($ids as $id) {
+			if (!isset($GLOBALS['wp_posts'][$id])) {
+				continue;
+			}
+			$p = $GLOBALS['wp_posts'][$id];
+			if ($p->post_status !== 'publish') {
+				continue;
+			}
+			if (!empty($GLOBALS['wp_meta'][$id]['nuclen_quiz_protected']) || !empty($GLOBALS['wp_meta'][$id][Summary_Service::PROTECTED_KEY])) {
+				continue;
+			}
+			$rows[] = (object) [
+				'ID' => $p->ID,
+				'post_title' => $p->post_title,
+				'post_content' => $p->post_content,
+			];
+		}
+		return $rows;
+	}
 }
 
 class AutoGenerationQueueTest extends TestCase {
-    private QueueDummyRemoteApiService $api;
-    protected function setUp(): void {
-        global $wp_options, $wp_autoload, $wp_posts, $wp_meta, $wp_events, $wpdb;
-        $wp_options = $wp_autoload = $wp_posts = $wp_meta = $wp_events = [];
-        $wpdb = new Queue_WPDB();
-        SettingsRepository::reset_for_tests();
-    }
+	private QueueDummyRemoteApiService $api;
+	protected function setUp(): void {
+		global $wp_options, $wp_autoload, $wp_posts, $wp_meta, $wp_events, $wpdb;
+		$wp_options = $wp_autoload = $wp_posts = $wp_meta = $wp_events = [];
+		$wpdb = new Queue_WPDB();
+		SettingsRepository::reset_for_tests();
+	}
 
-    private function makeQueue(): AutoGenerationQueue {
-        $this->api = new QueueDummyRemoteApiService();
-        $storage   = new QueueDummyContentStorageService();
-        return new AutoGenerationQueue($this->api, $storage, new \NuclearEngagement\Services\PostDataFetcher());
-    }
+	private function makeQueue(): AutoGenerationQueue {
+		$this->api = new QueueDummyRemoteApiService();
+		$storage   = new QueueDummyContentStorageService();
+		return new AutoGenerationQueue($this->api, $storage, new \NuclearEngagement\Services\PostDataFetcher());
+	}
 
-    public function test_queue_post_sets_autoload_no(): void {
-        $q = $this->makeQueue();
-        $q->queue_post(1, 'quiz');
-        $this->assertSame('no', $GLOBALS['wp_autoload']['nuclen_autogen_queue']);
-    }
+	public function test_queue_post_sets_autoload_no(): void {
+		$q = $this->makeQueue();
+		$q->queue_post(1, 'quiz');
+		$this->assertSame('no', $GLOBALS['wp_autoload']['nuclen_autogen_queue']);
+	}
 
-    public function test_process_queue_schedules_event(): void {
-        global $wp_posts, $wp_events;
-        $wp_posts[1] = (object)[ 'ID' => 1, 'post_title' => 'T', 'post_content' => 'C' ];
-        $q = $this->makeQueue();
-        $q->queue_post(1, 'quiz');
-        $q->process_queue();
-        $this->assertNotEmpty($wp_events);
-    }
+	public function test_process_queue_schedules_event(): void {
+		global $wp_posts, $wp_events;
+		$wp_posts[1] = (object)[ 'ID' => 1, 'post_title' => 'T', 'post_content' => 'C' ];
+		$q = $this->makeQueue();
+		$q->queue_post(1, 'quiz');
+		$q->process_queue();
+		$this->assertNotEmpty($wp_events);
+	}
 
-    public function test_process_queue_updates_option_once(): void {
-        global $wp_posts, $update_option_calls;
+	public function test_process_queue_updates_option_once(): void {
+		global $wp_posts, $update_option_calls;
 
-        for ($i = 1; $i <= 6; $i++) {
-            $wp_posts[$i] = (object) [ 'ID' => $i, 'post_title' => 'T' . $i, 'post_content' => 'C' . $i ];
-        }
+		for ($i = 1; $i <= 6; $i++) {
+			$wp_posts[$i] = (object) [ 'ID' => $i, 'post_title' => 'T' . $i, 'post_content' => 'C' . $i ];
+		}
 
-        $q = $this->makeQueue();
-        for ($i = 1; $i <= 6; $i++) {
-            $q->queue_post($i, 'quiz');
-        }
+		$q = $this->makeQueue();
+		for ($i = 1; $i <= 6; $i++) {
+			$q->queue_post($i, 'quiz');
+		}
 
-        $update_option_calls = [];
-        $q->process_queue();
+		$update_option_calls = [];
+		$q->process_queue();
 
-        $this->assertSame(1, $update_option_calls['nuclen_active_generations'] ?? 0);
-    }
+		$this->assertSame(1, $update_option_calls['nuclen_active_generations'] ?? 0);
+	}
 
-    public function test_process_queue_sends_unprotected_posts(): void {
-        global $wp_posts, $wp_meta;
+	public function test_process_queue_sends_unprotected_posts(): void {
+		global $wp_posts, $wp_meta;
 
-        $wp_posts[1] = (object) [ 'ID' => 1, 'post_title' => 'A', 'post_content' => '<b>C1</b>', 'post_status' => 'publish' ];
-        $wp_posts[2] = (object) [ 'ID' => 2, 'post_title' => 'B', 'post_content' => '<i>C2</i>', 'post_status' => 'publish' ];
-        $wp_meta[1]  = [ 'nuclen_quiz_protected' => 1 ];
+		$wp_posts[1] = (object) [ 'ID' => 1, 'post_title' => 'A', 'post_content' => '<b>C1</b>', 'post_status' => 'publish' ];
+		$wp_posts[2] = (object) [ 'ID' => 2, 'post_title' => 'B', 'post_content' => '<i>C2</i>', 'post_status' => 'publish' ];
+		$wp_meta[1]  = [ 'nuclen_quiz_protected' => 1 ];
 
-        $q = $this->makeQueue();
-        $q->queue_post(1, 'quiz');
-        $q->queue_post(2, 'quiz');
-        $q->process_queue();
+		$q = $this->makeQueue();
+		$q->queue_post(1, 'quiz');
+		$q->queue_post(2, 'quiz');
+		$q->process_queue();
 
-        $this->assertSame([
-            ['id' => 2, 'title' => 'B', 'content' => 'C2'],
-        ], $this->api->lastData['posts']);
-    }
+		$this->assertSame([
+			['id' => 2, 'title' => 'B', 'content' => 'C2'],
+		], $this->api->lastData['posts']);
+	}
 }

--- a/tests/AutoGenerationSchedulerTest.php
+++ b/tests/AutoGenerationSchedulerTest.php
@@ -4,41 +4,41 @@ use NuclearEngagement\Services\AutoGenerationScheduler;
 use NuclearEngagement\Core\SettingsRepository;
 
 class SchedulerDummyRemoteApiService {
-    public array $updates = [];
-    public $generateResponse = [];
-    public array $lastData = [];
-    public function send_posts_to_generate(array $data): array { return []; }
-    public function fetch_updates(string $id): array { return $this->updates[$id] ?? []; }
+	public array $updates = [];
+	public $generateResponse = [];
+	public array $lastData = [];
+	public function send_posts_to_generate(array $data): array { return []; }
+	public function fetch_updates(string $id): array { return $this->updates[$id] ?? []; }
 }
 
 class SchedulerDummyContentStorageService {
-    public array $stored = [];
-    public function storeResults(array $results, string $workflowType): array { $this->stored[] = [$results, $workflowType]; return array_fill_keys(array_keys($results), true); }
+	public array $stored = [];
+	public function storeResults(array $results, string $workflowType): array { $this->stored[] = [$results, $workflowType]; return array_fill_keys(array_keys($results), true); }
 }
 
 class AutoGenerationSchedulerTest extends TestCase {
-    protected function setUp(): void {
-        global $wp_options;
-        $wp_options = [];
-        SettingsRepository::reset_for_tests();
-    }
+	protected function setUp(): void {
+		global $wp_options;
+		$wp_options = [];
+		SettingsRepository::reset_for_tests();
+	}
 
-    private function makeScheduler(?SchedulerDummyRemoteApiService $api = null): AutoGenerationScheduler {
-        $settings = SettingsRepository::get_instance();
-        $api      = $api ?: new SchedulerDummyRemoteApiService();
-        $storage  = new SchedulerDummyContentStorageService();
-        $poller   = new \NuclearEngagement\Services\GenerationPoller($settings, $api, $storage);
-        return new AutoGenerationScheduler($poller);
-    }
+	private function makeScheduler(?SchedulerDummyRemoteApiService $api = null): AutoGenerationScheduler {
+		$settings = SettingsRepository::get_instance();
+		$api      = $api ?: new SchedulerDummyRemoteApiService();
+		$storage  = new SchedulerDummyContentStorageService();
+		$poller   = new \NuclearEngagement\Services\GenerationPoller($settings, $api, $storage);
+		return new AutoGenerationScheduler($poller);
+	}
 
-    public function test_poll_generation_success_clears_entry(): void {
-        global $wp_options;
-        $id = 'gen123';
-        $wp_options['nuclen_active_generations'] = [ $id => ['foo'=>'bar'] ];
-        $api = new SchedulerDummyRemoteApiService();
-        $api->updates[$id] = ['results' => ['1'=>['ok']]];
-        $scheduler = $this->makeScheduler($api);
-        $scheduler->poll_generation($id, 'quiz', [1], 1);
-        $this->assertArrayNotHasKey($id, $wp_options['nuclen_active_generations'] ?? []);
-    }
+	public function test_poll_generation_success_clears_entry(): void {
+		global $wp_options;
+		$id = 'gen123';
+		$wp_options['nuclen_active_generations'] = [ $id => ['foo'=>'bar'] ];
+		$api = new SchedulerDummyRemoteApiService();
+		$api->updates[$id] = ['results' => ['1'=>['ok']]];
+		$scheduler = $this->makeScheduler($api);
+		$scheduler->poll_generation($id, 'quiz', [1], 1);
+		$this->assertArrayNotHasKey($id, $wp_options['nuclen_active_generations'] ?? []);
+	}
 }

--- a/tests/AutoGenerationServiceTest.php
+++ b/tests/AutoGenerationServiceTest.php
@@ -6,181 +6,181 @@ use NuclearEngagement\Services\ApiException;
 use NuclearEngagement\Modules\Summary\Summary_Service;
 
 class ServiceDummyRemoteApiService {
-    public array $updates = [];
-    public $generateResponse = [];
-    public array $lastData = [];
-    public function send_posts_to_generate(array $data): array {
-        if ($this->generateResponse instanceof \Exception) {
-            throw $this->generateResponse;
-        }
-        $this->lastData = $data;
-        return $this->generateResponse;
-    }
-    public function fetch_updates(string $id): array { return $this->updates[$id] ?? []; }
+	public array $updates = [];
+	public $generateResponse = [];
+	public array $lastData = [];
+	public function send_posts_to_generate(array $data): array {
+		if ($this->generateResponse instanceof \Exception) {
+			throw $this->generateResponse;
+		}
+		$this->lastData = $data;
+		return $this->generateResponse;
+	}
+	public function fetch_updates(string $id): array { return $this->updates[$id] ?? []; }
 }
 
 class ServiceDummyContentStorageService {
-    public array $stored = [];
-    public function storeResults(array $results, string $workflowType): array {
-        $this->stored[] = [$results, $workflowType];
-        return array_fill_keys(array_keys($results), true);
-    }
+	public array $stored = [];
+	public function storeResults(array $results, string $workflowType): array {
+		$this->stored[] = [$results, $workflowType];
+		return array_fill_keys(array_keys($results), true);
+	}
 }
 
 class Service_WPDB {
-    public $posts = 'wp_posts';
-    public $postmeta = 'wp_postmeta';
-    public array $args = [];
-    public function prepare($sql, ...$args) { $this->args = $args; return $sql; }
-    public function get_results($sql) {
-        $ids = array_slice($this->args, 2);
-        $rows = [];
-        foreach ($ids as $id) {
-            if (!isset($GLOBALS['wp_posts'][$id])) { continue; }
-            $p = $GLOBALS['wp_posts'][$id];
-            if ($p->post_status !== 'publish') { continue; }
-            if (!empty($GLOBALS['wp_meta'][$id]['nuclen_quiz_protected']) || !empty($GLOBALS['wp_meta'][$id][Summary_Service::PROTECTED_KEY])) {
-                continue;
-            }
-            $rows[] = (object) [ 'ID' => $p->ID, 'post_title' => $p->post_title, 'post_content' => $p->post_content ];
-        }
-        return $rows;
-    }
+	public $posts = 'wp_posts';
+	public $postmeta = 'wp_postmeta';
+	public array $args = [];
+	public function prepare($sql, ...$args) { $this->args = $args; return $sql; }
+	public function get_results($sql) {
+		$ids = array_slice($this->args, 2);
+		$rows = [];
+		foreach ($ids as $id) {
+			if (!isset($GLOBALS['wp_posts'][$id])) { continue; }
+			$p = $GLOBALS['wp_posts'][$id];
+			if ($p->post_status !== 'publish') { continue; }
+			if (!empty($GLOBALS['wp_meta'][$id]['nuclen_quiz_protected']) || !empty($GLOBALS['wp_meta'][$id][Summary_Service::PROTECTED_KEY])) {
+				continue;
+			}
+			$rows[] = (object) [ 'ID' => $p->ID, 'post_title' => $p->post_title, 'post_content' => $p->post_content ];
+		}
+		return $rows;
+	}
 }
 
 class AutoGenerationServiceTest extends TestCase {
-    protected function setUp(): void {
-        global $wp_options, $wp_autoload, $wp_posts, $wp_meta, $wp_events, $wpdb;
-        $wp_options = $wp_autoload = $wp_posts = $wp_meta = $wp_events = [];
-        $wpdb = new Service_WPDB();
-        SettingsRepository::reset_for_tests();
-    }
+	protected function setUp(): void {
+		global $wp_options, $wp_autoload, $wp_posts, $wp_meta, $wp_events, $wpdb;
+		$wp_options = $wp_autoload = $wp_posts = $wp_meta = $wp_events = [];
+		$wpdb = new Service_WPDB();
+		SettingsRepository::reset_for_tests();
+	}
 
-    private function makeService(?ServiceDummyRemoteApiService $api = null): AutoGenerationService {
-        $settings = SettingsRepository::get_instance();
-        $api      = $api ?: new ServiceDummyRemoteApiService();
-        $storage  = new ServiceDummyContentStorageService();
+	private function makeService(?ServiceDummyRemoteApiService $api = null): AutoGenerationService {
+		$settings = SettingsRepository::get_instance();
+		$api      = $api ?: new ServiceDummyRemoteApiService();
+		$storage  = new ServiceDummyContentStorageService();
 
-        $poller    = new \NuclearEngagement\Services\GenerationPoller($settings, $api, $storage);
-        $scheduler = new \NuclearEngagement\Services\AutoGenerationScheduler($poller);
-        $queue     = new \NuclearEngagement\Services\AutoGenerationQueue($api, $storage, new \NuclearEngagement\Services\PostDataFetcher());
-        $handler   = new \NuclearEngagement\Services\PublishGenerationHandler($settings);
+		$poller    = new \NuclearEngagement\Services\GenerationPoller($settings, $api, $storage);
+		$scheduler = new \NuclearEngagement\Services\AutoGenerationScheduler($poller);
+		$queue     = new \NuclearEngagement\Services\AutoGenerationQueue($api, $storage, new \NuclearEngagement\Services\PostDataFetcher());
+		$handler   = new \NuclearEngagement\Services\PublishGenerationHandler($settings);
 
-        return new AutoGenerationService($settings, $queue, $scheduler, $handler);
-    }
+		return new AutoGenerationService($settings, $queue, $scheduler, $handler);
+	}
 
-    public function test_generate_single_sets_autoload_no(): void {
-        global $wp_autoload, $wp_posts;
-        $wp_posts[1] = (object)[ 'ID' => 1, 'post_title' => 'T', 'post_content' => 'C' ];
-        $service = $this->makeService();
-        $service->generate_single(1, 'quiz');
-        $this->assertSame('no', $wp_autoload['nuclen_autogen_queue']);
-    }
+	public function test_generate_single_sets_autoload_no(): void {
+		global $wp_autoload, $wp_posts;
+		$wp_posts[1] = (object)[ 'ID' => 1, 'post_title' => 'T', 'post_content' => 'C' ];
+		$service = $this->makeService();
+		$service->generate_single(1, 'quiz');
+		$this->assertSame('no', $wp_autoload['nuclen_autogen_queue']);
+	}
 
-    public function test_generate_single_does_not_schedule_on_error(): void {
-        global $wp_posts, $wp_events, $wp_options;
-        $wp_posts[1] = (object)[ 'ID' => 1, 'post_title' => 'T', 'post_content' => 'C' ];
-        $api = new ServiceDummyRemoteApiService();
-        $api->generateResponse = new ApiException('nope');
-        $service = $this->makeService($api);
-        $service->generate_single(1, 'quiz');
-        $service->process_queue();
-        $this->assertEmpty($wp_events);
-        $this->assertEmpty($wp_options['nuclen_active_generations'] ?? []);
-        $this->assertArrayNotHasKey('nuclen_autogen_queue', $wp_options);
-    }
+	public function test_generate_single_does_not_schedule_on_error(): void {
+		global $wp_posts, $wp_events, $wp_options;
+		$wp_posts[1] = (object)[ 'ID' => 1, 'post_title' => 'T', 'post_content' => 'C' ];
+		$api = new ServiceDummyRemoteApiService();
+		$api->generateResponse = new ApiException('nope');
+		$service = $this->makeService($api);
+		$service->generate_single(1, 'quiz');
+		$service->process_queue();
+		$this->assertEmpty($wp_events);
+		$this->assertEmpty($wp_options['nuclen_active_generations'] ?? []);
+		$this->assertArrayNotHasKey('nuclen_autogen_queue', $wp_options);
+	}
 
-    public function test_process_queue_handles_runtime_exception(): void {
-        global $wp_posts, $wp_events, $wp_options;
-        $wp_posts[1] = (object)[ 'ID' => 1, 'post_title' => 'T', 'post_content' => 'C' ];
-        $api = new ServiceDummyRemoteApiService();
-        $api->generateResponse = new \RuntimeException('missing key');
-        $service = $this->makeService($api);
-        $service->generate_single(1, 'quiz');
-        $service->process_queue();
-        $this->assertEmpty($wp_events);
-        $this->assertEmpty($wp_options['nuclen_active_generations'] ?? []);
-        $this->assertArrayNotHasKey('nuclen_autogen_queue', $wp_options);
-    }
+	public function test_process_queue_handles_runtime_exception(): void {
+		global $wp_posts, $wp_events, $wp_options;
+		$wp_posts[1] = (object)[ 'ID' => 1, 'post_title' => 'T', 'post_content' => 'C' ];
+		$api = new ServiceDummyRemoteApiService();
+		$api->generateResponse = new \RuntimeException('missing key');
+		$service = $this->makeService($api);
+		$service->generate_single(1, 'quiz');
+		$service->process_queue();
+		$this->assertEmpty($wp_events);
+		$this->assertEmpty($wp_options['nuclen_active_generations'] ?? []);
+		$this->assertArrayNotHasKey('nuclen_autogen_queue', $wp_options);
+	}
 
-    public function test_poll_generation_removes_entry_after_success(): void {
-        global $wp_options;
-        $id = 'gen123';
-        $wp_options['nuclen_active_generations'] = [ $id => ['foo'=>'bar'] ];
-        $api = new ServiceDummyRemoteApiService();
-        $api->updates[$id] = ['results' => ['1'=>['ok']]];
-        $service = $this->makeService($api);
-        $service->poll_generation($id, 'quiz', [1], 1);
-        $this->assertArrayNotHasKey($id, $wp_options['nuclen_active_generations'] ?? []);
-    }
+	public function test_poll_generation_removes_entry_after_success(): void {
+		global $wp_options;
+		$id = 'gen123';
+		$wp_options['nuclen_active_generations'] = [ $id => ['foo'=>'bar'] ];
+		$api = new ServiceDummyRemoteApiService();
+		$api->updates[$id] = ['results' => ['1'=>['ok']]];
+		$service = $this->makeService($api);
+		$service->poll_generation($id, 'quiz', [1], 1);
+		$this->assertArrayNotHasKey($id, $wp_options['nuclen_active_generations'] ?? []);
+	}
 
-    public function test_poll_generation_removes_entry_after_final_failure(): void {
-        global $wp_options;
-        $id = 'gen999';
-        $wp_options['nuclen_active_generations'] = [ $id => ['foo'=>'bar'] ];
-        $api = new ServiceDummyRemoteApiService();
-        $service = $this->makeService($api);
-        $service->poll_generation($id, 'quiz', [1], NUCLEN_MAX_POLL_ATTEMPTS);
-        $this->assertArrayNotHasKey($id, $wp_options['nuclen_active_generations'] ?? []);
-    }
+	public function test_poll_generation_removes_entry_after_final_failure(): void {
+		global $wp_options;
+		$id = 'gen999';
+		$wp_options['nuclen_active_generations'] = [ $id => ['foo'=>'bar'] ];
+		$api = new ServiceDummyRemoteApiService();
+		$service = $this->makeService($api);
+		$service->poll_generation($id, 'quiz', [1], NUCLEN_MAX_POLL_ATTEMPTS);
+		$this->assertArrayNotHasKey($id, $wp_options['nuclen_active_generations'] ?? []);
+	}
 
-    public function test_poll_generation_schedules_with_increasing_delay(): void {
-        global $wp_events;
-        $api = new ServiceDummyRemoteApiService();
-        $api->updates['gid'] = ['success' => true];
-        $service = $this->makeService($api);
-        $start = time();
-        $service->poll_generation('gid', 'quiz', [1], 2);
-        $this->assertNotEmpty($wp_events);
-        $event = $wp_events[0];
-        $delay = $event['timestamp'] - $start;
-        $this->assertGreaterThanOrEqual(NUCLEN_POLL_RETRY_DELAY * 2, $delay);
-        $this->assertSame('gid', $event['args'][0]);
-        $this->assertSame(3, $event['args'][3]);
-    }
+	public function test_poll_generation_schedules_with_increasing_delay(): void {
+		global $wp_events;
+		$api = new ServiceDummyRemoteApiService();
+		$api->updates['gid'] = ['success' => true];
+		$service = $this->makeService($api);
+		$start = time();
+		$service->poll_generation('gid', 'quiz', [1], 2);
+		$this->assertNotEmpty($wp_events);
+		$event = $wp_events[0];
+		$delay = $event['timestamp'] - $start;
+		$this->assertGreaterThanOrEqual(NUCLEN_POLL_RETRY_DELAY * 2, $delay);
+		$this->assertSame('gid', $event['args'][0]);
+		$this->assertSame(3, $event['args'][3]);
+	}
 
-    public function test_handle_post_publish_queues_generation(): void {
-        global $wp_posts, $wp_events, $wp_meta, $wp_options;
+	public function test_handle_post_publish_queues_generation(): void {
+		global $wp_posts, $wp_events, $wp_meta, $wp_options;
 
-        $post = (object) [
-            'ID' => 5,
-            'post_title' => 'T',
-            'post_content' => 'C',
-            'post_type' => 'post',
-        ];
-        $wp_posts[5] = $post;
-        $wp_meta[5] = [];
+		$post = (object) [
+			'ID' => 5,
+			'post_title' => 'T',
+			'post_content' => 'C',
+			'post_type' => 'post',
+		];
+		$wp_posts[5] = $post;
+		$wp_meta[5] = [];
 
-        $settings = SettingsRepository::get_instance();
-        $settings->set_bool('auto_generate_quiz_on_publish', true)
-                 ->set_array('generation_post_types', ['post'])
-                 ->save();
+		$settings = SettingsRepository::get_instance();
+		$settings->set_bool('auto_generate_quiz_on_publish', true)
+				 ->set_array('generation_post_types', ['post'])
+				 ->save();
 
-        $service = $this->makeService();
-        $service->handle_post_publish('publish', 'draft', $post);
+		$service = $this->makeService();
+		$service->handle_post_publish('publish', 'draft', $post);
 
-        $this->assertCount(1, $wp_events);
-        $event = $wp_events[0];
-        $this->assertSame('nuclen_start_generation', $event['hook']);
-        $this->assertSame([5, 'quiz'], $event['args']);
-    }
+		$this->assertCount(1, $wp_events);
+		$event = $wp_events[0];
+		$this->assertSame('nuclen_start_generation', $event['hook']);
+		$this->assertSame([5, 'quiz'], $event['args']);
+	}
 
-    public function test_process_queue_skips_protected_posts(): void {
-        global $wp_posts, $wp_meta, $wp_events;
+	public function test_process_queue_skips_protected_posts(): void {
+		global $wp_posts, $wp_meta, $wp_events;
 
-        $wp_posts[1] = (object) [ 'ID' => 1, 'post_title' => 'A', 'post_content' => 'C1' ];
-        $wp_posts[2] = (object) [ 'ID' => 2, 'post_title' => 'B', 'post_content' => 'C2' ];
-        $wp_meta[1]  = [ 'nuclen_quiz_protected' => 1 ];
+		$wp_posts[1] = (object) [ 'ID' => 1, 'post_title' => 'A', 'post_content' => 'C1' ];
+		$wp_posts[2] = (object) [ 'ID' => 2, 'post_title' => 'B', 'post_content' => 'C2' ];
+		$wp_meta[1]  = [ 'nuclen_quiz_protected' => 1 ];
 
-        $api     = new ServiceDummyRemoteApiService();
-        $service = $this->makeService( $api );
+		$api     = new ServiceDummyRemoteApiService();
+		$service = $this->makeService( $api );
 
-        $service->generate_single( 1, 'quiz' );
-        $service->generate_single( 2, 'quiz' );
-        $service->process_queue();
+		$service->generate_single( 1, 'quiz' );
+		$service->generate_single( 2, 'quiz' );
+		$service->process_queue();
 
-        $this->assertCount( 1, $api->lastData['posts'] );
-        $this->assertSame( 2, $api->lastData['posts'][0]['id'] );
-        $this->assertCount( 1, $wp_events );
-    }
+		$this->assertCount( 1, $api->lastData['posts'] );
+		$this->assertSame( 2, $api->lastData['posts'][0]['id'] );
+		$this->assertCount( 1, $wp_events );
+	}
 }

--- a/tests/BlocksTest.php
+++ b/tests/BlocksTest.php
@@ -1,76 +1,76 @@
 <?php
 namespace NuclearEngagement\Services {
-    class LoggingService {
-        public static array $logs = [];
-        public static function log(string $msg): void {
-            self::$logs[] = $msg;
-        }
-    }
+	class LoggingService {
+		public static array $logs = [];
+		public static function log(string $msg): void {
+			self::$logs[] = $msg;
+		}
+	}
 }
 
 namespace {
-    use PHPUnit\Framework\TestCase;
-    use NuclearEngagement\Core\Blocks;
-    function register_block_type(string $name, array $args): void {
-        $GLOBALS['block_regs'][$name] = $args;
-    }
-    function wp_script_is(string $handle, string $list = ''): bool {
-        return $GLOBALS['script_is'] ?? false;
-    }
-    if (!function_exists('__')) {
-        function __($t, $d = null) { return $t; }
-    }
-    if (!function_exists('esc_html__')) {
-        function esc_html__($t, $d = null) { return $t; }
-    }
-    function do_shortcode(string $code) {
-        $GLOBALS['shortcode_calls'][] = $code;
-        return 'OUT:' . $code;
-    }
+	use PHPUnit\Framework\TestCase;
+	use NuclearEngagement\Core\Blocks;
+	function register_block_type(string $name, array $args): void {
+		$GLOBALS['block_regs'][$name] = $args;
+	}
+	function wp_script_is(string $handle, string $list = ''): bool {
+		return $GLOBALS['script_is'] ?? false;
+	}
+	if (!function_exists('__')) {
+		function __($t, $d = null) { return $t; }
+	}
+	if (!function_exists('esc_html__')) {
+		function esc_html__($t, $d = null) { return $t; }
+	}
+	function do_shortcode(string $code) {
+		$GLOBALS['shortcode_calls'][] = $code;
+		return 'OUT:' . $code;
+	}
 
-    require_once dirname(__DIR__) . '/nuclear-engagement/inc/Core/Blocks.php';
+	require_once dirname(__DIR__) . '/nuclear-engagement/inc/Core/Blocks.php';
 
-    class BlocksTest extends TestCase {
-        protected function setUp(): void {
-            $GLOBALS['block_regs'] = [];
-            $GLOBALS['script_is'] = true;
-            $GLOBALS['shortcode_calls'] = [];
-            \NuclearEngagement\Services\LoggingService::$logs = [];
-        }
+	class BlocksTest extends TestCase {
+		protected function setUp(): void {
+			$GLOBALS['block_regs'] = [];
+			$GLOBALS['script_is'] = true;
+			$GLOBALS['shortcode_calls'] = [];
+			\NuclearEngagement\Services\LoggingService::$logs = [];
+		}
 
-        public function test_missing_script_triggers_logging(): void {
-            $GLOBALS['script_is'] = false;
-            Blocks::register();
-            $this->assertSame(
-                ['Nuclear Engagement: nuclen-admin script missing.'],
-                \NuclearEngagement\Services\LoggingService::$logs
-            );
-            $this->assertSame([], $GLOBALS['block_regs']);
-        }
+		public function test_missing_script_triggers_logging(): void {
+			$GLOBALS['script_is'] = false;
+			Blocks::register();
+			$this->assertSame(
+				['Nuclear Engagement: nuclen-admin script missing.'],
+				\NuclearEngagement\Services\LoggingService::$logs
+			);
+			$this->assertSame([], $GLOBALS['block_regs']);
+		}
 
-        public function test_registers_two_blocks_and_callbacks_use_shortcodes(): void {
-            Blocks::register();
-            $this->assertCount(2, $GLOBALS['block_regs']);
-            $this->assertArrayHasKey('nuclear-engagement/quiz', $GLOBALS['block_regs']);
-            $this->assertArrayHasKey('nuclear-engagement/summary', $GLOBALS['block_regs']);
+		public function test_registers_two_blocks_and_callbacks_use_shortcodes(): void {
+			Blocks::register();
+			$this->assertCount(2, $GLOBALS['block_regs']);
+			$this->assertArrayHasKey('nuclear-engagement/quiz', $GLOBALS['block_regs']);
+			$this->assertArrayHasKey('nuclear-engagement/summary', $GLOBALS['block_regs']);
 
-            $quiz_cb = $GLOBALS['block_regs']['nuclear-engagement/quiz']['render_callback'];
-            $summary_cb = $GLOBALS['block_regs']['nuclear-engagement/summary']['render_callback'];
+			$quiz_cb = $GLOBALS['block_regs']['nuclear-engagement/quiz']['render_callback'];
+			$summary_cb = $GLOBALS['block_regs']['nuclear-engagement/summary']['render_callback'];
 
-            $this->assertIsCallable($quiz_cb);
-            $this->assertIsCallable($summary_cb);
+			$this->assertIsCallable($quiz_cb);
+			$this->assertIsCallable($summary_cb);
 
-            $quiz_html = $quiz_cb();
-            $summary_html = $summary_cb();
+			$quiz_html = $quiz_cb();
+			$summary_html = $summary_cb();
 
-            $this->assertSame('OUT:[nuclear_engagement_quiz]', $quiz_html);
-            $this->assertSame('OUT:[nuclear_engagement_summary]', $summary_html);
+			$this->assertSame('OUT:[nuclear_engagement_quiz]', $quiz_html);
+			$this->assertSame('OUT:[nuclear_engagement_summary]', $summary_html);
 
-            $this->assertSame([
-                '[nuclear_engagement_quiz]',
-                '[nuclear_engagement_summary]'
-            ], $GLOBALS['shortcode_calls']);
-            $this->assertSame([], \NuclearEngagement\Services\LoggingService::$logs);
-        }
-    }
+			$this->assertSame([
+				'[nuclear_engagement_quiz]',
+				'[nuclear_engagement_summary]'
+			], $GLOBALS['shortcode_calls']);
+			$this->assertSame([], \NuclearEngagement\Services\LoggingService::$logs);
+		}
+	}
 }

--- a/tests/BootstrapTest.php
+++ b/tests/BootstrapTest.php
@@ -1,57 +1,57 @@
 <?php
 namespace BootstrapTestNS {
-    $GLOBALS['test_actions'] = [];
-    $GLOBALS['test_activation'] = [];
-    $GLOBALS['test_deactivation'] = [];
+	$GLOBALS['test_actions'] = [];
+	$GLOBALS['test_activation'] = [];
+	$GLOBALS['test_deactivation'] = [];
 
-    function add_action(...$args) {
-        $GLOBALS['test_actions'][] = $args;
-    }
-    function register_activation_hook(...$args) {
-        $GLOBALS['test_activation'][] = $args;
-    }
-    function register_deactivation_hook(...$args) {
-        $GLOBALS['test_deactivation'][] = $args;
-    }
-    if (!function_exists('__')) {
-        function __($text, $domain = null) { return $text; }
-    }
-    if (!function_exists('get_file_data')) {
-        function get_file_data($file, $keys, $type = null) { return ['Version' => '1.0']; }
-    }
-    if (!defined('NUCLEN_PLUGIN_FILE')) {
-        define('NUCLEN_PLUGIN_FILE', dirname(__DIR__) . '/nuclear-engagement/nuclear-engagement.php');
-    }
-    require dirname(__DIR__) . '/nuclear-engagement/bootstrap.php';
+	function add_action(...$args) {
+		$GLOBALS['test_actions'][] = $args;
+	}
+	function register_activation_hook(...$args) {
+		$GLOBALS['test_activation'][] = $args;
+	}
+	function register_deactivation_hook(...$args) {
+		$GLOBALS['test_deactivation'][] = $args;
+	}
+	if (!function_exists('__')) {
+		function __($text, $domain = null) { return $text; }
+	}
+	if (!function_exists('get_file_data')) {
+		function get_file_data($file, $keys, $type = null) { return ['Version' => '1.0']; }
+	}
+	if (!defined('NUCLEN_PLUGIN_FILE')) {
+		define('NUCLEN_PLUGIN_FILE', dirname(__DIR__) . '/nuclear-engagement/nuclear-engagement.php');
+	}
+	require dirname(__DIR__) . '/nuclear-engagement/bootstrap.php';
 }
 
 namespace {
-    use PHPUnit\Framework\TestCase;
+	use PHPUnit\Framework\TestCase;
 
-    class BootstrapTest extends TestCase {
-        public function test_hooks_registered(): void {
-            $found_plugins_loaded = false;
-            $found_init = false;
-            foreach ($GLOBALS['test_actions'] as $args) {
-                if ($args[0] === 'plugins_loaded' && $args[1] === 'nuclear_engagement_init') {
-                    $found_plugins_loaded = true;
-                }
-                if ($args[0] === 'init' && $args[1] === 'nuclear_engagement_load_textdomain') {
-                    $found_init = true;
-                }
-            }
-            $this->assertTrue($found_plugins_loaded, 'plugins_loaded hook not registered');
-            $this->assertTrue($found_init, 'init hook not registered');
-            $this->assertNotEmpty($GLOBALS['test_activation']);
-            $this->assertNotEmpty($GLOBALS['test_deactivation']);
-            $this->assertSame(NUCLEN_PLUGIN_FILE, $GLOBALS['test_activation'][0][0]);
-            $this->assertSame(NUCLEN_PLUGIN_FILE, $GLOBALS['test_deactivation'][0][0]);
-            $this->assertIsArray($GLOBALS['test_activation'][0][1]);
-            $this->assertInstanceOf(\NuclearEngagement\Core\Installer::class, $GLOBALS['test_activation'][0][1][0]);
-            $this->assertSame('activate', $GLOBALS['test_activation'][0][1][1]);
-            $this->assertIsArray($GLOBALS['test_deactivation'][0][1]);
-            $this->assertInstanceOf(\NuclearEngagement\Core\Installer::class, $GLOBALS['test_deactivation'][0][1][0]);
-            $this->assertSame('deactivate', $GLOBALS['test_deactivation'][0][1][1]);
-        }
-    }
+	class BootstrapTest extends TestCase {
+		public function test_hooks_registered(): void {
+			$found_plugins_loaded = false;
+			$found_init = false;
+			foreach ($GLOBALS['test_actions'] as $args) {
+				if ($args[0] === 'plugins_loaded' && $args[1] === 'nuclear_engagement_init') {
+					$found_plugins_loaded = true;
+				}
+				if ($args[0] === 'init' && $args[1] === 'nuclear_engagement_load_textdomain') {
+					$found_init = true;
+				}
+			}
+			$this->assertTrue($found_plugins_loaded, 'plugins_loaded hook not registered');
+			$this->assertTrue($found_init, 'init hook not registered');
+			$this->assertNotEmpty($GLOBALS['test_activation']);
+			$this->assertNotEmpty($GLOBALS['test_deactivation']);
+			$this->assertSame(NUCLEN_PLUGIN_FILE, $GLOBALS['test_activation'][0][0]);
+			$this->assertSame(NUCLEN_PLUGIN_FILE, $GLOBALS['test_deactivation'][0][0]);
+			$this->assertIsArray($GLOBALS['test_activation'][0][1]);
+			$this->assertInstanceOf(\NuclearEngagement\Core\Installer::class, $GLOBALS['test_activation'][0][1][0]);
+			$this->assertSame('activate', $GLOBALS['test_activation'][0][1][1]);
+			$this->assertIsArray($GLOBALS['test_deactivation'][0][1]);
+			$this->assertInstanceOf(\NuclearEngagement\Core\Installer::class, $GLOBALS['test_deactivation'][0][1][0]);
+			$this->assertSame('deactivate', $GLOBALS['test_deactivation'][0][1][1]);
+		}
+	}
 }

--- a/tests/ContainerRegistrarTest.php
+++ b/tests/ContainerRegistrarTest.php
@@ -10,50 +10,50 @@ require_once dirname(__DIR__) . '/nuclear-engagement/inc/Core/Defaults.php';
 require_once dirname(__DIR__) . '/nuclear-engagement/inc/Core/ContainerRegistrar.php';
 
 class ContainerRegistrarTest extends TestCase {
-    private Container $container;
-    private SettingsRepository $settings;
+	private Container $container;
+	private SettingsRepository $settings;
 
-    protected function setUp(): void {
-        SettingsRepository::reset_for_tests();
-        $this->container = Container::getInstance();
-        $this->container->reset();
-        $this->settings = SettingsRepository::get_instance();
-    }
+	protected function setUp(): void {
+		SettingsRepository::reset_for_tests();
+		$this->container = Container::getInstance();
+		$this->container->reset();
+		$this->settings = SettingsRepository::get_instance();
+	}
 
-    public function test_register_adds_expected_services_and_controllers(): void {
-        ContainerRegistrar::register($this->container, $this->settings);
+	public function test_register_adds_expected_services_and_controllers(): void {
+		ContainerRegistrar::register($this->container, $this->settings);
 
-        $expected = [
-            'settings',
-            'admin_notice_service',
-            'logging_service',
-            'remote_request',
-            'api_response_handler',
-            'remote_api',
-            'content_storage',
-            'generation_poller',
-            'auto_generation_queue',
-            'auto_generation_scheduler',
-            'publish_generation_handler',
-            'auto_generation_service',
-            'generation_service',
-            'pointer_service',
-            'posts_query_service',
-            'dashboard_data_service',
-            'version_service',
-            'generate_controller',
-            'updates_controller',
-            'pointer_controller',
-            'posts_count_controller',
-            'content_controller',
-            'optin_export_controller',
-        ];
+		$expected = [
+			'settings',
+			'admin_notice_service',
+			'logging_service',
+			'remote_request',
+			'api_response_handler',
+			'remote_api',
+			'content_storage',
+			'generation_poller',
+			'auto_generation_queue',
+			'auto_generation_scheduler',
+			'publish_generation_handler',
+			'auto_generation_service',
+			'generation_service',
+			'pointer_service',
+			'posts_query_service',
+			'dashboard_data_service',
+			'version_service',
+			'generate_controller',
+			'updates_controller',
+			'pointer_controller',
+			'posts_count_controller',
+			'content_controller',
+			'optin_export_controller',
+		];
 
-        foreach ($expected as $id) {
-            $this->assertTrue(
-                $this->container->has($id),
-                "Service {$id} not registered"
-            );
-        }
-    }
+		foreach ($expected as $id) {
+			$this->assertTrue(
+				$this->container->has($id),
+				"Service {$id} not registered"
+			);
+		}
+	}
 }

--- a/tests/ContainerTest.php
+++ b/tests/ContainerTest.php
@@ -3,40 +3,40 @@ use PHPUnit\Framework\TestCase;
 use NuclearEngagement\Core\Container;
 
 class ContainerTest extends TestCase {
-    protected function setUp(): void {
-        Container::getInstance()->reset();
-    }
+	protected function setUp(): void {
+		Container::getInstance()->reset();
+	}
 
-    public function test_singleton_returns_same_instance(): void {
-        $a = Container::getInstance();
-        $b = Container::getInstance();
-        $this->assertSame($a, $b);
-    }
+	public function test_singleton_returns_same_instance(): void {
+		$a = Container::getInstance();
+		$b = Container::getInstance();
+		$this->assertSame($a, $b);
+	}
 
-    public function test_register_and_get_service(): void {
-        $container = Container::getInstance();
-        $obj = new stdClass();
-        $container->register('foo', static function () use ($obj) {
-            return $obj;
-        });
-        $this->assertTrue($container->has('foo'));
-        $this->assertSame($obj, $container->get('foo'));
-    }
+	public function test_register_and_get_service(): void {
+		$container = Container::getInstance();
+		$obj = new stdClass();
+		$container->register('foo', static function () use ($obj) {
+			return $obj;
+		});
+		$this->assertTrue($container->has('foo'));
+		$this->assertSame($obj, $container->get('foo'));
+	}
 
-    public function test_get_throws_for_unknown_service(): void {
-        $this->expectException(\RuntimeException::class);
-        Container::getInstance()->get('missing');
-    }
+	public function test_get_throws_for_unknown_service(): void {
+		$this->expectException(\RuntimeException::class);
+		Container::getInstance()->get('missing');
+	}
 
-    public function test_reset_clears_registered_services(): void {
-        $c = Container::getInstance();
-        $c->register('foo', static function () {
-            return new stdClass();
-        });
-        $c->get('foo');
-        $c->reset();
-        $this->assertFalse($c->has('foo'));
-        $this->expectException(\RuntimeException::class);
-        $c->get('foo');
-    }
+	public function test_reset_clears_registered_services(): void {
+		$c = Container::getInstance();
+		$c->register('foo', static function () {
+			return new stdClass();
+		});
+		$c->get('foo');
+		$c->reset();
+		$this->assertFalse($c->has('foo'));
+		$this->expectException(\RuntimeException::class);
+		$c->get('foo');
+	}
 }

--- a/tests/ContentControllerTest.php
+++ b/tests/ContentControllerTest.php
@@ -1,180 +1,180 @@
 <?php
 namespace NuclearEngagement\Services {
-    class LoggingService {
-        public static array $logs = [];
-        public static function log(string $msg): void {
-            self::$logs[] = $msg;
-        }
-        public static function log_exception(\Throwable $e): void {
-            self::$logs[] = $e->getMessage();
-        }
-    }
+	class LoggingService {
+		public static array $logs = [];
+		public static function log(string $msg): void {
+			self::$logs[] = $msg;
+		}
+		public static function log_exception(\Throwable $e): void {
+			self::$logs[] = $e->getMessage();
+		}
+	}
 }
 
 namespace {
-    use PHPUnit\Framework\TestCase;
-    use NuclearEngagement\Front\Controller\Rest\ContentController;
-    use NuclearEngagement\Core\SettingsRepository;
-    use NuclearEngagement\Services\ContentStorageService;
-    use NuclearEngagement\Modules\Summary\Summary_Service;
-    if (!function_exists('__')) {
-        function __($t, $d = null) { return $t; }
-    }
-    if (!function_exists('sanitize_text_field')) {
-        function sanitize_text_field($t) { return $t; }
-    }
-    if (!function_exists('current_user_can')) {
-        function current_user_can($cap) { return true; }
-    }
-    if (!class_exists('WP_REST_Response')) {
-        class WP_REST_Response {
-            public $data;
-            public $status;
-            public function __construct($data = null, $status = 200) {
-                $this->data = $data;
-                $this->status = $status;
-            }
-        }
-    }
+	use PHPUnit\Framework\TestCase;
+	use NuclearEngagement\Front\Controller\Rest\ContentController;
+	use NuclearEngagement\Core\SettingsRepository;
+	use NuclearEngagement\Services\ContentStorageService;
+	use NuclearEngagement\Modules\Summary\Summary_Service;
+	if (!function_exists('__')) {
+		function __($t, $d = null) { return $t; }
+	}
+	if (!function_exists('sanitize_text_field')) {
+		function sanitize_text_field($t) { return $t; }
+	}
+	if (!function_exists('current_user_can')) {
+		function current_user_can($cap) { return true; }
+	}
+	if (!class_exists('WP_REST_Response')) {
+		class WP_REST_Response {
+			public $data;
+			public $status;
+			public function __construct($data = null, $status = 200) {
+				$this->data = $data;
+				$this->status = $status;
+			}
+		}
+	}
 
-    class DummyRequest {
-        private $json;
-        private $headers;
-        public function __construct($json = null, array $headers = []) {
-            $this->json = $json;
-            $this->headers = $headers;
-        }
-        public function get_json_params() {
-            return $this->json;
-        }
-        public function get_header($name) {
-            return $this->headers[$name] ?? '';
-        }
-    }
+	class DummyRequest {
+		private $json;
+		private $headers;
+		public function __construct($json = null, array $headers = []) {
+			$this->json = $json;
+			$this->headers = $headers;
+		}
+		public function get_json_params() {
+			return $this->json;
+		}
+		public function get_header($name) {
+			return $this->headers[$name] ?? '';
+		}
+	}
 
-    class DummyStorage {
-        public array $stored = [];
-        public function storeResults(array $results, string $workflowType): array {
-            global $wp_meta;
-            $metaKey = $workflowType === 'quiz' ? 'nuclen-quiz-data' : Summary_Service::META_KEY;
-            foreach ($results as $id => $data) {
-                $wp_meta[$id][$metaKey] = $data;
-            }
-            $this->stored[] = [$results, $workflowType];
-            return array_fill_keys(array_keys($results), true);
-        }
-    }
+	class DummyStorage {
+		public array $stored = [];
+		public function storeResults(array $results, string $workflowType): array {
+			global $wp_meta;
+			$metaKey = $workflowType === 'quiz' ? 'nuclen-quiz-data' : Summary_Service::META_KEY;
+			foreach ($results as $id => $data) {
+				$wp_meta[$id][$metaKey] = $data;
+			}
+			$this->stored[] = [$results, $workflowType];
+			return array_fill_keys(array_keys($results), true);
+		}
+	}
 
-    class FailingStorage extends DummyStorage {
-        public function storeResults(array $results, string $workflowType): array {
-            parent::storeResults($results, $workflowType);
-            return array_fill_keys(array_keys($results), 'fail');
-        }
-    }
+	class FailingStorage extends DummyStorage {
+		public function storeResults(array $results, string $workflowType): array {
+			parent::storeResults($results, $workflowType);
+			return array_fill_keys(array_keys($results), 'fail');
+		}
+	}
 
-    class ContentControllerTest extends TestCase {
-        protected function setUp(): void {
-            global $wp_options, $wp_autoload, $wp_posts, $wp_meta;
-            $wp_options = $wp_autoload = $wp_posts = $wp_meta = [];
-            SettingsRepository::reset_for_tests();
-            \NuclearEngagement\Services\LoggingService::$logs = [];
-        }
+	class ContentControllerTest extends TestCase {
+		protected function setUp(): void {
+			global $wp_options, $wp_autoload, $wp_posts, $wp_meta;
+			$wp_options = $wp_autoload = $wp_posts = $wp_meta = [];
+			SettingsRepository::reset_for_tests();
+			\NuclearEngagement\Services\LoggingService::$logs = [];
+		}
 
-    public function test_handle_invalid_json_returns_error(): void {
-        $settings = SettingsRepository::get_instance();
-        $storage = new ContentStorageService($settings);
-        $controller = new ContentController($storage, $settings);
-        $req = new DummyRequest();
+	public function test_handle_invalid_json_returns_error(): void {
+		$settings = SettingsRepository::get_instance();
+		$storage = new ContentStorageService($settings);
+		$controller = new ContentController($storage, $settings);
+		$req = new DummyRequest();
 
-            $res = $controller->handle($req);
+			$res = $controller->handle($req);
 
-        $this->assertInstanceOf(WP_Error::class, $res);
-        $this->assertNotEmpty(\NuclearEngagement\Services\LoggingService::$logs);
-    }
+		$this->assertInstanceOf(WP_Error::class, $res);
+		$this->assertNotEmpty(\NuclearEngagement\Services\LoggingService::$logs);
+	}
 
-    public function test_valid_password_returns_rest_response(): void {
-        global $wp_posts;
-        $wp_posts[1] = (object)['ID' => 1];
+	public function test_valid_password_returns_rest_response(): void {
+		global $wp_posts;
+		$wp_posts[1] = (object)['ID' => 1];
 
-        $settings = SettingsRepository::get_instance();
-        $settings->set_string('plugin_password', 'secret')->save();
+		$settings = SettingsRepository::get_instance();
+		$settings->set_string('plugin_password', 'secret')->save();
 
-        $storage = new DummyStorage();
-        $controller = new ContentController($storage, $settings);
+		$storage = new DummyStorage();
+		$controller = new ContentController($storage, $settings);
 
-        $data = [
-            'workflow' => 'summary',
-            'results'  => [1 => ['summary' => 'ok', 'date' => '2025-01-01']],
-        ];
-        $req = new DummyRequest($data, ['X-WP-App-Password' => 'secret']);
+		$data = [
+			'workflow' => 'summary',
+			'results'  => [1 => ['summary' => 'ok', 'date' => '2025-01-01']],
+		];
+		$req = new DummyRequest($data, ['X-WP-App-Password' => 'secret']);
 
-        $this->assertTrue($controller->permissions($req));
+		$this->assertTrue($controller->permissions($req));
 
-        $res = $controller->handle($req);
+		$res = $controller->handle($req);
 
-        $this->assertInstanceOf(WP_REST_Response::class, $res);
-        $this->assertSame(200, $res->status);
-        $this->assertNotEmpty($storage->stored);
-    }
+		$this->assertInstanceOf(WP_REST_Response::class, $res);
+		$this->assertSame(200, $res->status);
+		$this->assertNotEmpty($storage->stored);
+	}
 
-    public function test_valid_nonce_returns_rest_response(): void {
-        global $wp_posts;
-        $wp_posts[2] = (object)['ID' => 2];
+	public function test_valid_nonce_returns_rest_response(): void {
+		global $wp_posts;
+		$wp_posts[2] = (object)['ID' => 2];
 
-        $settings = SettingsRepository::get_instance();
-        $storage  = new DummyStorage();
-        $controller = new ContentController($storage, $settings);
+		$settings = SettingsRepository::get_instance();
+		$storage  = new DummyStorage();
+		$controller = new ContentController($storage, $settings);
 
-        $data = [
-            'workflow' => 'quiz',
-            'results'  => [2 => ['questions' => [], 'date' => '2025-01-02']],
-        ];
-        $req = new DummyRequest($data, ['X-WP-Nonce' => 'valid']);
+		$data = [
+			'workflow' => 'quiz',
+			'results'  => [2 => ['questions' => [], 'date' => '2025-01-02']],
+		];
+		$req = new DummyRequest($data, ['X-WP-Nonce' => 'valid']);
 
-        $this->assertTrue($controller->permissions($req));
-        $res = $controller->handle($req);
+		$this->assertTrue($controller->permissions($req));
+		$res = $controller->handle($req);
 
-        $this->assertInstanceOf(WP_REST_Response::class, $res);
-        $this->assertSame(200, $res->status);
-        $this->assertNotEmpty($storage->stored);
-    }
+		$this->assertInstanceOf(WP_REST_Response::class, $res);
+		$this->assertSame(200, $res->status);
+		$this->assertNotEmpty($storage->stored);
+	}
 
-    public function test_invalid_credentials_return_error(): void {
-        $settings = SettingsRepository::get_instance();
-        $settings->set_string('plugin_password', 'secret')->save();
+	public function test_invalid_credentials_return_error(): void {
+		$settings = SettingsRepository::get_instance();
+		$settings->set_string('plugin_password', 'secret')->save();
 
-        $storage  = new DummyStorage();
-        $controller = new ContentController($storage, $settings);
-        $data = ['workflow' => 'quiz', 'results' => [3 => ['questions' => []]]];
-        $req = new DummyRequest($data, ['X-WP-App-Password' => 'wrong']);
+		$storage  = new DummyStorage();
+		$controller = new ContentController($storage, $settings);
+		$data = ['workflow' => 'quiz', 'results' => [3 => ['questions' => []]]];
+		$req = new DummyRequest($data, ['X-WP-App-Password' => 'wrong']);
 
-        $allowed = $controller->permissions($req);
-        $res = $allowed ? $controller->handle($req)
-                        : new WP_Error('rest_forbidden', 'forbidden', ['status' => 401]);
+		$allowed = $controller->permissions($req);
+		$res = $allowed ? $controller->handle($req)
+						: new WP_Error('rest_forbidden', 'forbidden', ['status' => 401]);
 
-        $this->assertFalse($allowed);
-        $this->assertInstanceOf(WP_Error::class, $res);
-        $this->assertSame(401, $res->data['status']);
-    }
+		$this->assertFalse($allowed);
+		$this->assertInstanceOf(WP_Error::class, $res);
+		$this->assertSame(401, $res->data['status']);
+	}
 
-    public function test_storage_failure_returns_error(): void {
-        global $wp_posts;
-        $wp_posts[4] = (object)['ID' => 4];
+	public function test_storage_failure_returns_error(): void {
+		global $wp_posts;
+		$wp_posts[4] = (object)['ID' => 4];
 
-        $settings = SettingsRepository::get_instance();
-        $storage  = new FailingStorage();
-        $controller = new ContentController($storage, $settings);
+		$settings = SettingsRepository::get_instance();
+		$storage  = new FailingStorage();
+		$controller = new ContentController($storage, $settings);
 
-        $data = [
-            'workflow' => 'summary',
-            'results'  => [4 => ['summary' => 'bad']],
-        ];
-        $req = new DummyRequest($data, ['X-WP-Nonce' => 'valid']);
+		$data = [
+			'workflow' => 'summary',
+			'results'  => [4 => ['summary' => 'bad']],
+		];
+		$req = new DummyRequest($data, ['X-WP-Nonce' => 'valid']);
 
-        $this->assertTrue($controller->permissions($req));
-        $res = $controller->handle($req);
+		$this->assertTrue($controller->permissions($req));
+		$res = $controller->handle($req);
 
-        $this->assertInstanceOf(\WP_Error::class, $res);
-    }
-    }
+		$this->assertInstanceOf(\WP_Error::class, $res);
+	}
+	}
 }

--- a/tests/ContentStorageServiceFailureTest.php
+++ b/tests/ContentStorageServiceFailureTest.php
@@ -1,30 +1,30 @@
 <?php
 namespace NuclearEngagement\Services {
-    function update_post_meta($postId, $key, $value) { return false; }
-    if (!function_exists('sanitize_text_field')) {
-        function sanitize_text_field($text) { return trim($text); }
-    }
+	function update_post_meta($postId, $key, $value) { return false; }
+	if (!function_exists('sanitize_text_field')) {
+		function sanitize_text_field($text) { return trim($text); }
+	}
 }
 
 namespace {
-    use PHPUnit\Framework\TestCase;
-    use NuclearEngagement\Services\ContentStorageService;
-    use NuclearEngagement\Core\SettingsRepository;
+	use PHPUnit\Framework\TestCase;
+	use NuclearEngagement\Services\ContentStorageService;
+	use NuclearEngagement\Core\SettingsRepository;
 
-    class ContentStorageServiceFailureTest extends TestCase {
-        protected function setUp(): void {
-            global $wp_options, $wp_autoload, $wp_meta;
-            $wp_options = $wp_autoload = $wp_meta = [];
-            SettingsRepository::reset_for_tests();
-        }
+	class ContentStorageServiceFailureTest extends TestCase {
+		protected function setUp(): void {
+			global $wp_options, $wp_autoload, $wp_meta;
+			$wp_options = $wp_autoload = $wp_meta = [];
+			SettingsRepository::reset_for_tests();
+		}
 
-        public function test_store_results_returns_failure_status(): void {
-            $settings = SettingsRepository::get_instance();
-            $service = new ContentStorageService($settings);
-            $data = ['summary' => 'S'];
-            $result = $service->storeResults([1 => $data], 'summary');
-            $this->assertSame('Failed to update summary data for post 1', $result[1]);
-        }
-    }
+		public function test_store_results_returns_failure_status(): void {
+			$settings = SettingsRepository::get_instance();
+			$service = new ContentStorageService($settings);
+			$data = ['summary' => 'S'];
+			$result = $service->storeResults([1 => $data], 'summary');
+			$this->assertSame('Failed to update summary data for post 1', $result[1]);
+		}
+	}
 }
 

--- a/tests/ContentStorageServiceTest.php
+++ b/tests/ContentStorageServiceTest.php
@@ -1,98 +1,98 @@
 <?php
 namespace NuclearEngagement\Services {
-    function update_post_meta($postId, $key, $value) {
-        $GLOBALS['wp_meta'][$postId][$key] = $value;
-        return true;
-    }
-    if (!function_exists('sanitize_text_field')) {
-        function sanitize_text_field($text) { return trim($text); }
-    }
+	function update_post_meta($postId, $key, $value) {
+		$GLOBALS['wp_meta'][$postId][$key] = $value;
+		return true;
+	}
+	if (!function_exists('sanitize_text_field')) {
+		function sanitize_text_field($text) { return trim($text); }
+	}
 }
 
 namespace {
-    use PHPUnit\Framework\TestCase;
-    use NuclearEngagement\Services\ContentStorageService;
-    use NuclearEngagement\Core\SettingsRepository;
-    class ContentStorageServiceTest extends TestCase {
-        protected function setUp(): void {
-            global $wp_options, $wp_autoload, $wp_meta;
-            $wp_options = $wp_autoload = $wp_meta = [];
-            NuclearEngagement\SettingsRepository::reset_for_tests();
-        }
+	use PHPUnit\Framework\TestCase;
+	use NuclearEngagement\Services\ContentStorageService;
+	use NuclearEngagement\Core\SettingsRepository;
+	class ContentStorageServiceTest extends TestCase {
+		protected function setUp(): void {
+			global $wp_options, $wp_autoload, $wp_meta;
+			$wp_options = $wp_autoload = $wp_meta = [];
+			NuclearEngagement\SettingsRepository::reset_for_tests();
+		}
 
-        public function test_store_quiz_data_filters_and_limits_answers(): void {
-            $settings = NuclearEngagement\SettingsRepository::get_instance();
-            $settings->set_int('answers_per_question', 2)->save();
-            $service = new NuclearEngagement\Services\ContentStorageService($settings);
-            $data = [
-                'questions' => [
-                    [
-                        'question' => 'Q1',
-                        'answers' => ['A1','A2','A3',''],
-                        'explanation' => 'E1',
-                    ],
-                    [
-                        'question' => '',
-                        'answers' => ['A'],
-                    ],
-                    [
-                        'question' => 'Q2',
-                        'answers' => ['A1'],
-                    ],
-                ],
-                'date' => '2025-01-01',
-            ];
-            $service->storeQuizData(1, $data);
-            $expected = [
-                'questions' => [
-                    [
-                        'question' => 'Q1',
-                        'answers' => ['A1','A2'],
-                        'explanation' => 'E1',
-                    ],
-                    [
-                        'question' => 'Q2',
-                        'answers' => ['A1'],
-                        'explanation' => '',
-                    ],
-                ],
-                'date' => '2025-01-01',
-            ];
-            $this->assertSame($expected, $GLOBALS['wp_meta'][1]['nuclen-quiz-data']);
-        }
+		public function test_store_quiz_data_filters_and_limits_answers(): void {
+			$settings = NuclearEngagement\SettingsRepository::get_instance();
+			$settings->set_int('answers_per_question', 2)->save();
+			$service = new NuclearEngagement\Services\ContentStorageService($settings);
+			$data = [
+				'questions' => [
+					[
+						'question' => 'Q1',
+						'answers' => ['A1','A2','A3',''],
+						'explanation' => 'E1',
+					],
+					[
+						'question' => '',
+						'answers' => ['A'],
+					],
+					[
+						'question' => 'Q2',
+						'answers' => ['A1'],
+					],
+				],
+				'date' => '2025-01-01',
+			];
+			$service->storeQuizData(1, $data);
+			$expected = [
+				'questions' => [
+					[
+						'question' => 'Q1',
+						'answers' => ['A1','A2'],
+						'explanation' => 'E1',
+					],
+					[
+						'question' => 'Q2',
+						'answers' => ['A1'],
+						'explanation' => '',
+					],
+				],
+				'date' => '2025-01-01',
+			];
+			$this->assertSame($expected, $GLOBALS['wp_meta'][1]['nuclen-quiz-data']);
+		}
 
-        public function test_store_quiz_data_throws_when_no_valid_question(): void {
-            $settings = NuclearEngagement\SettingsRepository::get_instance();
-            $service = new NuclearEngagement\Services\ContentStorageService($settings);
-            $data = [
-                'questions' => [
-                    [ 'question' => '', 'answers' => [''] ],
-                    [ 'question' => ' ', 'answers' => [] ],
-                ],
-            ];
-            $this->expectException(\InvalidArgumentException::class);
-            $service->storeQuizData(1, $data);
-        }
+		public function test_store_quiz_data_throws_when_no_valid_question(): void {
+			$settings = NuclearEngagement\SettingsRepository::get_instance();
+			$service = new NuclearEngagement\Services\ContentStorageService($settings);
+			$data = [
+				'questions' => [
+					[ 'question' => '', 'answers' => [''] ],
+					[ 'question' => ' ', 'answers' => [] ],
+				],
+			];
+			$this->expectException(\InvalidArgumentException::class);
+			$service->storeQuizData(1, $data);
+		}
 
-        public function test_store_quiz_data_sanitizes_and_adds_date(): void {
-            $settings = NuclearEngagement\SettingsRepository::get_instance();
-            $service  = new NuclearEngagement\Services\ContentStorageService($settings);
-            $data = [
-                'questions' => [
-                    [
-                        'question'    => '  Q1  ',
-                        'answers'     => [' A1 ', ''],
-                        'explanation' => '  E1 ',
-                    ],
-                ],
-            ];
-            $service->storeQuizData(5, $data);
-            $saved = $GLOBALS['wp_meta'][5]['nuclen-quiz-data'];
-            $this->assertSame('Q1', $saved['questions'][0]['question']);
-            $this->assertSame(['A1'], $saved['questions'][0]['answers']);
-            $this->assertSame('E1', $saved['questions'][0]['explanation']);
-            $this->assertArrayHasKey('date', $saved);
-            $this->assertNotEmpty($saved['date']);
-        }
-    }
+		public function test_store_quiz_data_sanitizes_and_adds_date(): void {
+			$settings = NuclearEngagement\SettingsRepository::get_instance();
+			$service  = new NuclearEngagement\Services\ContentStorageService($settings);
+			$data = [
+				'questions' => [
+					[
+						'question'    => '  Q1  ',
+						'answers'     => [' A1 ', ''],
+						'explanation' => '  E1 ',
+					],
+				],
+			];
+			$service->storeQuizData(5, $data);
+			$saved = $GLOBALS['wp_meta'][5]['nuclen-quiz-data'];
+			$this->assertSame('Q1', $saved['questions'][0]['question']);
+			$this->assertSame(['A1'], $saved['questions'][0]['answers']);
+			$this->assertSame('E1', $saved['questions'][0]['explanation']);
+			$this->assertArrayHasKey('date', $saved);
+			$this->assertNotEmpty($saved['date']);
+		}
+	}
 }

--- a/tests/DashboardDataServiceTest.php
+++ b/tests/DashboardDataServiceTest.php
@@ -1,216 +1,216 @@
 <?php
 namespace NuclearEngagement\Services {
-    class LoggingService {
-        public static array $logs = [];
-        public static function log(string $msg): void { self::$logs[] = $msg; }
-    }
+	class LoggingService {
+		public static array $logs = [];
+		public static function log(string $msg): void { self::$logs[] = $msg; }
+	}
 }
 
 namespace {
-    use PHPUnit\Framework\TestCase;
-    use NuclearEngagement\Services\DashboardDataService;
+	use PHPUnit\Framework\TestCase;
+	use NuclearEngagement\Services\DashboardDataService;
 
 if ( ! function_exists( 'date_i18n' ) ) {
-    function date_i18n( $format, $timestamp ) { return date( $format, $timestamp ); }
+	function date_i18n( $format, $timestamp ) { return date( $format, $timestamp ); }
 }
 if ( ! defined( 'MINUTE_IN_SECONDS' ) ) {
-    define( 'MINUTE_IN_SECONDS', 60 );
+	define( 'MINUTE_IN_SECONDS', 60 );
 }
 
 // ------------------------------------------------------
 // Simple object cache stubs
 // ------------------------------------------------------
 if ( ! isset( $GLOBALS['wp_cache'] ) ) {
-    $GLOBALS['wp_cache'] = [];
+	$GLOBALS['wp_cache'] = [];
 }
 if ( ! isset( $GLOBALS['transients'] ) ) {
-    $GLOBALS['transients'] = [];
+	$GLOBALS['transients'] = [];
 }
 if ( ! function_exists( 'wp_cache_get' ) ) {
-    function wp_cache_get( $key, $group = '', $force = false, &$found = null ) {
-        $found = isset( $GLOBALS['wp_cache'][ $group ][ $key ] );
-        return $GLOBALS['wp_cache'][ $group ][ $key ] ?? false;
-    }
+	function wp_cache_get( $key, $group = '', $force = false, &$found = null ) {
+		$found = isset( $GLOBALS['wp_cache'][ $group ][ $key ] );
+		return $GLOBALS['wp_cache'][ $group ][ $key ] ?? false;
+	}
 }
 if ( ! function_exists( 'wp_cache_set' ) ) {
-    function wp_cache_set( $key, $value, $group = '', $ttl = 0 ) {
-        $GLOBALS['wp_cache'][ $group ][ $key ] = $value;
-    }
+	function wp_cache_set( $key, $value, $group = '', $ttl = 0 ) {
+		$GLOBALS['wp_cache'][ $group ][ $key ] = $value;
+	}
 }
 if ( ! function_exists( 'wp_cache_flush_group' ) ) {
-    function wp_cache_flush_group( $group ) {
-        unset( $GLOBALS['wp_cache'][ $group ] );
-    }
+	function wp_cache_flush_group( $group ) {
+		unset( $GLOBALS['wp_cache'][ $group ] );
+	}
 }
 if ( ! function_exists( 'get_transient' ) ) {
-    function get_transient( $key ) {
-        return $GLOBALS['transients'][ $key ] ?? false;
-    }
+	function get_transient( $key ) {
+		return $GLOBALS['transients'][ $key ] ?? false;
+	}
 }
 if ( ! function_exists( 'set_transient' ) ) {
-    function set_transient( $key, $value, $ttl = 0 ) {
-        $GLOBALS['transients'][ $key ] = $value;
-    }
+	function set_transient( $key, $value, $ttl = 0 ) {
+		$GLOBALS['transients'][ $key ] = $value;
+	}
 }
 if ( ! function_exists( 'delete_transient' ) ) {
-    function delete_transient( $key ) {
-        unset( $GLOBALS['transients'][ $key ] );
-    }
+	function delete_transient( $key ) {
+		unset( $GLOBALS['transients'][ $key ] );
+	}
 }
 
 class DashboardDataServiceTest extends TestCase {
-    protected function setUp(): void {
-        global $wp_options, $wp_posts, $wpdb;
-        $wp_options = $wp_posts = [];
-        $wpdb = null;
-    }
+	protected function setUp(): void {
+		global $wp_options, $wp_posts, $wpdb;
+		$wp_options = $wp_posts = [];
+		$wpdb = null;
+	}
 
-    public function test_get_group_counts_returns_results(): void {
-        global $wpdb;
-        $wpdb = new class {
-            public $posts = 'wp_posts';
-            public $postmeta = 'wp_postmeta';
-            public array $args = [];
-            public function prepare( $query, ...$args ) { $this->args = $args; return 'SQL'; }
-            public function get_results( $sql, $output ) { return [ [ 'g' => 'draft', 'w' => 'with', 'c' => 2 ] ]; }
-        };
+	public function test_get_group_counts_returns_results(): void {
+		global $wpdb;
+		$wpdb = new class {
+			public $posts = 'wp_posts';
+			public $postmeta = 'wp_postmeta';
+			public array $args = [];
+			public function prepare( $query, ...$args ) { $this->args = $args; return 'SQL'; }
+			public function get_results( $sql, $output ) { return [ [ 'g' => 'draft', 'w' => 'with', 'c' => 2 ] ]; }
+		};
 
-        $svc = new DashboardDataService();
-        $res = $svc->get_group_counts( 'p.post_status', 'key', ['post'], ['draft'] );
+		$svc = new DashboardDataService();
+		$res = $svc->get_group_counts( 'p.post_status', 'key', ['post'], ['draft'] );
 
-        $this->assertSame( [ [ 'g' => 'draft', 'w' => 'with', 'c' => 2 ] ], $res );
-        $this->assertSame( ['key','post','draft'], $wpdb->args );
-    }
+		$this->assertSame( [ [ 'g' => 'draft', 'w' => 'with', 'c' => 2 ] ], $res );
+		$this->assertSame( ['key','post','draft'], $wpdb->args );
+	}
 
-    public function test_get_dual_counts_returns_results(): void {
-        global $wpdb;
-        $wpdb = new class {
-            public $posts = 'wp_posts';
-            public $postmeta = 'wp_postmeta';
-            public array $args = [];
-            public function prepare( $query, ...$args ) { $this->args = $args; return 'SQL'; }
-            public function get_results( $sql, $output ) { return [ [ 'g' => 1, 'quiz_with' => 1, 'quiz_without' => 0, 'summary_with' => 1, 'summary_without' => 0 ] ]; }
-        };
+	public function test_get_dual_counts_returns_results(): void {
+		global $wpdb;
+		$wpdb = new class {
+			public $posts = 'wp_posts';
+			public $postmeta = 'wp_postmeta';
+			public array $args = [];
+			public function prepare( $query, ...$args ) { $this->args = $args; return 'SQL'; }
+			public function get_results( $sql, $output ) { return [ [ 'g' => 1, 'quiz_with' => 1, 'quiz_without' => 0, 'summary_with' => 1, 'summary_without' => 0 ] ]; }
+		};
 
-        $svc = new DashboardDataService();
-        $res = $svc->get_dual_counts( 'p.post_author', ['post'], ['publish'] );
+		$svc = new DashboardDataService();
+		$res = $svc->get_dual_counts( 'p.post_author', ['post'], ['publish'] );
 
-        $this->assertSame( 1, $res[0]['quiz_with'] );
-        $this->assertSame( ['post','publish'], $wpdb->args );
-    }
+		$this->assertSame( 1, $res[0]['quiz_with'] );
+		$this->assertSame( ['post','publish'], $wpdb->args );
+	}
 
-    public function test_get_scheduled_generations_formats_results(): void {
-        global $wp_options, $wp_posts;
-        $wp_posts[5] = (object) [ 'post_title' => 'Post' ];
-        $wp_options['nuclen_active_generations'] = [
-            'gen' => [
-                'post_ids' => [5],
-                'workflow_type' => 'quiz',
-                'attempt' => 3,
-                'next_poll' => 1000,
-            ],
-        ];
-        $wp_options['date_format'] = 'Y-m-d';
-        $wp_options['time_format'] = 'H:i';
+	public function test_get_scheduled_generations_formats_results(): void {
+		global $wp_options, $wp_posts;
+		$wp_posts[5] = (object) [ 'post_title' => 'Post' ];
+		$wp_options['nuclen_active_generations'] = [
+			'gen' => [
+				'post_ids' => [5],
+				'workflow_type' => 'quiz',
+				'attempt' => 3,
+				'next_poll' => 1000,
+			],
+		];
+		$wp_options['date_format'] = 'Y-m-d';
+		$wp_options['time_format'] = 'H:i';
 
-        $svc = new DashboardDataService();
-        $tasks = $svc->get_scheduled_generations();
+		$svc = new DashboardDataService();
+		$tasks = $svc->get_scheduled_generations();
 
-        $this->assertCount( 1, $tasks );
-        $this->assertSame( 'Post', $tasks[0]['post_title'] );
-        $this->assertSame( 'quiz', $tasks[0]['workflow_type'] );
-        $this->assertSame( 3, $tasks[0]['attempt'] );
-        $this->assertSame( date( 'Y-m-d H:i', 1000 ), $tasks[0]['next_poll'] );
-    }
+		$this->assertCount( 1, $tasks );
+		$this->assertSame( 'Post', $tasks[0]['post_title'] );
+		$this->assertSame( 'quiz', $tasks[0]['workflow_type'] );
+		$this->assertSame( 3, $tasks[0]['attempt'] );
+		$this->assertSame( date( 'Y-m-d H:i', 1000 ), $tasks[0]['next_poll'] );
+	}
 
-    public function test_group_counts_are_cached(): void {
-        global $wpdb;
-        $wpdb = new class {
-            public $posts = 'wp_posts';
-            public $postmeta = 'wp_postmeta';
-            public array $args = [];
-            public int $calls = 0;
-            public function prepare( $query, ...$args ) { $this->args = $args; return 'SQL'; }
-            public function get_results( $sql, $output ) { $this->calls++; return [ [ 'g' => 'draft', 'w' => 'with', 'c' => 2 ] ]; }
-        };
+	public function test_group_counts_are_cached(): void {
+		global $wpdb;
+		$wpdb = new class {
+			public $posts = 'wp_posts';
+			public $postmeta = 'wp_postmeta';
+			public array $args = [];
+			public int $calls = 0;
+			public function prepare( $query, ...$args ) { $this->args = $args; return 'SQL'; }
+			public function get_results( $sql, $output ) { $this->calls++; return [ [ 'g' => 'draft', 'w' => 'with', 'c' => 2 ] ]; }
+		};
 
-        $svc = new DashboardDataService();
-        $svc->get_group_counts( 'p.post_status', 'key', ['post'], ['draft'] );
-        $this->assertSame( 1, $wpdb->calls );
+		$svc = new DashboardDataService();
+		$svc->get_group_counts( 'p.post_status', 'key', ['post'], ['draft'] );
+		$this->assertSame( 1, $wpdb->calls );
 
-        $svc->get_group_counts( 'p.post_status', 'key', ['post'], ['draft'] );
-        $this->assertSame( 1, $wpdb->calls );
+		$svc->get_group_counts( 'p.post_status', 'key', ['post'], ['draft'] );
+		$this->assertSame( 1, $wpdb->calls );
 
-        \NuclearEngagement\Core\InventoryCache::clear();
+		\NuclearEngagement\Core\InventoryCache::clear();
 
-        $svc->get_group_counts( 'p.post_status', 'key', ['post'], ['draft'] );
-        $this->assertSame( 2, $wpdb->calls );
-    }
+		$svc->get_group_counts( 'p.post_status', 'key', ['post'], ['draft'] );
+		$this->assertSame( 2, $wpdb->calls );
+	}
 
-    public function test_dual_counts_are_cached(): void {
-        global $wpdb;
-        $wpdb = new class {
-            public $posts = 'wp_posts';
-            public $postmeta = 'wp_postmeta';
-            public array $args = [];
-            public int $calls = 0;
-            public function prepare( $query, ...$args ) { $this->args = $args; return 'SQL'; }
-            public function get_results( $sql, $output ) { $this->calls++; return [ [ 'g' => 1, 'quiz_with' => 1, 'quiz_without' => 0, 'summary_with' => 1, 'summary_without' => 0 ] ]; }
-        };
+	public function test_dual_counts_are_cached(): void {
+		global $wpdb;
+		$wpdb = new class {
+			public $posts = 'wp_posts';
+			public $postmeta = 'wp_postmeta';
+			public array $args = [];
+			public int $calls = 0;
+			public function prepare( $query, ...$args ) { $this->args = $args; return 'SQL'; }
+			public function get_results( $sql, $output ) { $this->calls++; return [ [ 'g' => 1, 'quiz_with' => 1, 'quiz_without' => 0, 'summary_with' => 1, 'summary_without' => 0 ] ]; }
+		};
 
-        $svc = new DashboardDataService();
-        $svc->get_dual_counts( 'p.post_author', ['post'], ['publish'] );
-        $this->assertSame( 1, $wpdb->calls );
+		$svc = new DashboardDataService();
+		$svc->get_dual_counts( 'p.post_author', ['post'], ['publish'] );
+		$this->assertSame( 1, $wpdb->calls );
 
-        $svc->get_dual_counts( 'p.post_author', ['post'], ['publish'] );
-        $this->assertSame( 1, $wpdb->calls );
+		$svc->get_dual_counts( 'p.post_author', ['post'], ['publish'] );
+		$this->assertSame( 1, $wpdb->calls );
 
-        \NuclearEngagement\Core\InventoryCache::clear();
+		\NuclearEngagement\Core\InventoryCache::clear();
 
-        $svc->get_dual_counts( 'p.post_author', ['post'], ['publish'] );
-        $this->assertSame( 2, $wpdb->calls );
-    }
+		$svc->get_dual_counts( 'p.post_author', ['post'], ['publish'] );
+		$this->assertSame( 2, $wpdb->calls );
+	}
 
-    public function test_group_counts_returns_empty_on_error(): void {
-        global $wpdb, $wp_cache, $transients;
-        $wp_cache = $transients = [];
-        $wpdb = new class {
-            public $posts = 'wp_posts';
-            public $postmeta = 'wp_postmeta';
-            public string $last_error = '';
-            public function prepare( $q, ...$a ) { return 'SQL'; }
-            public function get_results( $sql, $output ) { $this->last_error = 'fail'; return []; }
-        };
+	public function test_group_counts_returns_empty_on_error(): void {
+		global $wpdb, $wp_cache, $transients;
+		$wp_cache = $transients = [];
+		$wpdb = new class {
+			public $posts = 'wp_posts';
+			public $postmeta = 'wp_postmeta';
+			public string $last_error = '';
+			public function prepare( $q, ...$a ) { return 'SQL'; }
+			public function get_results( $sql, $output ) { $this->last_error = 'fail'; return []; }
+		};
 
-        \NuclearEngagement\Services\LoggingService::$logs = [];
+		\NuclearEngagement\Services\LoggingService::$logs = [];
 
-        $svc = new DashboardDataService();
-        $res = $svc->get_group_counts( 'p.post_status', 'key', ['post'], ['draft'] );
-        $this->assertSame( [], $res );
-        $this->assertSame( ['Dashboard query error: fail'], \NuclearEngagement\Services\LoggingService::$logs );
-        $this->assertEmpty( $wp_cache );
-        $this->assertEmpty( $transients );
-    }
+		$svc = new DashboardDataService();
+		$res = $svc->get_group_counts( 'p.post_status', 'key', ['post'], ['draft'] );
+		$this->assertSame( [], $res );
+		$this->assertSame( ['Dashboard query error: fail'], \NuclearEngagement\Services\LoggingService::$logs );
+		$this->assertEmpty( $wp_cache );
+		$this->assertEmpty( $transients );
+	}
 
-    public function test_dual_counts_returns_empty_on_error(): void {
-        global $wpdb, $wp_cache, $transients;
-        $wp_cache = $transients = [];
-        $wpdb = new class {
-            public $posts = 'wp_posts';
-            public $postmeta = 'wp_postmeta';
-            public string $last_error = '';
-            public function prepare( $q, ...$a ) { return 'SQL'; }
-            public function get_results( $sql, $output ) { $this->last_error = 'fail'; return []; }
-        };
+	public function test_dual_counts_returns_empty_on_error(): void {
+		global $wpdb, $wp_cache, $transients;
+		$wp_cache = $transients = [];
+		$wpdb = new class {
+			public $posts = 'wp_posts';
+			public $postmeta = 'wp_postmeta';
+			public string $last_error = '';
+			public function prepare( $q, ...$a ) { return 'SQL'; }
+			public function get_results( $sql, $output ) { $this->last_error = 'fail'; return []; }
+		};
 
-        \NuclearEngagement\Services\LoggingService::$logs = [];
+		\NuclearEngagement\Services\LoggingService::$logs = [];
 
-        $svc = new DashboardDataService();
-        $res = $svc->get_dual_counts( 'p.post_author', ['post'], ['publish'] );
-        $this->assertSame( [], $res );
-        $this->assertSame( ['Dashboard query error: fail'], \NuclearEngagement\Services\LoggingService::$logs );
-        $this->assertEmpty( $wp_cache );
-        $this->assertEmpty( $transients );
-    }
+		$svc = new DashboardDataService();
+		$res = $svc->get_dual_counts( 'p.post_author', ['post'], ['publish'] );
+		$this->assertSame( [], $res );
+		$this->assertSame( ['Dashboard query error: fail'], \NuclearEngagement\Services\LoggingService::$logs );
+		$this->assertEmpty( $wp_cache );
+		$this->assertEmpty( $transients );
+	}
 }
 }

--- a/tests/DefaultsTest.php
+++ b/tests/DefaultsTest.php
@@ -3,9 +3,9 @@ use PHPUnit\Framework\TestCase;
 use NuclearEngagement\Core\Defaults;
 
 class DefaultsTest extends TestCase {
-    public function test_defaults_contains_theme_key() {
-        $defaults = Defaults::nuclen_get_default_settings();
-        $this->assertArrayHasKey('theme', $defaults);
-        $this->assertEquals('bright', $defaults['theme']);
-    }
+	public function test_defaults_contains_theme_key() {
+		$defaults = Defaults::nuclen_get_default_settings();
+		$this->assertArrayHasKey('theme', $defaults);
+		$this->assertEquals('bright', $defaults['theme']);
+	}
 }

--- a/tests/GenerateControllerTest.php
+++ b/tests/GenerateControllerTest.php
@@ -1,66 +1,66 @@
 <?php
 namespace NuclearEngagement\Services {
-    class GenerationService {
-        public array $received = [];
-        public function generateContent(GenerateRequest $r) { $this->received[] = $r; return new \NuclearEngagement\Responses\GenerateResponse(); }
-    }
-    class LoggingService {
-        public static array $errors = [];
-        public static function log_exception(\Throwable $e): void { self::$errors[] = $e->getMessage(); }
-        public static function log(string $m): void { self::$errors[] = $m; }
-    }
+	class GenerationService {
+		public array $received = [];
+		public function generateContent(GenerateRequest $r) { $this->received[] = $r; return new \NuclearEngagement\Responses\GenerateResponse(); }
+	}
+	class LoggingService {
+		public static array $errors = [];
+		public static function log_exception(\Throwable $e): void { self::$errors[] = $e->getMessage(); }
+		public static function log(string $m): void { self::$errors[] = $m; }
+	}
 }
 
 namespace NuclearEngagement\Responses {
-    class GenerateResponse {
-        public function toArray(): array { return ['ok'=>1]; }
-    }
+	class GenerateResponse {
+		public function toArray(): array { return ['ok'=>1]; }
+	}
 }
 
 namespace {
-    use PHPUnit\Framework\TestCase;
-    use NuclearEngagement\Admin\Controller\Ajax\GenerateController;
-    use NuclearEngagement\Requests\GenerateRequest;
-    if (!function_exists('check_ajax_referer')) { function check_ajax_referer($a,$f,$d=false){ return true; } }
-    if (!function_exists('current_user_can')) { function current_user_can($c){ return true; } }
-    if (!function_exists('wp_send_json_success')) { function wp_send_json_success($d){ $GLOBALS['json_response']=['success',$d]; } }
-    if (!function_exists('wp_send_json_error')) { function wp_send_json_error($d,$c=0){ $GLOBALS['json_response']=['error',$d,$c]; } }
-    if (!function_exists('status_header')) { function status_header($c){ $GLOBALS['status_header']=$c; } }
-    if (!function_exists('sanitize_text_field')) { function sanitize_text_field($t){ return $t; } }
-    if (!function_exists('wp_unslash')) { function wp_unslash($d){ return $d; } }
-    if (!function_exists('__')) { function __($t,$d=null){ return $t; } }
+	use PHPUnit\Framework\TestCase;
+	use NuclearEngagement\Admin\Controller\Ajax\GenerateController;
+	use NuclearEngagement\Requests\GenerateRequest;
+	if (!function_exists('check_ajax_referer')) { function check_ajax_referer($a,$f,$d=false){ return true; } }
+	if (!function_exists('current_user_can')) { function current_user_can($c){ return true; } }
+	if (!function_exists('wp_send_json_success')) { function wp_send_json_success($d){ $GLOBALS['json_response']=['success',$d]; } }
+	if (!function_exists('wp_send_json_error')) { function wp_send_json_error($d,$c=0){ $GLOBALS['json_response']=['error',$d,$c]; } }
+	if (!function_exists('status_header')) { function status_header($c){ $GLOBALS['status_header']=$c; } }
+	if (!function_exists('sanitize_text_field')) { function sanitize_text_field($t){ return $t; } }
+	if (!function_exists('wp_unslash')) { function wp_unslash($d){ return $d; } }
+	if (!function_exists('__')) { function __($t,$d=null){ return $t; } }
 
-    require_once __DIR__ . '/../nuclear-engagement/admin/Controller/Ajax/BaseController.php';
-    require_once __DIR__ . '/../nuclear-engagement/admin/Controller/Ajax/GenerateController.php';
-    require_once __DIR__ . '/../nuclear-engagement/inc/Requests/GenerateRequest.php';
-    
-    class GenerateControllerTest extends TestCase {
-        protected function setUp(): void {
-            $_POST = [];
-            $GLOBALS['json_response'] = null;
-            $GLOBALS['status_header'] = null;
-        }
+	require_once __DIR__ . '/../nuclear-engagement/admin/Controller/Ajax/BaseController.php';
+	require_once __DIR__ . '/../nuclear-engagement/admin/Controller/Ajax/GenerateController.php';
+	require_once __DIR__ . '/../nuclear-engagement/inc/Requests/GenerateRequest.php';
+	
+	class GenerateControllerTest extends TestCase {
+		protected function setUp(): void {
+			$_POST = [];
+			$GLOBALS['json_response'] = null;
+			$GLOBALS['status_header'] = null;
+		}
 
-        public function test_valid_request_calls_service(): void {
-            $service = new \NuclearEngagement\Services\GenerationService();
-            $controller = new GenerateController($service);
-            $_POST['payload'] = json_encode([
-                'nuclen_selected_post_ids' => json_encode([1]),
-                'nuclen_selected_generate_workflow' => 'quiz'
-            ]);
-            $_POST['security'] = 'valid';
-            $controller->handle();
-            $this->assertSame(['success',['ok'=>1]], $GLOBALS['json_response']);
-            $this->assertInstanceOf(GenerateRequest::class, $service->received[0]);
-        }
+		public function test_valid_request_calls_service(): void {
+			$service = new \NuclearEngagement\Services\GenerationService();
+			$controller = new GenerateController($service);
+			$_POST['payload'] = json_encode([
+				'nuclen_selected_post_ids' => json_encode([1]),
+				'nuclen_selected_generate_workflow' => 'quiz'
+			]);
+			$_POST['security'] = 'valid';
+			$controller->handle();
+			$this->assertSame(['success',['ok'=>1]], $GLOBALS['json_response']);
+			$this->assertInstanceOf(GenerateRequest::class, $service->received[0]);
+		}
 
-        public function test_missing_payload_returns_400(): void {
-            $service = new \NuclearEngagement\Services\GenerationService();
-            $controller = new GenerateController($service);
-            $_POST['security'] = 'valid';
-            $controller->handle();
-            $this->assertSame(400, $GLOBALS['status_header']);
-            $this->assertSame('Missing payload in request', $GLOBALS['json_response'][1]['message']);
-        }
-    }
+		public function test_missing_payload_returns_400(): void {
+			$service = new \NuclearEngagement\Services\GenerationService();
+			$controller = new GenerateController($service);
+			$_POST['security'] = 'valid';
+			$controller->handle();
+			$this->assertSame(400, $GLOBALS['status_header']);
+			$this->assertSame('Missing payload in request', $GLOBALS['json_response'][1]['message']);
+		}
+	}
 }

--- a/tests/GenerationPollerTest.php
+++ b/tests/GenerationPollerTest.php
@@ -1,90 +1,90 @@
 <?php
 namespace NuclearEngagement\Services {
-    class LoggingService {
-        public static array $logs = [];
-        public static array $notices = [];
-        public static function log(string $msg): void { self::$logs[] = $msg; }
-        public static function notify_admin(string $msg): void { self::$notices[] = $msg; }
-    }
+	class LoggingService {
+		public static array $logs = [];
+		public static array $notices = [];
+		public static function log(string $msg): void { self::$logs[] = $msg; }
+		public static function notify_admin(string $msg): void { self::$notices[] = $msg; }
+	}
 }
 
 namespace {
-    use PHPUnit\Framework\TestCase;
-    use NuclearEngagement\Services\GenerationPoller;
-    use NuclearEngagement\Core\SettingsRepository;
+	use PHPUnit\Framework\TestCase;
+	use NuclearEngagement\Services\GenerationPoller;
+	use NuclearEngagement\Core\SettingsRepository;
 
-    class PollerDummyRemoteApiService {
-        public array $updates = [];
-        public function fetch_updates(string $id): array {
-            return $this->updates[$id] ?? [];
-        }
-    }
+	class PollerDummyRemoteApiService {
+		public array $updates = [];
+		public function fetch_updates(string $id): array {
+			return $this->updates[$id] ?? [];
+		}
+	}
 
-    class PollerDummyContentStorageService {
-        public array $calls = [];
-        public function storeResults(array $results, string $workflow): array {
-            $this->calls[] = [$results, $workflow];
-            return array_fill_keys(array_keys($results), true);
-        }
-    }
+	class PollerDummyContentStorageService {
+		public array $calls = [];
+		public function storeResults(array $results, string $workflow): array {
+			$this->calls[] = [$results, $workflow];
+			return array_fill_keys(array_keys($results), true);
+		}
+	}
 
-    class GenerationPollerTest extends TestCase {
-        protected function setUp(): void {
-            global $wp_options, $wp_events;
-            $wp_options = $wp_events = [];
-            \NuclearEngagement\Services\LoggingService::$logs = [];
-            \NuclearEngagement\Services\LoggingService::$notices = [];
-            SettingsRepository::reset_for_tests();
-        }
+	class GenerationPollerTest extends TestCase {
+		protected function setUp(): void {
+			global $wp_options, $wp_events;
+			$wp_options = $wp_events = [];
+			\NuclearEngagement\Services\LoggingService::$logs = [];
+			\NuclearEngagement\Services\LoggingService::$notices = [];
+			SettingsRepository::reset_for_tests();
+		}
 
-        private function makePoller(?PollerDummyRemoteApiService $api = null, ?PollerDummyContentStorageService $store = null): GenerationPoller {
-            $settings = SettingsRepository::get_instance();
-            $settings->set_bool('connected', true)
-                     ->set_bool('wp_app_pass_created', true)
-                     ->save();
-            $api = $api ?: new PollerDummyRemoteApiService();
-            $store = $store ?: new PollerDummyContentStorageService();
-            return new GenerationPoller($settings, $api, $store);
-        }
+		private function makePoller(?PollerDummyRemoteApiService $api = null, ?PollerDummyContentStorageService $store = null): GenerationPoller {
+			$settings = SettingsRepository::get_instance();
+			$settings->set_bool('connected', true)
+					 ->set_bool('wp_app_pass_created', true)
+					 ->save();
+			$api = $api ?: new PollerDummyRemoteApiService();
+			$store = $store ?: new PollerDummyContentStorageService();
+			return new GenerationPoller($settings, $api, $store);
+		}
 
-        public function test_cleanup_generation_removes_ids(): void {
-            global $wp_options;
-            $wp_options['nuclen_active_generations'] = [
-                'a' => ['x'],
-                'b' => ['y'],
-            ];
-            $poller = $this->makePoller();
-            $ref = new \ReflectionMethod(GenerationPoller::class, 'cleanup_generation');
-            $ref->setAccessible(true);
-            $ref->invoke($poller, 'a');
-            $this->assertArrayNotHasKey('a', $wp_options['nuclen_active_generations']);
-            $this->assertArrayHasKey('b', $wp_options['nuclen_active_generations']);
-            $ref->invoke($poller, 'b');
-            $this->assertArrayNotHasKey('nuclen_active_generations', $wp_options);
-        }
+		public function test_cleanup_generation_removes_ids(): void {
+			global $wp_options;
+			$wp_options['nuclen_active_generations'] = [
+				'a' => ['x'],
+				'b' => ['y'],
+			];
+			$poller = $this->makePoller();
+			$ref = new \ReflectionMethod(GenerationPoller::class, 'cleanup_generation');
+			$ref->setAccessible(true);
+			$ref->invoke($poller, 'a');
+			$this->assertArrayNotHasKey('a', $wp_options['nuclen_active_generations']);
+			$this->assertArrayHasKey('b', $wp_options['nuclen_active_generations']);
+			$ref->invoke($poller, 'b');
+			$this->assertArrayNotHasKey('nuclen_active_generations', $wp_options);
+		}
 
-        public function test_poll_generation_stores_results_and_clears_option(): void {
-            global $wp_options, $wp_events;
-            $id = 'gid1';
-            $wp_options['nuclen_active_generations'] = [$id => ['foo']];
-            $api = new PollerDummyRemoteApiService();
-            $api->updates[$id] = ['results' => ['1' => ['ok']]];
-            $store = new PollerDummyContentStorageService();
-            $poller = $this->makePoller($api, $store);
-            $poller->poll_generation($id, 'quiz', [1], 1);
-            $this->assertCount(1, $store->calls);
-            $this->assertArrayNotHasKey($id, $wp_options['nuclen_active_generations'] ?? []);
-            $this->assertEmpty($wp_events);
-        }
+		public function test_poll_generation_stores_results_and_clears_option(): void {
+			global $wp_options, $wp_events;
+			$id = 'gid1';
+			$wp_options['nuclen_active_generations'] = [$id => ['foo']];
+			$api = new PollerDummyRemoteApiService();
+			$api->updates[$id] = ['results' => ['1' => ['ok']]];
+			$store = new PollerDummyContentStorageService();
+			$poller = $this->makePoller($api, $store);
+			$poller->poll_generation($id, 'quiz', [1], 1);
+			$this->assertCount(1, $store->calls);
+			$this->assertArrayNotHasKey($id, $wp_options['nuclen_active_generations'] ?? []);
+			$this->assertEmpty($wp_events);
+		}
 
-        public function test_poll_generation_exceeds_max_attempts_removes_id(): void {
-            global $wp_options, $wp_events;
-            $id = 'gid2';
-            $wp_options['nuclen_active_generations'] = [$id => ['foo']];
-            $poller = $this->makePoller();
-            $poller->poll_generation($id, 'quiz', [1], NUCLEN_MAX_POLL_ATTEMPTS + 1);
-            $this->assertArrayNotHasKey($id, $wp_options['nuclen_active_generations'] ?? []);
-            $this->assertEmpty($wp_events);
-        }
-    }
+		public function test_poll_generation_exceeds_max_attempts_removes_id(): void {
+			global $wp_options, $wp_events;
+			$id = 'gid2';
+			$wp_options['nuclen_active_generations'] = [$id => ['foo']];
+			$poller = $this->makePoller();
+			$poller->poll_generation($id, 'quiz', [1], NUCLEN_MAX_POLL_ATTEMPTS + 1);
+			$this->assertArrayNotHasKey($id, $wp_options['nuclen_active_generations'] ?? []);
+			$this->assertEmpty($wp_events);
+		}
+	}
 }

--- a/tests/GenerationServiceSingleTest.php
+++ b/tests/GenerationServiceSingleTest.php
@@ -1,99 +1,99 @@
 <?php
 namespace NuclearEngagement\Services {
-    // Stub LoggingService to avoid filesystem calls
-    class LoggingService {
-        public static array $logs = [];
-        public static function log(string $msg): void {
-            self::$logs[] = $msg;
-        }
-        public static function log_exception(\Throwable $e): void {
-            self::$logs[] = $e->getMessage();
-        }
-    }
+	// Stub LoggingService to avoid filesystem calls
+	class LoggingService {
+		public static array $logs = [];
+		public static function log(string $msg): void {
+			self::$logs[] = $msg;
+		}
+		public static function log_exception(\Throwable $e): void {
+			self::$logs[] = $e->getMessage();
+		}
+	}
 }
 
 namespace {
-    use PHPUnit\Framework\TestCase;
-    use NuclearEngagement\Services\GenerationService;
-    use NuclearEngagement\Core\SettingsRepository;
-    use NuclearEngagement\Services\ApiException;
-    class DummyGenApi {
-        public ?\Exception $exception = null;
-        public array $response = [];
-        public function send_posts_to_generate(array $data): array {
-            if ($this->exception) {
-                throw $this->exception;
-            }
-            return $this->response;
-        }
-        public function fetch_updates(string $id): array { return []; }
-    }
+	use PHPUnit\Framework\TestCase;
+	use NuclearEngagement\Services\GenerationService;
+	use NuclearEngagement\Core\SettingsRepository;
+	use NuclearEngagement\Services\ApiException;
+	class DummyGenApi {
+		public ?\Exception $exception = null;
+		public array $response = [];
+		public function send_posts_to_generate(array $data): array {
+			if ($this->exception) {
+				throw $this->exception;
+			}
+			return $this->response;
+		}
+		public function fetch_updates(string $id): array { return []; }
+	}
 
-    class DummyStorage {
-        public array $stored = [];
-        public function storeResults(array $r, string $t): array {
-            $this->stored[] = [$r, $t];
-            return array_fill_keys(array_keys($r), true);
-        }
-    }
+	class DummyStorage {
+		public array $stored = [];
+		public function storeResults(array $r, string $t): array {
+			$this->stored[] = [$r, $t];
+			return array_fill_keys(array_keys($r), true);
+		}
+	}
 
-    class GenerationServiceSingleTest extends TestCase {
-        protected function setUp(): void {
-            global $wp_posts, $wp_events, $wp_options, $wp_meta, $wp_autoload;
-            $wp_posts = $wp_events = $wp_options = $wp_meta = $wp_autoload = [];
-            SettingsRepository::reset_for_tests();
-        }
+	class GenerationServiceSingleTest extends TestCase {
+		protected function setUp(): void {
+			global $wp_posts, $wp_events, $wp_options, $wp_meta, $wp_autoload;
+			$wp_posts = $wp_events = $wp_options = $wp_meta = $wp_autoload = [];
+			SettingsRepository::reset_for_tests();
+		}
 
-        private function makeService(?DummyGenApi $api = null, ?DummyStorage $store = null): GenerationService {
-            $settings = SettingsRepository::get_instance();
-            $api = $api ?: new DummyGenApi();
-            $store = $store ?: new DummyStorage();
-            return new GenerationService($settings, $api, $store);
-        }
+		private function makeService(?DummyGenApi $api = null, ?DummyStorage $store = null): GenerationService {
+			$settings = SettingsRepository::get_instance();
+			$api = $api ?: new DummyGenApi();
+			$store = $store ?: new DummyStorage();
+			return new GenerationService($settings, $api, $store);
+		}
 
-        public function test_generate_single_schedules_poll_when_no_results(): void {
-            global $wp_posts, $wp_events;
-            $wp_posts[1] = (object)[
-                'ID' => 1,
-                'post_title' => 'T',
-                'post_content' => 'C',
-                'post_type' => 'post',
-                'post_status' => 'publish',
-            ];
-            $api = new DummyGenApi();
-            $api->response = [];
-            $store = new DummyStorage();
-            $service = $this->makeService($api, $store);
-            $service->generateSingle(1, 'quiz');
-            $this->assertEmpty($store->stored);
-            $this->assertCount(1, $wp_events);
-            $event = $wp_events[0];
-            $this->assertSame('nuclen_poll_generation', $event['hook']);
-            $this->assertSame('quiz', $event['args'][1]);
-            $this->assertSame(1, $event['args'][2]);
-            $this->assertSame(1, $event['args'][3]);
-            $this->assertStringStartsWith('auto_1_', $event['args'][0]);
-        }
+		public function test_generate_single_schedules_poll_when_no_results(): void {
+			global $wp_posts, $wp_events;
+			$wp_posts[1] = (object)[
+				'ID' => 1,
+				'post_title' => 'T',
+				'post_content' => 'C',
+				'post_type' => 'post',
+				'post_status' => 'publish',
+			];
+			$api = new DummyGenApi();
+			$api->response = [];
+			$store = new DummyStorage();
+			$service = $this->makeService($api, $store);
+			$service->generateSingle(1, 'quiz');
+			$this->assertEmpty($store->stored);
+			$this->assertCount(1, $wp_events);
+			$event = $wp_events[0];
+			$this->assertSame('nuclen_poll_generation', $event['hook']);
+			$this->assertSame('quiz', $event['args'][1]);
+			$this->assertSame(1, $event['args'][2]);
+			$this->assertSame(1, $event['args'][3]);
+			$this->assertStringStartsWith('auto_1_', $event['args'][0]);
+		}
 
-        public function test_generate_single_rethrows_api_errors(): void {
-            global $wp_posts, $wp_events;
-            $wp_posts[2] = (object)[
-                'ID' => 2,
-                'post_title' => 'T2',
-                'post_content' => 'C2',
-                'post_type' => 'post',
-                'post_status' => 'publish',
-            ];
-            $api = new DummyGenApi();
-            $api->exception = new ApiException('fail', 500);
-            $service = $this->makeService($api);
-            $this->expectException(ApiException::class);
-            $this->expectExceptionMessage('fail');
-            try {
-                $service->generateSingle(2, 'quiz');
-            } finally {
-                $this->assertEmpty($wp_events);
-            }
-        }
-    }
+		public function test_generate_single_rethrows_api_errors(): void {
+			global $wp_posts, $wp_events;
+			$wp_posts[2] = (object)[
+				'ID' => 2,
+				'post_title' => 'T2',
+				'post_content' => 'C2',
+				'post_type' => 'post',
+				'post_status' => 'publish',
+			];
+			$api = new DummyGenApi();
+			$api->exception = new ApiException('fail', 500);
+			$service = $this->makeService($api);
+			$this->expectException(ApiException::class);
+			$this->expectExceptionMessage('fail');
+			try {
+				$service->generateSingle(2, 'quiz');
+			} finally {
+				$this->assertEmpty($wp_events);
+			}
+		}
+	}
 }

--- a/tests/GenerationServiceTest.php
+++ b/tests/GenerationServiceTest.php
@@ -7,170 +7,170 @@ use NuclearEngagement\Services\ApiException;
 use NuclearEngagement\Modules\Summary\Summary_Service;
 
 class GS_WPDB {
-    public $posts = 'wp_posts';
-    public $postmeta = 'wp_postmeta';
-    public array $prepared_sqls = [];
-    public array $args = [];
-    public array $results_sqls = [];
+	public $posts = 'wp_posts';
+	public $postmeta = 'wp_postmeta';
+	public array $prepared_sqls = [];
+	public array $args = [];
+	public array $results_sqls = [];
 
-    public function prepare($sql, ...$args) {
-        $this->prepared_sqls[] = $sql;
-        $this->args = $args;
-        return $sql;
-    }
+	public function prepare($sql, ...$args) {
+		$this->prepared_sqls[] = $sql;
+		$this->args = $args;
+		return $sql;
+	}
 
-    public function get_results($sql) {
-        $this->results_sqls[] = $sql;
-        $ids = array_slice($this->args, 2);
-        $rows = [];
-        foreach ($ids as $id) {
-            if (!isset($GLOBALS['wp_posts'][$id])) { continue; }
-            $p = $GLOBALS['wp_posts'][$id];
-            if ($p->post_status !== 'publish') { continue; }
-            if (!empty($GLOBALS['wp_meta'][$id]['nuclen_quiz_protected']) || !empty($GLOBALS['wp_meta'][$id][Summary_Service::PROTECTED_KEY])) { continue; }
-            $rows[] = (object) [
-                'ID' => $p->ID,
-                'post_title' => $p->post_title,
-                'post_content' => $p->post_content,
-            ];
-        }
-        return $rows;
-    }
+	public function get_results($sql) {
+		$this->results_sqls[] = $sql;
+		$ids = array_slice($this->args, 2);
+		$rows = [];
+		foreach ($ids as $id) {
+			if (!isset($GLOBALS['wp_posts'][$id])) { continue; }
+			$p = $GLOBALS['wp_posts'][$id];
+			if ($p->post_status !== 'publish') { continue; }
+			if (!empty($GLOBALS['wp_meta'][$id]['nuclen_quiz_protected']) || !empty($GLOBALS['wp_meta'][$id][Summary_Service::PROTECTED_KEY])) { continue; }
+			$rows[] = (object) [
+				'ID' => $p->ID,
+				'post_title' => $p->post_title,
+				'post_content' => $p->post_content,
+			];
+		}
+		return $rows;
+	}
 }
 
 class GSRemoteApi {
-    public function send_posts_to_generate(array $data): array {
-        throw new ApiException('api fail', 401);
-    }
-    public function fetch_updates(string $id): array { return []; }
+	public function send_posts_to_generate(array $data): array {
+		throw new ApiException('api fail', 401);
+	}
+	public function fetch_updates(string $id): array { return []; }
 }
 
 class GSStorage {
-    public array $stored = [];
-    public function storeResults(array $r, string $t): array { $this->stored[] = [$r,$t]; return array_fill_keys(array_keys($r), true); }
+	public array $stored = [];
+	public function storeResults(array $r, string $t): array { $this->stored[] = [$r,$t]; return array_fill_keys(array_keys($r), true); }
 }
 
 class GenerationServiceTest extends TestCase {
-    protected function setUp(): void {
-        global $wp_posts, $wp_options, $wp_autoload, $wp_meta, $wpdb;
-        $wp_posts = $wp_options = $wp_autoload = $wp_meta = [];
-        $wpdb = new GS_WPDB();
-        SettingsRepository::reset_for_tests();
-    }
+	protected function setUp(): void {
+		global $wp_posts, $wp_options, $wp_autoload, $wp_meta, $wpdb;
+		$wp_posts = $wp_options = $wp_autoload = $wp_meta = [];
+		$wpdb = new GS_WPDB();
+		SettingsRepository::reset_for_tests();
+	}
 
-    private function makeService(): GenerationService {
-        $settings = SettingsRepository::get_instance();
-        $api = new GSRemoteApi();
-        $storage = new GSStorage();
-        return new GenerationService($settings, $api, $storage);
-    }
+	private function makeService(): GenerationService {
+		$settings = SettingsRepository::get_instance();
+		$api = new GSRemoteApi();
+		$storage = new GSStorage();
+		return new GenerationService($settings, $api, $storage);
+	}
 
-    public function test_generate_content_returns_error_response_on_exception(): void {
-        global $wp_posts;
-        $wp_posts[1] = (object)[
-            'ID' => 1,
-            'post_title' => 'T',
-            'post_content' => 'C',
-            'post_type' => 'post',
-            'post_status' => 'publish',
-        ];
-        $req = new GenerateRequest();
-        $req->postIds = [1];
-        $req->workflowType = 'quiz';
-        $req->generationId = 'gid';
-        $req->postType = 'post';
-        $req->postStatus = 'publish';
+	public function test_generate_content_returns_error_response_on_exception(): void {
+		global $wp_posts;
+		$wp_posts[1] = (object)[
+			'ID' => 1,
+			'post_title' => 'T',
+			'post_content' => 'C',
+			'post_type' => 'post',
+			'post_status' => 'publish',
+		];
+		$req = new GenerateRequest();
+		$req->postIds = [1];
+		$req->workflowType = 'quiz';
+		$req->generationId = 'gid';
+		$req->postType = 'post';
+		$req->postStatus = 'publish';
 
-        $service = $this->makeService();
-        $res = $service->generateContent($req);
-        $this->assertFalse($res->success);
-        $this->assertSame('api fail', $res->error);
-        $this->assertSame(401, $res->statusCode);
+		$service = $this->makeService();
+		$res = $service->generateContent($req);
+		$this->assertFalse($res->success);
+		$this->assertSame('api fail', $res->error);
+		$this->assertSame(401, $res->statusCode);
 
-        global $wpdb;
-        $this->assertNotEmpty($wpdb->prepared_sqls);
-        $this->assertStringContainsString('SELECT ID, post_title, post_content', $wpdb->prepared_sqls[0]);
-    }
+		global $wpdb;
+		$this->assertNotEmpty($wpdb->prepared_sqls);
+		$this->assertStringContainsString('SELECT ID, post_title, post_content', $wpdb->prepared_sqls[0]);
+	}
 
-    public function test_generate_content_sends_posts_from_wpdb(): void {
-        global $wp_posts, $wpdb;
+	public function test_generate_content_sends_posts_from_wpdb(): void {
+		global $wp_posts, $wpdb;
 
-        $wp_posts[1] = (object) [
-            'ID' => 1,
-            'post_title' => 'A',
-            'post_content' => '<b>C1</b>',
-            'post_type' => 'post',
-            'post_status' => 'publish',
-        ];
-        $wp_posts[2] = (object) [
-            'ID' => 2,
-            'post_title' => 'B',
-            'post_content' => '<i>C2</i>',
-            'post_type' => 'post',
-            'post_status' => 'publish',
-        ];
+		$wp_posts[1] = (object) [
+			'ID' => 1,
+			'post_title' => 'A',
+			'post_content' => '<b>C1</b>',
+			'post_type' => 'post',
+			'post_status' => 'publish',
+		];
+		$wp_posts[2] = (object) [
+			'ID' => 2,
+			'post_title' => 'B',
+			'post_content' => '<i>C2</i>',
+			'post_type' => 'post',
+			'post_status' => 'publish',
+		];
 
-        $api = new class {
-            public array $data = [];
-            public function send_posts_to_generate(array $d): array { $this->data = $d['posts']; return []; }
-            public function fetch_updates(string $id): array { return []; }
-        };
-        $storage = new GSStorage();
-        $service = new GenerationService(SettingsRepository::get_instance(), $api, $storage);
+		$api = new class {
+			public array $data = [];
+			public function send_posts_to_generate(array $d): array { $this->data = $d['posts']; return []; }
+			public function fetch_updates(string $id): array { return []; }
+		};
+		$storage = new GSStorage();
+		$service = new GenerationService(SettingsRepository::get_instance(), $api, $storage);
 
-        $req = new GenerateRequest();
-        $req->postIds = [1, 2];
-        $req->workflowType = 'quiz';
-        $req->generationId = 'gid';
-        $req->postType = 'post';
-        $req->postStatus = 'publish';
+		$req = new GenerateRequest();
+		$req->postIds = [1, 2];
+		$req->workflowType = 'quiz';
+		$req->generationId = 'gid';
+		$req->postType = 'post';
+		$req->postStatus = 'publish';
 
-        $service->generateContent($req);
+		$service->generateContent($req);
 
-        $this->assertCount(1, $wpdb->results_sqls);
-        $this->assertSame([
-            ['id' => 1, 'title' => 'A', 'content' => 'C1'],
-            ['id' => 2, 'title' => 'B', 'content' => 'C2'],
-        ], $api->data);
-    }
+		$this->assertCount(1, $wpdb->results_sqls);
+		$this->assertSame([
+			['id' => 1, 'title' => 'A', 'content' => 'C1'],
+			['id' => 2, 'title' => 'B', 'content' => 'C2'],
+		], $api->data);
+	}
 
-    public function test_generate_content_chunks_large_id_lists(): void {
-        if ( ! defined( 'NUCLEN_POST_FETCH_CHUNK' ) ) {
-            define( 'NUCLEN_POST_FETCH_CHUNK', 2 );
-        }
+	public function test_generate_content_chunks_large_id_lists(): void {
+		if ( ! defined( 'NUCLEN_POST_FETCH_CHUNK' ) ) {
+			define( 'NUCLEN_POST_FETCH_CHUNK', 2 );
+		}
 
-        global $wp_posts, $wpdb;
-        for ( $i = 1; $i <= 5; $i++ ) {
-            $wp_posts[ $i ] = (object) [
-                'ID' => $i,
-                'post_title' => 'T' . $i,
-                'post_content' => 'C' . $i,
-                'post_type' => 'post',
-                'post_status' => 'publish',
-            ];
-        }
+		global $wp_posts, $wpdb;
+		for ( $i = 1; $i <= 5; $i++ ) {
+			$wp_posts[ $i ] = (object) [
+				'ID' => $i,
+				'post_title' => 'T' . $i,
+				'post_content' => 'C' . $i,
+				'post_type' => 'post',
+				'post_status' => 'publish',
+			];
+		}
 
-        $api = new class {
-            public array $posts = [];
-            public function send_posts_to_generate( array $d ): array {
-                $this->posts = $d['posts'];
-                return [];
-            }
-            public function fetch_updates( string $id ): array { return []; }
-        };
-        $storage = new GSStorage();
-        $service = new GenerationService( SettingsRepository::get_instance(), $api, $storage );
+		$api = new class {
+			public array $posts = [];
+			public function send_posts_to_generate( array $d ): array {
+				$this->posts = $d['posts'];
+				return [];
+			}
+			public function fetch_updates( string $id ): array { return []; }
+		};
+		$storage = new GSStorage();
+		$service = new GenerationService( SettingsRepository::get_instance(), $api, $storage );
 
-        $req = new GenerateRequest();
-        $req->postIds = [1, 2, 3, 4, 5];
-        $req->workflowType = 'quiz';
-        $req->generationId = 'gid';
-        $req->postType = 'post';
-        $req->postStatus = 'publish';
+		$req = new GenerateRequest();
+		$req->postIds = [1, 2, 3, 4, 5];
+		$req->workflowType = 'quiz';
+		$req->generationId = 'gid';
+		$req->postType = 'post';
+		$req->postStatus = 'publish';
 
-        $service->generateContent( $req );
+		$service->generateContent( $req );
 
-        $this->assertCount( 3, $wpdb->results_sqls );
-        $this->assertCount( 5, $api->posts );
-    }
+		$this->assertCount( 3, $wpdb->results_sqls );
+		$this->assertCount( 5, $api->posts );
+	}
 }

--- a/tests/InventoryCacheTest.php
+++ b/tests/InventoryCacheTest.php
@@ -11,91 +11,91 @@ $GLOBALS['flush_count'] = 0;
 $GLOBALS['transients'] = [];
 
 if ( ! function_exists( 'wp_cache_get' ) ) {
-    function wp_cache_get( $key, $group = '', $force = false, &$found = null ) {
-        $found = isset( $GLOBALS['wp_cache'][ $group ][ $key ] );
-        return $GLOBALS['wp_cache'][ $group ][ $key ] ?? false;
-    }
+	function wp_cache_get( $key, $group = '', $force = false, &$found = null ) {
+		$found = isset( $GLOBALS['wp_cache'][ $group ][ $key ] );
+		return $GLOBALS['wp_cache'][ $group ][ $key ] ?? false;
+	}
 }
 if ( ! function_exists( 'wp_cache_set' ) ) {
-    function wp_cache_set( $key, $value, $group = '', $ttl = 0 ) {
-        $GLOBALS['wp_cache'][ $group ][ $key ] = $value;
-    }
+	function wp_cache_set( $key, $value, $group = '', $ttl = 0 ) {
+		$GLOBALS['wp_cache'][ $group ][ $key ] = $value;
+	}
 }
 if ( ! function_exists( 'wp_cache_delete' ) ) {
-    function wp_cache_delete( $key, $group = '' ) {
-        $GLOBALS['flush_count']++;
-        unset( $GLOBALS['wp_cache'][ $group ][ $key ] );
-    }
+	function wp_cache_delete( $key, $group = '' ) {
+		$GLOBALS['flush_count']++;
+		unset( $GLOBALS['wp_cache'][ $group ][ $key ] );
+	}
 }
 if ( ! function_exists( 'wp_cache_flush_group' ) ) {
-    function wp_cache_flush_group( $group ) {
-        unset( $GLOBALS['wp_cache'][ $group ] );
-    }
+	function wp_cache_flush_group( $group ) {
+		unset( $GLOBALS['wp_cache'][ $group ] );
+	}
 }
 
 if ( ! function_exists( 'get_transient' ) ) {
-    function get_transient( $key ) {
-        return $GLOBALS['transients'][ $key ] ?? false;
-    }
+	function get_transient( $key ) {
+		return $GLOBALS['transients'][ $key ] ?? false;
+	}
 }
 if ( ! function_exists( 'set_transient' ) ) {
-    function set_transient( $key, $value, $ttl = 0 ) {
-        $GLOBALS['transients'][ $key ] = $value;
-    }
+	function set_transient( $key, $value, $ttl = 0 ) {
+		$GLOBALS['transients'][ $key ] = $value;
+	}
 }
 if ( ! function_exists( 'delete_transient' ) ) {
-    function delete_transient( $key ) {
-        unset( $GLOBALS['transients'][ $key ] );
-    }
+	function delete_transient( $key ) {
+		unset( $GLOBALS['transients'][ $key ] );
+	}
 }
 
 if ( ! defined( 'HOUR_IN_SECONDS' ) ) {
-    define( 'HOUR_IN_SECONDS', 3600 );
+	define( 'HOUR_IN_SECONDS', 3600 );
 }
 
 if ( ! function_exists( 'get_current_blog_id' ) ) {
-    function get_current_blog_id() { return 1; }
+	function get_current_blog_id() { return 1; }
 }
 
 class InventoryCacheTest extends TestCase {
-    protected function setUp(): void {
-        global $wp_cache, $flush_count, $transients;
-        $wp_cache   = [];
-        $flush_count = 0;
-        $transients = [];
-    }
+	protected function setUp(): void {
+		global $wp_cache, $flush_count, $transients;
+		$wp_cache   = [];
+		$flush_count = 0;
+		$transients = [];
+	}
 
-    public function test_clear_is_debounced() {
-        InventoryCache::clear();
-        $this->assertSame( 1, $GLOBALS['flush_count'] );
+	public function test_clear_is_debounced() {
+		InventoryCache::clear();
+		$this->assertSame( 1, $GLOBALS['flush_count'] );
 
-        InventoryCache::clear();
-        $this->assertSame( 1, $GLOBALS['flush_count'] );
+		InventoryCache::clear();
+		$this->assertSame( 1, $GLOBALS['flush_count'] );
 
-        usleep( ( InventoryCache::CLEAR_DEBOUNCE + 1 ) * 1000000 );
-        InventoryCache::clear();
-        $this->assertSame( 2, $GLOBALS['flush_count'] );
-    }
+		usleep( ( InventoryCache::CLEAR_DEBOUNCE + 1 ) * 1000000 );
+		InventoryCache::clear();
+		$this->assertSame( 2, $GLOBALS['flush_count'] );
+	}
 
-    public function test_set_get_and_clear() {
-        $data = array( 'foo' => 'bar' );
+	public function test_set_get_and_clear() {
+		$data = array( 'foo' => 'bar' );
 
-        InventoryCache::set( $data );
+		InventoryCache::set( $data );
 
-        $key = InventoryCache::CACHE_KEY . '_' . get_current_blog_id();
+		$key = InventoryCache::CACHE_KEY . '_' . get_current_blog_id();
 
-        $this->assertSame( $data, $GLOBALS['wp_cache'][ InventoryCache::CACHE_GROUP ][ $key ] );
-        $this->assertSame( $data, $GLOBALS['transients'][ $key ] );
+		$this->assertSame( $data, $GLOBALS['wp_cache'][ InventoryCache::CACHE_GROUP ][ $key ] );
+		$this->assertSame( $data, $GLOBALS['transients'][ $key ] );
 
-        $this->assertSame( $data, InventoryCache::get() );
+		$this->assertSame( $data, InventoryCache::get() );
 
-        unset( $GLOBALS['wp_cache'][ InventoryCache::CACHE_GROUP ][ $key ] );
-        $this->assertSame( $data, InventoryCache::get(), 'falls back to transient' );
+		unset( $GLOBALS['wp_cache'][ InventoryCache::CACHE_GROUP ][ $key ] );
+		$this->assertSame( $data, InventoryCache::get(), 'falls back to transient' );
 
-        InventoryCache::clear();
+		InventoryCache::clear();
 
-        $this->assertArrayNotHasKey( $key, $GLOBALS['wp_cache'][ InventoryCache::CACHE_GROUP ] ?? array() );
-        $this->assertArrayNotHasKey( $key, $GLOBALS['transients'] );
-        $this->assertNull( InventoryCache::get() );
-    }
+		$this->assertArrayNotHasKey( $key, $GLOBALS['wp_cache'][ InventoryCache::CACHE_GROUP ] ?? array() );
+		$this->assertArrayNotHasKey( $key, $GLOBALS['transients'] );
+		$this->assertNull( InventoryCache::get() );
+	}
 }

--- a/tests/LoggingServiceTest.php
+++ b/tests/LoggingServiceTest.php
@@ -1,43 +1,43 @@
 <?php
 namespace NuclearEngagement\Services {
 	function add_action(...$args) {
-	    $GLOBALS['ls_actions'][] = $args;
+		$GLOBALS['ls_actions'][] = $args;
 	}
 	function file_put_contents($file, $data, $flags = 0) {
-	    $GLOBALS['ls_puts'][] = $file;
-	    return \file_put_contents($file, $data, $flags);
+		$GLOBALS['ls_puts'][] = $file;
+		return \file_put_contents($file, $data, $flags);
 	}
 	function register_shutdown_function($cb) {
-	    $GLOBALS['ls_shutdown'][] = $cb;
+		$GLOBALS['ls_shutdown'][] = $cb;
 	}
 	function error_log($msg) {
-	    $GLOBALS['ls_errors'][] = $msg;
+		$GLOBALS['ls_errors'][] = $msg;
 	}
 	function rename($from, $to) {
-	    if (!empty($GLOBALS['ls_rename_fail'])) {
-	        return false;
-	    }
-	    return \rename($from, $to);
+		if (!empty($GLOBALS['ls_rename_fail'])) {
+			return false;
+		}
+		return \rename($from, $to);
 	}
 	if (!function_exists('apply_filters')) {
-	    function apply_filters($hook, $value) {
-	        if ($hook === 'nuclen_enable_log_buffer' && isset($GLOBALS['ls_filter_buffer'])) {
-	            return $GLOBALS['ls_filter_buffer'];
-	        }
-	        return $value;
-	    }
+		function apply_filters($hook, $value) {
+			if ($hook === 'nuclen_enable_log_buffer' && isset($GLOBALS['ls_filter_buffer'])) {
+				return $GLOBALS['ls_filter_buffer'];
+			}
+			return $value;
+		}
 	}
 	if (!function_exists('esc_html')) {
-	    function esc_html($text) { return $text; }
+		function esc_html($text) { return $text; }
 	}
 
 	class AdminNoticeService {
-	    public array $messages = [];
-	    public function add(string $msg): void {
-	        $this->messages[] = $msg;
-	        add_action('admin_notices', [$this, 'render']);
-	    }
-	    public function render(): void {}
+		public array $messages = [];
+		public function add(string $msg): void {
+			$this->messages[] = $msg;
+			add_action('admin_notices', [$this, 'render']);
+		}
+		public function render(): void {}
 	}
 }
 
@@ -46,155 +46,155 @@ namespace {
 	use NuclearEngagement\Services\LoggingService;
 	use NuclearEngagement\Services\AdminNoticeService;
 	class LoggingServiceTest extends TestCase {
-	    private static string $plugin_dir;
-	    private LoggingService $logger;
+		private static string $plugin_dir;
+		private LoggingService $logger;
 
-	    public static function setUpBeforeClass(): void {
-	        self::$plugin_dir = sys_get_temp_dir() . '/ls_plugin_' . uniqid();
-	        if (!defined('NUCLEN_PLUGIN_DIR')) {
-	            define('NUCLEN_PLUGIN_DIR', self::$plugin_dir . '/');
-	        }
-	    }
-	    protected function setUp(): void {
-	        $GLOBALS['ls_actions'] = [];
-	        $GLOBALS['ls_errors'] = [];
-	        $GLOBALS['ls_puts'] = [];
-	        $GLOBALS['ls_shutdown'] = [];
-	        $GLOBALS['test_upload_basedir'] = sys_get_temp_dir() . '/ls_' . uniqid();
-	        mkdir($GLOBALS['test_upload_basedir']);
-	        $GLOBALS['ls_filter_buffer'] = false;
-	        $GLOBALS['ls_rename_fail'] = false;
-	        if (!is_dir(self::$plugin_dir)) {
-	            mkdir(self::$plugin_dir, 0777, true);
-	        }
+		public static function setUpBeforeClass(): void {
+			self::$plugin_dir = sys_get_temp_dir() . '/ls_plugin_' . uniqid();
+			if (!defined('NUCLEN_PLUGIN_DIR')) {
+				define('NUCLEN_PLUGIN_DIR', self::$plugin_dir . '/');
+			}
+		}
+		protected function setUp(): void {
+			$GLOBALS['ls_actions'] = [];
+			$GLOBALS['ls_errors'] = [];
+			$GLOBALS['ls_puts'] = [];
+			$GLOBALS['ls_shutdown'] = [];
+			$GLOBALS['test_upload_basedir'] = sys_get_temp_dir() . '/ls_' . uniqid();
+			mkdir($GLOBALS['test_upload_basedir']);
+			$GLOBALS['ls_filter_buffer'] = false;
+			$GLOBALS['ls_rename_fail'] = false;
+			if (!is_dir(self::$plugin_dir)) {
+				mkdir(self::$plugin_dir, 0777, true);
+			}
 
-	        $this->logger = new LoggingService(new AdminNoticeService());
-	    }
+			$this->logger = new LoggingService(new AdminNoticeService());
+		}
 
-	    protected function tearDown(): void {
-	        $this->logger->flush();
-	        foreach ($GLOBALS['ls_shutdown'] as $cb) {
-	            $cb();
-	        }
-	        unset($GLOBALS['ls_filter_buffer']);
-	        unset($GLOBALS['ls_rename_fail']);
-	        $base = $GLOBALS['test_upload_basedir'];
-	        foreach (glob("$base/*") as $file) {
-	            @unlink($file);
-	        }
-	        @rmdir($base);
-	        if (is_dir(self::$plugin_dir)) {
-	            array_map('unlink', glob(self::$plugin_dir . '/*'));
-	            rmdir(self::$plugin_dir);
-	        }
-	    }
+		protected function tearDown(): void {
+			$this->logger->flush();
+			foreach ($GLOBALS['ls_shutdown'] as $cb) {
+				$cb();
+			}
+			unset($GLOBALS['ls_filter_buffer']);
+			unset($GLOBALS['ls_rename_fail']);
+			$base = $GLOBALS['test_upload_basedir'];
+			foreach (glob("$base/*") as $file) {
+				@unlink($file);
+			}
+			@rmdir($base);
+			if (is_dir(self::$plugin_dir)) {
+				array_map('unlink', glob(self::$plugin_dir . '/*'));
+				rmdir(self::$plugin_dir);
+			}
+		}
 
-	    public function test_unwritable_directory_triggers_fallback(): void {
-	        chmod($GLOBALS['test_upload_basedir'], 0555);
-	        $this->logger->log('test message');
-	        $this->assertSame(['test message'], $GLOBALS['ls_errors']);
-	        $this->assertSame('admin_notices', $GLOBALS['ls_actions'][0][0]);
-	    }
+		public function test_unwritable_directory_triggers_fallback(): void {
+			chmod($GLOBALS['test_upload_basedir'], 0555);
+			$this->logger->log('test message');
+			$this->assertSame(['test message'], $GLOBALS['ls_errors']);
+			$this->assertSame('admin_notices', $GLOBALS['ls_actions'][0][0]);
+		}
 
-	    public function test_logs_message_to_file_when_writable(): void {
-	        $this->logger->log('hello world');
-	        $info = $this->logger->get_log_file_info();
-	        $this->assertFileExists($info['path']);
-	        $contents = file_get_contents($info['path']);
-	        $this->assertStringContainsString('hello world', $contents);
-	    }
+		public function test_logs_message_to_file_when_writable(): void {
+			$this->logger->log('hello world');
+			$info = $this->logger->get_log_file_info();
+			$this->assertFileExists($info['path']);
+			$contents = file_get_contents($info['path']);
+			$this->assertStringContainsString('hello world', $contents);
+		}
 
-	    public function test_debug_logs_only_when_constant_defined(): void {
-	        $this->logger->debug('no constant');
-	        $info = $this->logger->get_log_file_info();
-	        $this->assertFileDoesNotExist($info['path']);
+		public function test_debug_logs_only_when_constant_defined(): void {
+			$this->logger->debug('no constant');
+			$info = $this->logger->get_log_file_info();
+			$this->assertFileDoesNotExist($info['path']);
 
-	        if (!defined('WP_DEBUG')) {
-	            define('WP_DEBUG', true);
-	        }
-	        $this->logger->debug('debug message');
-	        $this->assertFileExists($info['path']);
-	        $contents = file_get_contents($info['path']);
-	        $this->assertStringContainsString('[DEBUG] debug message', $contents);
-	    }
+			if (!defined('WP_DEBUG')) {
+				define('WP_DEBUG', true);
+			}
+			$this->logger->debug('debug message');
+			$this->assertFileExists($info['path']);
+			$contents = file_get_contents($info['path']);
+			$this->assertStringContainsString('[DEBUG] debug message', $contents);
+		}
 
-	    public function test_logs_strip_html_and_truncate_long_message(): void {
-	        $long = '<p>' . str_repeat('a', 1005) . '</p>';
-	        $this->logger->log($long);
-	        $info = $this->logger->get_log_file_info();
-	        $this->assertFileExists($info['path']);
-	        $contents = file_get_contents($info['path']);
-	        $expected = str_repeat('a', 1000) . '...';
-	        $this->assertStringContainsString($expected, $contents);
-	        $this->assertStringNotContainsString('<p>', $contents);
-	    }
+		public function test_logs_strip_html_and_truncate_long_message(): void {
+			$long = '<p>' . str_repeat('a', 1005) . '</p>';
+			$this->logger->log($long);
+			$info = $this->logger->get_log_file_info();
+			$this->assertFileExists($info['path']);
+			$contents = file_get_contents($info['path']);
+			$expected = str_repeat('a', 1000) . '...';
+			$this->assertStringContainsString($expected, $contents);
+			$this->assertStringNotContainsString('<p>', $contents);
+		}
 
-	    public function test_buffered_logging_single_write(): void {
-	        $GLOBALS['ls_filter_buffer'] = true;
-	        for ($i = 0; $i < 5; $i++) {
-	            $this->logger->log("msg $i");
-	        }
-	        $info = $this->logger->get_log_file_info();
-	        $this->assertFileDoesNotExist($info['path']);
+		public function test_buffered_logging_single_write(): void {
+			$GLOBALS['ls_filter_buffer'] = true;
+			for ($i = 0; $i < 5; $i++) {
+				$this->logger->log("msg $i");
+			}
+			$info = $this->logger->get_log_file_info();
+			$this->assertFileDoesNotExist($info['path']);
 
-	        $this->logger->flush();
+			$this->logger->flush();
 
-	        $this->assertFileExists($info['path']);
-	        $this->assertCount(1, $GLOBALS['ls_puts']);
-	        $contents = file_get_contents($info['path']);
-	        $this->assertStringContainsString('msg 4', $contents);
-	    }
+			$this->assertFileExists($info['path']);
+			$this->assertCount(1, $GLOBALS['ls_puts']);
+			$contents = file_get_contents($info['path']);
+			$this->assertStringContainsString('msg 4', $contents);
+		}
 
-	    public function test_rotation_failure_triggers_fallback(): void {
-	        if (!defined('NUCLEN_LOG_FILE_MAX_SIZE')) {
-	            define('NUCLEN_LOG_FILE_MAX_SIZE', 1);
-	        }
-	        $info = $this->logger->get_log_file_info();
-	        if (!file_exists($info['dir'])) {
-	            mkdir($info['dir'], 0777, true);
-	        }
-	        file_put_contents($info['path'], 'aa');
-	        $GLOBALS['ls_rename_fail'] = true;
+		public function test_rotation_failure_triggers_fallback(): void {
+			if (!defined('NUCLEN_LOG_FILE_MAX_SIZE')) {
+				define('NUCLEN_LOG_FILE_MAX_SIZE', 1);
+			}
+			$info = $this->logger->get_log_file_info();
+			if (!file_exists($info['dir'])) {
+				mkdir($info['dir'], 0777, true);
+			}
+			file_put_contents($info['path'], 'aa');
+			$GLOBALS['ls_rename_fail'] = true;
 
-	        $this->logger->log('rotate');
+			$this->logger->log('rotate');
 
-	        $this->assertNotEmpty($GLOBALS['ls_errors']);
-	        $this->assertStringContainsString('Failed to rotate log file', $GLOBALS['ls_errors'][0]);
-	    }
+			$this->assertNotEmpty($GLOBALS['ls_errors']);
+			$this->assertStringContainsString('Failed to rotate log file', $GLOBALS['ls_errors'][0]);
+		}
 
-	    public function test_upload_dir_error_returns_fallback_info(): void {
-	        $GLOBALS['test_upload_error'] = 'fail';
-	        $info = $this->logger->get_log_file_info();
-	        $expected_dir = rtrim(NUCLEN_PLUGIN_DIR, '/') . '/logs';
-	        $this->assertSame($expected_dir, $info['dir']);
-	        $this->assertSame($expected_dir . '/log.txt', $info['path']);
-	        $this->assertSame('', $info['url']);
-	        $this->assertSame('admin_notices', $GLOBALS['ls_actions'][0][0]);
-	        $this->assertNotEmpty($GLOBALS['ls_errors']);
-	        unset($GLOBALS['test_upload_error']);
-	    }
+		public function test_upload_dir_error_returns_fallback_info(): void {
+			$GLOBALS['test_upload_error'] = 'fail';
+			$info = $this->logger->get_log_file_info();
+			$expected_dir = rtrim(NUCLEN_PLUGIN_DIR, '/') . '/logs';
+			$this->assertSame($expected_dir, $info['dir']);
+			$this->assertSame($expected_dir . '/log.txt', $info['path']);
+			$this->assertSame('', $info['url']);
+			$this->assertSame('admin_notices', $GLOBALS['ls_actions'][0][0]);
+			$this->assertNotEmpty($GLOBALS['ls_errors']);
+			unset($GLOBALS['test_upload_error']);
+		}
 
-	    public function test_log_exception_without_debug(): void {
-	        $e = new \Exception('oops');
-	        $this->logger->log_exception($e);
-	        $info = $this->logger->get_log_file_info();
-	        $this->assertFileExists($info['path']);
-	        $contents = file_get_contents($info['path']);
-	        $this->assertStringContainsString('oops in', $contents);
-	        $this->assertStringNotContainsString('Stack trace:', $contents);
-	    }
+		public function test_log_exception_without_debug(): void {
+			$e = new \Exception('oops');
+			$this->logger->log_exception($e);
+			$info = $this->logger->get_log_file_info();
+			$this->assertFileExists($info['path']);
+			$contents = file_get_contents($info['path']);
+			$this->assertStringContainsString('oops in', $contents);
+			$this->assertStringNotContainsString('Stack trace:', $contents);
+		}
 
-	    public function test_log_exception_with_debug(): void {
-	        if (!defined('WP_DEBUG')) {
-	            define('WP_DEBUG', true);
-	        }
-	        $e = new \Exception('boom');
-	        $this->logger->log_exception($e);
-	        $info = $this->logger->get_log_file_info();
-	        $this->assertFileExists($info['path']);
-	        $contents = file_get_contents($info['path']);
-	        $this->assertStringContainsString('boom in', $contents);
-	        $this->assertStringContainsString('Stack trace:', $contents);
-	    }
+		public function test_log_exception_with_debug(): void {
+			if (!defined('WP_DEBUG')) {
+				define('WP_DEBUG', true);
+			}
+			$e = new \Exception('boom');
+			$this->logger->log_exception($e);
+			$info = $this->logger->get_log_file_info();
+			$this->assertFileExists($info['path']);
+			$contents = file_get_contents($info['path']);
+			$this->assertStringContainsString('boom in', $contents);
+			$this->assertStringContainsString('Stack trace:', $contents);
+		}
 	}
 }

--- a/tests/MetaRegistrationTest.php
+++ b/tests/MetaRegistrationTest.php
@@ -1,75 +1,75 @@
 <?php
 namespace NuclearEngagement {
-    if (!function_exists('sanitize_text_field')) {
-        function sanitize_text_field($text) { return trim($text); }
-    }
-    if (!function_exists('wp_kses_post')) {
-        function wp_kses_post($text) { return $text; }
-    }
-    if (!function_exists('wp_kses')) {
-        function wp_kses($text, $allowed_html) {
-            $allowed = '<' . implode('><', array_keys($allowed_html)) . '>';
-            return strip_tags($text, $allowed);
-        }
-    }
+	if (!function_exists('sanitize_text_field')) {
+		function sanitize_text_field($text) { return trim($text); }
+	}
+	if (!function_exists('wp_kses_post')) {
+		function wp_kses_post($text) { return $text; }
+	}
+	if (!function_exists('wp_kses')) {
+		function wp_kses($text, $allowed_html) {
+			$allowed = '<' . implode('><', array_keys($allowed_html)) . '>';
+			return strip_tags($text, $allowed);
+		}
+	}
 }
 
 namespace {
-    use PHPUnit\Framework\TestCase;
-    use NuclearEngagement\Core\MetaRegistration;
-    require_once dirname(__DIR__) . '/nuclear-engagement/inc/Core/MetaRegistration.php';
+	use PHPUnit\Framework\TestCase;
+	use NuclearEngagement\Core\MetaRegistration;
+	require_once dirname(__DIR__) . '/nuclear-engagement/inc/Core/MetaRegistration.php';
 
-    class MetaRegistrationTest extends TestCase {
-        public function test_invalid_input_returns_empty_string(): void {
-            $this->assertSame('', MetaRegistration::sanitize_quiz_data('bad'));
-            $this->assertSame('', MetaRegistration::sanitize_summary_data(false));
-        }
+	class MetaRegistrationTest extends TestCase {
+		public function test_invalid_input_returns_empty_string(): void {
+			$this->assertSame('', MetaRegistration::sanitize_quiz_data('bad'));
+			$this->assertSame('', MetaRegistration::sanitize_summary_data(false));
+		}
 
-        public function test_quiz_data_sanitizes_structure(): void {
-            $input = [
-                'date' => ' 2024-05-01 ',
-                'questions' => [
-                    [
-                        'question' => '<i>Q1</i>',
-                        'answers' => ['A1', '<b>A2</b>'],
-                        'explanation' => '<p>E1</p>'
-                    ],
-                    'ignore',
-                    [
-                        'question' => 'Q2'
-                    ]
-                ]
-            ];
+		public function test_quiz_data_sanitizes_structure(): void {
+			$input = [
+				'date' => ' 2024-05-01 ',
+				'questions' => [
+					[
+						'question' => '<i>Q1</i>',
+						'answers' => ['A1', '<b>A2</b>'],
+						'explanation' => '<p>E1</p>'
+					],
+					'ignore',
+					[
+						'question' => 'Q2'
+					]
+				]
+			];
 
-            $expected = [
-                'date' => '2024-05-01',
-                'questions' => [
-                    [
-                        'question' => '<i>Q1</i>',
-                        'answers' => ['A1', '<b>A2</b>'],
-                        'explanation' => '<p>E1</p>'
-                    ],
-                    [
-                        'question' => 'Q2',
-                        'answers' => [],
-                        'explanation' => ''
-                    ]
-                ]
-            ];
+			$expected = [
+				'date' => '2024-05-01',
+				'questions' => [
+					[
+						'question' => '<i>Q1</i>',
+						'answers' => ['A1', '<b>A2</b>'],
+						'explanation' => '<p>E1</p>'
+					],
+					[
+						'question' => 'Q2',
+						'answers' => [],
+						'explanation' => ''
+					]
+				]
+			];
 
-            $this->assertSame($expected, MetaRegistration::sanitize_quiz_data($input));
-        }
+			$this->assertSame($expected, MetaRegistration::sanitize_quiz_data($input));
+		}
 
-        public function test_summary_data_sanitizes_structure(): void {
-            $input = [
-                'date' => ' 2024 ',
-                'summary' => '<p>hello <script>alert("x")</script> <a href="/">Link</a></p>'
-            ];
-            $expected = [
-                'date' => '2024',
-                'summary' => '<p>hello alert("x") <a href="/">Link</a></p>'
-            ];
-            $this->assertSame($expected, MetaRegistration::sanitize_summary_data($input));
-        }
-    }
+		public function test_summary_data_sanitizes_structure(): void {
+			$input = [
+				'date' => ' 2024 ',
+				'summary' => '<p>hello <script>alert("x")</script> <a href="/">Link</a></p>'
+			];
+			$expected = [
+				'date' => '2024',
+				'summary' => '<p>hello alert("x") <a href="/">Link</a></p>'
+			];
+			$this->assertSame($expected, MetaRegistration::sanitize_summary_data($input));
+		}
+	}
 }

--- a/tests/MetaboxUpdateErrorTest.php
+++ b/tests/MetaboxUpdateErrorTest.php
@@ -1,78 +1,78 @@
 <?php
 namespace NuclearEngagement\Admin {
-    function current_user_can($cap, $id) { return true; }
-    function wp_unslash($val) { return $val; }
-    function sanitize_text_field($val) { return $val; }
-    function wp_kses_post($val) { return $val; }
-    function update_post_meta($id, $key, $value) {}
-    function delete_post_meta($id, $key) {}
-    function clean_post_cache($id) {}
-    function remove_action(...$args) {}
-    function add_action(...$args) {}
-    function get_gmt_from_date($time) { return $time; }
-    function wp_update_post(array $data, $error = false) { return $GLOBALS['mb_result']; }
+	function current_user_can($cap, $id) { return true; }
+	function wp_unslash($val) { return $val; }
+	function sanitize_text_field($val) { return $val; }
+	function wp_kses_post($val) { return $val; }
+	function update_post_meta($id, $key, $value) {}
+	function delete_post_meta($id, $key) {}
+	function clean_post_cache($id) {}
+	function remove_action(...$args) {}
+	function add_action(...$args) {}
+	function get_gmt_from_date($time) { return $time; }
+	function wp_update_post(array $data, $error = false) { return $GLOBALS['mb_result']; }
 }
 
 namespace NuclearEngagement\Services {
-    class LoggingService {
-        public static array $logs = [];
-        public static array $notices = [];
-        public static function log(string $msg): void { self::$logs[] = $msg; }
-        public static function notify_admin(string $msg): void { self::$notices[] = $msg; }
-    }
+	class LoggingService {
+		public static array $logs = [];
+		public static array $notices = [];
+		public static function log(string $msg): void { self::$logs[] = $msg; }
+		public static function notify_admin(string $msg): void { self::$notices[] = $msg; }
+	}
 }
 
 namespace {
-    use PHPUnit\Framework\TestCase;
-    require_once dirname(__DIR__) . '/nuclear-engagement/admin/Traits/AdminQuizMetabox.php';
-    require_once dirname(__DIR__) . '/nuclear-engagement/admin/Traits/AdminSummaryMetabox.php';
+	use PHPUnit\Framework\TestCase;
+	require_once dirname(__DIR__) . '/nuclear-engagement/admin/Traits/AdminQuizMetabox.php';
+	require_once dirname(__DIR__) . '/nuclear-engagement/admin/Traits/AdminSummaryMetabox.php';
 
-    class DummyRepo {
-        public function get($key, $default = 0) { return 1; }
-    }
+	class DummyRepo {
+		public function get($key, $default = 0) { return 1; }
+	}
 
-    class QuizBox {
-        use \NuclearEngagement\Admin\Traits\AdminQuizMetabox;
-        public function nuclen_get_settings_repository() { return new DummyRepo(); }
-    }
+	class QuizBox {
+		use \NuclearEngagement\Admin\Traits\AdminQuizMetabox;
+		public function nuclen_get_settings_repository() { return new DummyRepo(); }
+	}
 
-    class SummaryBox {
-        use \NuclearEngagement\Admin\Traits\AdminSummaryMetabox;
-        public function nuclen_get_settings_repository() { return new DummyRepo(); }
-    }
+	class SummaryBox {
+		use \NuclearEngagement\Admin\Traits\AdminSummaryMetabox;
+		public function nuclen_get_settings_repository() { return new DummyRepo(); }
+	}
 
-    class MetaboxUpdateErrorTest extends TestCase {
-        protected function setUp(): void {
-            $_POST = [
-                'nuclen_quiz_data_nonce' => 'n',
-                'nuclen_quiz_data' => [],
-                'nuclen_summary_data_nonce' => 'n',
-                'nuclen_summary_data' => [],
-            ];
-            $GLOBALS['mb_result'] = new \WP_Error();
-            \NuclearEngagement\Services\LoggingService::$logs = [];
-            \NuclearEngagement\Services\LoggingService::$notices = [];
-            $GLOBALS['test_verify_nonce'] = true;
-        }
+	class MetaboxUpdateErrorTest extends TestCase {
+		protected function setUp(): void {
+			$_POST = [
+				'nuclen_quiz_data_nonce' => 'n',
+				'nuclen_quiz_data' => [],
+				'nuclen_summary_data_nonce' => 'n',
+				'nuclen_summary_data' => [],
+			];
+			$GLOBALS['mb_result'] = new \WP_Error();
+			\NuclearEngagement\Services\LoggingService::$logs = [];
+			\NuclearEngagement\Services\LoggingService::$notices = [];
+			$GLOBALS['test_verify_nonce'] = true;
+		}
 
-        protected function tearDown(): void {
-            unset($GLOBALS['test_verify_nonce']);
-        }
+		protected function tearDown(): void {
+			unset($GLOBALS['test_verify_nonce']);
+		}
 
-        public function test_quiz_update_error_logs_and_notifies(): void {
-            $box = new QuizBox();
-            $box->nuclen_save_quiz_data_meta(1);
-            $expected = ['Failed to update modified time for post 1: error'];
-            $this->assertSame($expected, \NuclearEngagement\Services\LoggingService::$logs);
-            $this->assertSame($expected, \NuclearEngagement\Services\LoggingService::$notices);
-        }
+		public function test_quiz_update_error_logs_and_notifies(): void {
+			$box = new QuizBox();
+			$box->nuclen_save_quiz_data_meta(1);
+			$expected = ['Failed to update modified time for post 1: error'];
+			$this->assertSame($expected, \NuclearEngagement\Services\LoggingService::$logs);
+			$this->assertSame($expected, \NuclearEngagement\Services\LoggingService::$notices);
+		}
 
-        public function test_summary_update_error_logs_and_notifies(): void {
-            $box = new SummaryBox();
-            $box->nuclen_save_summary_data_meta(2);
-            $expected = ['Failed to update modified time for post 2: error'];
-            $this->assertSame($expected, \NuclearEngagement\Services\LoggingService::$logs);
-            $this->assertSame($expected, \NuclearEngagement\Services\LoggingService::$notices);
-        }
-    }
+		public function test_summary_update_error_logs_and_notifies(): void {
+			$box = new SummaryBox();
+			$box->nuclen_save_summary_data_meta(2);
+			$expected = ['Failed to update modified time for post 2: error'];
+			$this->assertSame($expected, \NuclearEngagement\Services\LoggingService::$logs);
+			$this->assertSame($expected, \NuclearEngagement\Services\LoggingService::$notices);
+		}
+	}
 }

--- a/tests/ModuleLoaderTest.php
+++ b/tests/ModuleLoaderTest.php
@@ -3,48 +3,48 @@ use PHPUnit\Framework\TestCase;
 use NuclearEngagement\Core\ModuleLoader;
 
 class ModuleLoaderTest extends TestCase {
-    private static string $dir;
+	private static string $dir;
 
-    public static function setUpBeforeClass(): void {
-        self::$dir = sys_get_temp_dir() . '/mods_' . uniqid();
-        mkdir(self::$dir . '/inc/Modules/Alpha', 0777, true);
-        mkdir(self::$dir . '/inc/Modules/Beta', 0777, true);
-        file_put_contents(self::$dir . '/inc/Modules/Alpha/loader.php', "<?php\n\$GLOBALS['loaded'][] = 'alpha';\n");
-        file_put_contents(self::$dir . '/inc/Modules/Beta/loader.php', "<?php\n\$GLOBALS['loaded'][] = 'beta';\n");
-        require_once dirname(__DIR__) . '/nuclear-engagement/inc/Core/ModuleLoader.php';
-    }
+	public static function setUpBeforeClass(): void {
+		self::$dir = sys_get_temp_dir() . '/mods_' . uniqid();
+		mkdir(self::$dir . '/inc/Modules/Alpha', 0777, true);
+		mkdir(self::$dir . '/inc/Modules/Beta', 0777, true);
+		file_put_contents(self::$dir . '/inc/Modules/Alpha/loader.php', "<?php\n\$GLOBALS['loaded'][] = 'alpha';\n");
+		file_put_contents(self::$dir . '/inc/Modules/Beta/loader.php', "<?php\n\$GLOBALS['loaded'][] = 'beta';\n");
+		require_once dirname(__DIR__) . '/nuclear-engagement/inc/Core/ModuleLoader.php';
+	}
 
-    protected function setUp(): void {
-        $GLOBALS['loaded'] = [];
-    }
+	protected function setUp(): void {
+		$GLOBALS['loaded'] = [];
+	}
 
-    public static function tearDownAfterClass(): void {
-        self::deleteDir(self::$dir);
-    }
+	public static function tearDownAfterClass(): void {
+		self::deleteDir(self::$dir);
+	}
 
-    private static function deleteDir(string $dir): void {
-        if (!is_dir($dir)) {
-            return;
-        }
-        $items = scandir($dir);
-        foreach ($items as $item) {
-            if ($item === '.' || $item === '..') {
-                continue;
-            }
-            $path = $dir . '/' . $item;
-            if (is_dir($path)) {
-                self::deleteDir($path);
-            } else {
-                @unlink($path);
-            }
-        }
-        @rmdir($dir);
-    }
+	private static function deleteDir(string $dir): void {
+		if (!is_dir($dir)) {
+			return;
+		}
+		$items = scandir($dir);
+		foreach ($items as $item) {
+			if ($item === '.' || $item === '..') {
+				continue;
+			}
+			$path = $dir . '/' . $item;
+			if (is_dir($path)) {
+				self::deleteDir($path);
+			} else {
+				@unlink($path);
+			}
+		}
+		@rmdir($dir);
+	}
 
-    public function test_load_all_loads_modules(): void {
-        $loader = new ModuleLoader(self::$dir . '/');
-        $loader->load_all();
-        sort($GLOBALS['loaded']);
-        $this->assertSame(['alpha', 'beta'], $GLOBALS['loaded']);
-    }
+	public function test_load_all_loads_modules(): void {
+		$loader = new ModuleLoader(self::$dir . '/');
+		$loader->load_all();
+		sort($GLOBALS['loaded']);
+		$this->assertSame(['alpha', 'beta'], $GLOBALS['loaded']);
+	}
 }

--- a/tests/NuclenTOCHeadingsTest.php
+++ b/tests/NuclenTOCHeadingsTest.php
@@ -1,7 +1,7 @@
 <?php
 namespace {
-    use PHPUnit\Framework\TestCase;
-    use NuclearEngagement\Modules\TOC\Nuclen_TOC_Headings;
+	use PHPUnit\Framework\TestCase;
+	use NuclearEngagement\Modules\TOC\Nuclen_TOC_Headings;
 
 // ------------------------------------------------------
 // Constants and WordPress function stubs
@@ -14,22 +14,22 @@ if (!defined('NUCLEN_TOC_URL')) { define('NUCLEN_TOC_URL', 'http://example.com/'
 $GLOBALS['wp_cache'] = $GLOBALS['transients'] = [];
 
 if (!function_exists('wp_cache_get')) {
-    function wp_cache_get($key, $group = '') { return $GLOBALS['wp_cache'][$group][$key] ?? false; }
+	function wp_cache_get($key, $group = '') { return $GLOBALS['wp_cache'][$group][$key] ?? false; }
 }
 if (!function_exists('wp_cache_set')) {
-    function wp_cache_set($key, $value, $group = '', $ttl = 0) { $GLOBALS['wp_cache'][$group][$key] = $value; }
+	function wp_cache_set($key, $value, $group = '', $ttl = 0) { $GLOBALS['wp_cache'][$group][$key] = $value; }
 }
 if (!function_exists('get_transient')) {
-    function get_transient($key) { return $GLOBALS['transients'][$key] ?? false; }
+	function get_transient($key) { return $GLOBALS['transients'][$key] ?? false; }
 }
 if (!function_exists('set_transient')) {
-    function set_transient($key, $value, $ttl = 0) { $GLOBALS['transients'][$key] = $value; }
+	function set_transient($key, $value, $ttl = 0) { $GLOBALS['transients'][$key] = $value; }
 }
 if (!function_exists('sanitize_title')) {
-    function sanitize_title($text) { $text = strtolower(trim($text)); $text = preg_replace('/[^a-z0-9_-]+/','-',$text); return trim($text,'-'); }
+	function sanitize_title($text) { $text = strtolower(trim($text)); $text = preg_replace('/[^a-z0-9_-]+/','-',$text); return trim($text,'-'); }
 }
 if (!function_exists('sanitize_html_class')) {
-    function sanitize_html_class($text) { $text = strtolower(trim($text)); $text = preg_replace('/[^a-z0-9_-]+/','-',$text); return trim($text,'-'); }
+	function sanitize_html_class($text) { $text = strtolower(trim($text)); $text = preg_replace('/[^a-z0-9_-]+/','-',$text); return trim($text,'-'); }
 }
 if (!function_exists('esc_attr')) { function esc_attr($t){ return htmlspecialchars($t, ENT_QUOTES); } }
 if (!function_exists('__')) { function __($t, $d = null) { return $t; } }
@@ -40,42 +40,42 @@ if (!function_exists('get_the_ID')) { function get_the_ID() { return $GLOBALS['c
 }
 
 namespace NuclearEngagement\Modules\TOC {
-    if (!function_exists('apply_filters')) {
-        function apply_filters($hook, $value) {
-            if ($hook === 'nuclen_toc_enable_heading_ids' && array_key_exists('toc_enable_heading_ids', $GLOBALS)) {
-                return $GLOBALS['toc_enable_heading_ids'];
-            }
-            return \apply_filters($hook, $value);
-        }
-    }
+	if (!function_exists('apply_filters')) {
+		function apply_filters($hook, $value) {
+			if ($hook === 'nuclen_toc_enable_heading_ids' && array_key_exists('toc_enable_heading_ids', $GLOBALS)) {
+				return $GLOBALS['toc_enable_heading_ids'];
+			}
+			return \apply_filters($hook, $value);
+		}
+	}
 }
 
 namespace {
-    require_once NUCLEN_TOC_DIR . 'includes/polyfills.php';
-    require_once NUCLEN_TOC_DIR . 'includes/class-nuclen-toc-utils.php';
-    require_once NUCLEN_TOC_DIR . 'includes/class-nuclen-toc-headings.php';
+	require_once NUCLEN_TOC_DIR . 'includes/polyfills.php';
+	require_once NUCLEN_TOC_DIR . 'includes/class-nuclen-toc-utils.php';
+	require_once NUCLEN_TOC_DIR . 'includes/class-nuclen-toc-headings.php';
 
-    class NuclenTOCHeadingsTest extends TestCase {
-        protected function setUp(): void {
-            $GLOBALS['toc_enable_heading_ids'] = true;
-            $GLOBALS['wp_cache'] = [];
-            $GLOBALS['transients'] = [];
-        }
+	class NuclenTOCHeadingsTest extends TestCase {
+		protected function setUp(): void {
+			$GLOBALS['toc_enable_heading_ids'] = true;
+			$GLOBALS['wp_cache'] = [];
+			$GLOBALS['transients'] = [];
+		}
 
-        public function test_injects_unique_ids(): void {
-            $headings = new \NuclearEngagement\Modules\TOC\Nuclen_TOC_Headings();
-            $html = '<h2>Intro</h2><h2>Intro</h2><h2 id="custom">X</h2>';
-            $out = $headings->add_heading_ids($html);
-            $this->assertStringContainsString('<h2 id="intro">Intro</h2>', $out);
-            $this->assertStringContainsString('<h2 id="intro-2">Intro</h2>', $out);
-            $this->assertStringContainsString('<h2 id="custom">X</h2>', $out);
-        }
+		public function test_injects_unique_ids(): void {
+			$headings = new \NuclearEngagement\Modules\TOC\Nuclen_TOC_Headings();
+			$html = '<h2>Intro</h2><h2>Intro</h2><h2 id="custom">X</h2>';
+			$out = $headings->add_heading_ids($html);
+			$this->assertStringContainsString('<h2 id="intro">Intro</h2>', $out);
+			$this->assertStringContainsString('<h2 id="intro-2">Intro</h2>', $out);
+			$this->assertStringContainsString('<h2 id="custom">X</h2>', $out);
+		}
 
-        public function test_filter_disables_injection(): void {
-            $GLOBALS['toc_enable_heading_ids'] = false;
-            $headings = new \NuclearEngagement\Modules\TOC\Nuclen_TOC_Headings();
-            $html = '<h2>Intro</h2>';
-            $this->assertSame($html, $headings->add_heading_ids($html));
-        }
-    }
+		public function test_filter_disables_injection(): void {
+			$GLOBALS['toc_enable_heading_ids'] = false;
+			$headings = new \NuclearEngagement\Modules\TOC\Nuclen_TOC_Headings();
+			$html = '<h2>Intro</h2>';
+			$this->assertSame($html, $headings->add_heading_ids($html));
+		}
+	}
 }

--- a/tests/NuclenTOCMetaCacheTest.php
+++ b/tests/NuclenTOCMetaCacheTest.php
@@ -1,46 +1,46 @@
 <?php
 namespace NuclearEngagement\Modules\TOC {
-    function update_post_meta($postId, $key, $value){
-        $GLOBALS['wp_meta'][$postId][$key] = $value; return true;
-    }
-    function delete_post_meta($postId, $key){ unset($GLOBALS['wp_meta'][$postId][$key]); }
+	function update_post_meta($postId, $key, $value){
+		$GLOBALS['wp_meta'][$postId][$key] = $value; return true;
+	}
+	function delete_post_meta($postId, $key){ unset($GLOBALS['wp_meta'][$postId][$key]); }
 }
 
 namespace {
-    use PHPUnit\Framework\TestCase;
-    use NuclearEngagement\Modules\TOC\Nuclen_TOC_Utils;
-    use NuclearEngagement\Modules\TOC\Nuclen_TOC_Headings;
-    if (!defined('HOUR_IN_SECONDS')) { define('HOUR_IN_SECONDS', 3600); }
-    if (!defined('NUCLEN_TOC_DIR')) { define('NUCLEN_TOC_DIR', dirname(__DIR__).'/nuclear-engagement/inc/Modules/TOC/'); }
-    if (!defined('NUCLEN_TOC_URL')) { define('NUCLEN_TOC_URL', 'http://example.com/'); }
-    require_once NUCLEN_TOC_DIR.'includes/polyfills.php';
-    require_once NUCLEN_TOC_DIR.'includes/class-nuclen-toc-utils.php';
-    require_once NUCLEN_TOC_DIR.'includes/class-nuclen-toc-headings.php';
+	use PHPUnit\Framework\TestCase;
+	use NuclearEngagement\Modules\TOC\Nuclen_TOC_Utils;
+	use NuclearEngagement\Modules\TOC\Nuclen_TOC_Headings;
+	if (!defined('HOUR_IN_SECONDS')) { define('HOUR_IN_SECONDS', 3600); }
+	if (!defined('NUCLEN_TOC_DIR')) { define('NUCLEN_TOC_DIR', dirname(__DIR__).'/nuclear-engagement/inc/Modules/TOC/'); }
+	if (!defined('NUCLEN_TOC_URL')) { define('NUCLEN_TOC_URL', 'http://example.com/'); }
+	require_once NUCLEN_TOC_DIR.'includes/polyfills.php';
+	require_once NUCLEN_TOC_DIR.'includes/class-nuclen-toc-utils.php';
+	require_once NUCLEN_TOC_DIR.'includes/class-nuclen-toc-headings.php';
 
-    class NuclenTOCMetaCacheTest extends TestCase {
-        protected function setUp(): void {
-            $GLOBALS['wp_posts'] = [];
-            $GLOBALS['wp_meta'] = [];
-            $GLOBALS['wp_cache'] = [];
-            $GLOBALS['transients'] = [];
-        }
+	class NuclenTOCMetaCacheTest extends TestCase {
+		protected function setUp(): void {
+			$GLOBALS['wp_posts'] = [];
+			$GLOBALS['wp_meta'] = [];
+			$GLOBALS['wp_cache'] = [];
+			$GLOBALS['transients'] = [];
+		}
 
-        public function test_extract_returns_meta_when_available(): void {
-            $post = (object)[ 'ID' => 1, 'post_content' => '<h2>One</h2>' ];
-            $stored = [ [ 'tag'=>'h2','level'=>2,'text'=>'One','inner'=>'One','id'=>'one' ] ];
-            $GLOBALS['wp_posts'][1] = $post;
-            $GLOBALS['wp_meta'][1][Nuclen_TOC_Headings::META_KEY] = $stored;
-            $result = Nuclen_TOC_Utils::extract($post->post_content, [2], 1);
-            $this->assertSame($stored, $result);
-        }
+		public function test_extract_returns_meta_when_available(): void {
+			$post = (object)[ 'ID' => 1, 'post_content' => '<h2>One</h2>' ];
+			$stored = [ [ 'tag'=>'h2','level'=>2,'text'=>'One','inner'=>'One','id'=>'one' ] ];
+			$GLOBALS['wp_posts'][1] = $post;
+			$GLOBALS['wp_meta'][1][Nuclen_TOC_Headings::META_KEY] = $stored;
+			$result = Nuclen_TOC_Utils::extract($post->post_content, [2], 1);
+			$this->assertSame($stored, $result);
+		}
 
-        public function test_cache_saved_on_save_post(): void {
-            $post = (object)[ 'ID' => 2, 'post_content' => '<h2>Two</h2>' ];
-            $handler = new Nuclen_TOC_Headings();
-            $handler->cache_headings_on_save(2, $post, true);
-            $this->assertArrayHasKey(Nuclen_TOC_Headings::META_KEY, $GLOBALS['wp_meta'][2]);
-            $saved = $GLOBALS['wp_meta'][2][Nuclen_TOC_Headings::META_KEY];
-            $this->assertSame('two', $saved[0]['id']);
-        }
-    }
+		public function test_cache_saved_on_save_post(): void {
+			$post = (object)[ 'ID' => 2, 'post_content' => '<h2>Two</h2>' ];
+			$handler = new Nuclen_TOC_Headings();
+			$handler->cache_headings_on_save(2, $post, true);
+			$this->assertArrayHasKey(Nuclen_TOC_Headings::META_KEY, $GLOBALS['wp_meta'][2]);
+			$saved = $GLOBALS['wp_meta'][2][Nuclen_TOC_Headings::META_KEY];
+			$this->assertSame('two', $saved[0]['id']);
+		}
+	}
 }

--- a/tests/NuclenTOCRenderTest.php
+++ b/tests/NuclenTOCRenderTest.php
@@ -1,9 +1,9 @@
 <?php
 namespace {
-    use PHPUnit\Framework\TestCase;
-    use NuclearEngagement\Modules\TOC\Nuclen_TOC_Render;
-    use NuclearEngagement\Core\SettingsRepository;
-    use NuclearEngagement\Core\Container;
+	use PHPUnit\Framework\TestCase;
+	use NuclearEngagement\Modules\TOC\Nuclen_TOC_Render;
+	use NuclearEngagement\Core\SettingsRepository;
+	use NuclearEngagement\Core\Container;
 
 // ------------------------------------------------------
 // Constants and WordPress function stubs
@@ -16,16 +16,16 @@ if (!defined('NUCLEN_TOC_URL')) { define('NUCLEN_TOC_URL', 'http://example.com/'
 $GLOBALS['wp_cache'] = $GLOBALS['transients'] = [];
 
 if (!function_exists('wp_cache_get')) {
-    function wp_cache_get($key, $group = '') { return $GLOBALS['wp_cache'][$group][$key] ?? false; }
+	function wp_cache_get($key, $group = '') { return $GLOBALS['wp_cache'][$group][$key] ?? false; }
 }
 if (!function_exists('wp_cache_set')) {
-    function wp_cache_set($key, $value, $group = '', $ttl = 0) { $GLOBALS['wp_cache'][$group][$key] = $value; }
+	function wp_cache_set($key, $value, $group = '', $ttl = 0) { $GLOBALS['wp_cache'][$group][$key] = $value; }
 }
 if (!function_exists('get_transient')) {
-    function get_transient($key) { return $GLOBALS['transients'][$key] ?? false; }
+	function get_transient($key) { return $GLOBALS['transients'][$key] ?? false; }
 }
 if (!function_exists('set_transient')) {
-    function set_transient($key, $value, $ttl = 0) { $GLOBALS['transients'][$key] = $value; }
+	function set_transient($key, $value, $ttl = 0) { $GLOBALS['transients'][$key] = $value; }
 }
 if (!function_exists('sanitize_title')) { function sanitize_title($t){ $t=strtolower(trim($t)); $t=preg_replace('/[^a-z0-9_-]+/','-',$t); return trim($t,'-'); } }
 if (!function_exists('sanitize_html_class')) { function sanitize_html_class($t){ $t=strtolower(trim($t)); $t=preg_replace('/[^a-z0-9_-]+/','-',$t); return trim($t,'-'); } }
@@ -39,11 +39,11 @@ if (!function_exists('apply_filters')) { function apply_filters($hook,$value){ r
 if (!function_exists('add_filter')) { function add_filter(...$a) {} }
 if (!function_exists('add_shortcode')) { function add_shortcode(...$a) {} }
 if (!function_exists('shortcode_atts')) {
-    function shortcode_atts($pairs,$atts,$shortcode='') {
-        $out=$pairs; foreach($pairs as $name=>$default){ if(isset($atts[$name])) $out[$name]=$atts[$name]; }
-        foreach($atts as $name=>$value){ if(!isset($out[$name])) $out[$name]=$value; }
-        return $out;
-    }
+	function shortcode_atts($pairs,$atts,$shortcode='') {
+		$out=$pairs; foreach($pairs as $name=>$default){ if(isset($atts[$name])) $out[$name]=$atts[$name]; }
+		foreach($atts as $name=>$value){ if(!isset($out[$name])) $out[$name]=$value; }
+		return $out;
+	}
 }
 if (!function_exists('wp_unique_id')) { function wp_unique_id($p=''){ static $i=1; return $p.$i++; } }
 if (!function_exists('wp_script_is')) { function wp_script_is($h,$l='enqueued'){ return false; } }
@@ -56,59 +56,59 @@ if (!function_exists('wp_localize_script')) { function wp_localize_script($h,$o,
 if (!function_exists('is_singular')) { function is_singular(){ return true; } }
 if (!function_exists('get_the_ID')) { function get_the_ID(){ return $GLOBALS['current_post_id'] ?? 0; } }
 
-    require_once NUCLEN_TOC_DIR . 'includes/polyfills.php';
-    require_once NUCLEN_TOC_DIR . 'includes/class-nuclen-toc-utils.php';
-    require_once NUCLEN_TOC_DIR . 'includes/class-nuclen-toc-view.php';
-    require_once NUCLEN_TOC_DIR . 'includes/class-nuclen-toc-assets.php';
-    require_once NUCLEN_TOC_DIR . 'includes/class-nuclen-toc-headings.php';
-    require_once NUCLEN_TOC_DIR . 'includes/class-nuclen-toc-render.php';
-    require_once dirname(__DIR__) . '/nuclear-engagement/inc/Core/SettingsCache.php';
-    require_once dirname(__DIR__) . '/nuclear-engagement/inc/Core/SettingsRepository.php';
-    require_once dirname(__DIR__) . '/nuclear-engagement/inc/Core/Defaults.php';
-    require_once dirname(__DIR__) . '/nuclear-engagement/inc/Core/Container.php';
+	require_once NUCLEN_TOC_DIR . 'includes/polyfills.php';
+	require_once NUCLEN_TOC_DIR . 'includes/class-nuclen-toc-utils.php';
+	require_once NUCLEN_TOC_DIR . 'includes/class-nuclen-toc-view.php';
+	require_once NUCLEN_TOC_DIR . 'includes/class-nuclen-toc-assets.php';
+	require_once NUCLEN_TOC_DIR . 'includes/class-nuclen-toc-headings.php';
+	require_once NUCLEN_TOC_DIR . 'includes/class-nuclen-toc-render.php';
+	require_once dirname(__DIR__) . '/nuclear-engagement/inc/Core/SettingsCache.php';
+	require_once dirname(__DIR__) . '/nuclear-engagement/inc/Core/SettingsRepository.php';
+	require_once dirname(__DIR__) . '/nuclear-engagement/inc/Core/Defaults.php';
+	require_once dirname(__DIR__) . '/nuclear-engagement/inc/Core/Container.php';
 
-    class NuclenTOCRenderTest extends TestCase {
-        protected function setUp(): void {
-            global $wp_posts, $current_post_id, $wp_cache, $transients;
-            $wp_posts = [];
-            $current_post_id = 0;
-            $wp_cache = [];
-            $transients = [];
-            SettingsRepository::reset_for_tests();
-            Container::getInstance()->reset();
-        }
+	class NuclenTOCRenderTest extends TestCase {
+		protected function setUp(): void {
+			global $wp_posts, $current_post_id, $wp_cache, $transients;
+			$wp_posts = [];
+			$current_post_id = 0;
+			$wp_cache = [];
+			$transients = [];
+			SettingsRepository::reset_for_tests();
+			Container::getInstance()->reset();
+		}
 
-        private function registerSettings(): SettingsRepository {
-            $settings = SettingsRepository::get_instance([
-                'toc_heading_levels' => [2,3],
-                'toc_show_toggle'    => true,
-                'toc_show_content'   => true,
-            ]);
-            Container::getInstance()->register('settings', static function () use ($settings) {
-                return $settings;
-            });
-            return $settings;
-        }
+		private function registerSettings(): SettingsRepository {
+			$settings = SettingsRepository::get_instance([
+				'toc_heading_levels' => [2,3],
+				'toc_show_toggle'    => true,
+				'toc_show_content'   => true,
+			]);
+			Container::getInstance()->register('settings', static function () use ($settings) {
+				return $settings;
+			});
+			return $settings;
+		}
 
-        public function test_shortcode_outputs_markup(): void {
-            global $wp_posts, $current_post_id;
-            $current_post_id = 1;
-            $wp_posts[1] = (object)[
-                'ID' => 1,
-                'post_content' => '<h2>One</h2><h3>Sub</h3>',
-            ];
-            $this->registerSettings();
-            $render = new \NuclearEngagement\Modules\TOC\Nuclen_TOC_Render( SettingsRepository::get_instance() );
-            $out = $render->nuclen_toc_shortcode([]);
-            $this->assertStringContainsString('<nav id="', $out);
-            $this->assertStringContainsString('<a href="#one">One</a>', $out);
-            $this->assertStringContainsString('<a href="#sub">Sub</a>', $out);
-        }
+		public function test_shortcode_outputs_markup(): void {
+			global $wp_posts, $current_post_id;
+			$current_post_id = 1;
+			$wp_posts[1] = (object)[
+				'ID' => 1,
+				'post_content' => '<h2>One</h2><h3>Sub</h3>',
+			];
+			$this->registerSettings();
+			$render = new \NuclearEngagement\Modules\TOC\Nuclen_TOC_Render( SettingsRepository::get_instance() );
+			$out = $render->nuclen_toc_shortcode([]);
+			$this->assertStringContainsString('<nav id="', $out);
+			$this->assertStringContainsString('<a href="#one">One</a>', $out);
+			$this->assertStringContainsString('<a href="#sub">Sub</a>', $out);
+		}
 
-        public function test_shortcode_returns_empty_when_no_post(): void {
-            $this->registerSettings();
-            $render = new \NuclearEngagement\Modules\TOC\Nuclen_TOC_Render( SettingsRepository::get_instance() );
-            $this->assertSame('', $render->nuclen_toc_shortcode([]));
-        }
-    }
+		public function test_shortcode_returns_empty_when_no_post(): void {
+			$this->registerSettings();
+			$render = new \NuclearEngagement\Modules\TOC\Nuclen_TOC_Render( SettingsRepository::get_instance() );
+			$this->assertSame('', $render->nuclen_toc_shortcode([]));
+		}
+	}
 }

--- a/tests/OnboardingPointersTest.php
+++ b/tests/OnboardingPointersTest.php
@@ -5,14 +5,14 @@ use NuclearEngagement\Admin\OnboardingPointers;
 require_once __DIR__ . '/../nuclear-engagement/admin/OnboardingPointers.php';
 
 class OnboardingPointersTest extends TestCase {
-    public function test_get_pointers_returns_expected_structure(): void {
-        $pointers = OnboardingPointers::get_pointers();
-        $this->assertIsArray($pointers);
-        $this->assertArrayHasKey('post.php', $pointers);
-        $first = $pointers['post.php'][0];
-        $this->assertArrayHasKey('id', $first);
-        $this->assertArrayHasKey('target', $first);
-        $this->assertArrayHasKey('title', $first);
-        $this->assertArrayHasKey('content', $first);
-    }
+	public function test_get_pointers_returns_expected_structure(): void {
+		$pointers = OnboardingPointers::get_pointers();
+		$this->assertIsArray($pointers);
+		$this->assertArrayHasKey('post.php', $pointers);
+		$first = $pointers['post.php'][0];
+		$this->assertArrayHasKey('id', $first);
+		$this->assertArrayHasKey('target', $first);
+		$this->assertArrayHasKey('title', $first);
+		$this->assertArrayHasKey('content', $first);
+	}
 }

--- a/tests/OnboardingTest.php
+++ b/tests/OnboardingTest.php
@@ -1,83 +1,83 @@
 <?php
 namespace {
-    use PHPUnit\Framework\TestCase;
-    use NuclearEngagement\Admin\Onboarding;
-    if (!function_exists('wp_enqueue_style')) {
-        function wp_enqueue_style($handle) { $GLOBALS['enqueued_styles'][] = $handle; }
-    }
-    if (!function_exists('wp_enqueue_script')) {
-        function wp_enqueue_script($handle, $src='', $deps=array(), $ver='', $in_footer=false) { $GLOBALS['enqueued_scripts'][] = $handle; }
-    }
-    if (!function_exists('wp_add_inline_script')) {
-        function wp_add_inline_script($handle, $code, $pos='after') { $GLOBALS['inline_script'][$handle] = $code; }
-    }
-    if (!function_exists('admin_url')) {
-        function admin_url($path='') { return 'admin-ajax.php'; }
-    }
-    if (!function_exists('wp_create_nonce')) {
-        function wp_create_nonce($a) { return 'nonce123'; }
-    }
-    if (!function_exists('plugin_dir_url')) {
-        function plugin_dir_url($file) { return ''; }
-    }
-    if (!function_exists('current_user_can')) {
-        function current_user_can($cap) { return $GLOBALS['can_manage'] ?? true; }
-    }
-    if (!function_exists('check_ajax_referer')) {
-        function check_ajax_referer($a,$f) { return true; }
-    }
-    if (!function_exists('wp_send_json_success')) {
-        function wp_send_json_success($data) { $GLOBALS['json_response'] = ['success',$data]; }
-    }
-    if (!function_exists('wp_send_json_error')) {
-        function wp_send_json_error($data,$code=0) { $GLOBALS['json_response'] = ['error',$data,$code]; }
-    }
-    if (!function_exists('sanitize_text_field')) { function sanitize_text_field($t){ return $t; } }
-    if (!function_exists('wp_unslash')) { function wp_unslash($d){ return $d; } }
+	use PHPUnit\Framework\TestCase;
+	use NuclearEngagement\Admin\Onboarding;
+	if (!function_exists('wp_enqueue_style')) {
+		function wp_enqueue_style($handle) { $GLOBALS['enqueued_styles'][] = $handle; }
+	}
+	if (!function_exists('wp_enqueue_script')) {
+		function wp_enqueue_script($handle, $src='', $deps=array(), $ver='', $in_footer=false) { $GLOBALS['enqueued_scripts'][] = $handle; }
+	}
+	if (!function_exists('wp_add_inline_script')) {
+		function wp_add_inline_script($handle, $code, $pos='after') { $GLOBALS['inline_script'][$handle] = $code; }
+	}
+	if (!function_exists('admin_url')) {
+		function admin_url($path='') { return 'admin-ajax.php'; }
+	}
+	if (!function_exists('wp_create_nonce')) {
+		function wp_create_nonce($a) { return 'nonce123'; }
+	}
+	if (!function_exists('plugin_dir_url')) {
+		function plugin_dir_url($file) { return ''; }
+	}
+	if (!function_exists('current_user_can')) {
+		function current_user_can($cap) { return $GLOBALS['can_manage'] ?? true; }
+	}
+	if (!function_exists('check_ajax_referer')) {
+		function check_ajax_referer($a,$f) { return true; }
+	}
+	if (!function_exists('wp_send_json_success')) {
+		function wp_send_json_success($data) { $GLOBALS['json_response'] = ['success',$data]; }
+	}
+	if (!function_exists('wp_send_json_error')) {
+		function wp_send_json_error($data,$code=0) { $GLOBALS['json_response'] = ['error',$data,$code]; }
+	}
+	if (!function_exists('sanitize_text_field')) { function sanitize_text_field($t){ return $t; } }
+	if (!function_exists('wp_unslash')) { function wp_unslash($d){ return $d; } }
 }
 
 namespace {
-    require_once __DIR__ . '/../nuclear-engagement/admin/OnboardingPointers.php';
-    require_once __DIR__ . '/../nuclear-engagement/admin/Onboarding.php';
+	require_once __DIR__ . '/../nuclear-engagement/admin/OnboardingPointers.php';
+	require_once __DIR__ . '/../nuclear-engagement/admin/Onboarding.php';
 
-    class OnboardingTest extends TestCase {
-        protected function setUp(): void {
-            global $enqueued_scripts, $inline_script, $wp_user_meta, $json_response, $can_manage;
-            $enqueued_scripts = $inline_script = [];
-            $wp_user_meta = [];
-            $json_response = null;
-            $can_manage = true;
-        }
+	class OnboardingTest extends TestCase {
+		protected function setUp(): void {
+			global $enqueued_scripts, $inline_script, $wp_user_meta, $json_response, $can_manage;
+			$enqueued_scripts = $inline_script = [];
+			$wp_user_meta = [];
+			$json_response = null;
+			$can_manage = true;
+		}
 
-        public function test_enqueue_pointers_enqueues_and_injects(): void {
-            global $enqueued_scripts, $inline_script, $wp_user_meta;
-            $wp_user_meta[1]['nuclen_pointer_dismissed_nuclen_postedit_step1'] = true;
-            $onb = new Onboarding();
-            $onb->enqueue_nuclen_onboarding_pointers('post.php');
-            $this->assertContains('nuclen-onboarding', $enqueued_scripts);
-            $this->assertArrayHasKey('nuclen-onboarding', $inline_script);
-            $json = str_replace('window.nePointerData = ', '', rtrim($inline_script['nuclen-onboarding'], ';'));
-            $data = json_decode($json, true);
-            $ids = array_column($data['pointers'], 'id');
-            $this->assertNotContains('nuclen_postedit_step1', $ids);
-        }
+		public function test_enqueue_pointers_enqueues_and_injects(): void {
+			global $enqueued_scripts, $inline_script, $wp_user_meta;
+			$wp_user_meta[1]['nuclen_pointer_dismissed_nuclen_postedit_step1'] = true;
+			$onb = new Onboarding();
+			$onb->enqueue_nuclen_onboarding_pointers('post.php');
+			$this->assertContains('nuclen-onboarding', $enqueued_scripts);
+			$this->assertArrayHasKey('nuclen-onboarding', $inline_script);
+			$json = str_replace('window.nePointerData = ', '', rtrim($inline_script['nuclen-onboarding'], ';'));
+			$data = json_decode($json, true);
+			$ids = array_column($data['pointers'], 'id');
+			$this->assertNotContains('nuclen_postedit_step1', $ids);
+		}
 
-        public function test_ajax_dismiss_pointer_permission_failure(): void {
-            global $json_response, $can_manage;
-            $can_manage = false;
-            $onb = new Onboarding();
-            $_POST = ['pointer' => 'x', 'nonce' => 'n'];
-            $onb->nuclen_ajax_dismiss_pointer();
-            $this->assertSame(['error',['message'=>'No permission'],0], $json_response);
-        }
+		public function test_ajax_dismiss_pointer_permission_failure(): void {
+			global $json_response, $can_manage;
+			$can_manage = false;
+			$onb = new Onboarding();
+			$_POST = ['pointer' => 'x', 'nonce' => 'n'];
+			$onb->nuclen_ajax_dismiss_pointer();
+			$this->assertSame(['error',['message'=>'No permission'],0], $json_response);
+		}
 
-        public function test_ajax_dismiss_pointer_updates_meta(): void {
-            global $json_response, $wp_user_meta;
-            $onb = new Onboarding();
-            $_POST = ['pointer' => 'abc', 'nonce' => 'n'];
-            $onb->nuclen_ajax_dismiss_pointer();
-            $this->assertTrue($wp_user_meta[1]['nuclen_pointer_dismissed_abc']);
-            $this->assertSame(['success',['message'=>'Pointer dismissed.']], $json_response);
-        }
-    }
+		public function test_ajax_dismiss_pointer_updates_meta(): void {
+			global $json_response, $wp_user_meta;
+			$onb = new Onboarding();
+			$_POST = ['pointer' => 'abc', 'nonce' => 'n'];
+			$onb->nuclen_ajax_dismiss_pointer();
+			$this->assertTrue($wp_user_meta[1]['nuclen_pointer_dismissed_abc']);
+			$this->assertSame(['success',['message'=>'Pointer dismissed.']], $json_response);
+		}
+	}
 }

--- a/tests/OptinDataTest.php
+++ b/tests/OptinDataTest.php
@@ -3,35 +3,35 @@ use PHPUnit\Framework\TestCase;
 use NuclearEngagement\OptinData;
 
 class OptinDataTest extends TestCase {
-    private \ReflectionMethod $escapeMethod;
+	private \ReflectionMethod $escapeMethod;
 
-    protected function setUp(): void {
-        $this->escapeMethod = new \ReflectionMethod(OptinData::class, 'escape_csv_field');
-        $this->escapeMethod->setAccessible(true);
-    }
+	protected function setUp(): void {
+		$this->escapeMethod = new \ReflectionMethod(OptinData::class, 'escape_csv_field');
+		$this->escapeMethod->setAccessible(true);
+	}
 
-    public function test_escape_csv_field_prefixes_formula() {
-        $this->assertSame("'=1+1", $this->escapeMethod->invoke(null, '=1+1'));
-        $this->assertSame("'+SUM(A1)", $this->escapeMethod->invoke(null, '+SUM(A1)'));
-    }
+	public function test_escape_csv_field_prefixes_formula() {
+		$this->assertSame("'=1+1", $this->escapeMethod->invoke(null, '=1+1'));
+		$this->assertSame("'+SUM(A1)", $this->escapeMethod->invoke(null, '+SUM(A1)'));
+	}
 
-    public function test_escape_csv_field_unchanged() {
-        $this->assertSame('plain', $this->escapeMethod->invoke(null, 'plain'));
-    }
+	public function test_escape_csv_field_unchanged() {
+		$this->assertSame('plain', $this->escapeMethod->invoke(null, 'plain'));
+	}
 
-    public function test_dbDelta_not_called_when_table_exists() {
-        global $dbDelta_called, $wpdb;
+	public function test_dbDelta_not_called_when_table_exists() {
+		global $dbDelta_called, $wpdb;
 
-        $dbDelta_called = false;
-        $wpdb = new class {
-            public $prefix = 'wp_';
-            public function get_charset_collate() { return ''; }
-            public function prepare($query, $param) { return $param; }
-            public function get_var($query) { return 'wp_nuclen_optins'; }
-        };
+		$dbDelta_called = false;
+		$wpdb = new class {
+			public $prefix = 'wp_';
+			public function get_charset_collate() { return ''; }
+			public function prepare($query, $param) { return $param; }
+			public function get_var($query) { return 'wp_nuclen_optins'; }
+		};
 
-        OptinData::maybe_create_table();
+		OptinData::maybe_create_table();
 
-        $this->assertFalse($dbDelta_called);
-    }
+		$this->assertFalse($dbDelta_called);
+	}
 }

--- a/tests/OptinExportControllerTest.php
+++ b/tests/OptinExportControllerTest.php
@@ -1,34 +1,34 @@
 <?php
 namespace NuclearEngagement\Services {
-    class OptinExportService {
-        public static int $calls = 0;
-        public function stream_csv(): void { self::$calls++; }
-    }
+	class OptinExportService {
+		public static int $calls = 0;
+		public function stream_csv(): void { self::$calls++; }
+	}
 }
 
 namespace NuclearEngagement {
-    use NuclearEngagement\Services\OptinExportService;
-    class OptinData {
-        public static function handle_export(): void {
-            ( new OptinExportService() )->stream_csv();
-        }
-    }
+	use NuclearEngagement\Services\OptinExportService;
+	class OptinData {
+		public static function handle_export(): void {
+			( new OptinExportService() )->stream_csv();
+		}
+	}
 }
 
 namespace {
-    use PHPUnit\Framework\TestCase;
-    use NuclearEngagement\Admin\Controller\OptinExportController;
-    require_once __DIR__ . '/../nuclear-engagement/admin/Controller/OptinExportController.php';
+	use PHPUnit\Framework\TestCase;
+	use NuclearEngagement\Admin\Controller\OptinExportController;
+	require_once __DIR__ . '/../nuclear-engagement/admin/Controller/OptinExportController.php';
 
-    class OptinExportControllerTest extends TestCase {
-        protected function setUp(): void {
-            \NuclearEngagement\Services\OptinExportService::$calls = 0;
-        }
+	class OptinExportControllerTest extends TestCase {
+		protected function setUp(): void {
+			\NuclearEngagement\Services\OptinExportService::$calls = 0;
+		}
 
-        public function test_handle_invokes_export(): void {
-            $c = new OptinExportController();
-            $c->handle();
-            $this->assertSame(1, \NuclearEngagement\Services\OptinExportService::$calls);
-        }
-    }
+		public function test_handle_invokes_export(): void {
+			$c = new OptinExportController();
+			$c->handle();
+			$this->assertSame(1, \NuclearEngagement\Services\OptinExportService::$calls);
+		}
+	}
 }

--- a/tests/PluginTest.php
+++ b/tests/PluginTest.php
@@ -1,186 +1,186 @@
 <?php
 namespace NuclearEngagement\Core {
-    function register_activation_hook($file, $callback) {
-        $GLOBALS['ph_activation'][] = [$file, $callback];
-    }
-    function add_action(...$args) { $GLOBALS['ph_actions'][] = $args; }
-    function add_filter(...$args) { $GLOBALS['ph_filters'][] = $args; }
-    function remove_action(...$args) { $GLOBALS['ph_removed'][] = $args; }
+	function register_activation_hook($file, $callback) {
+		$GLOBALS['ph_activation'][] = [$file, $callback];
+	}
+	function add_action(...$args) { $GLOBALS['ph_actions'][] = $args; }
+	function add_filter(...$args) { $GLOBALS['ph_filters'][] = $args; }
+	function remove_action(...$args) { $GLOBALS['ph_removed'][] = $args; }
 
-    class ModuleLoader {
-        public static int $calls = 0;
-        public function __construct(string $base_dir = NUCLEN_PLUGIN_DIR) {}
-        public function load_all(): void { self::$calls++; }
-    }
+	class ModuleLoader {
+		public static int $calls = 0;
+		public function __construct(string $base_dir = NUCLEN_PLUGIN_DIR) {}
+		public function load_all(): void { self::$calls++; }
+	}
 }
 
 namespace NuclearEngagement\Services {
-    function add_action(...$args) { $GLOBALS['ph_actions'][] = $args; }
-    class LoggingService {
-        public static array $notices = [];
-        public static function notify_admin(string $msg): void { self::$notices[] = $msg; }
-        public static function log(string $msg): void {}
-        public static function log_exception($e): void {}
-    }
+	function add_action(...$args) { $GLOBALS['ph_actions'][] = $args; }
+	class LoggingService {
+		public static array $notices = [];
+		public static function notify_admin(string $msg): void { self::$notices[] = $msg; }
+		public static function log(string $msg): void {}
+		public static function log_exception($e): void {}
+	}
 }
 
 namespace NuclearEngagement {
-    class OptinData {
-        public static int $table_exists_calls = 0;
-        public static int $create_table_calls = 0;
-        public static bool $table_exists = false;
-        public static bool $create_result = true;
-        public static function init(): void {}
-        public static function table_exists(): bool {
-            self::$table_exists_calls++;
-            return self::$table_exists;
-        }
-        public static function maybe_create_table(): bool {
-            self::$create_table_calls++;
-            return self::$create_result;
-        }
-    }
+	class OptinData {
+		public static int $table_exists_calls = 0;
+		public static int $create_table_calls = 0;
+		public static bool $table_exists = false;
+		public static bool $create_result = true;
+		public static function init(): void {}
+		public static function table_exists(): bool {
+			self::$table_exists_calls++;
+			return self::$table_exists;
+		}
+		public static function maybe_create_table(): bool {
+			self::$create_table_calls++;
+			return self::$create_result;
+		}
+	}
 }
 
 namespace NuclearEngagement\Admin {
-    class Admin { public function __construct(...$args) {} }
-    class Onboarding { public function nuclen_register_hooks() {} }
-    class Setup {
-        public function __construct(...$args) {}
-        public function nuclen_add_setup_page() {}
-        public function nuclen_handle_connect_app() {}
-        public function nuclen_handle_generate_app_password() {}
-        public function nuclen_handle_reset_api_key() {}
-        public function nuclen_handle_reset_wp_app_connection() {}
-    }
+	class Admin { public function __construct(...$args) {} }
+	class Onboarding { public function nuclen_register_hooks() {} }
+	class Setup {
+		public function __construct(...$args) {}
+		public function nuclen_add_setup_page() {}
+		public function nuclen_handle_connect_app() {}
+		public function nuclen_handle_generate_app_password() {}
+		public function nuclen_handle_reset_api_key() {}
+		public function nuclen_handle_reset_wp_app_connection() {}
+	}
 }
 
 namespace NuclearEngagement\Front {
-    class FrontClass {
-        public function __construct(...$args) {}
-        public function wp_enqueue_styles() {}
-        public function wp_enqueue_scripts() {}
-        public function nuclen_register_quiz_shortcode() {}
-        public function nuclen_register_summary_shortcode() {}
-        public function nuclen_auto_insert_shortcodes() {}
-    }
+	class FrontClass {
+		public function __construct(...$args) {}
+		public function wp_enqueue_styles() {}
+		public function wp_enqueue_scripts() {}
+		public function nuclen_register_quiz_shortcode() {}
+		public function nuclen_register_summary_shortcode() {}
+		public function nuclen_auto_insert_shortcodes() {}
+	}
 }
 
 namespace NuclearEngagement {
-    class Blocks { public static function register() {} }
+	class Blocks { public static function register() {} }
 }
 
 namespace {
-    use PHPUnit\Framework\TestCase;
-    use NuclearEngagement\Core\Plugin;
-    use NuclearEngagement\Core\Container;
-    use NuclearEngagement\Core\SettingsRepository;
-    use NuclearEngagement\Core\Defaults;
-    if (!defined('NUCLEN_PLUGIN_DIR')) {
-        define('NUCLEN_PLUGIN_DIR', dirname(__DIR__) . '/nuclear-engagement/');
-    }
+	use PHPUnit\Framework\TestCase;
+	use NuclearEngagement\Core\Plugin;
+	use NuclearEngagement\Core\Container;
+	use NuclearEngagement\Core\SettingsRepository;
+	use NuclearEngagement\Core\Defaults;
+	if (!defined('NUCLEN_PLUGIN_DIR')) {
+		define('NUCLEN_PLUGIN_DIR', dirname(__DIR__) . '/nuclear-engagement/');
+	}
 
-    spl_autoload_register(static function ($class) {
-        $prefix = 'NuclearEngagement\\';
-        if (strpos($class, $prefix) !== 0) {
-            return;
-        }
-        $relative = str_replace('\\', '/', substr($class, strlen($prefix)));
-        $paths = [];
-        $paths[] = NUCLEN_PLUGIN_DIR . $relative . '.php';
-        $segments = explode('/', $relative);
-        if (in_array($segments[0], ['Admin','Front'], true)) {
-            $segments[0] = strtolower($segments[0]);
-            $paths[] = NUCLEN_PLUGIN_DIR . implode('/', $segments) . '.php';
-            if (isset($segments[1])) {
-                $paths[] = NUCLEN_PLUGIN_DIR . $segments[0] . '/traits/' . $segments[1] . '.php';
-            }
-        }
-        $paths[] = NUCLEN_PLUGIN_DIR . 'inc/' . $relative . '.php';
-        $paths[] = NUCLEN_PLUGIN_DIR . 'inc/Core/' . $relative . '.php';
-        foreach ($paths as $file) {
-            if (file_exists($file)) {
-                require_once $file;
-                return;
-            }
-        }
-    });
+	spl_autoload_register(static function ($class) {
+		$prefix = 'NuclearEngagement\\';
+		if (strpos($class, $prefix) !== 0) {
+			return;
+		}
+		$relative = str_replace('\\', '/', substr($class, strlen($prefix)));
+		$paths = [];
+		$paths[] = NUCLEN_PLUGIN_DIR . $relative . '.php';
+		$segments = explode('/', $relative);
+		if (in_array($segments[0], ['Admin','Front'], true)) {
+			$segments[0] = strtolower($segments[0]);
+			$paths[] = NUCLEN_PLUGIN_DIR . implode('/', $segments) . '.php';
+			if (isset($segments[1])) {
+				$paths[] = NUCLEN_PLUGIN_DIR . $segments[0] . '/traits/' . $segments[1] . '.php';
+			}
+		}
+		$paths[] = NUCLEN_PLUGIN_DIR . 'inc/' . $relative . '.php';
+		$paths[] = NUCLEN_PLUGIN_DIR . 'inc/Core/' . $relative . '.php';
+		foreach ($paths as $file) {
+			if (file_exists($file)) {
+				require_once $file;
+				return;
+			}
+		}
+	});
 
-    require_once dirname(__DIR__) . '/nuclear-engagement/inc/Core/Container.php';
-    require_once dirname(__DIR__) . '/nuclear-engagement/inc/Core/SettingsRepository.php';
-    require_once dirname(__DIR__) . '/nuclear-engagement/inc/Core/Defaults.php';
-    require_once dirname(__DIR__) . '/nuclear-engagement/inc/Core/ContainerRegistrar.php';
-    require_once dirname(__DIR__) . '/nuclear-engagement/inc/Core/Loader.php';
-    require_once dirname(__DIR__) . '/nuclear-engagement/inc/Core/Plugin.php';
+	require_once dirname(__DIR__) . '/nuclear-engagement/inc/Core/Container.php';
+	require_once dirname(__DIR__) . '/nuclear-engagement/inc/Core/SettingsRepository.php';
+	require_once dirname(__DIR__) . '/nuclear-engagement/inc/Core/Defaults.php';
+	require_once dirname(__DIR__) . '/nuclear-engagement/inc/Core/ContainerRegistrar.php';
+	require_once dirname(__DIR__) . '/nuclear-engagement/inc/Core/Loader.php';
+	require_once dirname(__DIR__) . '/nuclear-engagement/inc/Core/Plugin.php';
 
-    class PluginTest extends TestCase {
-        protected function setUp(): void {
-            $GLOBALS['ph_actions'] = [];
-            $GLOBALS['ph_filters'] = [];
-            $GLOBALS['ph_activation'] = [];
-            $GLOBALS['ph_removed'] = [];
-            \NuclearEngagement\Services\LoggingService::$notices = [];
-            \NuclearEngagement\OptinData::$table_exists_calls = 0;
-            \NuclearEngagement\OptinData::$create_table_calls = 0;
-            \NuclearEngagement\OptinData::$table_exists = false;
-            \NuclearEngagement\OptinData::$create_result = true;
-            SettingsRepository::reset_for_tests();
-            Container::getInstance()->reset();
-        }
+	class PluginTest extends TestCase {
+		protected function setUp(): void {
+			$GLOBALS['ph_actions'] = [];
+			$GLOBALS['ph_filters'] = [];
+			$GLOBALS['ph_activation'] = [];
+			$GLOBALS['ph_removed'] = [];
+			\NuclearEngagement\Services\LoggingService::$notices = [];
+			\NuclearEngagement\OptinData::$table_exists_calls = 0;
+			\NuclearEngagement\OptinData::$create_table_calls = 0;
+			\NuclearEngagement\OptinData::$table_exists = false;
+			\NuclearEngagement\OptinData::$create_result = true;
+			SettingsRepository::reset_for_tests();
+			Container::getInstance()->reset();
+		}
 
-        public function test_plugin_initializes_and_registers_hooks(): void {
-            $plugin = new Plugin();
+		public function test_plugin_initializes_and_registers_hooks(): void {
+			$plugin = new Plugin();
 
-            $repo = $plugin->nuclen_get_settings_repository();
-            $this->assertSame(Defaults::nuclen_get_default_settings(), $repo->get_defaults());
+			$repo = $plugin->nuclen_get_settings_repository();
+			$this->assertSame(Defaults::nuclen_get_default_settings(), $repo->get_defaults());
 
-            $container = $plugin->get_container();
-            $this->assertTrue($container->has('settings'));
-            $this->assertSame($repo, $container->get('settings'));
+			$container = $plugin->get_container();
+			$this->assertTrue($container->has('settings'));
+			$this->assertSame($repo, $container->get('settings'));
 
-            $loader = $plugin->nuclen_get_loader();
-            $ref = new \ReflectionProperty($loader, 'actions');
-            $ref->setAccessible(true);
-            $actions = $ref->getValue($loader);
-            $found = false;
-            foreach ($actions as $a) {
-                if ($a['hook'] === 'admin_menu' && $a['callback'] === 'nuclen_add_setup_page') {
-                    $found = true;
-                }
-            }
-            $this->assertTrue($found, 'admin_menu action not registered');
+			$loader = $plugin->nuclen_get_loader();
+			$ref = new \ReflectionProperty($loader, 'actions');
+			$ref->setAccessible(true);
+			$actions = $ref->getValue($loader);
+			$found = false;
+			foreach ($actions as $a) {
+				if ($a['hook'] === 'admin_menu' && $a['callback'] === 'nuclen_add_setup_page') {
+					$found = true;
+				}
+			}
+			$this->assertTrue($found, 'admin_menu action not registered');
 
-            $ref = new \ReflectionProperty($loader, 'filters');
-            $ref->setAccessible(true);
-            $filters = $ref->getValue($loader);
-            $found = false;
-            foreach ($filters as $f) {
-                if ($f['hook'] === 'the_content' && $f['callback'] === 'nuclen_auto_insert_shortcodes' && $f['priority'] === 50) {
-                    $found = true;
-                }
-            }
-            $this->assertTrue($found, 'the_content filter not registered');
+			$ref = new \ReflectionProperty($loader, 'filters');
+			$ref->setAccessible(true);
+			$filters = $ref->getValue($loader);
+			$found = false;
+			foreach ($filters as $f) {
+				if ($f['hook'] === 'the_content' && $f['callback'] === 'nuclen_auto_insert_shortcodes' && $f['priority'] === 50) {
+					$found = true;
+				}
+			}
+			$this->assertTrue($found, 'the_content filter not registered');
 
-            $registered_hooks = array_column($GLOBALS['ph_actions'], 0);
-            $this->assertContains(\NuclearEngagement\Services\AutoGenerationService::START_HOOK, $registered_hooks);
-            $this->assertContains(\NuclearEngagement\Services\AutoGenerationService::QUEUE_HOOK, $registered_hooks);
-            $this->assertContains('nuclen_poll_generation', $registered_hooks);
-            $this->assertContains('transition_post_status', $registered_hooks);
-        }
+			$registered_hooks = array_column($GLOBALS['ph_actions'], 0);
+			$this->assertContains(\NuclearEngagement\Services\AutoGenerationService::START_HOOK, $registered_hooks);
+			$this->assertContains(\NuclearEngagement\Services\AutoGenerationService::QUEUE_HOOK, $registered_hooks);
+			$this->assertContains('nuclen_poll_generation', $registered_hooks);
+			$this->assertContains('transition_post_status', $registered_hooks);
+		}
 
-        public function test_activation_hook_callback_executes(): void {
-            $plugin = new Plugin();
-            $this->assertNotEmpty($GLOBALS['ph_activation']);
-            [$file, $cb] = $GLOBALS['ph_activation'][0];
-            $expected = dirname(__DIR__) . '/nuclear-engagement/nuclear-engagement.php';
-            $this->assertSame($expected, $file);
-            $this->assertIsCallable($cb);
+		public function test_activation_hook_callback_executes(): void {
+			$plugin = new Plugin();
+			$this->assertNotEmpty($GLOBALS['ph_activation']);
+			[$file, $cb] = $GLOBALS['ph_activation'][0];
+			$expected = dirname(__DIR__) . '/nuclear-engagement/nuclear-engagement.php';
+			$this->assertSame($expected, $file);
+			$this->assertIsCallable($cb);
 
-            \NuclearEngagement\OptinData::$table_exists = false;
-            \NuclearEngagement\OptinData::$create_result = true;
-            call_user_func($cb);
-            $this->assertSame(1, \NuclearEngagement\OptinData::$create_table_calls);
-            $this->assertEmpty(\NuclearEngagement\Services\LoggingService::$notices);
-        }
-    }
+			\NuclearEngagement\OptinData::$table_exists = false;
+			\NuclearEngagement\OptinData::$create_result = true;
+			call_user_func($cb);
+			$this->assertSame(1, \NuclearEngagement\OptinData::$create_table_calls);
+			$this->assertEmpty(\NuclearEngagement\Services\LoggingService::$notices);
+		}
+	}
 }

--- a/tests/PointerControllerTest.php
+++ b/tests/PointerControllerTest.php
@@ -1,96 +1,96 @@
 <?php
 namespace NuclearEngagement\Services {
-    class LoggingService {
-        public static array $exceptions = [];
-        public static function log_exception(\Throwable $e): void {
-            self::$exceptions[] = $e->getMessage();
-        }
-    }
+	class LoggingService {
+		public static array $exceptions = [];
+		public static function log_exception(\Throwable $e): void {
+			self::$exceptions[] = $e->getMessage();
+		}
+	}
 }
 
 namespace {
-    use PHPUnit\Framework\TestCase;
-    use NuclearEngagement\Admin\Controller\Ajax\PointerController;
-    use NuclearEngagement\Services\PointerService;
-    if (!function_exists('check_ajax_referer')) {
-        function check_ajax_referer($a, $f, $d = false) { return true; }
-    }
-    if (!function_exists('current_user_can')) {
-        function current_user_can($c) { return true; }
-    }
-    if (!function_exists('wp_send_json_success')) {
-        function wp_send_json_success($d) { $GLOBALS['json_response'] = ['success', $d]; }
-    }
-    if (!function_exists('wp_send_json_error')) {
-        function wp_send_json_error($d, $c = 0) { $GLOBALS['json_response'] = ['error', $d, $c]; }
-    }
-    if (!function_exists('status_header')) {
-        function status_header($c) { $GLOBALS['status_header'] = $c; }
-    }
-    if (!function_exists('sanitize_text_field')) {
-        function sanitize_text_field($t) { return is_string($t) ? trim($t) : ''; }
-    }
-    if (!function_exists('wp_unslash')) {
-        function wp_unslash($d) { return $d; }
-    }
-    if (!function_exists('get_current_user_id')) {
-        function get_current_user_id() { return 5; }
-    }
-    if (!function_exists('__')) {
-        function __($t, $d = null) { return $t; }
-    }
+	use PHPUnit\Framework\TestCase;
+	use NuclearEngagement\Admin\Controller\Ajax\PointerController;
+	use NuclearEngagement\Services\PointerService;
+	if (!function_exists('check_ajax_referer')) {
+		function check_ajax_referer($a, $f, $d = false) { return true; }
+	}
+	if (!function_exists('current_user_can')) {
+		function current_user_can($c) { return true; }
+	}
+	if (!function_exists('wp_send_json_success')) {
+		function wp_send_json_success($d) { $GLOBALS['json_response'] = ['success', $d]; }
+	}
+	if (!function_exists('wp_send_json_error')) {
+		function wp_send_json_error($d, $c = 0) { $GLOBALS['json_response'] = ['error', $d, $c]; }
+	}
+	if (!function_exists('status_header')) {
+		function status_header($c) { $GLOBALS['status_header'] = $c; }
+	}
+	if (!function_exists('sanitize_text_field')) {
+		function sanitize_text_field($t) { return is_string($t) ? trim($t) : ''; }
+	}
+	if (!function_exists('wp_unslash')) {
+		function wp_unslash($d) { return $d; }
+	}
+	if (!function_exists('get_current_user_id')) {
+		function get_current_user_id() { return 5; }
+	}
+	if (!function_exists('__')) {
+		function __($t, $d = null) { return $t; }
+	}
 
-    require_once dirname(__DIR__) . '/nuclear-engagement/admin/Controller/Ajax/BaseController.php';
-    require_once dirname(__DIR__) . '/nuclear-engagement/admin/Controller/Ajax/PointerController.php';
+	require_once dirname(__DIR__) . '/nuclear-engagement/admin/Controller/Ajax/BaseController.php';
+	require_once dirname(__DIR__) . '/nuclear-engagement/admin/Controller/Ajax/PointerController.php';
 
-    class DummyPointerService extends PointerService {
-        public array $args = [];
-        public ?\Exception $throw = null;
+	class DummyPointerService extends PointerService {
+		public array $args = [];
+		public ?\Exception $throw = null;
 
-        public function dismissPointer(string $pointerId, int $userId): void {
-            $this->args[] = [$pointerId, $userId];
-            if ($this->throw) {
-                throw $this->throw;
-            }
-        }
-    }
+		public function dismissPointer(string $pointerId, int $userId): void {
+			$this->args[] = [$pointerId, $userId];
+			if ($this->throw) {
+				throw $this->throw;
+			}
+		}
+	}
 
-    class PointerControllerTest extends TestCase {
-        protected function setUp(): void {
-            $_POST = [];
-            $GLOBALS['json_response'] = null;
-            $GLOBALS['status_header'] = null;
-            \NuclearEngagement\Services\LoggingService::$exceptions = [];
-        }
+	class PointerControllerTest extends TestCase {
+		protected function setUp(): void {
+			$_POST = [];
+			$GLOBALS['json_response'] = null;
+			$GLOBALS['status_header'] = null;
+			\NuclearEngagement\Services\LoggingService::$exceptions = [];
+		}
 
-        public function test_dismiss_success(): void {
-            $service = new DummyPointerService();
-            $controller = new PointerController($service);
-            $_POST = ['pointer' => 'abc', 'nonce' => 'n'];
-            $controller->dismiss();
-            $this->assertSame([['abc', 5]], $service->args);
-            $this->assertSame(['success', ['message' => 'Pointer dismissed.']], $GLOBALS['json_response']);
-        }
+		public function test_dismiss_success(): void {
+			$service = new DummyPointerService();
+			$controller = new PointerController($service);
+			$_POST = ['pointer' => 'abc', 'nonce' => 'n'];
+			$controller->dismiss();
+			$this->assertSame([['abc', 5]], $service->args);
+			$this->assertSame(['success', ['message' => 'Pointer dismissed.']], $GLOBALS['json_response']);
+		}
 
-        public function test_invalid_input_returns_error(): void {
-            $service = new DummyPointerService();
-            $service->throw = new \InvalidArgumentException('bad');
-            $controller = new PointerController($service);
-            $_POST = ['pointer' => '', 'nonce' => 'n'];
-            $controller->dismiss();
-            $this->assertSame([['', 5]], $service->args);
-            $this->assertSame(500, $GLOBALS['status_header']);
-            $this->assertSame(['error', ['message' => 'bad'], 500], $GLOBALS['json_response']);
-        }
+		public function test_invalid_input_returns_error(): void {
+			$service = new DummyPointerService();
+			$service->throw = new \InvalidArgumentException('bad');
+			$controller = new PointerController($service);
+			$_POST = ['pointer' => '', 'nonce' => 'n'];
+			$controller->dismiss();
+			$this->assertSame([['', 5]], $service->args);
+			$this->assertSame(500, $GLOBALS['status_header']);
+			$this->assertSame(['error', ['message' => 'bad'], 500], $GLOBALS['json_response']);
+		}
 
-        public function test_exception_logs_and_returns_generic_error(): void {
-            $service = new DummyPointerService();
-            $service->throw = new \Exception('fail');
-            $controller = new PointerController($service);
-            $_POST = ['pointer' => 'abc', 'nonce' => 'n'];
-            $controller->dismiss();
-            $this->assertSame('fail', \NuclearEngagement\Services\LoggingService::$exceptions[0]);
-            $this->assertSame(['error', ['message' => 'An error occurred'], 500], $GLOBALS['json_response']);
-        }
-    }
+		public function test_exception_logs_and_returns_generic_error(): void {
+			$service = new DummyPointerService();
+			$service->throw = new \Exception('fail');
+			$controller = new PointerController($service);
+			$_POST = ['pointer' => 'abc', 'nonce' => 'n'];
+			$controller->dismiss();
+			$this->assertSame('fail', \NuclearEngagement\Services\LoggingService::$exceptions[0]);
+			$this->assertSame(['error', ['message' => 'An error occurred'], 500], $GLOBALS['json_response']);
+		}
+	}
 }

--- a/tests/PointerServiceTest.php
+++ b/tests/PointerServiceTest.php
@@ -3,27 +3,27 @@ use PHPUnit\Framework\TestCase;
 use NuclearEngagement\Services\PointerService;
 
 class PointerServiceTest extends TestCase {
-    protected function setUp(): void {
-        $GLOBALS['wp_user_meta'] = [];
-    }
+	protected function setUp(): void {
+		$GLOBALS['wp_user_meta'] = [];
+	}
 
-    public function test_dismiss_pointer_sets_meta(): void {
-        $service = new PointerService();
-        $service->dismissPointer('intro', 10);
-        $this->assertTrue(
-            $GLOBALS['wp_user_meta'][10]['nuclen_pointer_dismissed_intro'] ?? false
-        );
-    }
+	public function test_dismiss_pointer_sets_meta(): void {
+		$service = new PointerService();
+		$service->dismissPointer('intro', 10);
+		$this->assertTrue(
+			$GLOBALS['wp_user_meta'][10]['nuclen_pointer_dismissed_intro'] ?? false
+		);
+	}
 
-    public function test_get_undismissed_filters_dismissed(): void {
-        $GLOBALS['wp_user_meta'][5]['nuclen_pointer_dismissed_a'] = true;
-        $pointers = [
-            ['id' => 'a', 'title' => 'A'],
-            ['id' => 'b', 'title' => 'B'],
-        ];
-        $service = new PointerService();
-        $undismissed = $service->getUndismissedPointers($pointers, 5);
-        $this->assertCount(1, $undismissed);
-        $this->assertSame('b', $undismissed[0]['id']);
-    }
+	public function test_get_undismissed_filters_dismissed(): void {
+		$GLOBALS['wp_user_meta'][5]['nuclen_pointer_dismissed_a'] = true;
+		$pointers = [
+			['id' => 'a', 'title' => 'A'],
+			['id' => 'b', 'title' => 'B'],
+		];
+		$service = new PointerService();
+		$undismissed = $service->getUndismissedPointers($pointers, 5);
+		$this->assertCount(1, $undismissed);
+		$this->assertSame('b', $undismissed[0]['id']);
+	}
 }

--- a/tests/PostDataFetcherTest.php
+++ b/tests/PostDataFetcherTest.php
@@ -1,91 +1,91 @@
 <?php
 namespace NuclearEngagement\Services {
-    class LoggingService {
-        public static array $logs = [];
-        public static function log(string $msg): void { self::$logs[] = $msg; }
-    }
+	class LoggingService {
+		public static array $logs = [];
+		public static function log(string $msg): void { self::$logs[] = $msg; }
+	}
 }
 
 namespace {
-    use PHPUnit\Framework\TestCase;
-    use NuclearEngagement\Services\PostDataFetcher;
-    class PDF_WPDB {
-        public $posts = 'wp_posts';
-        public $postmeta = 'wp_postmeta';
-        public string $last_error = '';
-        public array $args = [];
-        public int $calls = 0;
-        public function prepare($sql, ...$args) { $this->args = $args; return 'SQL'; }
-        public function get_results($sql) {
-            $this->calls++;
-            if ($this->last_error) { return []; }
-            $ids = array_slice($this->args, 2);
-            $rows = [];
-            foreach ($ids as $id) {
-                $rows[] = (object)[ 'ID'=>$id, 'post_title'=>'T'.$id, 'post_content'=>'C'.$id ];
-            }
-            return $rows;
-        }
-    }
+	use PHPUnit\Framework\TestCase;
+	use NuclearEngagement\Services\PostDataFetcher;
+	class PDF_WPDB {
+		public $posts = 'wp_posts';
+		public $postmeta = 'wp_postmeta';
+		public string $last_error = '';
+		public array $args = [];
+		public int $calls = 0;
+		public function prepare($sql, ...$args) { $this->args = $args; return 'SQL'; }
+		public function get_results($sql) {
+			$this->calls++;
+			if ($this->last_error) { return []; }
+			$ids = array_slice($this->args, 2);
+			$rows = [];
+			foreach ($ids as $id) {
+				$rows[] = (object)[ 'ID'=>$id, 'post_title'=>'T'.$id, 'post_content'=>'C'.$id ];
+			}
+			return $rows;
+		}
+	}
 
-    if (!isset($GLOBALS['wp_cache'])) { $GLOBALS['wp_cache'] = []; }
-    if (!function_exists('wp_cache_get')) {
-        function wp_cache_get($key, $group = '', $force = false, &$found = null) {
-            $found = isset($GLOBALS['wp_cache'][$group][$key]);
-            return $GLOBALS['wp_cache'][$group][$key] ?? false;
-        }
-    }
-    if (!function_exists('wp_cache_set')) {
-        function wp_cache_set($key, $value, $group = '', $ttl = 0) {
-            $GLOBALS['wp_cache'][$group][$key] = $value;
-        }
-    }
-    if (!function_exists('wp_cache_flush_group')) {
-        function wp_cache_flush_group($group) { unset($GLOBALS['wp_cache'][$group]); }
-    }
-    if (!function_exists('wp_cache_flush')) {
-        function wp_cache_flush() { $GLOBALS['wp_cache'] = []; }
-    }
-    if (!function_exists('get_current_blog_id')) { function get_current_blog_id(){ return 1; } }
-    if (!function_exists('add_action')) { function add_action(...$a){} }
+	if (!isset($GLOBALS['wp_cache'])) { $GLOBALS['wp_cache'] = []; }
+	if (!function_exists('wp_cache_get')) {
+		function wp_cache_get($key, $group = '', $force = false, &$found = null) {
+			$found = isset($GLOBALS['wp_cache'][$group][$key]);
+			return $GLOBALS['wp_cache'][$group][$key] ?? false;
+		}
+	}
+	if (!function_exists('wp_cache_set')) {
+		function wp_cache_set($key, $value, $group = '', $ttl = 0) {
+			$GLOBALS['wp_cache'][$group][$key] = $value;
+		}
+	}
+	if (!function_exists('wp_cache_flush_group')) {
+		function wp_cache_flush_group($group) { unset($GLOBALS['wp_cache'][$group]); }
+	}
+	if (!function_exists('wp_cache_flush')) {
+		function wp_cache_flush() { $GLOBALS['wp_cache'] = []; }
+	}
+	if (!function_exists('get_current_blog_id')) { function get_current_blog_id(){ return 1; } }
+	if (!function_exists('add_action')) { function add_action(...$a){} }
 
-    require_once __DIR__ . '/../nuclear-engagement/inc/Services/PostDataFetcher.php';
+	require_once __DIR__ . '/../nuclear-engagement/inc/Services/PostDataFetcher.php';
 
-    class PostDataFetcherTest extends TestCase {
-        protected function setUp(): void {
-            global $wpdb;
-            $wpdb = new PDF_WPDB();
-            \NuclearEngagement\Services\LoggingService::$logs = [];
-            $GLOBALS['wp_cache'] = [];
-        }
+	class PostDataFetcherTest extends TestCase {
+		protected function setUp(): void {
+			global $wpdb;
+			$wpdb = new PDF_WPDB();
+			\NuclearEngagement\Services\LoggingService::$logs = [];
+			$GLOBALS['wp_cache'] = [];
+		}
 
-        public function test_fetch_logs_error_and_returns_empty_array(): void {
-            $fetcher = new PostDataFetcher();
-            $rows = $fetcher->fetch([1]);
-            $this->assertSame([], $rows);
-            $this->assertSame(['Post fetch error: fail'], \NuclearEngagement\Services\LoggingService::$logs);
-        }
+		public function test_fetch_logs_error_and_returns_empty_array(): void {
+			$fetcher = new PostDataFetcher();
+			$rows = $fetcher->fetch([1]);
+			$this->assertSame([], $rows);
+			$this->assertSame(['Post fetch error: fail'], \NuclearEngagement\Services\LoggingService::$logs);
+		}
 
-        public function test_fetch_uses_cache(): void {
-            global $wpdb;
-            $wpdb->last_error = '';
-            $fetcher = new PostDataFetcher();
-            $rows1 = $fetcher->fetch([1]);
-            $this->assertSame(1, $wpdb->calls);
-            $rows2 = $fetcher->fetch([1]);
-            $this->assertSame(1, $wpdb->calls, 'second call should use cache');
-            $this->assertEquals($rows1, $rows2);
-        }
+		public function test_fetch_uses_cache(): void {
+			global $wpdb;
+			$wpdb->last_error = '';
+			$fetcher = new PostDataFetcher();
+			$rows1 = $fetcher->fetch([1]);
+			$this->assertSame(1, $wpdb->calls);
+			$rows2 = $fetcher->fetch([1]);
+			$this->assertSame(1, $wpdb->calls, 'second call should use cache');
+			$this->assertEquals($rows1, $rows2);
+		}
 
-        public function test_clear_cache_forces_refetch(): void {
-            global $wpdb;
-            $wpdb->last_error = '';
-            $fetcher = new PostDataFetcher();
-            $fetcher->fetch([2]);
-            $this->assertSame(1, $wpdb->calls);
-            PostDataFetcher::clear_cache();
-            $fetcher->fetch([2]);
-            $this->assertSame(2, $wpdb->calls);
-        }
-    }
+		public function test_clear_cache_forces_refetch(): void {
+			global $wpdb;
+			$wpdb->last_error = '';
+			$fetcher = new PostDataFetcher();
+			$fetcher->fetch([2]);
+			$this->assertSame(1, $wpdb->calls);
+			PostDataFetcher::clear_cache();
+			$fetcher->fetch([2]);
+			$this->assertSame(2, $wpdb->calls);
+		}
+	}
 }

--- a/tests/PostMetaMigrationTest.php
+++ b/tests/PostMetaMigrationTest.php
@@ -1,58 +1,58 @@
 <?php
 namespace NuclearEngagement\Services {
-    // Stub LoggingService to capture log messages
-    class LoggingService {
-        public static array $logs = [];
-        public static function log(string $msg): void {
-            self::$logs[] = $msg;
-        }
-    }
+	// Stub LoggingService to capture log messages
+	class LoggingService {
+		public static array $logs = [];
+		public static function log(string $msg): void {
+			self::$logs[] = $msg;
+		}
+	}
 }
 
 namespace {
-    use PHPUnit\Framework\TestCase;
-    use NuclearEngagement\Services\LoggingService;
+	use PHPUnit\Framework\TestCase;
+	use NuclearEngagement\Services\LoggingService;
 
-    class PostMetaMigrationTest extends TestCase {
-        protected function setUp(): void {
-            global $wpdb, $wp_options, $wp_autoload;
-            $wp_options = $wp_autoload = [];
-            $wpdb = new class {
-                public string $last_error = '';
-                public string $postmeta = 'wp_postmeta';
-                public int $queries = 0;
-                public function prepare($q, ...$args) { return $q; }
-                public function query($sql) {
-                    $this->queries++;
-                    $this->last_error = 'fail';
-                    return false;
-                }
-            };
-            LoggingService::$logs = [];
-        }
+	class PostMetaMigrationTest extends TestCase {
+		protected function setUp(): void {
+			global $wpdb, $wp_options, $wp_autoload;
+			$wp_options = $wp_autoload = [];
+			$wpdb = new class {
+				public string $last_error = '';
+				public string $postmeta = 'wp_postmeta';
+				public int $queries = 0;
+				public function prepare($q, ...$args) { return $q; }
+				public function query($sql) {
+					$this->queries++;
+					$this->last_error = 'fail';
+					return false;
+				}
+			};
+			LoggingService::$logs = [];
+		}
 
-        private function load_bootstrap(): void {
-            if (!defined('NUCLEN_PLUGIN_FILE')) {
-                define('NUCLEN_PLUGIN_FILE', dirname(__DIR__) . '/nuclear-engagement/nuclear-engagement.php');
-            }
-            // Stub classes used when bootstrap runs
-            if (!class_exists('NuclearEngagement\\MetaRegistration')) {
-                class_alias(\stdClass::class, 'NuclearEngagement\\MetaRegistration');
-            }
-            if (!class_exists('NuclearEngagement\\Plugin')) {
-                class_alias(\stdClass::class, 'NuclearEngagement\\Plugin');
-            }
-            require_once dirname(__DIR__) . '/nuclear-engagement/bootstrap.php';
-        }
+		private function load_bootstrap(): void {
+			if (!defined('NUCLEN_PLUGIN_FILE')) {
+				define('NUCLEN_PLUGIN_FILE', dirname(__DIR__) . '/nuclear-engagement/nuclear-engagement.php');
+			}
+			// Stub classes used when bootstrap runs
+			if (!class_exists('NuclearEngagement\\MetaRegistration')) {
+				class_alias(\stdClass::class, 'NuclearEngagement\\MetaRegistration');
+			}
+			if (!class_exists('NuclearEngagement\\Plugin')) {
+				class_alias(\stdClass::class, 'NuclearEngagement\\Plugin');
+			}
+			require_once dirname(__DIR__) . '/nuclear-engagement/bootstrap.php';
+		}
 
-        public function test_logs_error_and_sets_option_on_failure(): void {
-            $this->load_bootstrap();
-            $installer = new \NuclearEngagement\Core\Installer();
-            $installer->migrate_post_meta();
-            $this->assertNotEmpty(LoggingService::$logs);
-            $this->assertSame('fail', get_option('nuclen_meta_migration_error'));
-            $this->assertFalse(get_option('nuclen_meta_migration_done'));
-        }
-    }
+		public function test_logs_error_and_sets_option_on_failure(): void {
+			$this->load_bootstrap();
+			$installer = new \NuclearEngagement\Core\Installer();
+			$installer->migrate_post_meta();
+			$this->assertNotEmpty(LoggingService::$logs);
+			$this->assertSame('fail', get_option('nuclen_meta_migration_error'));
+			$this->assertFalse(get_option('nuclen_meta_migration_done'));
+		}
+	}
 }
 

--- a/tests/PostsCountControllerTest.php
+++ b/tests/PostsCountControllerTest.php
@@ -1,63 +1,63 @@
 <?php
 namespace NuclearEngagement\Services {
-    class LoggingService {
-        public static array $exceptions = [];
-        public static function log_exception(\Throwable $e): void { self::$exceptions[] = $e->getMessage(); }
-    }
+	class LoggingService {
+		public static array $exceptions = [];
+		public static function log_exception(\Throwable $e): void { self::$exceptions[] = $e->getMessage(); }
+	}
 }
 
 namespace {
-    use PHPUnit\Framework\TestCase;
-    use NuclearEngagement\Admin\Controller\Ajax\PostsCountController;
-    use NuclearEngagement\Requests\PostsCountRequest;
-    // ------------------------------------------------------
-    // Basic stubs for WordPress AJAX functions
-    // ------------------------------------------------------
-    if (!function_exists('check_ajax_referer')) { function check_ajax_referer($a,$f,$d=false){ return true; } }
-    if (!function_exists('current_user_can')) { function current_user_can($c){ return true; } }
-    if (!function_exists('wp_send_json_success')) { function wp_send_json_success($data){ $GLOBALS['json_response'] = ['success',$data]; } }
-    if (!function_exists('wp_send_json_error')) { function wp_send_json_error($data,$code=0){ $GLOBALS['json_response'] = ['error',$data,$code]; } }
-    if (!function_exists('status_header')) { function status_header($code){ $GLOBALS['status_header'] = $code; } }
-    if (!function_exists('sanitize_text_field')) { function sanitize_text_field($t){ return $t; } }
-    if (!function_exists('wp_unslash')) { function wp_unslash($d){ return $d; } }
-    if (!function_exists('absint')) { function absint($v){ return abs(intval($v)); } }
-    if (!function_exists('__')) { function __($t,$d=null){ return $t; } }
+	use PHPUnit\Framework\TestCase;
+	use NuclearEngagement\Admin\Controller\Ajax\PostsCountController;
+	use NuclearEngagement\Requests\PostsCountRequest;
+	// ------------------------------------------------------
+	// Basic stubs for WordPress AJAX functions
+	// ------------------------------------------------------
+	if (!function_exists('check_ajax_referer')) { function check_ajax_referer($a,$f,$d=false){ return true; } }
+	if (!function_exists('current_user_can')) { function current_user_can($c){ return true; } }
+	if (!function_exists('wp_send_json_success')) { function wp_send_json_success($data){ $GLOBALS['json_response'] = ['success',$data]; } }
+	if (!function_exists('wp_send_json_error')) { function wp_send_json_error($data,$code=0){ $GLOBALS['json_response'] = ['error',$data,$code]; } }
+	if (!function_exists('status_header')) { function status_header($code){ $GLOBALS['status_header'] = $code; } }
+	if (!function_exists('sanitize_text_field')) { function sanitize_text_field($t){ return $t; } }
+	if (!function_exists('wp_unslash')) { function wp_unslash($d){ return $d; } }
+	if (!function_exists('absint')) { function absint($v){ return abs(intval($v)); } }
+	if (!function_exists('__')) { function __($t,$d=null){ return $t; } }
 
-    require_once dirname(__DIR__) . '/nuclear-engagement/admin/Controller/Ajax/BaseController.php';
-    require_once dirname(__DIR__) . '/nuclear-engagement/admin/Controller/Ajax/PostsCountController.php';
-    require_once dirname(__DIR__) . '/nuclear-engagement/inc/Requests/PostsCountRequest.php';
+	require_once dirname(__DIR__) . '/nuclear-engagement/admin/Controller/Ajax/BaseController.php';
+	require_once dirname(__DIR__) . '/nuclear-engagement/admin/Controller/Ajax/PostsCountController.php';
+	require_once dirname(__DIR__) . '/nuclear-engagement/inc/Requests/PostsCountRequest.php';
 
-    class DummyService {
-        public array $requests = [];
-        public array $result = ['count'=>1,'post_ids'=>[7]];
-        public function getPostsCount(PostsCountRequest $req): array {
-            $this->requests[] = $req;
-            return $this->result;
-        }
-    }
+	class DummyService {
+		public array $requests = [];
+		public array $result = ['count'=>1,'post_ids'=>[7]];
+		public function getPostsCount(PostsCountRequest $req): array {
+			$this->requests[] = $req;
+			return $this->result;
+		}
+	}
 
-    class PostsCountControllerTest extends TestCase {
-        protected function setUp(): void {
-            $_POST = [];
-            $GLOBALS['json_response'] = null;
-        }
+	class PostsCountControllerTest extends TestCase {
+		protected function setUp(): void {
+			$_POST = [];
+			$GLOBALS['json_response'] = null;
+		}
 
-        public function test_handle_outputs_json_success(): void {
-            $service = new DummyService();
-            $controller = new PostsCountController($service);
+		public function test_handle_outputs_json_success(): void {
+			$service = new DummyService();
+			$controller = new PostsCountController($service);
 
-            $_POST = [
-                'nuclen_post_type' => 'post',
-                'nuclen_post_status' => 'publish',
-                'nuclen_generate_workflow' => 'quiz',
-                'security' => 'valid',
-            ];
+			$_POST = [
+				'nuclen_post_type' => 'post',
+				'nuclen_post_status' => 'publish',
+				'nuclen_generate_workflow' => 'quiz',
+				'security' => 'valid',
+			];
 
-            $controller->handle();
+			$controller->handle();
 
-            $this->assertSame(['success',$service->result], $GLOBALS['json_response']);
-            $this->assertInstanceOf(PostsCountRequest::class, $service->requests[0]);
-            $this->assertSame('post', $service->requests[0]->postType);
-        }
-    }
+			$this->assertSame(['success',$service->result], $GLOBALS['json_response']);
+			$this->assertInstanceOf(PostsCountRequest::class, $service->requests[0]);
+			$this->assertSame('post', $service->requests[0]->postType);
+		}
+	}
 }

--- a/tests/PostsQueryServiceTest.php
+++ b/tests/PostsQueryServiceTest.php
@@ -1,168 +1,168 @@
 <?php
 namespace NuclearEngagement\Services {
-    // Simplified LoggingService stub
-    class LoggingService {
-        public static array $logs = [];
-        public static function log(string $msg): void { self::$logs[] = $msg; }
-    }
+	// Simplified LoggingService stub
+	class LoggingService {
+		public static array $logs = [];
+		public static function log(string $msg): void { self::$logs[] = $msg; }
+	}
 }
 
 namespace {
-    use PHPUnit\Framework\TestCase;
-    use NuclearEngagement\Services\PostsQueryService;
-    use NuclearEngagement\Requests\PostsCountRequest;
-    use NuclearEngagement\Modules\Summary\Summary_Service;
-    if (!defined('MINUTE_IN_SECONDS')) { define('MINUTE_IN_SECONDS', 60); }
+	use PHPUnit\Framework\TestCase;
+	use NuclearEngagement\Services\PostsQueryService;
+	use NuclearEngagement\Requests\PostsCountRequest;
+	use NuclearEngagement\Modules\Summary\Summary_Service;
+	if (!defined('MINUTE_IN_SECONDS')) { define('MINUTE_IN_SECONDS', 60); }
 
-    // ------------------------------------------------------
-    // Object cache stubs
-    // ------------------------------------------------------
-    if (!isset($GLOBALS['wp_cache'])) { $GLOBALS['wp_cache'] = []; }
-    if (!isset($GLOBALS['transients'])) { $GLOBALS['transients'] = []; }
-    if (!function_exists('wp_cache_get')) {
-        function wp_cache_get($key, $group = '', $force = false, &$found = null) {
-            $found = isset($GLOBALS['wp_cache'][$group][$key]);
-            return $GLOBALS['wp_cache'][$group][$key] ?? false;
-        }
-    }
-    if (!function_exists('wp_cache_set')) {
-        function wp_cache_set($key, $value, $group = '', $ttl = 0) {
-            $GLOBALS['wp_cache'][$group][$key] = $value;
-        }
-    }
-    if (!function_exists('wp_cache_flush_group')) {
-        function wp_cache_flush_group($group) { unset($GLOBALS['wp_cache'][$group]); }
-    }
-    if (!function_exists('wp_cache_flush')) {
-        function wp_cache_flush() { $GLOBALS['wp_cache'] = []; }
-    }
-    if (!function_exists('get_transient')) {
-        function get_transient($key) { return $GLOBALS['transients'][$key] ?? false; }
-    }
-    if (!function_exists('set_transient')) {
-        function set_transient($key, $value, $ttl = 0) { $GLOBALS['transients'][$key] = $value; }
-    }
+	// ------------------------------------------------------
+	// Object cache stubs
+	// ------------------------------------------------------
+	if (!isset($GLOBALS['wp_cache'])) { $GLOBALS['wp_cache'] = []; }
+	if (!isset($GLOBALS['transients'])) { $GLOBALS['transients'] = []; }
+	if (!function_exists('wp_cache_get')) {
+		function wp_cache_get($key, $group = '', $force = false, &$found = null) {
+			$found = isset($GLOBALS['wp_cache'][$group][$key]);
+			return $GLOBALS['wp_cache'][$group][$key] ?? false;
+		}
+	}
+	if (!function_exists('wp_cache_set')) {
+		function wp_cache_set($key, $value, $group = '', $ttl = 0) {
+			$GLOBALS['wp_cache'][$group][$key] = $value;
+		}
+	}
+	if (!function_exists('wp_cache_flush_group')) {
+		function wp_cache_flush_group($group) { unset($GLOBALS['wp_cache'][$group]); }
+	}
+	if (!function_exists('wp_cache_flush')) {
+		function wp_cache_flush() { $GLOBALS['wp_cache'] = []; }
+	}
+	if (!function_exists('get_transient')) {
+		function get_transient($key) { return $GLOBALS['transients'][$key] ?? false; }
+	}
+	if (!function_exists('set_transient')) {
+		function set_transient($key, $value, $ttl = 0) { $GLOBALS['transients'][$key] = $value; }
+	}
 
-    // Basic WordPress stubs
-    if (!function_exists('sanitize_text_field')) { function sanitize_text_field($t){ return $t; } }
-    if (!function_exists('absint')) { function absint($v){ return abs(intval($v)); } }
-    if (!function_exists('wp_unslash')) { function wp_unslash($v){ return $v; } }
+	// Basic WordPress stubs
+	if (!function_exists('sanitize_text_field')) { function sanitize_text_field($t){ return $t; } }
+	if (!function_exists('absint')) { function absint($v){ return abs(intval($v)); } }
+	if (!function_exists('wp_unslash')) { function wp_unslash($v){ return $v; } }
 
-    // ------------------------------------------------------
-    // WPDB stub for getPostsCount
-    // ------------------------------------------------------
-    class PQ_WPDB {
-        public $posts = 'wp_posts';
-        public $postmeta = 'wp_postmeta';
-        public $term_relationships = 'wp_term_relationships';
-        public $term_taxonomy = 'wp_term_taxonomy';
-        public $last_error = '';
-        public int $get_var_calls = 0;
-        public array $ids = [];
-        public int $count = 0;
-        public function prepare($sql, ...$args) {
-            return vsprintf($sql, $args);
-        }
-        public function get_var($sql) {
-            $this->get_var_calls++;
-            return $this->count;
-        }
-        public function get_col($sql) {
-            $limit = 1000; $offset = 0;
-            if (preg_match('/LIMIT (\d+) OFFSET (\d+)/', $sql, $m)) {
-                $limit = (int)$m[1];
-                $offset = (int)$m[2];
-            }
-            return array_slice($this->ids, $offset, $limit);
-        }
-    }
+	// ------------------------------------------------------
+	// WPDB stub for getPostsCount
+	// ------------------------------------------------------
+	class PQ_WPDB {
+		public $posts = 'wp_posts';
+		public $postmeta = 'wp_postmeta';
+		public $term_relationships = 'wp_term_relationships';
+		public $term_taxonomy = 'wp_term_taxonomy';
+		public $last_error = '';
+		public int $get_var_calls = 0;
+		public array $ids = [];
+		public int $count = 0;
+		public function prepare($sql, ...$args) {
+			return vsprintf($sql, $args);
+		}
+		public function get_var($sql) {
+			$this->get_var_calls++;
+			return $this->count;
+		}
+		public function get_col($sql) {
+			$limit = 1000; $offset = 0;
+			if (preg_match('/LIMIT (\d+) OFFSET (\d+)/', $sql, $m)) {
+				$limit = (int)$m[1];
+				$offset = (int)$m[2];
+			}
+			return array_slice($this->ids, $offset, $limit);
+		}
+	}
 
-    require_once dirname(__DIR__) . '/nuclear-engagement/inc/Services/PostsQueryService.php';
-    require_once dirname(__DIR__) . '/nuclear-engagement/inc/Requests/PostsCountRequest.php';
+	require_once dirname(__DIR__) . '/nuclear-engagement/inc/Services/PostsQueryService.php';
+	require_once dirname(__DIR__) . '/nuclear-engagement/inc/Requests/PostsCountRequest.php';
 
-    class PostsQueryServiceTest extends TestCase {
-        protected function setUp(): void {
-            global $wp_cache, $transients, $wp_options;
-            $wp_cache = $transients = $wp_options = [];
-        }
+	class PostsQueryServiceTest extends TestCase {
+		protected function setUp(): void {
+			global $wp_cache, $transients, $wp_options;
+			$wp_cache = $transients = $wp_options = [];
+		}
 
-        public function test_build_query_args_full_request(): void {
-            $req = new PostsCountRequest();
-            $req->postType = 'post';
-            $req->postStatus = 'draft';
-            $req->categoryId = 5;
-            $req->authorId = 3;
-            $req->workflow = 'summary';
-            $req->allowRegenerate = false;
-            $req->regenerateProtected = false;
+		public function test_build_query_args_full_request(): void {
+			$req = new PostsCountRequest();
+			$req->postType = 'post';
+			$req->postStatus = 'draft';
+			$req->categoryId = 5;
+			$req->authorId = 3;
+			$req->workflow = 'summary';
+			$req->allowRegenerate = false;
+			$req->regenerateProtected = false;
 
-            $svc = new PostsQueryService();
-            $args = $svc->buildQueryArgs($req);
+			$svc = new PostsQueryService();
+			$args = $svc->buildQueryArgs($req);
 
-            $expected_meta = [
-                'relation' => 'AND',
-                [ 'key' => Summary_Service::META_KEY, 'compare' => 'NOT EXISTS' ],
-                [
-                    'relation' => 'OR',
-                    [ 'key' => Summary_Service::PROTECTED_KEY, 'compare' => 'NOT EXISTS' ],
-                    [ 'key' => Summary_Service::PROTECTED_KEY, 'value' => '1', 'compare' => '!=' ],
-                ],
-            ];
+			$expected_meta = [
+				'relation' => 'AND',
+				[ 'key' => Summary_Service::META_KEY, 'compare' => 'NOT EXISTS' ],
+				[
+					'relation' => 'OR',
+					[ 'key' => Summary_Service::PROTECTED_KEY, 'compare' => 'NOT EXISTS' ],
+					[ 'key' => Summary_Service::PROTECTED_KEY, 'value' => '1', 'compare' => '!=' ],
+				],
+			];
 
-            $this->assertSame([
-                'post_type' => 'post',
-                'posts_per_page' => -1,
-                'post_status' => 'draft',
-                'fields' => 'ids',
-                'cat' => 5,
-                'author' => 3,
-                'meta_query' => $expected_meta,
-                'update_post_meta_cache' => false,
-                'update_post_term_cache' => false,
-                'cache_results' => false,
-            ], $args);
-        }
+			$this->assertSame([
+				'post_type' => 'post',
+				'posts_per_page' => -1,
+				'post_status' => 'draft',
+				'fields' => 'ids',
+				'cat' => 5,
+				'author' => 3,
+				'meta_query' => $expected_meta,
+				'update_post_meta_cache' => false,
+				'update_post_term_cache' => false,
+				'cache_results' => false,
+			], $args);
+		}
 
-        public function test_build_query_args_no_meta(): void {
-            $req = new PostsCountRequest();
-            $req->postType = 'page';
-            $req->postStatus = 'any';
-            $req->workflow = 'quiz';
-            $req->allowRegenerate = true;
-            $req->regenerateProtected = true;
+		public function test_build_query_args_no_meta(): void {
+			$req = new PostsCountRequest();
+			$req->postType = 'page';
+			$req->postStatus = 'any';
+			$req->workflow = 'quiz';
+			$req->allowRegenerate = true;
+			$req->regenerateProtected = true;
 
-            $svc = new PostsQueryService();
-            $args = $svc->buildQueryArgs($req);
+			$svc = new PostsQueryService();
+			$args = $svc->buildQueryArgs($req);
 
-            $this->assertArrayNotHasKey('meta_query', $args);
-            $this->assertSame('page', $args['post_type']);
-            $this->assertSame('any', $args['post_status']);
-        }
+			$this->assertArrayNotHasKey('meta_query', $args);
+			$this->assertSame('page', $args['post_type']);
+			$this->assertSame('any', $args['post_status']);
+		}
 
-        public function test_get_posts_count_caches_results(): void {
-            global $wpdb, $wp_cache, $transients;
-            $wpdb = new PQ_WPDB();
-            $wpdb->count = 2;
-            $wpdb->ids = [1,2];
+		public function test_get_posts_count_caches_results(): void {
+			global $wpdb, $wp_cache, $transients;
+			$wpdb = new PQ_WPDB();
+			$wpdb->count = 2;
+			$wpdb->ids = [1,2];
 
-            $svc = new PostsQueryService();
-            $req = new PostsCountRequest();
-            $req->postType = 'post';
-            $req->workflow = 'quiz';
+			$svc = new PostsQueryService();
+			$req = new PostsCountRequest();
+			$req->postType = 'post';
+			$req->workflow = 'quiz';
 
-            $res1 = $svc->getPostsCount($req);
-            $this->assertSame(['count'=>2,'post_ids'=>[1,2]], $res1);
-            $this->assertSame(1, $wpdb->get_var_calls);
+			$res1 = $svc->getPostsCount($req);
+			$this->assertSame(['count'=>2,'post_ids'=>[1,2]], $res1);
+			$this->assertSame(1, $wpdb->get_var_calls);
 
-            $res2 = $svc->getPostsCount($req);
-            $this->assertSame($res1, $res2);
-            $this->assertSame(1, $wpdb->get_var_calls, 'uses cached result');
+			$res2 = $svc->getPostsCount($req);
+			$this->assertSame($res1, $res2);
+			$this->assertSame(1, $wpdb->get_var_calls, 'uses cached result');
 
-            PostsQueryService::clear_cache();
+			PostsQueryService::clear_cache();
 
-            $res3 = $svc->getPostsCount($req);
-            $this->assertSame($res1, $res3);
-            $this->assertSame(2, $wpdb->get_var_calls, 'cache cleared');
-        }
-    }
+			$res3 = $svc->getPostsCount($req);
+			$this->assertSame($res1, $res3);
+			$this->assertSame(2, $wpdb->get_var_calls, 'cache cleared');
+		}
+	}
 }

--- a/tests/PublishGenerationHandlerTest.php
+++ b/tests/PublishGenerationHandlerTest.php
@@ -1,84 +1,84 @@
 <?php
 namespace NuclearEngagement\Services {
-    class LoggingService {
-        public static array $logs = [];
-        public static function log(string $msg): void { self::$logs[] = $msg; }
-    }
+	class LoggingService {
+		public static array $logs = [];
+		public static function log(string $msg): void { self::$logs[] = $msg; }
+	}
 }
 
 namespace {
-    use PHPUnit\Framework\TestCase;
-    use NuclearEngagement\Services\PublishGenerationHandler;
-    use NuclearEngagement\Core\SettingsRepository;
-    if (!function_exists('current_user_can')) {
-        function current_user_can($cap, $id = 0) { return $GLOBALS['can_publish'] ?? true; }
-    }
-    if (!function_exists('wp_doing_cron')) {
-        function wp_doing_cron() { return $GLOBALS['doing_cron'] ?? false; }
-    }
-    if (!function_exists('wp_next_scheduled')) {
-        function wp_next_scheduled($hook, $args = null) { return $GLOBALS['next_scheduled'] ?? false; }
-    }
-    if (!function_exists('wp_schedule_single_event')) {
-        function wp_schedule_single_event($timestamp, $hook, $args) {
-            $GLOBALS['scheduled'][] = compact('timestamp','hook','args');
-            return $GLOBALS['schedule_result'] ?? true;
-        }
-    }
-    if (!function_exists('get_post_meta')) {
-        function get_post_meta($post_id, $key, $single) {
-            return $GLOBALS['meta'][$post_id][$key] ?? '';
-        }
-    }
+	use PHPUnit\Framework\TestCase;
+	use NuclearEngagement\Services\PublishGenerationHandler;
+	use NuclearEngagement\Core\SettingsRepository;
+	if (!function_exists('current_user_can')) {
+		function current_user_can($cap, $id = 0) { return $GLOBALS['can_publish'] ?? true; }
+	}
+	if (!function_exists('wp_doing_cron')) {
+		function wp_doing_cron() { return $GLOBALS['doing_cron'] ?? false; }
+	}
+	if (!function_exists('wp_next_scheduled')) {
+		function wp_next_scheduled($hook, $args = null) { return $GLOBALS['next_scheduled'] ?? false; }
+	}
+	if (!function_exists('wp_schedule_single_event')) {
+		function wp_schedule_single_event($timestamp, $hook, $args) {
+			$GLOBALS['scheduled'][] = compact('timestamp','hook','args');
+			return $GLOBALS['schedule_result'] ?? true;
+		}
+	}
+	if (!function_exists('get_post_meta')) {
+		function get_post_meta($post_id, $key, $single) {
+			return $GLOBALS['meta'][$post_id][$key] ?? '';
+		}
+	}
 
-    require_once __DIR__ . '/../nuclear-engagement/inc/Services/PublishGenerationHandler.php';
-    require_once __DIR__ . '/../nuclear-engagement/inc/Core/SettingsRepository.php';
+	require_once __DIR__ . '/../nuclear-engagement/inc/Services/PublishGenerationHandler.php';
+	require_once __DIR__ . '/../nuclear-engagement/inc/Core/SettingsRepository.php';
 
-    class PublishGenerationHandlerTest extends TestCase {
-        protected function setUp(): void {
-            $GLOBALS['scheduled'] = [];
-            $GLOBALS['meta'] = [];
-            $GLOBALS['schedule_result'] = true;
-            $GLOBALS['can_publish'] = true;
-            $GLOBALS['next_scheduled'] = false;
-            $GLOBALS['doing_cron'] = false;
-            \NuclearEngagement\Services\LoggingService::$logs = [];
-            SettingsRepository::reset_for_tests();
-        }
+	class PublishGenerationHandlerTest extends TestCase {
+		protected function setUp(): void {
+			$GLOBALS['scheduled'] = [];
+			$GLOBALS['meta'] = [];
+			$GLOBALS['schedule_result'] = true;
+			$GLOBALS['can_publish'] = true;
+			$GLOBALS['next_scheduled'] = false;
+			$GLOBALS['doing_cron'] = false;
+			\NuclearEngagement\Services\LoggingService::$logs = [];
+			SettingsRepository::reset_for_tests();
+		}
 
-        private function makeHandler(): PublishGenerationHandler {
-            $repo = SettingsRepository::get_instance([
-                'generation_post_types' => ['post'],
-                'auto_generate_quiz_on_publish' => true,
-                'auto_generate_summary_on_publish' => true,
-            ]);
-            return new PublishGenerationHandler($repo);
-        }
+		private function makeHandler(): PublishGenerationHandler {
+			$repo = SettingsRepository::get_instance([
+				'generation_post_types' => ['post'],
+				'auto_generate_quiz_on_publish' => true,
+				'auto_generate_summary_on_publish' => true,
+			]);
+			return new PublishGenerationHandler($repo);
+		}
 
-        public function test_schedules_generation_when_allowed(): void {
-            $handler = $this->makeHandler();
-            $post = (object)[ 'ID' => 1, 'post_type' => 'post' ];
-            $handler->handle_post_publish('publish', 'draft', $post);
-            $this->assertCount(2, $GLOBALS['scheduled']);
-            $this->assertSame([1,'quiz'], $GLOBALS['scheduled'][0]['args']);
-            $this->assertSame([1,'summary'], $GLOBALS['scheduled'][1]['args']);
-        }
+		public function test_schedules_generation_when_allowed(): void {
+			$handler = $this->makeHandler();
+			$post = (object)[ 'ID' => 1, 'post_type' => 'post' ];
+			$handler->handle_post_publish('publish', 'draft', $post);
+			$this->assertCount(2, $GLOBALS['scheduled']);
+			$this->assertSame([1,'quiz'], $GLOBALS['scheduled'][0]['args']);
+			$this->assertSame([1,'summary'], $GLOBALS['scheduled'][1]['args']);
+		}
 
-        public function test_skips_for_protected_or_unauthorized(): void {
-            $handler = $this->makeHandler();
-            $GLOBALS['can_publish'] = false;
-            $GLOBALS['meta'][5]['nuclen_quiz_protected'] = 1;
-            $post = (object)[ 'ID' => 5, 'post_type' => 'post' ];
-            $handler->handle_post_publish('publish', 'draft', $post);
-            $this->assertEmpty($GLOBALS['scheduled']);
-        }
+		public function test_skips_for_protected_or_unauthorized(): void {
+			$handler = $this->makeHandler();
+			$GLOBALS['can_publish'] = false;
+			$GLOBALS['meta'][5]['nuclen_quiz_protected'] = 1;
+			$post = (object)[ 'ID' => 5, 'post_type' => 'post' ];
+			$handler->handle_post_publish('publish', 'draft', $post);
+			$this->assertEmpty($GLOBALS['scheduled']);
+		}
 
-        public function test_logs_when_schedule_fails(): void {
-            $handler = $this->makeHandler();
-            $GLOBALS['schedule_result'] = false;
-            $post = (object)[ 'ID' => 3, 'post_type' => 'post' ];
-            $handler->handle_post_publish('publish', 'draft', $post);
-            $this->assertNotEmpty(\NuclearEngagement\Services\LoggingService::$logs);
-        }
-    }
+		public function test_logs_when_schedule_fails(): void {
+			$handler = $this->makeHandler();
+			$GLOBALS['schedule_result'] = false;
+			$post = (object)[ 'ID' => 3, 'post_type' => 'post' ];
+			$handler->handle_post_publish('publish', 'draft', $post);
+			$this->assertNotEmpty(\NuclearEngagement\Services\LoggingService::$logs);
+		}
+	}
 }

--- a/tests/QuizServiceFailureTest.php
+++ b/tests/QuizServiceFailureTest.php
@@ -1,44 +1,44 @@
 <?php
 namespace NuclearEngagement\Modules\Quiz {
-    function update_post_meta($postId, $key, $value) { return false; }
-    function delete_post_meta($postId, $key) {}
-    function clean_post_cache($id) {}
-    function sanitize_text_field($val) { return $val; }
-    function wp_kses_post($val) { return $val; }
+	function update_post_meta($postId, $key, $value) { return false; }
+	function delete_post_meta($postId, $key) {}
+	function clean_post_cache($id) {}
+	function sanitize_text_field($val) { return $val; }
+	function wp_kses_post($val) { return $val; }
 }
 
 namespace NuclearEngagement\Services {
-    class LoggingService {
-        public static array $logs = [];
-        public static array $notices = [];
-        public static function log(string $msg): void { self::$logs[] = $msg; }
-        public static function notify_admin(string $msg): void { self::$notices[] = $msg; }
-    }
+	class LoggingService {
+		public static array $logs = [];
+		public static array $notices = [];
+		public static function log(string $msg): void { self::$logs[] = $msg; }
+		public static function notify_admin(string $msg): void { self::$notices[] = $msg; }
+	}
 }
 
 namespace {
-    use PHPUnit\Framework\TestCase;
-    use NuclearEngagement\Modules\Quiz\Quiz_Service;
-    class QuizServiceFailureTest extends TestCase {
-        protected function setUp(): void {
-            \NuclearEngagement\Services\LoggingService::$logs = [];
-            \NuclearEngagement\Services\LoggingService::$notices = [];
-        }
+	use PHPUnit\Framework\TestCase;
+	use NuclearEngagement\Modules\Quiz\Quiz_Service;
+	class QuizServiceFailureTest extends TestCase {
+		protected function setUp(): void {
+			\NuclearEngagement\Services\LoggingService::$logs = [];
+			\NuclearEngagement\Services\LoggingService::$notices = [];
+		}
 
-        public function test_save_quiz_data_logs_on_failure(): void {
-            $service = new Quiz_Service();
-            $service->save_quiz_data(1, [ 'questions' => [ [ 'question' => 'Q', 'answers' => ['A'] ] ] ]);
-            $expected = ['Failed to update quiz data for post 1'];
-            $this->assertSame($expected, \NuclearEngagement\Services\LoggingService::$logs);
-            $this->assertSame($expected, \NuclearEngagement\Services\LoggingService::$notices);
-        }
+		public function test_save_quiz_data_logs_on_failure(): void {
+			$service = new Quiz_Service();
+			$service->save_quiz_data(1, [ 'questions' => [ [ 'question' => 'Q', 'answers' => ['A'] ] ] ]);
+			$expected = ['Failed to update quiz data for post 1'];
+			$this->assertSame($expected, \NuclearEngagement\Services\LoggingService::$logs);
+			$this->assertSame($expected, \NuclearEngagement\Services\LoggingService::$notices);
+		}
 
-        public function test_set_protected_logs_on_failure(): void {
-            $service = new Quiz_Service();
-            $service->set_protected(2, true);
-            $expected = ['Failed to update quiz protected flag for post 2'];
-            $this->assertSame($expected, \NuclearEngagement\Services\LoggingService::$logs);
-            $this->assertSame($expected, \NuclearEngagement\Services\LoggingService::$notices);
-        }
-    }
+		public function test_set_protected_logs_on_failure(): void {
+			$service = new Quiz_Service();
+			$service->set_protected(2, true);
+			$expected = ['Failed to update quiz protected flag for post 2'];
+			$this->assertSame($expected, \NuclearEngagement\Services\LoggingService::$logs);
+			$this->assertSame($expected, \NuclearEngagement\Services\LoggingService::$notices);
+		}
+	}
 }

--- a/tests/QuizShortcodeViewTest.php
+++ b/tests/QuizShortcodeViewTest.php
@@ -1,83 +1,83 @@
 <?php
 namespace NuclearEngagement\Front {
-    function get_the_ID() { return $GLOBALS['current_post_id'] ?? 0; }
-    function maybe_unserialize($data) { return is_string($data) ? unserialize($data) : $data; }
+	function get_the_ID() { return $GLOBALS['current_post_id'] ?? 0; }
+	function maybe_unserialize($data) { return is_string($data) ? unserialize($data) : $data; }
 }
 
 namespace {
-    use PHPUnit\Framework\TestCase;
-    use NuclearEngagement\Front\QuizShortcode;
-    use NuclearEngagement\Front\QuizView;
-    use NuclearEngagement\Core\SettingsRepository;
-    if (!function_exists('esc_html')) { function esc_html($t) { return $t; } }
-    if (!function_exists('esc_html__')) { function esc_html__($t,$d=null){ return $t; } }
-    if (!function_exists('__')) { function __($t,$d=null){ return $t; } }
-    if (!function_exists('wp_kses_post')) { function wp_kses_post($html){ return $html; } }
-    if (!function_exists('shortcode_unautop')) { function shortcode_unautop($html){ return $html; } }
-    if (!function_exists('esc_attr')) { function esc_attr($t){ return $t; } }
+	use PHPUnit\Framework\TestCase;
+	use NuclearEngagement\Front\QuizShortcode;
+	use NuclearEngagement\Front\QuizView;
+	use NuclearEngagement\Core\SettingsRepository;
+	if (!function_exists('esc_html')) { function esc_html($t) { return $t; } }
+	if (!function_exists('esc_html__')) { function esc_html__($t,$d=null){ return $t; } }
+	if (!function_exists('__')) { function __($t,$d=null){ return $t; } }
+	if (!function_exists('wp_kses_post')) { function wp_kses_post($html){ return $html; } }
+	if (!function_exists('shortcode_unautop')) { function shortcode_unautop($html){ return $html; } }
+	if (!function_exists('esc_attr')) { function esc_attr($t){ return $t; } }
 
-    class DummyFront {
-        public int $calls = 0;
-        public function nuclen_force_enqueue_assets(): void { $this->calls++; }
-    }
+	class DummyFront {
+		public int $calls = 0;
+		public function nuclen_force_enqueue_assets(): void { $this->calls++; }
+	}
 
-    class QuizShortcodeViewTest extends TestCase {
-        protected function setUp(): void {
-            global $wp_options, $wp_meta;
-            $wp_options = $wp_meta = [];
-            SettingsRepository::reset_for_tests();
-        }
+	class QuizShortcodeViewTest extends TestCase {
+		protected function setUp(): void {
+			global $wp_options, $wp_meta;
+			$wp_options = $wp_meta = [];
+			SettingsRepository::reset_for_tests();
+		}
 
-        private function makeShortcode(DummyFront $front): QuizShortcode {
-            $settings = SettingsRepository::get_instance();
-            return new QuizShortcode($settings, $front);
-        }
+		private function makeShortcode(DummyFront $front): QuizShortcode {
+			$settings = SettingsRepository::get_instance();
+			return new QuizShortcode($settings, $front);
+		}
 
-        public function test_render_outputs_markup_with_valid_data(): void {
-            global $wp_meta, $current_post_id;
-            $current_post_id = 3;
-            $wp_meta[3]['nuclen-quiz-data'] = [
-                'questions' => [ [ 'question' => 'Q', 'answers' => ['A'] ] ],
-            ];
+		public function test_render_outputs_markup_with_valid_data(): void {
+			global $wp_meta, $current_post_id;
+			$current_post_id = 3;
+			$wp_meta[3]['nuclen-quiz-data'] = [
+				'questions' => [ [ 'question' => 'Q', 'answers' => ['A'] ] ],
+			];
 
-            $settings = SettingsRepository::get_instance();
-            $settings->set_string('quiz_title', 'Title')
-                     ->set_bool('show_attribution', true)
-                     ->set_string('custom_quiz_html_before', '<p>Start</p>')
-                     ->save();
+			$settings = SettingsRepository::get_instance();
+			$settings->set_string('quiz_title', 'Title')
+					 ->set_bool('show_attribution', true)
+					 ->set_string('custom_quiz_html_before', '<p>Start</p>')
+					 ->save();
 
-            $front = new DummyFront();
-            $sc = $this->makeShortcode($front);
-            $html = $sc->render();
+			$front = new DummyFront();
+			$sc = $this->makeShortcode($front);
+			$html = $sc->render();
 
-            $this->assertStringContainsString('id="nuclen-quiz-container"', $html);
-            $this->assertStringContainsString('id="nuclen-quiz-title"', $html);
-            $this->assertStringContainsString('class="nuclen-attribution"', $html);
-            $this->assertSame(1, $front->calls);
-        }
+			$this->assertStringContainsString('id="nuclen-quiz-container"', $html);
+			$this->assertStringContainsString('id="nuclen-quiz-title"', $html);
+			$this->assertStringContainsString('class="nuclen-attribution"', $html);
+			$this->assertSame(1, $front->calls);
+		}
 
-        public function test_render_returns_empty_string_when_data_invalid(): void {
-            global $wp_meta, $current_post_id;
-            $current_post_id = 4;
-            $wp_meta[4]['nuclen-quiz-data'] = [ 'questions' => [ [ 'question' => '', 'answers' => [] ] ] ];
+		public function test_render_returns_empty_string_when_data_invalid(): void {
+			global $wp_meta, $current_post_id;
+			$current_post_id = 4;
+			$wp_meta[4]['nuclen-quiz-data'] = [ 'questions' => [ [ 'question' => '', 'answers' => [] ] ] ];
 
-            $front = new DummyFront();
-            $sc = $this->makeShortcode($front);
-            $this->assertSame('', $sc->render());
-        }
+			$front = new DummyFront();
+			$sc = $this->makeShortcode($front);
+			$this->assertSame('', $sc->render());
+		}
 
-        public function test_quiz_view_outputs_markup(): void {
-            $view = new QuizView();
-            $settings = [
-                'quiz_title'       => 'T',
-                'html_before'      => '<em>Hi</em>',
-                'show_attribution' => false,
-            ];
-            $html = $view->container($settings);
-            $this->assertStringContainsString('<section id="nuclen-quiz-container"', $html);
-            $this->assertStringContainsString('nuclen-quiz-progress-bar', $html);
-            $this->assertNotEmpty($view->attribution(true));
-            $this->assertSame('', $view->attribution(false));
-        }
-    }
+		public function test_quiz_view_outputs_markup(): void {
+			$view = new QuizView();
+			$settings = [
+				'quiz_title'       => 'T',
+				'html_before'      => '<em>Hi</em>',
+				'show_attribution' => false,
+			];
+			$html = $view->container($settings);
+			$this->assertStringContainsString('<section id="nuclen-quiz-container"', $html);
+			$this->assertStringContainsString('nuclen-quiz-progress-bar', $html);
+			$this->assertNotEmpty($view->attribution(true));
+			$this->assertSame('', $view->attribution(false));
+		}
+	}
 }

--- a/tests/RemoteApiServiceTest.php
+++ b/tests/RemoteApiServiceTest.php
@@ -1,139 +1,139 @@
 <?php
 namespace NuclearEngagement\Services {
-    class LoggingService {
-        public static array $logs = [];
-        public static array $notices = [];
-        public static function log(string $msg): void { self::$logs[] = $msg; }
-        public static function debug(string $msg): void { self::$logs[] = $msg; }
-        public static function notify_admin(string $msg): void { self::$notices[] = $msg; }
-    }
-    function get_site_url() { return 'http://example.com'; }
+	class LoggingService {
+		public static array $logs = [];
+		public static array $notices = [];
+		public static function log(string $msg): void { self::$logs[] = $msg; }
+		public static function debug(string $msg): void { self::$logs[] = $msg; }
+		public static function notify_admin(string $msg): void { self::$notices[] = $msg; }
+	}
+	function get_site_url() { return 'http://example.com'; }
 }
 
 namespace {
-    use PHPUnit\Framework\TestCase;
-    use NuclearEngagement\Services\RemoteApiService;
-    use NuclearEngagement\Services\ApiException;
-    use NuclearEngagement\Core\SettingsRepository;
+	use PHPUnit\Framework\TestCase;
+	use NuclearEngagement\Services\RemoteApiService;
+	use NuclearEngagement\Services\ApiException;
+	use NuclearEngagement\Core\SettingsRepository;
 if (!function_exists('__')) {
-    function __($t, $d = null) { return $t; }
+	function __($t, $d = null) { return $t; }
 }
 if ( ! isset( $GLOBALS['wp_cache'] ) ) { $GLOBALS['wp_cache'] = []; }
 if ( ! isset( $GLOBALS['transients'] ) ) { $GLOBALS['transients'] = []; }
 if ( ! function_exists( 'wp_cache_get' ) ) {
-    function wp_cache_get( $key, $group = '', $force = false, &$found = null ) {
-        $found = isset( $GLOBALS['wp_cache'][ $group ][ $key ] );
-        return $GLOBALS['wp_cache'][ $group ][ $key ] ?? false;
-    }
+	function wp_cache_get( $key, $group = '', $force = false, &$found = null ) {
+		$found = isset( $GLOBALS['wp_cache'][ $group ][ $key ] );
+		return $GLOBALS['wp_cache'][ $group ][ $key ] ?? false;
+	}
 }
 if ( ! function_exists( 'wp_cache_set' ) ) {
-    function wp_cache_set( $key, $value, $group = '', $ttl = 0 ) {
-        $GLOBALS['wp_cache'][ $group ][ $key ] = $value;
-    }
+	function wp_cache_set( $key, $value, $group = '', $ttl = 0 ) {
+		$GLOBALS['wp_cache'][ $group ][ $key ] = $value;
+	}
 }
 if ( ! function_exists( 'get_transient' ) ) {
-    function get_transient( $key ) { return $GLOBALS['transients'][ $key ] ?? false; }
+	function get_transient( $key ) { return $GLOBALS['transients'][ $key ] ?? false; }
 }
 if ( ! function_exists( 'set_transient' ) ) {
-    function set_transient( $key, $value, $ttl = 0 ) { $GLOBALS['transients'][ $key ] = $value; }
+	function set_transient( $key, $value, $ttl = 0 ) { $GLOBALS['transients'][ $key ] = $value; }
 }
 class RemoteApiServiceTest extends TestCase {
-    protected function setUp(): void {
-        $GLOBALS['test_http_response'] = null;
-        SettingsRepository::reset_for_tests();
-        $settings = SettingsRepository::get_instance();
-        $settings->set_string('api_key', 'key')->save();
-    }
+	protected function setUp(): void {
+		$GLOBALS['test_http_response'] = null;
+		SettingsRepository::reset_for_tests();
+		$settings = SettingsRepository::get_instance();
+		$settings->set_string('api_key', 'key')->save();
+	}
 
-    private function makeService(): RemoteApiService {
-        $req = new \NuclearEngagement\Services\Remote\RemoteRequest();
-        $handler = new \NuclearEngagement\Services\Remote\ApiResponseHandler();
-        return new RemoteApiService(SettingsRepository::get_instance(), $req, $handler);
-    }
+	private function makeService(): RemoteApiService {
+		$req = new \NuclearEngagement\Services\Remote\RemoteRequest();
+		$handler = new \NuclearEngagement\Services\Remote\ApiResponseHandler();
+		return new RemoteApiService(SettingsRepository::get_instance(), $req, $handler);
+	}
 
-    public function test_parses_json_message(): void {
-        $GLOBALS['test_http_response'] = ['code'=>400,'body'=>json_encode(['message'=>'bad'])];
-        $svc = $this->makeService();
-        $this->expectException(ApiException::class);
-        $this->expectExceptionMessage('bad');
-        try { $svc->send_posts_to_generate(['posts'=>[], 'workflow'=>[]]); } catch (ApiException $e) {
-            $this->assertSame(400, $e->getCode());
-            throw $e;
-        }
-    }
+	public function test_parses_json_message(): void {
+		$GLOBALS['test_http_response'] = ['code'=>400,'body'=>json_encode(['message'=>'bad'])];
+		$svc = $this->makeService();
+		$this->expectException(ApiException::class);
+		$this->expectExceptionMessage('bad');
+		try { $svc->send_posts_to_generate(['posts'=>[], 'workflow'=>[]]); } catch (ApiException $e) {
+			$this->assertSame(400, $e->getCode());
+			throw $e;
+		}
+	}
 
-    public function test_auth_error_sets_code(): void {
-        $GLOBALS['test_http_response'] = ['code'=>401,'body'=>json_encode(['error_code'=>'invalid_api_key'])];
-        $svc = $this->makeService();
-        try {
-            $svc->send_posts_to_generate(['posts'=>[], 'workflow'=>[]]);
-        } catch (ApiException $e) {
-            $this->assertSame(401, $e->getCode());
-            $this->assertSame('invalid_api_key', $e->getErrorCode());
-            $this->assertStringContainsString('Invalid API key', $e->getMessage());
-            return;
-        }
-        $this->fail('Exception not thrown');
-    }
+	public function test_auth_error_sets_code(): void {
+		$GLOBALS['test_http_response'] = ['code'=>401,'body'=>json_encode(['error_code'=>'invalid_api_key'])];
+		$svc = $this->makeService();
+		try {
+			$svc->send_posts_to_generate(['posts'=>[], 'workflow'=>[]]);
+		} catch (ApiException $e) {
+			$this->assertSame(401, $e->getCode());
+			$this->assertSame('invalid_api_key', $e->getErrorCode());
+			$this->assertStringContainsString('Invalid API key', $e->getMessage());
+			return;
+		}
+		$this->fail('Exception not thrown');
+	}
 
-    public function test_server_error_parses_error_field(): void {
-        $GLOBALS['test_http_response'] = ['code'=>500,'body'=>json_encode(['error'=>'oops'])];
-        $svc = $this->makeService();
-        try {
-            $svc->send_posts_to_generate(['posts'=>[], 'workflow'=>[]]);
-        } catch (ApiException $e) {
-            $this->assertSame(500, $e->getCode());
-            $this->assertSame('oops', $e->getMessage());
-            return;
-        }
-        $this->fail('Exception not thrown');
-    }
+	public function test_server_error_parses_error_field(): void {
+		$GLOBALS['test_http_response'] = ['code'=>500,'body'=>json_encode(['error'=>'oops'])];
+		$svc = $this->makeService();
+		try {
+			$svc->send_posts_to_generate(['posts'=>[], 'workflow'=>[]]);
+		} catch (ApiException $e) {
+			$this->assertSame(500, $e->getCode());
+			$this->assertSame('oops', $e->getMessage());
+			return;
+		}
+		$this->fail('Exception not thrown');
+	}
 
-    public function test_send_posts_wp_error_notifies(): void {
-        $GLOBALS['test_http_response'] = new \WP_Error('nope', 'bad');
-        \NuclearEngagement\Services\LoggingService::$notices = [];
-        $svc = $this->makeService();
-        $this->expectException(ApiException::class);
-        try {
-            $svc->send_posts_to_generate(['posts'=>[], 'workflow'=>[]]);
-        } catch (ApiException $e) {
-            $this->assertSame(['Failed to contact the Nuclear Engagement API.'], \NuclearEngagement\Services\LoggingService::$notices);
-            throw $e;
-        }
-    }
+	public function test_send_posts_wp_error_notifies(): void {
+		$GLOBALS['test_http_response'] = new \WP_Error('nope', 'bad');
+		\NuclearEngagement\Services\LoggingService::$notices = [];
+		$svc = $this->makeService();
+		$this->expectException(ApiException::class);
+		try {
+			$svc->send_posts_to_generate(['posts'=>[], 'workflow'=>[]]);
+		} catch (ApiException $e) {
+			$this->assertSame(['Failed to contact the Nuclear Engagement API.'], \NuclearEngagement\Services\LoggingService::$notices);
+			throw $e;
+		}
+	}
 
-    public function test_fetch_updates_wp_error_notifies(): void {
-        $GLOBALS['test_http_response'] = new \WP_Error('fail', 'oops');
-        \NuclearEngagement\Services\LoggingService::$notices = [];
-        $svc = $this->makeService();
-        $this->expectException(ApiException::class);
-        try {
-            $svc->fetch_updates('id');
-        } catch (ApiException $e) {
-            $this->assertSame(['Failed to contact the Nuclear Engagement API.'], \NuclearEngagement\Services\LoggingService::$notices);
-            throw $e;
-        }
-    }
+	public function test_fetch_updates_wp_error_notifies(): void {
+		$GLOBALS['test_http_response'] = new \WP_Error('fail', 'oops');
+		\NuclearEngagement\Services\LoggingService::$notices = [];
+		$svc = $this->makeService();
+		$this->expectException(ApiException::class);
+		try {
+			$svc->fetch_updates('id');
+		} catch (ApiException $e) {
+			$this->assertSame(['Failed to contact the Nuclear Engagement API.'], \NuclearEngagement\Services\LoggingService::$notices);
+			throw $e;
+		}
+	}
 
-    public function test_fetch_updates_returns_cached_value(): void {
-        global $wp_cache, $transients;
-        $wp_cache = ['nuclen_remote' => ['nuclen_update_gid' => ['x' => 1]]];
-        $transients = [];
-        $GLOBALS['test_http_response'] = new \WP_Error('fail', 'no call');
-        $svc = $this->makeService();
-        $res = $svc->fetch_updates('gid');
-        $this->assertSame(['x' => 1], $res);
-    }
+	public function test_fetch_updates_returns_cached_value(): void {
+		global $wp_cache, $transients;
+		$wp_cache = ['nuclen_remote' => ['nuclen_update_gid' => ['x' => 1]]];
+		$transients = [];
+		$GLOBALS['test_http_response'] = new \WP_Error('fail', 'no call');
+		$svc = $this->makeService();
+		$res = $svc->fetch_updates('gid');
+		$this->assertSame(['x' => 1], $res);
+	}
 
-    public function test_fetch_updates_caches_successful_response(): void {
-        global $wp_cache, $transients;
-        $wp_cache = $transients = [];
-        $GLOBALS['test_http_response'] = ['code'=>200,'body'=>json_encode(['ok'=>1])];
-        $svc = $this->makeService();
-        $res = $svc->fetch_updates('gid');
-        $this->assertSame(['ok'=>1], $res);
-        $this->assertSame(['ok'=>1], $wp_cache['nuclen_remote']['nuclen_update_gid']);
-        $this->assertSame(['ok'=>1], $transients['nuclen_update_gid']);
-    }
+	public function test_fetch_updates_caches_successful_response(): void {
+		global $wp_cache, $transients;
+		$wp_cache = $transients = [];
+		$GLOBALS['test_http_response'] = ['code'=>200,'body'=>json_encode(['ok'=>1])];
+		$svc = $this->makeService();
+		$res = $svc->fetch_updates('gid');
+		$this->assertSame(['ok'=>1], $res);
+		$this->assertSame(['ok'=>1], $wp_cache['nuclen_remote']['nuclen_update_gid']);
+		$this->assertSame(['ok'=>1], $transients['nuclen_update_gid']);
+	}
 }
 }

--- a/tests/RemoteRequestTest.php
+++ b/tests/RemoteRequestTest.php
@@ -1,35 +1,35 @@
 <?php
 namespace NuclearEngagement\Services\Remote {
-    function wp_remote_post(string $url, array $args = []) {
-        $GLOBALS['rr_called'] = ['url' => $url, 'args' => $args];
-        return null;
-    }
-    function wp_json_encode($data) { return json_encode($data); }
+	function wp_remote_post(string $url, array $args = []) {
+		$GLOBALS['rr_called'] = ['url' => $url, 'args' => $args];
+		return null;
+	}
+	function wp_json_encode($data) { return json_encode($data); }
 }
 
 namespace {
-    use PHPUnit\Framework\TestCase;
-    use NuclearEngagement\Services\Remote\RemoteRequest;
+	use PHPUnit\Framework\TestCase;
+	use NuclearEngagement\Services\Remote\RemoteRequest;
 
-    if (!defined('NUCLEN_PLUGIN_VERSION')) { define('NUCLEN_PLUGIN_VERSION', '1.0'); }
-    if (!defined('NUCLEN_API_TIMEOUT')) { define('NUCLEN_API_TIMEOUT', 30); }
+	if (!defined('NUCLEN_PLUGIN_VERSION')) { define('NUCLEN_PLUGIN_VERSION', '1.0'); }
+	if (!defined('NUCLEN_API_TIMEOUT')) { define('NUCLEN_API_TIMEOUT', 30); }
 
-    class RemoteRequestTest extends TestCase {
-        protected function setUp(): void {
-            unset($GLOBALS['rr_called']);
-        }
+	class RemoteRequestTest extends TestCase {
+		protected function setUp(): void {
+			unset($GLOBALS['rr_called']);
+		}
 
-        public function test_post_sends_json_request_with_headers(): void {
-            $req = new RemoteRequest();
-            $req->post('/path', ['data' => 1], 'key');
+		public function test_post_sends_json_request_with_headers(): void {
+			$req = new RemoteRequest();
+			$req->post('/path', ['data' => 1], 'key');
 
-            $this->assertArrayHasKey('rr_called', $GLOBALS);
-            $called = $GLOBALS['rr_called'];
-            $this->assertSame('https://app.nuclearengagement.com/api/path', $called['url']);
-            $this->assertSame(json_encode(['data' => 1]), $called['args']['body']);
-            $this->assertSame('application/json', $called['args']['headers']['Content-Type']);
-            $this->assertSame('key', $called['args']['headers']['X-API-Key']);
-            $this->assertStringContainsString(NUCLEN_PLUGIN_VERSION, $called['args']['user-agent']);
-        }
-    }
+			$this->assertArrayHasKey('rr_called', $GLOBALS);
+			$called = $GLOBALS['rr_called'];
+			$this->assertSame('https://app.nuclearengagement.com/api/path', $called['url']);
+			$this->assertSame(json_encode(['data' => 1]), $called['args']['body']);
+			$this->assertSame('application/json', $called['args']['headers']['Content-Type']);
+			$this->assertSame('key', $called['args']['headers']['X-API-Key']);
+			$this->assertStringContainsString(NUCLEN_PLUGIN_VERSION, $called['args']['user-agent']);
+		}
+	}
 }

--- a/tests/ScheduleFailureTest.php
+++ b/tests/ScheduleFailureTest.php
@@ -1,110 +1,110 @@
 <?php
 namespace NuclearEngagement\Services {
-    if (!class_exists('NuclearEngagement\\Services\\LoggingService')) {
-        class LoggingService {
-            public static array $logs = [];
-            public static array $notices = [];
-            public static function log(string $msg): void { self::$logs[] = $msg; }
-            public static function notify_admin(string $msg): void { self::$notices[] = $msg; }
-        }
-    }
-    function wp_schedule_single_event($timestamp, $hook, $args) {
-        return false;
-    }
+	if (!class_exists('NuclearEngagement\\Services\\LoggingService')) {
+		class LoggingService {
+			public static array $logs = [];
+			public static array $notices = [];
+			public static function log(string $msg): void { self::$logs[] = $msg; }
+			public static function notify_admin(string $msg): void { self::$notices[] = $msg; }
+		}
+	}
+	function wp_schedule_single_event($timestamp, $hook, $args) {
+		return false;
+	}
 }
 
 namespace {
-    use PHPUnit\Framework\TestCase;
-    use NuclearEngagement\Services\AutoGenerationService;
-    use NuclearEngagement\Services\GenerationPoller;
-    use NuclearEngagement\Core\SettingsRepository;
-    use NuclearEngagement\Modules\Summary\Summary_Service;
-    class ScheduleFailDummyRemoteApiService {
-        public array $updates = [];
-        public $generateResponse = [];
-        public array $lastData = [];
-        public function send_posts_to_generate(array $data): array {
-            $this->lastData = $data;
-            return $this->generateResponse;
-        }
-        public function fetch_updates(string $id): array {
-            return $this->updates[$id] ?? [];
-        }
-    }
+	use PHPUnit\Framework\TestCase;
+	use NuclearEngagement\Services\AutoGenerationService;
+	use NuclearEngagement\Services\GenerationPoller;
+	use NuclearEngagement\Core\SettingsRepository;
+	use NuclearEngagement\Modules\Summary\Summary_Service;
+	class ScheduleFailDummyRemoteApiService {
+		public array $updates = [];
+		public $generateResponse = [];
+		public array $lastData = [];
+		public function send_posts_to_generate(array $data): array {
+			$this->lastData = $data;
+			return $this->generateResponse;
+		}
+		public function fetch_updates(string $id): array {
+			return $this->updates[$id] ?? [];
+		}
+	}
 
-    class ScheduleFailDummyContentStorageService {
-        public array $stored = [];
-        public function storeResults(array $results, string $type): array {
-            $this->stored[] = [$results, $type];
-            return array_fill_keys(array_keys($results), true);
-        }
-    }
+	class ScheduleFailDummyContentStorageService {
+		public array $stored = [];
+		public function storeResults(array $results, string $type): array {
+			$this->stored[] = [$results, $type];
+			return array_fill_keys(array_keys($results), true);
+		}
+	}
 
-    class ScheduleFail_WPDB {
-        public $posts = 'wp_posts';
-        public $postmeta = 'wp_postmeta';
-        public array $args = [];
-        public function prepare($sql, ...$args) { $this->args = $args; return $sql; }
-        public function get_results($sql) {
-            $ids = array_slice($this->args, 2);
-            $rows = [];
-            foreach ($ids as $id) {
-                if (!isset($GLOBALS['wp_posts'][$id])) { continue; }
-                $p = $GLOBALS['wp_posts'][$id];
-                if ($p->post_status !== 'publish') { continue; }
-                if (!empty($GLOBALS['wp_meta'][$id]['nuclen_quiz_protected']) || !empty($GLOBALS['wp_meta'][$id][Summary_Service::PROTECTED_KEY])) { continue; }
-                $rows[] = (object) [ 'ID' => $p->ID, 'post_title' => $p->post_title, 'post_content' => $p->post_content ];
-            }
-            return $rows;
-        }
-    }
+	class ScheduleFail_WPDB {
+		public $posts = 'wp_posts';
+		public $postmeta = 'wp_postmeta';
+		public array $args = [];
+		public function prepare($sql, ...$args) { $this->args = $args; return $sql; }
+		public function get_results($sql) {
+			$ids = array_slice($this->args, 2);
+			$rows = [];
+			foreach ($ids as $id) {
+				if (!isset($GLOBALS['wp_posts'][$id])) { continue; }
+				$p = $GLOBALS['wp_posts'][$id];
+				if ($p->post_status !== 'publish') { continue; }
+				if (!empty($GLOBALS['wp_meta'][$id]['nuclen_quiz_protected']) || !empty($GLOBALS['wp_meta'][$id][Summary_Service::PROTECTED_KEY])) { continue; }
+				$rows[] = (object) [ 'ID' => $p->ID, 'post_title' => $p->post_title, 'post_content' => $p->post_content ];
+			}
+			return $rows;
+		}
+	}
 
-    class ScheduleFailureTest extends TestCase {
-        protected function setUp(): void {
-            global $wp_options, $wp_autoload, $wp_posts, $wp_meta, $wp_events, $wpdb;
-            $wp_options = $wp_autoload = $wp_posts = $wp_meta = $wp_events = [];
-            $wpdb = new ScheduleFail_WPDB();
-            \NuclearEngagement\Services\LoggingService::$logs = [];
-            \NuclearEngagement\Services\LoggingService::$notices = [];
-            SettingsRepository::reset_for_tests();
-        }
+	class ScheduleFailureTest extends TestCase {
+		protected function setUp(): void {
+			global $wp_options, $wp_autoload, $wp_posts, $wp_meta, $wp_events, $wpdb;
+			$wp_options = $wp_autoload = $wp_posts = $wp_meta = $wp_events = [];
+			$wpdb = new ScheduleFail_WPDB();
+			\NuclearEngagement\Services\LoggingService::$logs = [];
+			\NuclearEngagement\Services\LoggingService::$notices = [];
+			SettingsRepository::reset_for_tests();
+		}
 
-        private function makeService(?ScheduleFailDummyRemoteApiService $api = null): AutoGenerationService {
-            $settings = SettingsRepository::get_instance();
-            $api      = $api ?: new ScheduleFailDummyRemoteApiService();
-            $storage  = new ScheduleFailDummyContentStorageService();
-            $poller    = new GenerationPoller($settings, $api, $storage);
-            $scheduler = new \NuclearEngagement\Services\AutoGenerationScheduler($poller);
-            $queue     = new \NuclearEngagement\Services\AutoGenerationQueue($api, $storage, new \NuclearEngagement\Services\PostDataFetcher());
-            $handler   = new \NuclearEngagement\Services\PublishGenerationHandler($settings);
-            return new AutoGenerationService($settings, $queue, $scheduler, $handler);
-        }
+		private function makeService(?ScheduleFailDummyRemoteApiService $api = null): AutoGenerationService {
+			$settings = SettingsRepository::get_instance();
+			$api      = $api ?: new ScheduleFailDummyRemoteApiService();
+			$storage  = new ScheduleFailDummyContentStorageService();
+			$poller    = new GenerationPoller($settings, $api, $storage);
+			$scheduler = new \NuclearEngagement\Services\AutoGenerationScheduler($poller);
+			$queue     = new \NuclearEngagement\Services\AutoGenerationQueue($api, $storage, new \NuclearEngagement\Services\PostDataFetcher());
+			$handler   = new \NuclearEngagement\Services\PublishGenerationHandler($settings);
+			return new AutoGenerationService($settings, $queue, $scheduler, $handler);
+		}
 
-        public function test_queue_post_failure_notifies_admin(): void {
-            global $wp_posts, $wp_events;
-            $wp_posts[1] = (object)[ 'ID' => 1, 'post_title' => 'T', 'post_content' => 'C' ];
-            $service = $this->makeService();
-            $service->generate_single(1, 'quiz');
-            $this->assertEmpty($wp_events);
-            $this->assertNotEmpty(\NuclearEngagement\Services\LoggingService::$notices);
-        }
+		public function test_queue_post_failure_notifies_admin(): void {
+			global $wp_posts, $wp_events;
+			$wp_posts[1] = (object)[ 'ID' => 1, 'post_title' => 'T', 'post_content' => 'C' ];
+			$service = $this->makeService();
+			$service->generate_single(1, 'quiz');
+			$this->assertEmpty($wp_events);
+			$this->assertNotEmpty(\NuclearEngagement\Services\LoggingService::$notices);
+		}
 
-        public function test_process_queue_failure_notifies_admin(): void {
-            global $wp_posts;
-            $wp_posts[2] = (object)[ 'ID' => 2, 'post_title' => 'B', 'post_content' => 'C2' ];
-            update_option('nuclen_autogen_queue', ['quiz' => [2]], 'no');
-            $service = $this->makeService();
-            $service->process_queue();
-            $this->assertNotEmpty(\NuclearEngagement\Services\LoggingService::$notices);
-        }
+		public function test_process_queue_failure_notifies_admin(): void {
+			global $wp_posts;
+			$wp_posts[2] = (object)[ 'ID' => 2, 'post_title' => 'B', 'post_content' => 'C2' ];
+			update_option('nuclen_autogen_queue', ['quiz' => [2]], 'no');
+			$service = $this->makeService();
+			$service->process_queue();
+			$this->assertNotEmpty(\NuclearEngagement\Services\LoggingService::$notices);
+		}
 
-        public function test_poller_failure_notifies_admin(): void {
-            $settings = SettingsRepository::get_instance();
-            $api      = new ScheduleFailDummyRemoteApiService();
-            $storage  = new ScheduleFailDummyContentStorageService();
-            $poller   = new GenerationPoller($settings, $api, $storage);
-            $poller->poll_generation('gid', 'quiz', [1], 1);
-            $this->assertNotEmpty(\NuclearEngagement\Services\LoggingService::$notices);
-        }
-    }
+		public function test_poller_failure_notifies_admin(): void {
+			$settings = SettingsRepository::get_instance();
+			$api      = new ScheduleFailDummyRemoteApiService();
+			$storage  = new ScheduleFailDummyContentStorageService();
+			$poller   = new GenerationPoller($settings, $api, $storage);
+			$poller->poll_generation('gid', 'quiz', [1], 1);
+			$this->assertNotEmpty(\NuclearEngagement\Services\LoggingService::$notices);
+		}
+	}
 }

--- a/tests/SettingsCacheTest.php
+++ b/tests/SettingsCacheTest.php
@@ -7,88 +7,88 @@ use NuclearEngagement\Core\SettingsRepository;
 // WordPress cache stubs
 // ------------------------------------------------------
 if (!defined('HOUR_IN_SECONDS')) {
-    define('HOUR_IN_SECONDS', 3600);
+	define('HOUR_IN_SECONDS', 3600);
 }
 if (!isset($GLOBALS['wp_cache'])) {
-    $GLOBALS['wp_cache'] = [];
+	$GLOBALS['wp_cache'] = [];
 }
 $GLOBALS['delete_calls'] = 0;
 $GLOBALS['flush_group_calls'] = 0;
 $GLOBALS['flush_calls'] = 0;
 
 if (!function_exists('wp_cache_get')) {
-    function wp_cache_get($key, $group = '', $force = false, &$found = null) {
-        $found = isset($GLOBALS['wp_cache'][$group][$key]);
-        return $GLOBALS['wp_cache'][$group][$key] ?? false;
-    }
+	function wp_cache_get($key, $group = '', $force = false, &$found = null) {
+		$found = isset($GLOBALS['wp_cache'][$group][$key]);
+		return $GLOBALS['wp_cache'][$group][$key] ?? false;
+	}
 }
 if (!function_exists('wp_cache_set')) {
-    function wp_cache_set($key, $value, $group = '', $ttl = 0) {
-        $GLOBALS['wp_cache'][$group][$key] = $value;
-    }
+	function wp_cache_set($key, $value, $group = '', $ttl = 0) {
+		$GLOBALS['wp_cache'][$group][$key] = $value;
+	}
 }
 if (!function_exists('wp_cache_delete')) {
-    function wp_cache_delete($key, $group = '') {
-        $GLOBALS['delete_calls']++;
-        unset($GLOBALS['wp_cache'][$group][$key]);
-    }
+	function wp_cache_delete($key, $group = '') {
+		$GLOBALS['delete_calls']++;
+		unset($GLOBALS['wp_cache'][$group][$key]);
+	}
 }
 if (!function_exists('wp_cache_flush_group')) {
-    function wp_cache_flush_group($group) {
-        $GLOBALS['flush_group_calls']++;
-        unset($GLOBALS['wp_cache'][$group]);
-    }
+	function wp_cache_flush_group($group) {
+		$GLOBALS['flush_group_calls']++;
+		unset($GLOBALS['wp_cache'][$group]);
+	}
 }
 if (!function_exists('wp_cache_flush')) {
-    function wp_cache_flush() {
-        $GLOBALS['flush_calls']++;
-        $GLOBALS['wp_cache'] = [];
-    }
+	function wp_cache_flush() {
+		$GLOBALS['flush_calls']++;
+		$GLOBALS['wp_cache'] = [];
+	}
 }
 if (!function_exists('get_current_blog_id')) {
-    function get_current_blog_id() { return 1; }
+	function get_current_blog_id() { return 1; }
 }
 if (!function_exists('add_action')) {
-    function add_action(...$args) {}
+	function add_action(...$args) {}
 }
 
 require_once dirname(__DIR__) . '/nuclear-engagement/inc/Core/SettingsCache.php';
 
 class SettingsCacheTest extends TestCase {
-    protected function setUp(): void {
-        global $wp_cache, $delete_calls, $flush_group_calls, $flush_calls;
-        $wp_cache = [];
-        $delete_calls = $flush_group_calls = $flush_calls = 0;
-    }
+	protected function setUp(): void {
+		global $wp_cache, $delete_calls, $flush_group_calls, $flush_calls;
+		$wp_cache = [];
+		$delete_calls = $flush_group_calls = $flush_calls = 0;
+	}
 
-    public function test_get_returns_null_when_cache_missing(): void {
-        $cache = new SettingsCache();
-        $this->assertNull($cache->get());
-    }
+	public function test_get_returns_null_when_cache_missing(): void {
+		$cache = new SettingsCache();
+		$this->assertNull($cache->get());
+	}
 
-    public function test_set_and_get(): void {
-        $cache = new SettingsCache();
-        $data = ['foo' => 'bar'];
-        $cache->set($data);
-        $this->assertSame($data, $cache->get());
-    }
+	public function test_set_and_get(): void {
+		$cache = new SettingsCache();
+		$data = ['foo' => 'bar'];
+		$cache->set($data);
+		$this->assertSame($data, $cache->get());
+	}
 
-    public function test_invalidate_cache_deletes_and_flushes(): void {
-        $cache = new SettingsCache();
-        $cache->set(['a' => 'b']);
-        $cache->invalidate_cache();
-        $key = $cache->get_cache_key();
-        $this->assertArrayNotHasKey($key, $GLOBALS['wp_cache'][SettingsCache::CACHE_GROUP] ?? []);
-        $this->assertSame(1, $GLOBALS['delete_calls']);
-        $this->assertSame(1, $GLOBALS['flush_group_calls']);
-    }
+	public function test_invalidate_cache_deletes_and_flushes(): void {
+		$cache = new SettingsCache();
+		$cache->set(['a' => 'b']);
+		$cache->invalidate_cache();
+		$key = $cache->get_cache_key();
+		$this->assertArrayNotHasKey($key, $GLOBALS['wp_cache'][SettingsCache::CACHE_GROUP] ?? []);
+		$this->assertSame(1, $GLOBALS['delete_calls']);
+		$this->assertSame(1, $GLOBALS['flush_group_calls']);
+	}
 
-    public function test_maybe_invalidate_cache_only_for_plugin_option(): void {
-        $cache = new SettingsCache();
-        $cache->set(['a' => 'b']);
-        $cache->maybe_invalidate_cache('other_option');
-        $this->assertArrayHasKey($cache->get_cache_key(), $GLOBALS['wp_cache'][SettingsCache::CACHE_GROUP]);
-        $cache->maybe_invalidate_cache(SettingsRepository::OPTION);
-        $this->assertArrayNotHasKey($cache->get_cache_key(), $GLOBALS['wp_cache'][SettingsCache::CACHE_GROUP] ?? []);
-    }
+	public function test_maybe_invalidate_cache_only_for_plugin_option(): void {
+		$cache = new SettingsCache();
+		$cache->set(['a' => 'b']);
+		$cache->maybe_invalidate_cache('other_option');
+		$this->assertArrayHasKey($cache->get_cache_key(), $GLOBALS['wp_cache'][SettingsCache::CACHE_GROUP]);
+		$cache->maybe_invalidate_cache(SettingsRepository::OPTION);
+		$this->assertArrayNotHasKey($cache->get_cache_key(), $GLOBALS['wp_cache'][SettingsCache::CACHE_GROUP] ?? []);
+	}
 }

--- a/tests/SettingsPageSaveTraitTest.php
+++ b/tests/SettingsPageSaveTraitTest.php
@@ -1,81 +1,81 @@
 <?php
 namespace {
-    use PHPUnit\Framework\TestCase;
-    use NuclearEngagement\Admin\Traits\SettingsPageSaveTrait;
-    use NuclearEngagement\Admin\Traits\SettingsCollectTrait;
-    use NuclearEngagement\Admin\Traits\SettingsPersistTrait;
-    use NuclearEngagement\Admin\SettingsSanitizeTrait;
-    use NuclearEngagement\Core\SettingsRepository;
-    use NuclearEngagement\Core\Defaults;
+	use PHPUnit\Framework\TestCase;
+	use NuclearEngagement\Admin\Traits\SettingsPageSaveTrait;
+	use NuclearEngagement\Admin\Traits\SettingsCollectTrait;
+	use NuclearEngagement\Admin\Traits\SettingsPersistTrait;
+	use NuclearEngagement\Admin\SettingsSanitizeTrait;
+	use NuclearEngagement\Core\SettingsRepository;
+	use NuclearEngagement\Core\Defaults;
 
-    if (!function_exists('sanitize_text_field')) {
-        function sanitize_text_field($t) { return is_string($t) ? trim($t) : $t; }
-    }
-    if (!function_exists('wp_unslash')) { function wp_unslash($v){ return $v; } }
-    if (!function_exists('wp_kses_post')) { function wp_kses_post($v){ return $v; } }
-    if (!function_exists('check_admin_referer')) { function check_admin_referer($a,$b,$c=false){ return true; } }
-    if (!function_exists('esc_url_raw')) { function esc_url_raw($u){ return $u; } }
-    if (!function_exists('filter_input')) { function filter_input($type,$name,$filter=null,$opt=null){ return $_POST[$name] ?? null; } }
+	if (!function_exists('sanitize_text_field')) {
+		function sanitize_text_field($t) { return is_string($t) ? trim($t) : $t; }
+	}
+	if (!function_exists('wp_unslash')) { function wp_unslash($v){ return $v; } }
+	if (!function_exists('wp_kses_post')) { function wp_kses_post($v){ return $v; } }
+	if (!function_exists('check_admin_referer')) { function check_admin_referer($a,$b,$c=false){ return true; } }
+	if (!function_exists('esc_url_raw')) { function esc_url_raw($u){ return $u; } }
+	if (!function_exists('filter_input')) { function filter_input($type,$name,$filter=null,$opt=null){ return $_POST[$name] ?? null; } }
 
-    class DummySettingsPage {
-        use SettingsPageSaveTrait;
-        use SettingsCollectTrait;
-        use SettingsPersistTrait;
-        use SettingsSanitizeTrait;
-        public function nuclen_get_settings_repository() { return SettingsRepository::get_instance(); }
-    }
+	class DummySettingsPage {
+		use SettingsPageSaveTrait;
+		use SettingsCollectTrait;
+		use SettingsPersistTrait;
+		use SettingsSanitizeTrait;
+		public function nuclen_get_settings_repository() { return SettingsRepository::get_instance(); }
+	}
 
-    class SettingsPageSaveTraitTest extends TestCase {
-        private DummySettingsPage $page;
+	class SettingsPageSaveTraitTest extends TestCase {
+		private DummySettingsPage $page;
 
-        protected function setUp(): void {
-            global $wp_options;
-            $wp_options = [];
-            SettingsRepository::reset_for_tests();
-            $this->page = new DummySettingsPage();
-            $_POST = [];
-        }
+		protected function setUp(): void {
+			global $wp_options;
+			$wp_options = [];
+			SettingsRepository::reset_for_tests();
+			$this->page = new DummySettingsPage();
+			$_POST = [];
+		}
 
-        public function test_collect_input_returns_expected_keys(): void {
-            $_POST['nuclen_theme'] = 'dark';
-            $_POST['nuclen_font_size'] = '20';
-            $_POST['nuclen_display_quiz'] = 'before';
-            $_POST['nuclear_engagement_settings']['toc_heading_levels'] = [2,3];
-            $ref = new \ReflectionMethod($this->page, 'nuclen_collect_input');
-            $ref->setAccessible(true);
-            $result = $ref->invoke($this->page);
-            $this->assertSame('dark', $result['theme']);
-            $this->assertSame('20', $result['font_size']);
-            $this->assertSame('before', $result['display_quiz']);
-            $this->assertSame([2,3], $result['toc_heading_levels']);
-        }
+		public function test_collect_input_returns_expected_keys(): void {
+			$_POST['nuclen_theme'] = 'dark';
+			$_POST['nuclen_font_size'] = '20';
+			$_POST['nuclen_display_quiz'] = 'before';
+			$_POST['nuclear_engagement_settings']['toc_heading_levels'] = [2,3];
+			$ref = new \ReflectionMethod($this->page, 'nuclen_collect_input');
+			$ref->setAccessible(true);
+			$result = $ref->invoke($this->page);
+			$this->assertSame('dark', $result['theme']);
+			$this->assertSame('20', $result['font_size']);
+			$this->assertSame('before', $result['display_quiz']);
+			$this->assertSame([2,3], $result['toc_heading_levels']);
+		}
 
-        public function test_sanitize_and_defaults_merges_defaults(): void {
-            $raw = ['font_size' => '15'];
-            $defaults = Defaults::nuclen_get_default_settings();
-            $ref = new \ReflectionMethod($this->page, 'nuclen_sanitize_and_defaults');
-            $ref->setAccessible(true);
-            $result = $ref->invoke($this->page, $raw, $defaults);
-            $this->assertSame(15, $result['font_size']);
-            $this->assertSame($defaults['font_color'], $result['font_color']);
-        }
+		public function test_sanitize_and_defaults_merges_defaults(): void {
+			$raw = ['font_size' => '15'];
+			$defaults = Defaults::nuclen_get_default_settings();
+			$ref = new \ReflectionMethod($this->page, 'nuclen_sanitize_and_defaults');
+			$ref->setAccessible(true);
+			$result = $ref->invoke($this->page, $raw, $defaults);
+			$this->assertSame(15, $result['font_size']);
+			$this->assertSame($defaults['font_color'], $result['font_color']);
+		}
 
-        public function test_persist_settings_saves_via_repository(): void {
-            $ref = new \ReflectionMethod($this->page, 'nuclen_persist_settings');
-            $ref->setAccessible(true);
-            $saved = $ref->invoke($this->page, ['theme' => 'dark']);
-            $repo = SettingsRepository::get_instance();
-            $this->assertSame('dark', $repo->get('theme'));
-            $this->assertSame('dark', $saved['theme']);
-        }
+		public function test_persist_settings_saves_via_repository(): void {
+			$ref = new \ReflectionMethod($this->page, 'nuclen_persist_settings');
+			$ref->setAccessible(true);
+			$saved = $ref->invoke($this->page, ['theme' => 'dark']);
+			$repo = SettingsRepository::get_instance();
+			$this->assertSame('dark', $repo->get('theme'));
+			$this->assertSame('dark', $saved['theme']);
+		}
 
-        public function test_output_save_notice_prints_html(): void {
-            $ref = new \ReflectionMethod($this->page, 'nuclen_output_save_notice');
-            $ref->setAccessible(true);
-            ob_start();
-            $ref->invoke($this->page);
-            $html = ob_get_clean();
-            $this->assertStringContainsString('Settings saved.', $html);
-        }
-    }
+		public function test_output_save_notice_prints_html(): void {
+			$ref = new \ReflectionMethod($this->page, 'nuclen_output_save_notice');
+			$ref->setAccessible(true);
+			ob_start();
+			$ref->invoke($this->page);
+			$html = ob_get_clean();
+			$this->assertStringContainsString('Settings saved.', $html);
+		}
+	}
 }

--- a/tests/SettingsRepositoryTest.php
+++ b/tests/SettingsRepositoryTest.php
@@ -6,117 +6,117 @@ use NuclearEngagement\Core\SettingsCache;
 
 if (!isset($GLOBALS['wp_cache'])) { $GLOBALS['wp_cache'] = []; }
 if (!function_exists('wp_cache_get')) {
-    function wp_cache_get($key, $group = '', $force = false, &$found = null) {
-        $found = isset($GLOBALS['wp_cache'][$group][$key]);
-        return $GLOBALS['wp_cache'][$group][$key] ?? false;
-    }
+	function wp_cache_get($key, $group = '', $force = false, &$found = null) {
+		$found = isset($GLOBALS['wp_cache'][$group][$key]);
+		return $GLOBALS['wp_cache'][$group][$key] ?? false;
+	}
 }
 if (!function_exists('wp_cache_set')) {
-    function wp_cache_set($key, $value, $group = '', $ttl = 0) {
-        $GLOBALS['wp_cache'][$group][$key] = $value;
-    }
+	function wp_cache_set($key, $value, $group = '', $ttl = 0) {
+		$GLOBALS['wp_cache'][$group][$key] = $value;
+	}
 }
 if (!function_exists('wp_cache_delete')) {
-    function wp_cache_delete($key, $group = '') {
-        unset($GLOBALS['wp_cache'][$group][$key]);
-    }
+	function wp_cache_delete($key, $group = '') {
+		unset($GLOBALS['wp_cache'][$group][$key]);
+	}
 }
 if (!function_exists('wp_cache_flush_group')) {
-    function wp_cache_flush_group($group) { unset($GLOBALS['wp_cache'][$group]); }
+	function wp_cache_flush_group($group) { unset($GLOBALS['wp_cache'][$group]); }
 }
 if (!function_exists('wp_cache_flush')) {
-    function wp_cache_flush() { $GLOBALS['wp_cache'] = []; }
+	function wp_cache_flush() { $GLOBALS['wp_cache'] = []; }
 }
 if (!function_exists('get_current_blog_id')) {
-    function get_current_blog_id() { return 1; }
+	function get_current_blog_id() { return 1; }
 }
 if (!function_exists('sanitize_text_field')) {
-    function sanitize_text_field($text) { return trim($text); }
+	function sanitize_text_field($text) { return trim($text); }
 }
 
 class SettingsRepositoryTest extends TestCase {
-    private \ReflectionMethod $sanitizeMethod;
+	private \ReflectionMethod $sanitizeMethod;
 
-    protected function setUp(): void {
-        global $wp_options, $wp_autoload, $wp_cache;
-        $wp_options = $wp_autoload = $wp_cache = [];
-        SettingsRepository::reset_for_tests();
-        $this->sanitizeMethod = new \ReflectionMethod(SettingsSanitizer::class, 'sanitize_heading_levels');
-        $this->sanitizeMethod->setAccessible(true);
-    }
+	protected function setUp(): void {
+		global $wp_options, $wp_autoload, $wp_cache;
+		$wp_options = $wp_autoload = $wp_cache = [];
+		SettingsRepository::reset_for_tests();
+		$this->sanitizeMethod = new \ReflectionMethod(SettingsSanitizer::class, 'sanitize_heading_levels');
+		$this->sanitizeMethod->setAccessible(true);
+	}
 
-    public function test_sanitize_heading_levels_filters_invalid_values() {
-        $input = ['1', '2', '7', 'abc'];
-        $expected = [1,2];
-        $this->assertSame($expected, $this->sanitizeMethod->invoke(null, $input));
-    }
+	public function test_sanitize_heading_levels_filters_invalid_values() {
+		$input = ['1', '2', '7', 'abc'];
+		$expected = [1,2];
+		$this->assertSame($expected, $this->sanitizeMethod->invoke(null, $input));
+	}
 
-    public function test_singleton_returns_same_instance() {
-        $a = SettingsRepository::get_instance(['theme' => 'dark']);
-        $b = SettingsRepository::get_instance();
-        $this->assertSame($a, $b);
-    }
+	public function test_singleton_returns_same_instance() {
+		$a = SettingsRepository::get_instance(['theme' => 'dark']);
+		$b = SettingsRepository::get_instance();
+		$this->assertSame($a, $b);
+	}
 
-    public function test_sanitize_post_types_removes_invalid() {
-        SettingsRepository::reset_for_tests();
-        $ref = new \ReflectionMethod(SettingsSanitizer::class, 'sanitize_post_types');
-        $ref->setAccessible(true);
-        $input = ['POST', 'page', 'invalid', 'custom?'];
-        $expected = ['post', 'page'];
-        $this->assertSame($expected, $ref->invoke(null, $input));
-    }
+	public function test_sanitize_post_types_removes_invalid() {
+		SettingsRepository::reset_for_tests();
+		$ref = new \ReflectionMethod(SettingsSanitizer::class, 'sanitize_post_types');
+		$ref->setAccessible(true);
+		$input = ['POST', 'page', 'invalid', 'custom?'];
+		$expected = ['post', 'page'];
+		$this->assertSame($expected, $ref->invoke(null, $input));
+	}
 
-    public function test_should_autoload_based_on_size() {
-        SettingsRepository::reset_for_tests();
-        $instance = SettingsRepository::get_instance();
-        $ref = new \ReflectionMethod(SettingsRepository::class, 'should_autoload');
-        $ref->setAccessible(true);
-        $small = ['a' => 'b'];
-        $this->assertTrue($ref->invoke($instance, $small));
-        $big = ['data' => str_repeat('x', SettingsRepository::MAX_AUTOLOAD_SIZE + 1)];
-        $this->assertFalse($ref->invoke($instance, $big));
-    }
+	public function test_should_autoload_based_on_size() {
+		SettingsRepository::reset_for_tests();
+		$instance = SettingsRepository::get_instance();
+		$ref = new \ReflectionMethod(SettingsRepository::class, 'should_autoload');
+		$ref->setAccessible(true);
+		$small = ['a' => 'b'];
+		$this->assertTrue($ref->invoke($instance, $small));
+		$big = ['data' => str_repeat('x', SettingsRepository::MAX_AUTOLOAD_SIZE + 1)];
+		$this->assertFalse($ref->invoke($instance, $big));
+	}
 
-    public function test_get_defaults_includes_custom_values() {
-        SettingsRepository::reset_for_tests();
-        $instance = SettingsRepository::get_instance(['foo' => 'bar', 'theme' => 'dark']);
-        $defaults = $instance->get_defaults();
-        $this->assertSame('bar', $defaults['foo']);
-        $this->assertSame('dark', $defaults['theme']);
-        $this->assertArrayHasKey('quiz_title', $defaults);
-    }
+	public function test_get_defaults_includes_custom_values() {
+		SettingsRepository::reset_for_tests();
+		$instance = SettingsRepository::get_instance(['foo' => 'bar', 'theme' => 'dark']);
+		$defaults = $instance->get_defaults();
+		$this->assertSame('bar', $defaults['foo']);
+		$this->assertSame('dark', $defaults['theme']);
+		$this->assertArrayHasKey('quiz_title', $defaults);
+	}
 
-    public function test_cache_returns_cached_settings_until_invalidated() {
-        global $wp_options, $wp_cache;
+	public function test_cache_returns_cached_settings_until_invalidated() {
+		global $wp_options, $wp_cache;
 
-        $wp_options[SettingsRepository::OPTION] = ['theme' => 'dark'];
+		$wp_options[SettingsRepository::OPTION] = ['theme' => 'dark'];
 
-        $repo = SettingsRepository::get_instance();
+		$repo = SettingsRepository::get_instance();
 
-        $this->assertSame('dark', $repo->get_string('theme'));
+		$this->assertSame('dark', $repo->get_string('theme'));
 
-        $cache_key = 'settings_' . get_current_blog_id();
-        $this->assertArrayHasKey($cache_key, $wp_cache[SettingsCache::CACHE_GROUP]);
+		$cache_key = 'settings_' . get_current_blog_id();
+		$this->assertArrayHasKey($cache_key, $wp_cache[SettingsCache::CACHE_GROUP]);
 
-        $wp_options[SettingsRepository::OPTION] = ['theme' => 'light'];
+		$wp_options[SettingsRepository::OPTION] = ['theme' => 'light'];
 
-        $this->assertSame('dark', $repo->get_string('theme'));
+		$this->assertSame('dark', $repo->get_string('theme'));
 
-        $repo->invalidate_cache();
-        $this->assertArrayNotHasKey($cache_key, $wp_cache[SettingsCache::CACHE_GROUP] ?? []);
+		$repo->invalidate_cache();
+		$this->assertArrayNotHasKey($cache_key, $wp_cache[SettingsCache::CACHE_GROUP] ?? []);
 
-        $this->assertSame('light', $repo->get_string('theme'));
-    }
+		$this->assertSame('light', $repo->get_string('theme'));
+	}
 
-    public function test_save_sanitizes_values_and_clears_cache() {
-        global $wp_cache;
+	public function test_save_sanitizes_values_and_clears_cache() {
+		global $wp_cache;
 
-        $repo = SettingsRepository::get_instance(['toc_heading_levels' => [2,3]]);
-        $repo->get_all();
+		$repo = SettingsRepository::get_instance(['toc_heading_levels' => [2,3]]);
+		$repo->get_all();
 
-        $repo->set_array('toc_heading_levels', ['1','7','2'])->save();
+		$repo->set_array('toc_heading_levels', ['1','7','2'])->save();
 
-        $this->assertEmpty($wp_cache[SettingsCache::CACHE_GROUP] ?? []);
-        $this->assertSame([1,2], $repo->get_array('toc_heading_levels'));
-    }
+		$this->assertEmpty($wp_cache[SettingsCache::CACHE_GROUP] ?? []);
+		$this->assertSame([1,2], $repo->get_array('toc_heading_levels'));
+	}
 }

--- a/tests/SettingsSanitizerTest.php
+++ b/tests/SettingsSanitizerTest.php
@@ -3,57 +3,57 @@ use PHPUnit\Framework\TestCase;
 use NuclearEngagement\Core\SettingsSanitizer;
 
 if (!function_exists('sanitize_text_field')) {
-    function sanitize_text_field($text) {
-        return trim(strip_tags($text));
-    }
+	function sanitize_text_field($text) {
+		return trim(strip_tags($text));
+	}
 }
 if (!function_exists('rest_sanitize_boolean')) {
-    function rest_sanitize_boolean($value) {
-        return filter_var($value, FILTER_VALIDATE_BOOLEAN);
-    }
+	function rest_sanitize_boolean($value) {
+		return filter_var($value, FILTER_VALIDATE_BOOLEAN);
+	}
 }
 
 class SettingsSanitizerTest extends TestCase {
-    public function test_sanitize_settings_handles_various_inputs() {
-        $input = [
-            'api_key' => ' abc ',
-            'font_size' => '15',
-            'show_attribution' => '1',
-            'custom' => ' <b>foo</b> ',
-            'arr' => [ ' <i>bar</i> ', 8, [' <u>baz</u> ', false] ],
-            5 => 'ignored',
-        ];
-        $expected = [
-            'api_key' => 'abc',
-            'font_size' => 15,
-            'show_attribution' => true,
-            'custom' => 'foo',
-            'arr' => ['bar', 8, ['baz', false]],
-        ];
-        $this->assertSame($expected, SettingsSanitizer::sanitize_settings($input));
-        $result = SettingsSanitizer::sanitize_settings($input);
-        $this->assertArrayNotHasKey(5, $result);
-    }
+	public function test_sanitize_settings_handles_various_inputs() {
+		$input = [
+			'api_key' => ' abc ',
+			'font_size' => '15',
+			'show_attribution' => '1',
+			'custom' => ' <b>foo</b> ',
+			'arr' => [ ' <i>bar</i> ', 8, [' <u>baz</u> ', false] ],
+			5 => 'ignored',
+		];
+		$expected = [
+			'api_key' => 'abc',
+			'font_size' => 15,
+			'show_attribution' => true,
+			'custom' => 'foo',
+			'arr' => ['bar', 8, ['baz', false]],
+		];
+		$this->assertSame($expected, SettingsSanitizer::sanitize_settings($input));
+		$result = SettingsSanitizer::sanitize_settings($input);
+		$this->assertArrayNotHasKey(5, $result);
+	}
 
-    public function test_sanitize_setting_casts_types() {
-        $this->assertSame(10, SettingsSanitizer::sanitize_setting('font_size', '10'));
-        $this->assertTrue(SettingsSanitizer::sanitize_setting('connected', '1'));
-        $this->assertFalse(SettingsSanitizer::sanitize_setting('custom', false));
-        $this->assertSame(3, SettingsSanitizer::sanitize_setting('custom', '3'));
-        $this->assertSame(3.14, SettingsSanitizer::sanitize_setting('custom', 3.14));
-    }
+	public function test_sanitize_setting_casts_types() {
+		$this->assertSame(10, SettingsSanitizer::sanitize_setting('font_size', '10'));
+		$this->assertTrue(SettingsSanitizer::sanitize_setting('connected', '1'));
+		$this->assertFalse(SettingsSanitizer::sanitize_setting('custom', false));
+		$this->assertSame(3, SettingsSanitizer::sanitize_setting('custom', '3'));
+		$this->assertSame(3.14, SettingsSanitizer::sanitize_setting('custom', 3.14));
+	}
 
-    public function test_sanitize_array_recursively_sanitizes_strings() {
-        $ref = new \ReflectionMethod(SettingsSanitizer::class, 'sanitize_array');
-        $ref->setAccessible(true);
-        $input = [
-            'foo' => ' <strong>bar</strong> ',
-            'nested' => [' <em>baz</em> ', [' qux ']],
-        ];
-        $expected = [
-            'foo' => 'bar',
-            'nested' => ['baz', ['qux']],
-        ];
-        $this->assertSame($expected, $ref->invoke(null, $input));
-    }
+	public function test_sanitize_array_recursively_sanitizes_strings() {
+		$ref = new \ReflectionMethod(SettingsSanitizer::class, 'sanitize_array');
+		$ref->setAccessible(true);
+		$input = [
+			'foo' => ' <strong>bar</strong> ',
+			'nested' => [' <em>baz</em> ', [' qux ']],
+		];
+		$expected = [
+			'foo' => 'bar',
+			'nested' => ['baz', ['qux']],
+		];
+		$this->assertSame($expected, $ref->invoke(null, $input));
+	}
 }

--- a/tests/SetupHandlersTraitTest.php
+++ b/tests/SetupHandlersTraitTest.php
@@ -1,135 +1,135 @@
 <?php
 namespace NuclearEngagement\Services {
-    class SetupService {
-        public bool $validate_return = true;
-        public bool $send_return = true;
-        public array $validate_args = [];
-        public array $send_args = [];
-        public function validate_api_key(string $key): bool {
-            $this->validate_args[] = $key;
-            return $this->validate_return;
-        }
-        public function send_app_password(array $data): bool {
-            $this->send_args[] = $data;
-            return $this->send_return;
-        }
-    }
+	class SetupService {
+		public bool $validate_return = true;
+		public bool $send_return = true;
+		public array $validate_args = [];
+		public array $send_args = [];
+		public function validate_api_key(string $key): bool {
+			$this->validate_args[] = $key;
+			return $this->validate_return;
+		}
+		public function send_app_password(array $data): bool {
+			$this->send_args[] = $data;
+			return $this->send_return;
+		}
+	}
 }
 
 namespace {
-    use PHPUnit\Framework\TestCase;
-    use NuclearEngagement\Core\SettingsRepository;
-    use NuclearEngagement\Core\Container;
+	use PHPUnit\Framework\TestCase;
+	use NuclearEngagement\Core\SettingsRepository;
+	use NuclearEngagement\Core\Container;
 
-    class RedirectException extends \Exception {}
+	class RedirectException extends \Exception {}
 
-    // Global stubs for WordPress functions
-    if (!function_exists('current_user_can')) {
-        function current_user_can($cap) {
-            return $GLOBALS['can_manage'] ?? false;
-        }
-    }
-    if (!function_exists('sanitize_text_field')) {
-        function sanitize_text_field($val) { return $val; }
-    }
-    if (!function_exists('wp_unslash')) {
-        function wp_unslash($val) { return $val; }
-    }
-    if (!function_exists('wp_generate_password')) {
-        function wp_generate_password($len, $s1 = false, $s2 = false) { return 'pass'; }
-    }
-    if (!function_exists('wp_generate_uuid4')) {
-        function wp_generate_uuid4() { return 'uuid'; }
-    }
-    if (!function_exists('wp_get_current_user')) {
-        function wp_get_current_user() { return (object)['user_login' => 'admin']; }
-    }
-    if (!function_exists('get_site_url')) {
-        function get_site_url() { return 'http://example.com'; }
-    }
-    if (!function_exists('wp_cache_delete')) {
-        function wp_cache_delete($key, $group = '') { $GLOBALS['cache_deleted'][] = [$key,$group]; }
-    }
+	// Global stubs for WordPress functions
+	if (!function_exists('current_user_can')) {
+		function current_user_can($cap) {
+			return $GLOBALS['can_manage'] ?? false;
+		}
+	}
+	if (!function_exists('sanitize_text_field')) {
+		function sanitize_text_field($val) { return $val; }
+	}
+	if (!function_exists('wp_unslash')) {
+		function wp_unslash($val) { return $val; }
+	}
+	if (!function_exists('wp_generate_password')) {
+		function wp_generate_password($len, $s1 = false, $s2 = false) { return 'pass'; }
+	}
+	if (!function_exists('wp_generate_uuid4')) {
+		function wp_generate_uuid4() { return 'uuid'; }
+	}
+	if (!function_exists('wp_get_current_user')) {
+		function wp_get_current_user() { return (object)['user_login' => 'admin']; }
+	}
+	if (!function_exists('get_site_url')) {
+		function get_site_url() { return 'http://example.com'; }
+	}
+	if (!function_exists('wp_cache_delete')) {
+		function wp_cache_delete($key, $group = '') { $GLOBALS['cache_deleted'][] = [$key,$group]; }
+	}
 
-    require_once dirname(__DIR__) . '/nuclear-engagement/inc/Core/Container.php';
-    require_once dirname(__DIR__) . '/nuclear-engagement/inc/Core/SettingsRepository.php';
-    require_once dirname(__DIR__) . '/nuclear-engagement/inc/Core/Defaults.php';
-    require_once dirname(__DIR__) . '/nuclear-engagement/admin/SetupHandlersTrait.php';
+	require_once dirname(__DIR__) . '/nuclear-engagement/inc/Core/Container.php';
+	require_once dirname(__DIR__) . '/nuclear-engagement/inc/Core/SettingsRepository.php';
+	require_once dirname(__DIR__) . '/nuclear-engagement/inc/Core/Defaults.php';
+	require_once dirname(__DIR__) . '/nuclear-engagement/admin/SetupHandlersTrait.php';
 
 class DummySetup {
-    use \NuclearEngagement\Admin\SetupHandlersTrait;
-    public $redirect;
-    private $service;
-    public function __construct($service) { $this->service = $service; }
-    public function nuclen_get_setup_service(): \NuclearEngagement\Services\SetupService { return $this->service; }
-    public function nuclen_get_settings_repository() { return \NuclearEngagement\Core\Container::getInstance()->get('settings'); }
-    private function nuclen_redirect_with_error($msg): void { $this->redirect = ['error',$msg]; throw new RedirectException(); }
-    private function nuclen_redirect_with_success($msg): void { $this->redirect = ['success',$msg]; throw new RedirectException(); }
+	use \NuclearEngagement\Admin\SetupHandlersTrait;
+	public $redirect;
+	private $service;
+	public function __construct($service) { $this->service = $service; }
+	public function nuclen_get_setup_service(): \NuclearEngagement\Services\SetupService { return $this->service; }
+	public function nuclen_get_settings_repository() { return \NuclearEngagement\Core\Container::getInstance()->get('settings'); }
+	private function nuclen_redirect_with_error($msg): void { $this->redirect = ['error',$msg]; throw new RedirectException(); }
+	private function nuclen_redirect_with_success($msg): void { $this->redirect = ['success',$msg]; throw new RedirectException(); }
 }
 
-    class SetupHandlersTraitTest extends TestCase {
-        private $setup;
-        private $service;
+	class SetupHandlersTraitTest extends TestCase {
+		private $setup;
+		private $service;
 
-        protected function setUp(): void {
-            global $wp_options, $wp_autoload, $cache_deleted;
-            $wp_options = $wp_autoload = [];
-            $cache_deleted = [];
-            SettingsRepository::reset_for_tests();
-            Container::getInstance()->reset();
-            $settings = SettingsRepository::get_instance();
-            Container::getInstance()->register('settings', static function() use ($settings) { return $settings; });
-            $this->service = new \NuclearEngagement\Services\SetupService();
-            $this->setup = new DummySetup($this->service);
-            $GLOBALS['can_manage'] = true;
-            $GLOBALS['test_verify_nonce'] = true;
-            $_POST = [];
-        }
+		protected function setUp(): void {
+			global $wp_options, $wp_autoload, $cache_deleted;
+			$wp_options = $wp_autoload = [];
+			$cache_deleted = [];
+			SettingsRepository::reset_for_tests();
+			Container::getInstance()->reset();
+			$settings = SettingsRepository::get_instance();
+			Container::getInstance()->register('settings', static function() use ($settings) { return $settings; });
+			$this->service = new \NuclearEngagement\Services\SetupService();
+			$this->setup = new DummySetup($this->service);
+			$GLOBALS['can_manage'] = true;
+			$GLOBALS['test_verify_nonce'] = true;
+			$_POST = [];
+		}
 
-        protected function tearDown(): void {
-            unset($GLOBALS['can_manage'], $GLOBALS['test_verify_nonce'], $GLOBALS['cache_deleted']);
-        }
+		protected function tearDown(): void {
+			unset($GLOBALS['can_manage'], $GLOBALS['test_verify_nonce'], $GLOBALS['cache_deleted']);
+		}
 
-        public function test_connect_app_invalid_nonce(): void {
-            $GLOBALS['test_verify_nonce'] = false;
-            $_POST = [ 'nuclen_connect_app_nonce' => 'x', 'nuclen_api_key' => 'k' ];
-            $this->expectException(RedirectException::class);
-            try { $this->setup->nuclen_handle_connect_app(); } catch (RedirectException $e) {}
-            $this->assertSame(['error','Invalid nonce.'], $this->setup->redirect);
-            $this->assertEmpty($this->service->validate_args);
-        }
+		public function test_connect_app_invalid_nonce(): void {
+			$GLOBALS['test_verify_nonce'] = false;
+			$_POST = [ 'nuclen_connect_app_nonce' => 'x', 'nuclen_api_key' => 'k' ];
+			$this->expectException(RedirectException::class);
+			try { $this->setup->nuclen_handle_connect_app(); } catch (RedirectException $e) {}
+			$this->assertSame(['error','Invalid nonce.'], $this->setup->redirect);
+			$this->assertEmpty($this->service->validate_args);
+		}
 
-        public function test_connect_app_requires_capability(): void {
-            $GLOBALS['can_manage'] = false;
-            $_POST = [ 'nuclen_connect_app_nonce' => 'valid', 'nuclen_api_key' => 'k' ];
-            $this->expectException(RedirectException::class);
-            try { $this->setup->nuclen_handle_connect_app(); } catch (RedirectException $e) {}
-            $this->assertSame(['error','Insufficient permissions.'], $this->setup->redirect);
-        }
+		public function test_connect_app_requires_capability(): void {
+			$GLOBALS['can_manage'] = false;
+			$_POST = [ 'nuclen_connect_app_nonce' => 'valid', 'nuclen_api_key' => 'k' ];
+			$this->expectException(RedirectException::class);
+			try { $this->setup->nuclen_handle_connect_app(); } catch (RedirectException $e) {}
+			$this->assertSame(['error','Insufficient permissions.'], $this->setup->redirect);
+		}
 
-        public function test_generate_app_password_invalid_nonce(): void {
-            $GLOBALS['test_verify_nonce'] = false;
-            $_POST = [ 'nuclen_generate_app_password_nonce' => 'n' ];
-            $this->expectException(RedirectException::class);
-            try { $this->setup->nuclen_handle_generate_app_password(); } catch (RedirectException $e) {}
-            $this->assertSame(['error','Invalid nonce.'], $this->setup->redirect);
-        }
+		public function test_generate_app_password_invalid_nonce(): void {
+			$GLOBALS['test_verify_nonce'] = false;
+			$_POST = [ 'nuclen_generate_app_password_nonce' => 'n' ];
+			$this->expectException(RedirectException::class);
+			try { $this->setup->nuclen_handle_generate_app_password(); } catch (RedirectException $e) {}
+			$this->assertSame(['error','Invalid nonce.'], $this->setup->redirect);
+		}
 
-        public function test_successful_connect_and_password_creation(): void {
-            $_POST = [ 'nuclen_connect_app_nonce' => 'valid', 'nuclen_api_key' => 'gold' ];
-            $this->service->validate_return = true;
-            $this->service->send_return = true;
-            $this->expectException(RedirectException::class);
-            try { $this->setup->nuclen_handle_connect_app(); } catch (RedirectException $e) {}
-            $settings = SettingsRepository::get_instance();
-            $this->assertSame('gold', $settings->get_string('api_key'));
-            $this->assertTrue($settings->get_bool('connected'));
-            $this->assertTrue($settings->get_bool('wp_app_pass_created'));
-            $this->assertSame('uuid', $settings->get_string('wp_app_pass_uuid'));
-            $this->assertSame('pass', $settings->get_string('plugin_password'));
-            $this->assertSame(['success','Setup completed – you are ready to go!'], $this->setup->redirect);
-            $this->assertSame(['gold'], $this->service->validate_args);
-            $this->assertCount(1, $this->service->send_args);
-        }
-    }
+		public function test_successful_connect_and_password_creation(): void {
+			$_POST = [ 'nuclen_connect_app_nonce' => 'valid', 'nuclen_api_key' => 'gold' ];
+			$this->service->validate_return = true;
+			$this->service->send_return = true;
+			$this->expectException(RedirectException::class);
+			try { $this->setup->nuclen_handle_connect_app(); } catch (RedirectException $e) {}
+			$settings = SettingsRepository::get_instance();
+			$this->assertSame('gold', $settings->get_string('api_key'));
+			$this->assertTrue($settings->get_bool('connected'));
+			$this->assertTrue($settings->get_bool('wp_app_pass_created'));
+			$this->assertSame('uuid', $settings->get_string('wp_app_pass_uuid'));
+			$this->assertSame('pass', $settings->get_string('plugin_password'));
+			$this->assertSame(['success','Setup completed – you are ready to go!'], $this->setup->redirect);
+			$this->assertSame(['gold'], $this->service->validate_args);
+			$this->assertCount(1, $this->service->send_args);
+		}
+	}
 }

--- a/tests/SetupServiceTest.php
+++ b/tests/SetupServiceTest.php
@@ -1,72 +1,72 @@
 <?php
 namespace NuclearEngagement\Services {
-    class LoggingService {
-        public static array $logs = [];
-        public static array $notices = [];
-        public static function log(string $msg): void { self::$logs[] = $msg; }
-        public static function notify_admin(string $msg): void { self::$notices[] = $msg; }
-    }
-    function wp_json_encode($data) { return json_encode($data); }
+	class LoggingService {
+		public static array $logs = [];
+		public static array $notices = [];
+		public static function log(string $msg): void { self::$logs[] = $msg; }
+		public static function notify_admin(string $msg): void { self::$notices[] = $msg; }
+	}
+	function wp_json_encode($data) { return json_encode($data); }
 }
 
 namespace {
-    use PHPUnit\Framework\TestCase;
-    use NuclearEngagement\Services\SetupService;
-    use NuclearEngagement\Services\LoggingService;
+	use PHPUnit\Framework\TestCase;
+	use NuclearEngagement\Services\SetupService;
+	use NuclearEngagement\Services\LoggingService;
 
-    if (!defined('NUCLEN_PLUGIN_VERSION')) { define('NUCLEN_PLUGIN_VERSION', '1.0'); }
-    if (!defined('NUCLEN_API_TIMEOUT')) { define('NUCLEN_API_TIMEOUT', 30); }
+	if (!defined('NUCLEN_PLUGIN_VERSION')) { define('NUCLEN_PLUGIN_VERSION', '1.0'); }
+	if (!defined('NUCLEN_API_TIMEOUT')) { define('NUCLEN_API_TIMEOUT', 30); }
 
-    class SetupServiceTest extends TestCase {
-        protected function setUp(): void {
-            $GLOBALS['test_http_response'] = null;
-            LoggingService::$logs = [];
-            LoggingService::$notices = [];
-        }
+	class SetupServiceTest extends TestCase {
+		protected function setUp(): void {
+			$GLOBALS['test_http_response'] = null;
+			LoggingService::$logs = [];
+			LoggingService::$notices = [];
+		}
 
-        public function test_validate_api_key_success(): void {
-            $GLOBALS['test_http_response'] = ['code' => 200];
-            $svc = new SetupService();
-            $this->assertTrue($svc->validate_api_key('key'));
-            $this->assertEmpty(LoggingService::$logs);
-            $this->assertEmpty(LoggingService::$notices);
-        }
+		public function test_validate_api_key_success(): void {
+			$GLOBALS['test_http_response'] = ['code' => 200];
+			$svc = new SetupService();
+			$this->assertTrue($svc->validate_api_key('key'));
+			$this->assertEmpty(LoggingService::$logs);
+			$this->assertEmpty(LoggingService::$notices);
+		}
 
-        public function test_validate_api_key_failure_logs_error(): void {
-            $GLOBALS['test_http_response'] = new \WP_Error();
-            $svc = new SetupService();
-            $this->assertFalse($svc->validate_api_key('key'));
-            $this->assertSame(['API-key validation error: error'], LoggingService::$logs);
-            $this->assertSame(['Failed to validate API key.'], LoggingService::$notices);
-        }
+		public function test_validate_api_key_failure_logs_error(): void {
+			$GLOBALS['test_http_response'] = new \WP_Error();
+			$svc = new SetupService();
+			$this->assertFalse($svc->validate_api_key('key'));
+			$this->assertSame(['API-key validation error: error'], LoggingService::$logs);
+			$this->assertSame(['Failed to validate API key.'], LoggingService::$notices);
+		}
 
-        public function test_send_app_password_success(): void {
-            $GLOBALS['test_http_response'] = ['code' => 200];
-            $svc = new SetupService();
-            $data = ['appApiKey' => 'key', 'user' => 'u'];
-            $this->assertTrue($svc->send_app_password($data));
-            $this->assertEmpty(LoggingService::$logs);
-            $this->assertEmpty(LoggingService::$notices);
-        }
+		public function test_send_app_password_success(): void {
+			$GLOBALS['test_http_response'] = ['code' => 200];
+			$svc = new SetupService();
+			$data = ['appApiKey' => 'key', 'user' => 'u'];
+			$this->assertTrue($svc->send_app_password($data));
+			$this->assertEmpty(LoggingService::$logs);
+			$this->assertEmpty(LoggingService::$notices);
+		}
 
-        public function test_send_app_password_failure_logs_error(): void {
-            $GLOBALS['test_http_response'] = new \WP_Error();
-            $svc = new SetupService();
-            $data = ['appApiKey' => 'key', 'user' => 'u'];
-            $this->assertFalse($svc->send_app_password($data));
-            $this->assertSame(['Error sending creds: error'], LoggingService::$logs);
-            $this->assertSame(['Failed to send WordPress credentials.'], LoggingService::$notices);
-        }
+		public function test_send_app_password_failure_logs_error(): void {
+			$GLOBALS['test_http_response'] = new \WP_Error();
+			$svc = new SetupService();
+			$data = ['appApiKey' => 'key', 'user' => 'u'];
+			$this->assertFalse($svc->send_app_password($data));
+			$this->assertSame(['Error sending creds: error'], LoggingService::$logs);
+			$this->assertSame(['Failed to send WordPress credentials.'], LoggingService::$notices);
+		}
 
-        public function test_send_app_password_http_error_logs_error(): void {
-            $GLOBALS['test_http_response'] = ['code' => 400, 'body' => 'bad'];
-            $svc = new SetupService();
-            $data = ['appApiKey' => 'key', 'user' => 'u'];
-            $this->assertFalse($svc->send_app_password($data));
-            $this->assertSame([
-                'Unexpected creds response code: 400, body: bad'
-            ], LoggingService::$logs);
-            $this->assertSame(['Failed to send WordPress credentials.'], LoggingService::$notices);
-        }
-    }
+		public function test_send_app_password_http_error_logs_error(): void {
+			$GLOBALS['test_http_response'] = ['code' => 400, 'body' => 'bad'];
+			$svc = new SetupService();
+			$data = ['appApiKey' => 'key', 'user' => 'u'];
+			$this->assertFalse($svc->send_app_password($data));
+			$this->assertSame([
+				'Unexpected creds response code: 400, body: bad'
+			], LoggingService::$logs);
+			$this->assertSame(['Failed to send WordPress credentials.'], LoggingService::$notices);
+		}
+	}
 }

--- a/tests/SummaryMetaboxFailureTest.php
+++ b/tests/SummaryMetaboxFailureTest.php
@@ -1,64 +1,64 @@
 <?php
 namespace NuclearEngagement\Modules\Summary {
-    function current_user_can($cap, $id) { return true; }
-    function wp_unslash($val) { return $val; }
-    function sanitize_text_field($val) { return $val; }
-    function wp_kses_post($val) { return $val; }
-    function update_post_meta($id, $key, $value) { return false; }
-    function delete_post_meta($id, $key) {}
-    function clean_post_cache($id) {}
+	function current_user_can($cap, $id) { return true; }
+	function wp_unslash($val) { return $val; }
+	function sanitize_text_field($val) { return $val; }
+	function wp_kses_post($val) { return $val; }
+	function update_post_meta($id, $key, $value) { return false; }
+	function delete_post_meta($id, $key) {}
+	function clean_post_cache($id) {}
 }
 
 namespace NuclearEngagement\Services {
-    class LoggingService {
-        public static array $logs = [];
-        public static array $notices = [];
-        public static function log(string $msg): void { self::$logs[] = $msg; }
-        public static function notify_admin(string $msg): void { self::$notices[] = $msg; }
-    }
+	class LoggingService {
+		public static array $logs = [];
+		public static array $notices = [];
+		public static function log(string $msg): void { self::$logs[] = $msg; }
+		public static function notify_admin(string $msg): void { self::$notices[] = $msg; }
+	}
 }
 
 namespace {
-    use PHPUnit\Framework\TestCase;
-    use NuclearEngagement\Modules\Summary\Nuclen_Summary_Metabox;
-    use NuclearEngagement\Modules\Summary\Summary_Service;
-    class DummyRepo {
-        public function get($key, $default = 0) { return 0; }
-    }
+	use PHPUnit\Framework\TestCase;
+	use NuclearEngagement\Modules\Summary\Nuclen_Summary_Metabox;
+	use NuclearEngagement\Modules\Summary\Summary_Service;
+	class DummyRepo {
+		public function get($key, $default = 0) { return 0; }
+	}
 
-    class SummaryMetaboxFailureTest extends TestCase {
-        protected function setUp(): void {
-            $_POST = [
-                'nuclen_summary_data_nonce' => 'n',
-                'nuclen_summary_data' => [],
-            ];
-            \NuclearEngagement\Services\LoggingService::$logs = [];
-            \NuclearEngagement\Services\LoggingService::$notices = [];
-            $GLOBALS['test_verify_nonce'] = true;
-        }
+	class SummaryMetaboxFailureTest extends TestCase {
+		protected function setUp(): void {
+			$_POST = [
+				'nuclen_summary_data_nonce' => 'n',
+				'nuclen_summary_data' => [],
+			];
+			\NuclearEngagement\Services\LoggingService::$logs = [];
+			\NuclearEngagement\Services\LoggingService::$notices = [];
+			$GLOBALS['test_verify_nonce'] = true;
+		}
 
-        protected function tearDown(): void {
-            unset($GLOBALS['test_verify_nonce']);
-        }
+		protected function tearDown(): void {
+			unset($GLOBALS['test_verify_nonce']);
+		}
 
-        public function test_save_meta_logs_on_failure(): void {
-            $box = new Nuclen_Summary_Metabox(new DummyRepo());
-            $box->nuclen_save_summary_data_meta(1);
-            $expected = ['Failed to update summary data for post 1'];
-            $this->assertSame($expected, \NuclearEngagement\Services\LoggingService::$logs);
-            $this->assertSame($expected, \NuclearEngagement\Services\LoggingService::$notices);
-        }
+		public function test_save_meta_logs_on_failure(): void {
+			$box = new Nuclen_Summary_Metabox(new DummyRepo());
+			$box->nuclen_save_summary_data_meta(1);
+			$expected = ['Failed to update summary data for post 1'];
+			$this->assertSame($expected, \NuclearEngagement\Services\LoggingService::$logs);
+			$this->assertSame($expected, \NuclearEngagement\Services\LoggingService::$notices);
+		}
 
-        public function test_protected_flag_logs_on_failure(): void {
-            $_POST[Summary_Service::PROTECTED_KEY] = '1';
-            $box = new Nuclen_Summary_Metabox(new DummyRepo());
-            $box->nuclen_save_summary_data_meta(2);
-            $expected = [
-                'Failed to update summary data for post 2',
-                'Failed to update summary protected flag for post 2'
-            ];
-            $this->assertSame($expected, \NuclearEngagement\Services\LoggingService::$logs);
-            $this->assertSame($expected, \NuclearEngagement\Services\LoggingService::$notices);
-        }
-    }
+		public function test_protected_flag_logs_on_failure(): void {
+			$_POST[Summary_Service::PROTECTED_KEY] = '1';
+			$box = new Nuclen_Summary_Metabox(new DummyRepo());
+			$box->nuclen_save_summary_data_meta(2);
+			$expected = [
+				'Failed to update summary data for post 2',
+				'Failed to update summary protected flag for post 2'
+			];
+			$this->assertSame($expected, \NuclearEngagement\Services\LoggingService::$logs);
+			$this->assertSame($expected, \NuclearEngagement\Services\LoggingService::$notices);
+		}
+	}
 }

--- a/tests/SummaryShortcodeViewTest.php
+++ b/tests/SummaryShortcodeViewTest.php
@@ -1,82 +1,82 @@
 <?php
 namespace {
-    use PHPUnit\Framework\TestCase;
-    use NuclearEngagement\Modules\Summary\Nuclen_Summary_Shortcode as SummaryShortcode;
-    use NuclearEngagement\Modules\Summary\Nuclen_Summary_View as SummaryView;
-    use NuclearEngagement\Modules\Summary\Summary_Service;
-    use NuclearEngagement\Core\SettingsRepository;
+	use PHPUnit\Framework\TestCase;
+	use NuclearEngagement\Modules\Summary\Nuclen_Summary_Shortcode as SummaryShortcode;
+	use NuclearEngagement\Modules\Summary\Nuclen_Summary_View as SummaryView;
+	use NuclearEngagement\Modules\Summary\Summary_Service;
+	use NuclearEngagement\Core\SettingsRepository;
 
-    function get_the_ID() { return $GLOBALS['current_post_id'] ?? 0; }
-    if (!function_exists('esc_html')) {
-        function esc_html($t) { return $t; }
-    }
-    if (!function_exists('esc_html__')) {
-        function esc_html__($t, $d = null) { return $t; }
-    }
-    if (!function_exists('__')) {
-        function __($t, $d = null) { return $t; }
-    }
-    if (!function_exists('wp_kses_post')) {
-        function wp_kses_post($html) { return $html; }
-    }
-    if (!function_exists('esc_attr')) { function esc_attr($t){ return $t; } }
+	function get_the_ID() { return $GLOBALS['current_post_id'] ?? 0; }
+	if (!function_exists('esc_html')) {
+		function esc_html($t) { return $t; }
+	}
+	if (!function_exists('esc_html__')) {
+		function esc_html__($t, $d = null) { return $t; }
+	}
+	if (!function_exists('__')) {
+		function __($t, $d = null) { return $t; }
+	}
+	if (!function_exists('wp_kses_post')) {
+		function wp_kses_post($html) { return $html; }
+	}
+	if (!function_exists('esc_attr')) { function esc_attr($t){ return $t; } }
 
-    class DummyFront {
-        public int $calls = 0;
-        public function nuclen_force_enqueue_assets(): void { $this->calls++; }
-    }
+	class DummyFront {
+		public int $calls = 0;
+		public function nuclen_force_enqueue_assets(): void { $this->calls++; }
+	}
 
-    class SummaryShortcodeViewTest extends TestCase {
-        protected function setUp(): void {
-            global $wp_options, $wp_meta;
-            $wp_options = $wp_meta = [];
-            SettingsRepository::reset_for_tests();
-        }
+	class SummaryShortcodeViewTest extends TestCase {
+		protected function setUp(): void {
+			global $wp_options, $wp_meta;
+			$wp_options = $wp_meta = [];
+			SettingsRepository::reset_for_tests();
+		}
 
-        private function makeShortcode(DummyFront $front): SummaryShortcode {
-            $settings = SettingsRepository::get_instance();
-            return new SummaryShortcode($settings, $front);
-        }
+		private function makeShortcode(DummyFront $front): SummaryShortcode {
+			$settings = SettingsRepository::get_instance();
+			return new SummaryShortcode($settings, $front);
+		}
 
-        public function test_render_outputs_markup_with_valid_data(): void {
-            global $wp_meta, $current_post_id;
-            $current_post_id = 1;
-            $wp_meta[1][Summary_Service::META_KEY] = ['summary' => '<p>Hi</p>'];
+		public function test_render_outputs_markup_with_valid_data(): void {
+			global $wp_meta, $current_post_id;
+			$current_post_id = 1;
+			$wp_meta[1][Summary_Service::META_KEY] = ['summary' => '<p>Hi</p>'];
 
-            $settings = SettingsRepository::get_instance();
-            $settings->set_string('summary_title', 'Facts')->set_bool('show_attribution', true)->save();
+			$settings = SettingsRepository::get_instance();
+			$settings->set_string('summary_title', 'Facts')->set_bool('show_attribution', true)->save();
 
-            $front = new DummyFront();
-            $sc = $this->makeShortcode($front);
-            $html = $sc->render();
+			$front = new DummyFront();
+			$sc = $this->makeShortcode($front);
+			$html = $sc->render();
 
-            $this->assertStringContainsString('id="nuclen-summary-container"', $html);
-            $this->assertStringContainsString('<h2 id="nuclen-summary-title" class="nuclen-fg">Facts</h2>', $html);
-            $this->assertStringContainsString('class="nuclen-attribution"', $html);
-            $this->assertSame(1, $front->calls);
-        }
+			$this->assertStringContainsString('id="nuclen-summary-container"', $html);
+			$this->assertStringContainsString('<h2 id="nuclen-summary-title" class="nuclen-fg">Facts</h2>', $html);
+			$this->assertStringContainsString('class="nuclen-attribution"', $html);
+			$this->assertSame(1, $front->calls);
+		}
 
-        public function test_render_returns_empty_string_when_data_invalid(): void {
-            global $wp_meta, $current_post_id;
-            $current_post_id = 2;
-            $wp_meta[2][Summary_Service::META_KEY] = ['summary' => ''];
+		public function test_render_returns_empty_string_when_data_invalid(): void {
+			global $wp_meta, $current_post_id;
+			$current_post_id = 2;
+			$wp_meta[2][Summary_Service::META_KEY] = ['summary' => ''];
 
-            $front = new DummyFront();
-            $sc = $this->makeShortcode($front);
-            $this->assertSame('', $sc->render());
-        }
+			$front = new DummyFront();
+			$sc = $this->makeShortcode($front);
+			$this->assertSame('', $sc->render());
+		}
 
-        public function test_summary_view_outputs_markup(): void {
-            $view = new SummaryView();
-            $data = ['summary' => '<p>Ok</p>'];
-            $settings = ['summary_title' => 'Title'];
-            $html = $view->container($data, $settings);
-            $this->assertStringContainsString('<section id="nuclen-summary-container"', $html);
-            $this->assertStringContainsString('Title', $html);
-            $this->assertStringContainsString('<p>Ok</p>', $html);
+		public function test_summary_view_outputs_markup(): void {
+			$view = new SummaryView();
+			$data = ['summary' => '<p>Ok</p>'];
+			$settings = ['summary_title' => 'Title'];
+			$html = $view->container($data, $settings);
+			$this->assertStringContainsString('<section id="nuclen-summary-container"', $html);
+			$this->assertStringContainsString('Title', $html);
+			$this->assertStringContainsString('<p>Ok</p>', $html);
 
-            $this->assertNotEmpty($view->attribution(true));
-            $this->assertSame('', $view->attribution(false));
-        }
-    }
+			$this->assertNotEmpty($view->attribution(true));
+			$this->assertSame('', $view->attribution(false));
+		}
+	}
 }

--- a/tests/ThemeRegistryTest.php
+++ b/tests/ThemeRegistryTest.php
@@ -3,42 +3,42 @@ use PHPUnit\Framework\TestCase;
 use NuclearEngagement\Core\ThemeRegistry;
 
 class ThemeRegistryTest extends TestCase {
-    public static function setUpBeforeClass(): void {
-        require_once dirname(__DIR__) . '/nuclear-engagement/inc/Core/Themes.php';
-    }
+	public static function setUpBeforeClass(): void {
+		require_once dirname(__DIR__) . '/nuclear-engagement/inc/Core/Themes.php';
+	}
 
-    protected function setUp(): void {
-        $this->resetRegistry();
-    }
+	protected function setUp(): void {
+		$this->resetRegistry();
+	}
 
-    private function resetRegistry(): void {
-        $ref = new \ReflectionClass(ThemeRegistry::class);
-        $prop = $ref->getProperty('themes');
-        $prop->setAccessible(true);
-        $prop->setValue([
-            'bright' => 'nuclen-theme-bright.css',
-            'dark'   => 'nuclen-theme-dark.css',
-        ]);
-    }
+	private function resetRegistry(): void {
+		$ref = new \ReflectionClass(ThemeRegistry::class);
+		$prop = $ref->getProperty('themes');
+		$prop->setAccessible(true);
+		$prop->setValue([
+			'bright' => 'nuclen-theme-bright.css',
+			'dark'   => 'nuclen-theme-dark.css',
+		]);
+	}
 
-    public function test_get_themes_returns_default_themes(): void {
-        $expected = [
-            'bright' => 'nuclen-theme-bright.css',
-            'dark'   => 'nuclen-theme-dark.css',
-        ];
-        $this->assertSame($expected, ThemeRegistry::get_themes());
-    }
+	public function test_get_themes_returns_default_themes(): void {
+		$expected = [
+			'bright' => 'nuclen-theme-bright.css',
+			'dark'   => 'nuclen-theme-dark.css',
+		];
+		$this->assertSame($expected, ThemeRegistry::get_themes());
+	}
 
-    public function test_register_adds_new_theme(): void {
-        ThemeRegistry::register('blue', 'nuclen-blue.css');
-        $themes = ThemeRegistry::get_themes();
-        $this->assertArrayHasKey('blue', $themes);
-        $this->assertSame('nuclen-blue.css', $themes['blue']);
-    }
+	public function test_register_adds_new_theme(): void {
+		ThemeRegistry::register('blue', 'nuclen-blue.css');
+		$themes = ThemeRegistry::get_themes();
+		$this->assertArrayHasKey('blue', $themes);
+		$this->assertSame('nuclen-blue.css', $themes['blue']);
+	}
 
-    public function test_get_returns_stylesheet_or_null(): void {
-        ThemeRegistry::register('mono', 'mono.css');
-        $this->assertSame('mono.css', ThemeRegistry::get('mono'));
-        $this->assertNull(ThemeRegistry::get('missing'));
-    }
+	public function test_get_returns_stylesheet_or_null(): void {
+		ThemeRegistry::register('mono', 'mono.css');
+		$this->assertSame('mono.css', ThemeRegistry::get('mono'));
+		$this->assertNull(ThemeRegistry::get('missing'));
+	}
 }

--- a/tests/TocModuleTest.php
+++ b/tests/TocModuleTest.php
@@ -7,165 +7,165 @@ use NuclearEngagement\Core\Container;
 // WordPress function stubs
 // ------------------------------------------------------
 if ( ! defined( 'HOUR_IN_SECONDS' ) ) {
-    define( 'HOUR_IN_SECONDS', 3600 );
+	define( 'HOUR_IN_SECONDS', 3600 );
 }
 if ( ! defined( 'NUCLEN_TOC_SCROLL_OFFSET_DEFAULT' ) ) {
-    define( 'NUCLEN_TOC_SCROLL_OFFSET_DEFAULT', 72 );
+	define( 'NUCLEN_TOC_SCROLL_OFFSET_DEFAULT', 72 );
 }
 if ( ! defined( 'NUCLEN_TOC_DIR' ) ) {
-    define( 'NUCLEN_TOC_DIR', dirname( __DIR__ ) . '/nuclear-engagement/inc/Modules/TOC/' );
+	define( 'NUCLEN_TOC_DIR', dirname( __DIR__ ) . '/nuclear-engagement/inc/Modules/TOC/' );
 }
 if ( ! defined( 'NUCLEN_TOC_URL' ) ) {
-    define( 'NUCLEN_TOC_URL', 'http://example.com/' );
+	define( 'NUCLEN_TOC_URL', 'http://example.com/' );
 }
 
 $GLOBALS['wp_cache'] = [];
 $GLOBALS['transients'] = [];
 
 if ( ! function_exists( 'wp_cache_get' ) ) {
-    function wp_cache_get( $key, $group = '' ) {
-        return $GLOBALS['wp_cache'][ $group ][ $key ] ?? false;
-    }
+	function wp_cache_get( $key, $group = '' ) {
+		return $GLOBALS['wp_cache'][ $group ][ $key ] ?? false;
+	}
 }
 if ( ! function_exists( 'wp_cache_set' ) ) {
-    function wp_cache_set( $key, $value, $group = '', $ttl = 0 ) {
-        $GLOBALS['wp_cache'][ $group ][ $key ] = $value;
-    }
+	function wp_cache_set( $key, $value, $group = '', $ttl = 0 ) {
+		$GLOBALS['wp_cache'][ $group ][ $key ] = $value;
+	}
 }
 if ( ! function_exists( 'wp_cache_delete' ) ) {
-    function wp_cache_delete( $key, $group = '' ) {
-        unset( $GLOBALS['wp_cache'][ $group ][ $key ] );
-    }
+	function wp_cache_delete( $key, $group = '' ) {
+		unset( $GLOBALS['wp_cache'][ $group ][ $key ] );
+	}
 }
 if ( ! function_exists( 'wp_cache_flush_group' ) ) {
-    function wp_cache_flush_group( $group ) {
-        unset( $GLOBALS['wp_cache'][ $group ] );
-    }
+	function wp_cache_flush_group( $group ) {
+		unset( $GLOBALS['wp_cache'][ $group ] );
+	}
 }
 
 if ( ! function_exists( 'get_transient' ) ) {
-    function get_transient( $key ) {
-        return $GLOBALS['transients'][ $key ] ?? false;
-    }
+	function get_transient( $key ) {
+		return $GLOBALS['transients'][ $key ] ?? false;
+	}
 }
 if ( ! function_exists( 'set_transient' ) ) {
-    function set_transient( $key, $value, $ttl = 0 ) {
-        $GLOBALS['transients'][ $key ] = $value;
-    }
+	function set_transient( $key, $value, $ttl = 0 ) {
+		$GLOBALS['transients'][ $key ] = $value;
+	}
 }
 if ( ! function_exists( 'delete_transient' ) ) {
-    function delete_transient( $key ) {
-        unset( $GLOBALS['transients'][ $key ] );
-    }
+	function delete_transient( $key ) {
+		unset( $GLOBALS['transients'][ $key ] );
+	}
 }
 if ( ! function_exists( 'wp_list_pluck' ) ) {
-    function wp_list_pluck( array $list, string $field ) {
-        $out = [];
-        foreach ( $list as $item ) {
-            if ( is_array( $item ) && isset( $item[ $field ] ) ) {
-                $out[] = $item[ $field ];
-            } elseif ( is_object( $item ) && isset( $item->$field ) ) {
-                $out[] = $item->$field;
-            }
-        }
-        return $out;
-    }
+	function wp_list_pluck( array $list, string $field ) {
+		$out = [];
+		foreach ( $list as $item ) {
+			if ( is_array( $item ) && isset( $item[ $field ] ) ) {
+				$out[] = $item[ $field ];
+			} elseif ( is_object( $item ) && isset( $item->$field ) ) {
+				$out[] = $item->$field;
+			}
+		}
+		return $out;
+	}
 }
 if (!function_exists('sanitize_title')) {
-    function sanitize_title($text) {
-        $text = strtolower(trim($text));
-        $text = preg_replace('/[^a-z0-9_-]+/', '-', $text);
-        return trim($text, '-');
-    }
+	function sanitize_title($text) {
+		$text = strtolower(trim($text));
+		$text = preg_replace('/[^a-z0-9_-]+/', '-', $text);
+		return trim($text, '-');
+	}
 }
 if (!function_exists('sanitize_html_class')) {
-    function sanitize_html_class($text) {
-        $text = strtolower(trim($text));
-        $text = preg_replace('/[^a-z0-9_-]+/', '-', $text);
-        return trim($text, '-');
-    }
+	function sanitize_html_class($text) {
+		$text = strtolower(trim($text));
+		$text = preg_replace('/[^a-z0-9_-]+/', '-', $text);
+		return trim($text, '-');
+	}
 }
 if (!function_exists('sanitize_text_field')) {
-    function sanitize_text_field($text) {
-        return trim($text);
-    }
+	function sanitize_text_field($text) {
+		return trim($text);
+	}
 }
 if (!function_exists('esc_html')) {
-    function esc_html($text) {
-        return htmlspecialchars($text, ENT_QUOTES);
-    }
+	function esc_html($text) {
+		return htmlspecialchars($text, ENT_QUOTES);
+	}
 }
 if (!function_exists('esc_attr')) {
-    function esc_attr($text) {
-        return htmlspecialchars($text, ENT_QUOTES);
-    }
+	function esc_attr($text) {
+		return htmlspecialchars($text, ENT_QUOTES);
+	}
 }
 if (!function_exists('__')) {
-    function __($text, $domain = null) { return $text; }
+	function __($text, $domain = null) { return $text; }
 }
 if (!function_exists('esc_html__')) {
-    function esc_html__($text, $domain = null) { return esc_html($text); }
+	function esc_html__($text, $domain = null) { return esc_html($text); }
 }
 if (!function_exists('esc_attr__')) {
-    function esc_attr__($text, $domain = null) { return esc_attr($text); }
+	function esc_attr__($text, $domain = null) { return esc_attr($text); }
 }
 if (!function_exists('apply_filters')) {
-    function apply_filters($hook, $value) { return $value; }
+	function apply_filters($hook, $value) { return $value; }
 }
 if (!function_exists('add_filter')) {
-    function add_filter(...$args) {}
+	function add_filter(...$args) {}
 }
 if ( ! function_exists( 'add_shortcode' ) ) {
-    function add_shortcode( ...$args ) {}
+	function add_shortcode( ...$args ) {}
 }
 if ( ! function_exists( 'shortcode_atts' ) ) {
-    function shortcode_atts( $pairs, $atts, $shortcode = '' ) {
-        $out = $pairs;
-        foreach ( $pairs as $name => $default ) {
-            if ( isset( $atts[ $name ] ) ) {
-                $out[ $name ] = $atts[ $name ];
-            }
-        }
-        foreach ( $atts as $name => $value ) {
-            if ( ! isset( $out[ $name ] ) ) {
-                $out[ $name ] = $value;
-            }
-        }
-        return $out;
-    }
+	function shortcode_atts( $pairs, $atts, $shortcode = '' ) {
+		$out = $pairs;
+		foreach ( $pairs as $name => $default ) {
+			if ( isset( $atts[ $name ] ) ) {
+				$out[ $name ] = $atts[ $name ];
+			}
+		}
+		foreach ( $atts as $name => $value ) {
+			if ( ! isset( $out[ $name ] ) ) {
+				$out[ $name ] = $value;
+			}
+		}
+		return $out;
+	}
 }
 if ( ! function_exists( 'wp_unique_id' ) ) {
-    function wp_unique_id( $prefix = '' ) {
-        static $i = 1;
-        return $prefix . $i++;
-    }
+	function wp_unique_id( $prefix = '' ) {
+		static $i = 1;
+		return $prefix . $i++;
+	}
 }
 if ( ! function_exists( 'wp_script_is' ) ) {
-    function wp_script_is( $handle, $list = 'enqueued' ) { return false; }
+	function wp_script_is( $handle, $list = 'enqueued' ) { return false; }
 }
 if ( ! function_exists( 'wp_enqueue_script' ) ) {
-    function wp_enqueue_script( $handle ) {}
+	function wp_enqueue_script( $handle ) {}
 }
 if ( ! function_exists( 'wp_enqueue_style' ) ) {
-    function wp_enqueue_style( $handle ) {}
+	function wp_enqueue_style( $handle ) {}
 }
 if ( ! function_exists( 'wp_add_inline_style' ) ) {
-    function wp_add_inline_style( $handle, $css ) {}
+	function wp_add_inline_style( $handle, $css ) {}
 }
 if ( ! function_exists( 'wp_register_style' ) ) {
-    function wp_register_style( $handle, $src, $deps = [], $ver = '' ) {}
+	function wp_register_style( $handle, $src, $deps = [], $ver = '' ) {}
 }
 if ( ! function_exists( 'wp_register_script' ) ) {
-    function wp_register_script( $handle, $src, $deps = [], $ver = '', $in_footer = false ) {}
+	function wp_register_script( $handle, $src, $deps = [], $ver = '', $in_footer = false ) {}
 }
 if ( ! function_exists( 'wp_localize_script' ) ) {
-    function wp_localize_script( $handle, $object_name, $l10n ) {}
+	function wp_localize_script( $handle, $object_name, $l10n ) {}
 }
 if ( ! function_exists( 'is_singular' ) ) {
-    function is_singular() { return true; }
+	function is_singular() { return true; }
 }
 if ( ! function_exists( 'get_the_ID' ) ) {
-    function get_the_ID() { return $GLOBALS['current_post_id'] ?? 0; }
+	function get_the_ID() { return $GLOBALS['current_post_id'] ?? 0; }
 }
 
 // ------------------------------------------------------
@@ -183,81 +183,81 @@ require_once dirname(__DIR__) . '/nuclear-engagement/inc/Core/Defaults.php';
 require_once dirname(__DIR__) . '/nuclear-engagement/inc/Core/Container.php';
 
 class TocModuleTest extends TestCase {
-    protected function setUp(): void {
-        global $wp_posts, $wp_cache, $transients, $current_post_id;
-        $wp_posts   = [];
-        $wp_cache   = [];
-        $transients = [];
-        $current_post_id = 0;
-        SettingsRepository::reset_for_tests();
-        Container::getInstance()->reset();
-    }
+	protected function setUp(): void {
+		global $wp_posts, $wp_cache, $transients, $current_post_id;
+		$wp_posts   = [];
+		$wp_cache   = [];
+		$transients = [];
+		$current_post_id = 0;
+		SettingsRepository::reset_for_tests();
+		Container::getInstance()->reset();
+	}
 
-    private function registerSettings(): SettingsRepository {
-        $settings = SettingsRepository::get_instance([
-            'toc_heading_levels' => [2,3],
-            'toc_show_toggle'    => true,
-            'toc_show_content'   => true,
-        ]);
-        $c = Container::getInstance();
-        $c->register('settings', static function () use ($settings) {
-            return $settings;
-        });
-        return $settings;
-    }
+	private function registerSettings(): SettingsRepository {
+		$settings = SettingsRepository::get_instance([
+			'toc_heading_levels' => [2,3],
+			'toc_show_toggle'    => true,
+			'toc_show_content'   => true,
+		]);
+		$c = Container::getInstance();
+		$c->register('settings', static function () use ($settings) {
+			return $settings;
+		});
+		return $settings;
+	}
 
-    public function test_heading_ids_are_injected() {
-        $this->registerSettings();
-        $headings = new \NuclearEngagement\Modules\TOC\Nuclen_TOC_Headings();
-        $html = '<h2>Intro</h2><h2>Intro</h2><h3 class="no-toc">Skip</h3><h2 id="existing">X</h2>';
-        $result = $headings->add_heading_ids($html);
-        $this->assertStringContainsString('<h2 id="intro">Intro</h2>', $result);
-        $this->assertStringContainsString('<h2 id="intro-2">Intro</h2>', $result);
-        $this->assertStringContainsString('<h3 class="no-toc">Skip</h3>', $result);
-        $this->assertStringContainsString('<h2 id="existing">X</h2>', $result);
-    }
+	public function test_heading_ids_are_injected() {
+		$this->registerSettings();
+		$headings = new \NuclearEngagement\Modules\TOC\Nuclen_TOC_Headings();
+		$html = '<h2>Intro</h2><h2>Intro</h2><h3 class="no-toc">Skip</h3><h2 id="existing">X</h2>';
+		$result = $headings->add_heading_ids($html);
+		$this->assertStringContainsString('<h2 id="intro">Intro</h2>', $result);
+		$this->assertStringContainsString('<h2 id="intro-2">Intro</h2>', $result);
+		$this->assertStringContainsString('<h3 class="no-toc">Skip</h3>', $result);
+		$this->assertStringContainsString('<h2 id="existing">X</h2>', $result);
+	}
 
-    public function test_shortcode_outputs_expected_markup() {
-        global $wp_posts, $current_post_id;
-        $current_post_id = 1;
-        $wp_posts[1] = (object)[
-            'ID' => 1,
-            'post_content' => '<h2>One</h2><h3>Sub</h3>',
-        ];
-        $this->registerSettings();
-        $render = new \NuclearEngagement\Modules\TOC\Nuclen_TOC_Render( SettingsRepository::get_instance() );
-        $out = $render->nuclen_toc_shortcode([]);
-        $this->assertStringContainsString('<nav id="', $out);
-        $this->assertStringContainsString('<a href="#one">One</a>', $out);
-        $this->assertStringContainsString('<a href="#sub">Sub</a>', $out);
-        $this->assertStringContainsString('class="nuclen-toc', $out);
-    }
+	public function test_shortcode_outputs_expected_markup() {
+		global $wp_posts, $current_post_id;
+		$current_post_id = 1;
+		$wp_posts[1] = (object)[
+			'ID' => 1,
+			'post_content' => '<h2>One</h2><h3>Sub</h3>',
+		];
+		$this->registerSettings();
+		$render = new \NuclearEngagement\Modules\TOC\Nuclen_TOC_Render( SettingsRepository::get_instance() );
+		$out = $render->nuclen_toc_shortcode([]);
+		$this->assertStringContainsString('<nav id="', $out);
+		$this->assertStringContainsString('<a href="#one">One</a>', $out);
+		$this->assertStringContainsString('<a href="#sub">Sub</a>', $out);
+		$this->assertStringContainsString('class="nuclen-toc', $out);
+	}
 
-    public function test_shortcode_returns_empty_when_no_post() {
-        $this->registerSettings();
-        $render = new \NuclearEngagement\Modules\TOC\Nuclen_TOC_Render( SettingsRepository::get_instance() );
-        $this->assertSame('', $render->nuclen_toc_shortcode([]));
-    }
+	public function test_shortcode_returns_empty_when_no_post() {
+		$this->registerSettings();
+		$render = new \NuclearEngagement\Modules\TOC\Nuclen_TOC_Render( SettingsRepository::get_instance() );
+		$this->assertSame('', $render->nuclen_toc_shortcode([]));
+	}
 
-    public function test_cache_is_cleared_for_post() {
-        global $wp_posts, $wp_cache, $transients;
+	public function test_cache_is_cleared_for_post() {
+		global $wp_posts, $wp_cache, $transients;
 
-        $wp_posts[1] = (object) [
-            'ID'           => 1,
-            'post_content' => '<h2>One</h2>',
-        ];
+		$wp_posts[1] = (object) [
+			'ID'           => 1,
+			'post_content' => '<h2>One</h2>',
+		];
 
-        $this->registerSettings();
+		$this->registerSettings();
 
-        \NuclearEngagement\Modules\TOC\Nuclen_TOC_Utils::extract( $wp_posts[1]->post_content, [2, 3] );
-        $key = md5( $wp_posts[1]->post_content ) . '_23';
+		\NuclearEngagement\Modules\TOC\Nuclen_TOC_Utils::extract( $wp_posts[1]->post_content, [2, 3] );
+		$key = md5( $wp_posts[1]->post_content ) . '_23';
 
-        $this->assertArrayHasKey( $key, $wp_cache['nuclen_toc'] );
-        $this->assertArrayHasKey( 'nuclen_toc_' . $key, $transients );
+		$this->assertArrayHasKey( $key, $wp_cache['nuclen_toc'] );
+		$this->assertArrayHasKey( 'nuclen_toc_' . $key, $transients );
 
-        \NuclearEngagement\Modules\TOC\Nuclen_TOC_Utils::clear_cache_for_post( 1 );
+		\NuclearEngagement\Modules\TOC\Nuclen_TOC_Utils::clear_cache_for_post( 1 );
 
-        $this->assertArrayNotHasKey( $key, $wp_cache['nuclen_toc'] );
-        $this->assertArrayNotHasKey( 'nuclen_toc_' . $key, $transients );
-    }
+		$this->assertArrayNotHasKey( $key, $wp_cache['nuclen_toc'] );
+		$this->assertArrayNotHasKey( 'nuclen_toc_' . $key, $transients );
+	}
 }

--- a/tests/UninstallTest.php
+++ b/tests/UninstallTest.php
@@ -3,126 +3,126 @@ use PHPUnit\Framework\TestCase;
 use NuclearEngagement\Modules\Summary\Summary_Service;
 
 if (!defined('WP_UNINSTALL_PLUGIN')) {
-    define('WP_UNINSTALL_PLUGIN', true);
+	define('WP_UNINSTALL_PLUGIN', true);
 }
 
 if (!function_exists('delete_post_meta_by_key')) {
-    function delete_post_meta_by_key($key): void {
-        $GLOBALS['deleted_meta_keys'][] = $key;
-        foreach ($GLOBALS['wp_meta'] as &$post_meta) {
-            unset($post_meta[$key]);
-        }
-    }
+	function delete_post_meta_by_key($key): void {
+		$GLOBALS['deleted_meta_keys'][] = $key;
+		foreach ($GLOBALS['wp_meta'] as &$post_meta) {
+			unset($post_meta[$key]);
+		}
+	}
 }
 
 if (!function_exists('wp_delete_file')) {
-    function wp_delete_file(string $path): void {
-        $GLOBALS['deleted_files'][] = $path;
-        if (file_exists($path)) {
-            unlink($path);
-        }
-    }
+	function wp_delete_file(string $path): void {
+		$GLOBALS['deleted_files'][] = $path;
+		if (file_exists($path)) {
+			unlink($path);
+		}
+	}
 }
 
 if (!function_exists('esc_sql')) {
-    function esc_sql($sql) { return $sql; }
+	function esc_sql($sql) { return $sql; }
 }
 
 class DummyWPDB {
-    public string $prefix = 'wp_';
-    public array $queries = [];
-    public function query($sql) { $this->queries[] = $sql; }
+	public string $prefix = 'wp_';
+	public array $queries = [];
+	public function query($sql) { $this->queries[] = $sql; }
 }
 
 class UninstallTest extends TestCase {
-    private string $baseDir;
-    private string $pluginDir;
+	private string $baseDir;
+	private string $pluginDir;
 
-    protected function setUp(): void {
-        global $wp_options, $wp_meta, $wpdb;
-        $this->baseDir = sys_get_temp_dir() . '/uninstall_' . uniqid();
-        mkdir($this->baseDir, 0777, true);
-        $GLOBALS['test_upload_basedir'] = $this->baseDir;
-        $this->pluginDir = sys_get_temp_dir() . '/un_plugin_' . uniqid();
-        if (!defined('NUCLEN_PLUGIN_DIR')) {
-            define('NUCLEN_PLUGIN_DIR', $this->pluginDir . '/');
-        }
-        mkdir($this->pluginDir, 0777, true);
+	protected function setUp(): void {
+		global $wp_options, $wp_meta, $wpdb;
+		$this->baseDir = sys_get_temp_dir() . '/uninstall_' . uniqid();
+		mkdir($this->baseDir, 0777, true);
+		$GLOBALS['test_upload_basedir'] = $this->baseDir;
+		$this->pluginDir = sys_get_temp_dir() . '/un_plugin_' . uniqid();
+		if (!defined('NUCLEN_PLUGIN_DIR')) {
+			define('NUCLEN_PLUGIN_DIR', $this->pluginDir . '/');
+		}
+		mkdir($this->pluginDir, 0777, true);
 
-        $wp_options = [
-            'nuclear_engagement_settings' => [
-                'delete_settings_on_uninstall' => true,
-                'delete_generated_content_on_uninstall' => true,
-                'delete_optin_data_on_uninstall' => true,
-                'delete_log_file_on_uninstall' => true,
-                'delete_custom_css_on_uninstall' => true,
-            ],
-            'nuclear_engagement_setup' => ['installed' => true],
-            'nuclen_custom_css_version' => 'v1',
-        ];
+		$wp_options = [
+			'nuclear_engagement_settings' => [
+				'delete_settings_on_uninstall' => true,
+				'delete_generated_content_on_uninstall' => true,
+				'delete_optin_data_on_uninstall' => true,
+				'delete_log_file_on_uninstall' => true,
+				'delete_custom_css_on_uninstall' => true,
+			],
+			'nuclear_engagement_setup' => ['installed' => true],
+			'nuclen_custom_css_version' => 'v1',
+		];
 
-        $wp_meta = [
-            1 => [
-                'nuclen-quiz-data' => 'q',
-                'nuclen_quiz_protected' => '1',
-            ],
-            2 => [
-                Summary_Service::META_KEY => 's',
-            ],
-        ];
+		$wp_meta = [
+			1 => [
+				'nuclen-quiz-data' => 'q',
+				'nuclen_quiz_protected' => '1',
+			],
+			2 => [
+				Summary_Service::META_KEY => 's',
+			],
+		];
 
-        $logDir = $this->baseDir . '/nuclear-engagement';
-        mkdir($logDir, 0777, true);
-        file_put_contents($logDir . '/log.txt', 'log');
-        file_put_contents($logDir . '/nuclen-theme-custom.css', 'css');
+		$logDir = $this->baseDir . '/nuclear-engagement';
+		mkdir($logDir, 0777, true);
+		file_put_contents($logDir . '/log.txt', 'log');
+		file_put_contents($logDir . '/nuclen-theme-custom.css', 'css');
 
-        $GLOBALS['deleted_files'] = [];
-        $GLOBALS['deleted_meta_keys'] = [];
+		$GLOBALS['deleted_files'] = [];
+		$GLOBALS['deleted_meta_keys'] = [];
 
-        $wpdb = new DummyWPDB();
-    }
+		$wpdb = new DummyWPDB();
+	}
 
-    protected function tearDown(): void {
-        $this->deleteDir($this->baseDir);
-        $this->deleteDir($this->pluginDir);
-        unset($GLOBALS['test_upload_basedir']);
-        unset($GLOBALS['deleted_files'], $GLOBALS['deleted_meta_keys']);
-    }
+	protected function tearDown(): void {
+		$this->deleteDir($this->baseDir);
+		$this->deleteDir($this->pluginDir);
+		unset($GLOBALS['test_upload_basedir']);
+		unset($GLOBALS['deleted_files'], $GLOBALS['deleted_meta_keys']);
+	}
 
-    private function deleteDir(string $dir): void {
-        if (!is_dir($dir)) {
-            return;
-        }
-        foreach (glob($dir . '/*') as $file) {
-            if (is_dir($file)) {
-                $this->deleteDir($file);
-            } else {
-                unlink($file);
-            }
-        }
-        rmdir($dir);
-    }
+	private function deleteDir(string $dir): void {
+		if (!is_dir($dir)) {
+			return;
+		}
+		foreach (glob($dir . '/*') as $file) {
+			if (is_dir($file)) {
+				$this->deleteDir($file);
+			} else {
+				unlink($file);
+			}
+		}
+		rmdir($dir);
+	}
 
-    public function test_uninstall_removes_all_data(): void {
-        require __DIR__ . '/../nuclear-engagement/uninstall.php';
+	public function test_uninstall_removes_all_data(): void {
+		require __DIR__ . '/../nuclear-engagement/uninstall.php';
 
-        global $wp_options, $wp_meta;
+		global $wp_options, $wp_meta;
 
-        $this->assertArrayNotHasKey('nuclear_engagement_settings', $wp_options);
-        $this->assertArrayNotHasKey('nuclear_engagement_setup', $wp_options);
-        $this->assertArrayNotHasKey('nuclen_custom_css_version', $wp_options);
+		$this->assertArrayNotHasKey('nuclear_engagement_settings', $wp_options);
+		$this->assertArrayNotHasKey('nuclear_engagement_setup', $wp_options);
+		$this->assertArrayNotHasKey('nuclen_custom_css_version', $wp_options);
 
-        $this->assertEmpty($wp_meta[1]);
-        $this->assertEmpty($wp_meta[2]);
+		$this->assertEmpty($wp_meta[1]);
+		$this->assertEmpty($wp_meta[2]);
 
-        $this->assertFileDoesNotExist($this->baseDir . '/nuclear-engagement/log.txt');
-        $this->assertFileDoesNotExist($this->baseDir . '/nuclear-engagement/nuclen-theme-custom.css');
+		$this->assertFileDoesNotExist($this->baseDir . '/nuclear-engagement/log.txt');
+		$this->assertFileDoesNotExist($this->baseDir . '/nuclear-engagement/nuclen-theme-custom.css');
 
-        $this->assertSame(['nuclen-quiz-data', Summary_Service::META_KEY, 'nuclen_quiz_protected', Summary_Service::PROTECTED_KEY], $GLOBALS['deleted_meta_keys']);
-        $expected_files = [
-            $this->baseDir . '/nuclear-engagement/log.txt',
-            $this->baseDir . '/nuclear-engagement/nuclen-theme-custom.css',
-        ];
-        $this->assertSame($expected_files, $GLOBALS['deleted_files']);
-    }
+		$this->assertSame(['nuclen-quiz-data', Summary_Service::META_KEY, 'nuclen_quiz_protected', Summary_Service::PROTECTED_KEY], $GLOBALS['deleted_meta_keys']);
+		$expected_files = [
+			$this->baseDir . '/nuclear-engagement/log.txt',
+			$this->baseDir . '/nuclear-engagement/nuclen-theme-custom.css',
+		];
+		$this->assertSame($expected_files, $GLOBALS['deleted_files']);
+	}
 }

--- a/tests/UpdatesControllerTest.php
+++ b/tests/UpdatesControllerTest.php
@@ -1,101 +1,101 @@
 <?php
 namespace NuclearEngagement\Services {
-    class LoggingService {
-        public static array $logs = [];
-        public static function log(string $msg): void { self::$logs[] = $msg; }
-        public static function log_exception(\Throwable $e): void { self::$logs[] = $e->getMessage(); }
-    }
+	class LoggingService {
+		public static array $logs = [];
+		public static function log(string $msg): void { self::$logs[] = $msg; }
+		public static function log_exception(\Throwable $e): void { self::$logs[] = $e->getMessage(); }
+	}
 }
 
 namespace {
-    use PHPUnit\Framework\TestCase;
-    use NuclearEngagement\Admin\Controller\Ajax\UpdatesController;
-    use NuclearEngagement\Services\ApiException;
-    if (!function_exists('check_ajax_referer')) { function check_ajax_referer($a,$f,$d=false){ return true; } }
-    if (!function_exists('current_user_can')) { function current_user_can($c){ return true; } }
-    if (!function_exists('wp_send_json_success')) { function wp_send_json_success($d){ $GLOBALS['json_response']=['success',$d]; } }
-    if (!function_exists('wp_send_json_error')) { function wp_send_json_error($d,$c=0){ $GLOBALS['json_response']=['error',$d,$c]; } }
-    if (!function_exists('status_header')) { function status_header($c){ $GLOBALS['status_header']=$c; } }
-    if (!function_exists('sanitize_text_field')) { function sanitize_text_field($t){ return $t; } }
-    if (!function_exists('wp_unslash')) { function wp_unslash($d){ return $d; } }
-    if (!function_exists('__')) { function __($t,$d=null){ return $t; } }
+	use PHPUnit\Framework\TestCase;
+	use NuclearEngagement\Admin\Controller\Ajax\UpdatesController;
+	use NuclearEngagement\Services\ApiException;
+	if (!function_exists('check_ajax_referer')) { function check_ajax_referer($a,$f,$d=false){ return true; } }
+	if (!function_exists('current_user_can')) { function current_user_can($c){ return true; } }
+	if (!function_exists('wp_send_json_success')) { function wp_send_json_success($d){ $GLOBALS['json_response']=['success',$d]; } }
+	if (!function_exists('wp_send_json_error')) { function wp_send_json_error($d,$c=0){ $GLOBALS['json_response']=['error',$d,$c]; } }
+	if (!function_exists('status_header')) { function status_header($c){ $GLOBALS['status_header']=$c; } }
+	if (!function_exists('sanitize_text_field')) { function sanitize_text_field($t){ return $t; } }
+	if (!function_exists('wp_unslash')) { function wp_unslash($d){ return $d; } }
+	if (!function_exists('__')) { function __($t,$d=null){ return $t; } }
 
-    require_once __DIR__ . '/../nuclear-engagement/admin/Controller/Ajax/BaseController.php';
-    require_once __DIR__ . '/../nuclear-engagement/admin/Controller/Ajax/UpdatesController.php';
-    require_once __DIR__ . '/../nuclear-engagement/inc/Requests/UpdatesRequest.php';
-    require_once __DIR__ . '/../nuclear-engagement/inc/Responses/UpdatesResponse.php';
+	require_once __DIR__ . '/../nuclear-engagement/admin/Controller/Ajax/BaseController.php';
+	require_once __DIR__ . '/../nuclear-engagement/admin/Controller/Ajax/UpdatesController.php';
+	require_once __DIR__ . '/../nuclear-engagement/inc/Requests/UpdatesRequest.php';
+	require_once __DIR__ . '/../nuclear-engagement/inc/Responses/UpdatesResponse.php';
 
-    class DummyApi {
-        public $result = [];
-        public $exception = null;
-        public function fetch_updates(string $id): array {
-            if ($this->exception) {
-                throw $this->exception;
-            }
-            return $this->result;
-        }
-    }
+	class DummyApi {
+		public $result = [];
+		public $exception = null;
+		public function fetch_updates(string $id): array {
+			if ($this->exception) {
+				throw $this->exception;
+			}
+			return $this->result;
+		}
+	}
 
-    class DummyStorage {
-        public array $stored = [];
-        public function storeResults(array $results, string $workflow): array {
-            $this->stored[] = [$results, $workflow];
-            return array_fill_keys(array_keys($results), true);
-        }
-    }
+	class DummyStorage {
+		public array $stored = [];
+		public function storeResults(array $results, string $workflow): array {
+			$this->stored[] = [$results, $workflow];
+			return array_fill_keys(array_keys($results), true);
+		}
+	}
 
-    class UpdatesControllerTest extends TestCase {
-        protected function setUp(): void {
-            $_POST = [];
-            $GLOBALS['json_response'] = null;
-            $GLOBALS['status_header'] = null;
-        }
+	class UpdatesControllerTest extends TestCase {
+		protected function setUp(): void {
+			$_POST = [];
+			$GLOBALS['json_response'] = null;
+			$GLOBALS['status_header'] = null;
+		}
 
-        public function test_valid_data_stores_results_and_outputs_json(): void {
-            $_POST = ['generation_id' => 'gid', 'security' => 'valid'];
-            $api = new DummyApi();
-            $api->result = [
-                'processed' => 1,
-                'total' => 1,
-                'remaining_credits' => 5,
-                'results' => [
-                    '7' => [
-                        'questions' => [ ['question' => 'Q1', 'answers' => ['A1']] ],
-                        'date' => '2024-01-01'
-                    ]
-                ]
-            ];
-            $storage = new DummyStorage();
-            $c = new UpdatesController($api, $storage);
-            $c->handle();
-            $this->assertSame([['7'=>['questions'=>[['question'=>'Q1','answers'=>['A1']]],'date'=>'2024-01-01']], 'quiz'], $storage->stored[0]);
-            $this->assertSame('success', $GLOBALS['json_response'][0]);
-            $this->assertSame('quiz', $GLOBALS['json_response'][1]['workflow']);
-            $this->assertSame(1, $GLOBALS['json_response'][1]['processed']);
-        }
+		public function test_valid_data_stores_results_and_outputs_json(): void {
+			$_POST = ['generation_id' => 'gid', 'security' => 'valid'];
+			$api = new DummyApi();
+			$api->result = [
+				'processed' => 1,
+				'total' => 1,
+				'remaining_credits' => 5,
+				'results' => [
+					'7' => [
+						'questions' => [ ['question' => 'Q1', 'answers' => ['A1']] ],
+						'date' => '2024-01-01'
+					]
+				]
+			];
+			$storage = new DummyStorage();
+			$c = new UpdatesController($api, $storage);
+			$c->handle();
+			$this->assertSame([['7'=>['questions'=>[['question'=>'Q1','answers'=>['A1']]],'date'=>'2024-01-01']], 'quiz'], $storage->stored[0]);
+			$this->assertSame('success', $GLOBALS['json_response'][0]);
+			$this->assertSame('quiz', $GLOBALS['json_response'][1]['workflow']);
+			$this->assertSame(1, $GLOBALS['json_response'][1]['processed']);
+		}
 
-        public function test_api_exception_returns_error_response(): void {
-            $_POST = ['generation_id' => 'gid', 'security' => 'valid'];
-            $api = new DummyApi();
-            $api->exception = new ApiException('fail', 418);
-            $storage = new DummyStorage();
-            $c = new UpdatesController($api, $storage);
-            $c->handle();
-            $this->assertSame('error', $GLOBALS['json_response'][0]);
-            $this->assertSame('Failed to fetch updates. Please try again later.', $GLOBALS['json_response'][1]['message']);
-            $this->assertSame(418, $GLOBALS['status_header']);
-        }
+		public function test_api_exception_returns_error_response(): void {
+			$_POST = ['generation_id' => 'gid', 'security' => 'valid'];
+			$api = new DummyApi();
+			$api->exception = new ApiException('fail', 418);
+			$storage = new DummyStorage();
+			$c = new UpdatesController($api, $storage);
+			$c->handle();
+			$this->assertSame('error', $GLOBALS['json_response'][0]);
+			$this->assertSame('Failed to fetch updates. Please try again later.', $GLOBALS['json_response'][1]['message']);
+			$this->assertSame(418, $GLOBALS['status_header']);
+		}
 
-        public function test_general_exception_returns_error_response(): void {
-            $_POST = ['generation_id' => 'gid', 'security' => 'valid'];
-            $api = new DummyApi();
-            $api->exception = new \RuntimeException('boom');
-            $storage = new DummyStorage();
-            $c = new UpdatesController($api, $storage);
-            $c->handle();
-            $this->assertSame('error', $GLOBALS['json_response'][0]);
-            $this->assertSame('An unexpected error occurred.', $GLOBALS['json_response'][1]['message']);
-            $this->assertSame(500, $GLOBALS['status_header']);
-        }
-    }
+		public function test_general_exception_returns_error_response(): void {
+			$_POST = ['generation_id' => 'gid', 'security' => 'valid'];
+			$api = new DummyApi();
+			$api->exception = new \RuntimeException('boom');
+			$storage = new DummyStorage();
+			$c = new UpdatesController($api, $storage);
+			$c->handle();
+			$this->assertSame('error', $GLOBALS['json_response'][0]);
+			$this->assertSame('An unexpected error occurred.', $GLOBALS['json_response'][1]['message']);
+			$this->assertSame(500, $GLOBALS['status_header']);
+		}
+	}
 }

--- a/tests/UtilsTest.php
+++ b/tests/UtilsTest.php
@@ -1,80 +1,80 @@
 <?php
 namespace NuclearEngagement {
-    function get_option($name, $default = '') {
-        return $GLOBALS['ut_options'][$name] ?? $default;
-    }
+	function get_option($name, $default = '') {
+		return $GLOBALS['ut_options'][$name] ?? $default;
+	}
 }
 
 namespace NuclearEngagement\Services {
-    class LoggingService {
-        public static array $logs = [];
-        public static function log(string $msg): void { self::$logs[] = $msg; }
-    }
+	class LoggingService {
+		public static array $logs = [];
+		public static function log(string $msg): void { self::$logs[] = $msg; }
+	}
 }
 
 namespace {
-    use PHPUnit\Framework\TestCase;
-    use NuclearEngagement\Utils\Utils;
-    class UtilsTest extends TestCase {
-        protected function setUp(): void {
-            $GLOBALS['test_upload_basedir'] = sys_get_temp_dir() . '/ut_' . uniqid();
-            $GLOBALS['ut_options'] = [];
-            if (file_exists($GLOBALS['test_upload_basedir'])) {
-                // clean leftover
-                @unlink($GLOBALS['test_upload_basedir']);
-            }
-        }
+	use PHPUnit\Framework\TestCase;
+	use NuclearEngagement\Utils\Utils;
+	class UtilsTest extends TestCase {
+		protected function setUp(): void {
+			$GLOBALS['test_upload_basedir'] = sys_get_temp_dir() . '/ut_' . uniqid();
+			$GLOBALS['ut_options'] = [];
+			if (file_exists($GLOBALS['test_upload_basedir'])) {
+				// clean leftover
+				@unlink($GLOBALS['test_upload_basedir']);
+			}
+		}
 
-        protected function tearDown(): void {
-            $base = $GLOBALS['test_upload_basedir'];
-            if (is_dir($base)) {
-                array_map('unlink', glob("$base/*"));
-                rmdir($base);
-            }
-        }
+		protected function tearDown(): void {
+			$base = $GLOBALS['test_upload_basedir'];
+			if (is_dir($base)) {
+				array_map('unlink', glob("$base/*"));
+				rmdir($base);
+			}
+		}
 
-        public function test_directory_created_if_missing(): void {
-            $info = Utils::nuclen_get_custom_css_info();
-            $this->assertDirectoryExists($info['dir']);
-            $this->assertSame($info['path'], $info['dir'] . '/nuclen-theme-custom.css');
-        }
+		public function test_directory_created_if_missing(): void {
+			$info = Utils::nuclen_get_custom_css_info();
+			$this->assertDirectoryExists($info['dir']);
+			$this->assertSame($info['path'], $info['dir'] . '/nuclen-theme-custom.css');
+		}
 
-        public function test_version_generated_when_option_empty(): void {
-            $dir = $GLOBALS['test_upload_basedir'] . '/nuclear-engagement';
-            mkdir($dir, 0777, true);
-            $file = $dir . '/nuclen-theme-custom.css';
-            file_put_contents($file, 'body{}');
-            $info = Utils::nuclen_get_custom_css_info();
-            $file_mtime = filemtime($file);
-            $hash = md5_file($file);
-            $version = $file_mtime . '-' . substr($hash, 0, 8);
-            $this->assertStringContainsString('?v=' . $version, $info['url']);
-        }
+		public function test_version_generated_when_option_empty(): void {
+			$dir = $GLOBALS['test_upload_basedir'] . '/nuclear-engagement';
+			mkdir($dir, 0777, true);
+			$file = $dir . '/nuclen-theme-custom.css';
+			file_put_contents($file, 'body{}');
+			$info = Utils::nuclen_get_custom_css_info();
+			$file_mtime = filemtime($file);
+			$hash = md5_file($file);
+			$version = $file_mtime . '-' . substr($hash, 0, 8);
+			$this->assertStringContainsString('?v=' . $version, $info['url']);
+		}
 
-        public function test_version_from_option_used_when_set(): void {
-            $dir = $GLOBALS['test_upload_basedir'] . '/nuclear-engagement';
-            mkdir($dir, 0777, true);
-            $file = $dir . '/nuclen-theme-custom.css';
-            file_put_contents($file, 'body{}');
-            $GLOBALS['ut_options']['nuclen_custom_css_version'] = 'abc123';
-            $info = Utils::nuclen_get_custom_css_info();
-            $this->assertStringContainsString('?v=abc123', $info['url']);
-        }
+		public function test_version_from_option_used_when_set(): void {
+			$dir = $GLOBALS['test_upload_basedir'] . '/nuclear-engagement';
+			mkdir($dir, 0777, true);
+			$file = $dir . '/nuclen-theme-custom.css';
+			file_put_contents($file, 'body{}');
+			$GLOBALS['ut_options']['nuclen_custom_css_version'] = 'abc123';
+			$info = Utils::nuclen_get_custom_css_info();
+			$this->assertStringContainsString('?v=abc123', $info['url']);
+		}
 
-        public function test_returns_empty_array_on_directory_failure(): void {
-            $GLOBALS['test_wp_mkdir_p_failure'] = true;
-            $info = Utils::nuclen_get_custom_css_info();
-            $this->assertSame([], $info);
-            $this->assertNotEmpty(\NuclearEngagement\Services\LoggingService::$logs);
-            unset($GLOBALS['test_wp_mkdir_p_failure']);
-        }
+		public function test_returns_empty_array_on_directory_failure(): void {
+			$GLOBALS['test_wp_mkdir_p_failure'] = true;
+			$info = Utils::nuclen_get_custom_css_info();
+			$this->assertSame([], $info);
+			$this->assertNotEmpty(\NuclearEngagement\Services\LoggingService::$logs);
+			unset($GLOBALS['test_wp_mkdir_p_failure']);
+		}
 
-        public function test_returns_empty_array_on_upload_dir_error(): void {
-            $GLOBALS['test_upload_error'] = 'fail';
-            $info = Utils::nuclen_get_custom_css_info();
-            $this->assertSame([], $info);
-            $this->assertNotEmpty(\NuclearEngagement\Services\LoggingService::$logs);
-            unset($GLOBALS['test_upload_error']);
-        }
-    }
+		public function test_returns_empty_array_on_upload_dir_error(): void {
+			$GLOBALS['test_upload_error'] = 'fail';
+			$info = Utils::nuclen_get_custom_css_info();
+			$this->assertSame([], $info);
+			$this->assertNotEmpty(\NuclearEngagement\Services\LoggingService::$logs);
+			unset($GLOBALS['test_upload_error']);
+		}
+	}
 }

--- a/tests/VersionServiceTest.php
+++ b/tests/VersionServiceTest.php
@@ -1,41 +1,41 @@
 <?php
 namespace NuclearEngagement {
-    class AssetVersions {
-        public static function get(string $key): string {
-            return $GLOBALS['vs_stub_value'] ?? '';
-        }
-    }
+	class AssetVersions {
+		public static function get(string $key): string {
+			return $GLOBALS['vs_stub_value'] ?? '';
+		}
+	}
 }
 
 namespace {
-    use PHPUnit\Framework\TestCase;
-    use NuclearEngagement\Services\VersionService;
-    if (!function_exists('apply_filters')) {
-        function apply_filters($hook, $value, ...$args) {
-            if ($hook === 'nuclen_asset_version' && isset($GLOBALS['vs_filter'])) {
-                return $GLOBALS['vs_filter'];
-            }
-            return $value;
-        }
-    }
+	use PHPUnit\Framework\TestCase;
+	use NuclearEngagement\Services\VersionService;
+	if (!function_exists('apply_filters')) {
+		function apply_filters($hook, $value, ...$args) {
+			if ($hook === 'nuclen_asset_version' && isset($GLOBALS['vs_filter'])) {
+				return $GLOBALS['vs_filter'];
+			}
+			return $value;
+		}
+	}
 
-    class VersionServiceTest extends TestCase {
-        protected function setUp(): void {
-            $GLOBALS['vs_stub_value'] = 'original';
-            $GLOBALS['vs_filter'] = null;
-        }
+	class VersionServiceTest extends TestCase {
+		protected function setUp(): void {
+			$GLOBALS['vs_stub_value'] = 'original';
+			$GLOBALS['vs_filter'] = null;
+		}
 
-        public function test_get_returns_filtered_value(): void {
-            $GLOBALS['vs_stub_value'] = '1';
-            $GLOBALS['vs_filter'] = '2';
-            $svc = new VersionService();
-            $this->assertSame('2', $svc->get('admin_css'));
-        }
+		public function test_get_returns_filtered_value(): void {
+			$GLOBALS['vs_stub_value'] = '1';
+			$GLOBALS['vs_filter'] = '2';
+			$svc = new VersionService();
+			$this->assertSame('2', $svc->get('admin_css'));
+		}
 
-        public function test_get_throws_on_empty_key(): void {
-            $svc = new VersionService();
-            $this->expectException(InvalidArgumentException::class);
-            $svc->get('');
-        }
-    }
+		public function test_get_throws_on_empty_key(): void {
+			$svc = new VersionService();
+			$this->expectException(InvalidArgumentException::class);
+			$svc->get('');
+		}
+	}
 }

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -1,7 +1,7 @@
 <?php
 // Define ABSPATH to bypass exit calls
 if ( ! defined( 'ABSPATH' ) ) {
-    define( 'ABSPATH', __DIR__ . '/' );
+	define( 'ABSPATH', __DIR__ . '/' );
 }
 // Track calls to dbDelta in unit tests
 global $dbDelta_called;
@@ -10,22 +10,22 @@ $dbDelta_called = false;
 require_once __DIR__ . '/wp-stubs.php';
 // Minimal stubs for WordPress functions used in included files
 if (!function_exists('add_action')) {
-    function add_action(...$args) {}
+	function add_action(...$args) {}
 }
 if (!function_exists('absint')) {
-    function absint($maybeint) { return abs(intval($maybeint)); }
+	function absint($maybeint) { return abs(intval($maybeint)); }
 }
 if (!function_exists('plugin_dir_path')) {
-    function plugin_dir_path($file) { return dirname($file) . '/'; }
+	function plugin_dir_path($file) { return dirname($file) . '/'; }
 }
 if (!function_exists('get_plugin_data')) {
-    function get_plugin_data($file) { return ['Version' => '1.0']; }
+	function get_plugin_data($file) { return ['Version' => '1.0']; }
 }
 if (!function_exists('register_activation_hook')) {
-    function register_activation_hook(...$args) {}
+	function register_activation_hook(...$args) {}
 }
 if (!function_exists('register_deactivation_hook')) {
-    function register_deactivation_hook(...$args) {}
+	function register_deactivation_hook(...$args) {}
 }
 
 // Simple in-memory storage for options and related autoload flags
@@ -38,39 +38,39 @@ $GLOBALS['wp_events'] = [];
 $GLOBALS['wp_user_meta'] = [];
 
 if (!function_exists('update_option')) {
-    function update_option($name, $value, $autoload = 'yes') {
-        global $update_option_calls;
-        $update_option_calls[$name] = ($update_option_calls[$name] ?? 0) + 1;
-        $GLOBALS['wp_options'][$name] = $value;
-        $GLOBALS['wp_autoload'][$name] = $autoload;
-        return true;
-    }
+	function update_option($name, $value, $autoload = 'yes') {
+		global $update_option_calls;
+		$update_option_calls[$name] = ($update_option_calls[$name] ?? 0) + 1;
+		$GLOBALS['wp_options'][$name] = $value;
+		$GLOBALS['wp_autoload'][$name] = $autoload;
+		return true;
+	}
 }
 
 if (!function_exists('get_option')) {
-    function get_option($name, $default = false) {
-        return $GLOBALS['wp_options'][$name] ?? $default;
-    }
+	function get_option($name, $default = false) {
+		return $GLOBALS['wp_options'][$name] ?? $default;
+	}
 }
 
 if (!function_exists('delete_option')) {
-    function delete_option($name) {
-        unset($GLOBALS['wp_options'][$name], $GLOBALS['wp_autoload'][$name]);
-        return true;
-    }
+	function delete_option($name) {
+		unset($GLOBALS['wp_options'][$name], $GLOBALS['wp_autoload'][$name]);
+		return true;
+	}
 }
 
 if (!function_exists('update_user_meta')) {
-    function update_user_meta($user_id, $meta_key, $meta_value) {
-        $GLOBALS['wp_user_meta'][$user_id][$meta_key] = $meta_value;
-        return true;
-    }
+	function update_user_meta($user_id, $meta_key, $meta_value) {
+		$GLOBALS['wp_user_meta'][$user_id][$meta_key] = $meta_value;
+		return true;
+	}
 }
 
 if (!function_exists('get_user_meta')) {
-    function get_user_meta($user_id, $meta_key, $single = false) {
-        return $GLOBALS['wp_user_meta'][$user_id][$meta_key] ?? '';
-    }
+	function get_user_meta($user_id, $meta_key, $single = false) {
+		return $GLOBALS['wp_user_meta'][$user_id][$meta_key] ?? '';
+	}
 }
 
 // Include files for tests
@@ -79,61 +79,61 @@ require_once __DIR__ . '/../nuclear-engagement/inc/OptinData.php';
 require_once __DIR__ . '/../nuclear-engagement/inc/Core/SettingsRepository.php';
 require_once __DIR__ . '/../nuclear-engagement/inc/Core/SettingsSanitizer.php';
 if (!function_exists('sanitize_key')) {
-    function sanitize_key($key) { return strtolower(preg_replace('/[^a-z0-9_]/', '', $key)); }
+	function sanitize_key($key) { return strtolower(preg_replace('/[^a-z0-9_]/', '', $key)); }
 }
 if (!function_exists('post_type_exists')) {
-    function post_type_exists($type) { return in_array($type, ['post','page'], true); }
+	function post_type_exists($type) { return in_array($type, ['post','page'], true); }
 }
 if (!function_exists('wp_parse_args')) {
-    function wp_parse_args($args, $defaults = []) {
-        if (is_array($args)) {
-            return array_merge($defaults, $args);
-        }
-        parse_str((string) $args, $parsed);
-        return array_merge($defaults, $parsed);
-    }
+	function wp_parse_args($args, $defaults = []) {
+		if (is_array($args)) {
+			return array_merge($defaults, $args);
+		}
+		parse_str((string) $args, $parsed);
+		return array_merge($defaults, $parsed);
+	}
 }
 
 // Additional stubs used by services
 if (!function_exists('get_post')) {
-    function get_post($id) { return $GLOBALS['wp_posts'][$id] ?? null; }
+	function get_post($id) { return $GLOBALS['wp_posts'][$id] ?? null; }
 }
 if (!function_exists('get_the_title')) {
-    function get_the_title($id) { return $GLOBALS['wp_posts'][$id]->post_title ?? ''; }
+	function get_the_title($id) { return $GLOBALS['wp_posts'][$id]->post_title ?? ''; }
 }
 if (!function_exists('wp_strip_all_tags')) {
-    function wp_strip_all_tags($text) { return strip_tags($text); }
+	function wp_strip_all_tags($text) { return strip_tags($text); }
 }
 if (!function_exists('get_post_meta')) {
-    function get_post_meta($post_id, $key, $single) {
-        return $GLOBALS['wp_meta'][$post_id][$key] ?? '';
-    }
+	function get_post_meta($post_id, $key, $single) {
+		return $GLOBALS['wp_meta'][$post_id][$key] ?? '';
+	}
 }
 if (!function_exists('current_time')) {
-    function current_time($type) { return date('Y-m-d H:i:s'); }
+	function current_time($type) { return date('Y-m-d H:i:s'); }
 }
 if (!function_exists('wp_next_scheduled')) {
-    function wp_next_scheduled(...$args) { return false; }
+	function wp_next_scheduled(...$args) { return false; }
 }
 if (!function_exists('wp_schedule_single_event')) {
-    function wp_schedule_single_event($timestamp, $hook, $args) {
-        $GLOBALS['wp_events'][] = compact('timestamp', 'hook', 'args');
-    }
+	function wp_schedule_single_event($timestamp, $hook, $args) {
+		$GLOBALS['wp_events'][] = compact('timestamp', 'hook', 'args');
+	}
 }
 if (!function_exists('is_wp_error')) {
-    function is_wp_error($thing) { return $thing instanceof WP_Error; }
+	function is_wp_error($thing) { return $thing instanceof WP_Error; }
 }
 if (!class_exists('WP_Error')) {
-    class WP_Error {
-        public $data;
-        public $code;
-        public $message;
-        public function __construct($code = '', $message = '', $data = null) {
-            $this->code = $code;
-            $this->message = $message;
-            $this->data = $data;
-        }
-        public function get_error_message() { return $this->message ?: 'error'; }
-    }
+	class WP_Error {
+		public $data;
+		public $code;
+		public $message;
+		public function __construct($code = '', $message = '', $data = null) {
+			$this->code = $code;
+			$this->message = $message;
+			$this->data = $data;
+		}
+		public function get_error_message() { return $this->message ?: 'error'; }
+	}
 }
 

--- a/tests/frontend/admin-fetch.test.ts
+++ b/tests/frontend/admin-fetch.test.ts
@@ -5,9 +5,9 @@ import * as logger from '../../src/admin/ts/utils/logger';
 // helper to build a mock Response-like object
 function mockResponse(body: string, ok = true, status = 200) {
   return {
-    ok,
-    status,
-    text: vi.fn().mockResolvedValue(body)
+	ok,
+	status,
+	text: vi.fn().mockResolvedValue(body)
   } as unknown as Response;
 }
 
@@ -23,70 +23,70 @@ afterEach(() => {
 
 describe('nuclenFetchWithRetry', () => {
   it('returns parsed data when successful', async () => {
-    const fetchMock = vi.fn().mockResolvedValue(mockResponse('{"a":1}'));
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    (global as any).fetch = fetchMock;
-    const result = await nuclenFetchWithRetry<any>('u', { method: 'GET' }, 0);
-    expect(result).toEqual({ ok: true, status: 200, data: { a: 1 } });
-    expect(fetchMock).toHaveBeenCalledTimes(1);
+	const fetchMock = vi.fn().mockResolvedValue(mockResponse('{"a":1}'));
+	// eslint-disable-next-line @typescript-eslint/no-explicit-any
+	(global as any).fetch = fetchMock;
+	const result = await nuclenFetchWithRetry<any>('u', { method: 'GET' }, 0);
+	expect(result).toEqual({ ok: true, status: 200, data: { a: 1 } });
+	expect(fetchMock).toHaveBeenCalledTimes(1);
   });
 
   it('retries on failure then succeeds', async () => {
-    vi.useFakeTimers();
-    const err = new Error('net');
-    const fetchMock = vi
-      .fn()
-      .mockRejectedValueOnce(err)
-      .mockResolvedValueOnce(mockResponse(''));
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    (global as any).fetch = fetchMock;
-    vi.spyOn(logger, 'warn').mockImplementation(() => {});
-    vi.spyOn(logger, 'error').mockImplementation(() => {});
-    const promise = nuclenFetchWithRetry('u', {}, 1, 10);
-    await vi.runAllTimersAsync();
-    const result = await promise;
-    expect(result.ok).toBe(true);
-    expect(fetchMock).toHaveBeenCalledTimes(2);
-    vi.useRealTimers();
+	vi.useFakeTimers();
+	const err = new Error('net');
+	const fetchMock = vi
+	  .fn()
+	  .mockRejectedValueOnce(err)
+	  .mockResolvedValueOnce(mockResponse(''));
+	// eslint-disable-next-line @typescript-eslint/no-explicit-any
+	(global as any).fetch = fetchMock;
+	vi.spyOn(logger, 'warn').mockImplementation(() => {});
+	vi.spyOn(logger, 'error').mockImplementation(() => {});
+	const promise = nuclenFetchWithRetry('u', {}, 1, 10);
+	await vi.runAllTimersAsync();
+	const result = await promise;
+	expect(result.ok).toBe(true);
+	expect(fetchMock).toHaveBeenCalledTimes(2);
+	vi.useRealTimers();
   });
 });
 
 describe('nuclenFetchUpdates', () => {
   beforeEach(() => {
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    (window as any).nuclenAjax = { ajax_url: 'a', fetch_action: 'f', nonce: 'n' };
+	// eslint-disable-next-line @typescript-eslint/no-explicit-any
+	(window as any).nuclenAjax = { ajax_url: 'a', fetch_action: 'f', nonce: 'n' };
   });
 
   it('returns response data when ok', async () => {
-    const data = { success: true };
-    const fetchMock = vi.fn().mockResolvedValue(mockResponse(JSON.stringify(data)));
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    (global as any).fetch = fetchMock;
-    const res = await nuclenFetchUpdates('id');
-    expect(res).toEqual(data);
+	const data = { success: true };
+	const fetchMock = vi.fn().mockResolvedValue(mockResponse(JSON.stringify(data)));
+	// eslint-disable-next-line @typescript-eslint/no-explicit-any
+	(global as any).fetch = fetchMock;
+	const res = await nuclenFetchUpdates('id');
+	expect(res).toEqual(data);
   });
 
   it('throws on error response', async () => {
-    const fetchMock = vi.fn().mockResolvedValue(mockResponse('bad', false, 500));
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    (global as any).fetch = fetchMock;
-    await expect(nuclenFetchUpdates()).rejects.toThrow('bad');
+	const fetchMock = vi.fn().mockResolvedValue(mockResponse('bad', false, 500));
+	// eslint-disable-next-line @typescript-eslint/no-explicit-any
+	(global as any).fetch = fetchMock;
+	await expect(nuclenFetchUpdates()).rejects.toThrow('bad');
   });
 });
 
 describe('NuclenStartGeneration', () => {
   beforeEach(() => {
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    (window as any).nuclenAdminVars = { ajax_url: 'a' };
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    (window as any).nuclenAjax = { nonce: 'n' };
+	// eslint-disable-next-line @typescript-eslint/no-explicit-any
+	(window as any).nuclenAdminVars = { ajax_url: 'a' };
+	// eslint-disable-next-line @typescript-eslint/no-explicit-any
+	(window as any).nuclenAjax = { nonce: 'n' };
   });
 
   it('throws message from response when generation fails', async () => {
-    const body = { success: false, data: { message: 'nope' } };
-    const fetchMock = vi.fn().mockResolvedValue(mockResponse(JSON.stringify(body)));
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    (global as any).fetch = fetchMock;
-    await expect(NuclenStartGeneration({})).rejects.toThrow('nope');
+	const body = { success: false, data: { message: 'nope' } };
+	const fetchMock = vi.fn().mockResolvedValue(mockResponse(JSON.stringify(body)));
+	// eslint-disable-next-line @typescript-eslint/no-explicit-any
+	(global as any).fetch = fetchMock;
+	await expect(NuclenStartGeneration({})).rejects.toThrow('nope');
   });
 });

--- a/tests/frontend/admin-polling.test.ts
+++ b/tests/frontend/admin-polling.test.ts
@@ -8,53 +8,53 @@ afterEach(() => {
 
 describe('NuclenPollAndPullUpdates', () => {
   beforeEach(() => {
-    vi.useFakeTimers();
+	vi.useFakeTimers();
   });
 
   afterEach(() => {
-    vi.useRealTimers();
+	vi.useRealTimers();
   });
 
   it('polls until processed >= total', async () => {
-    const fetchMock = vi
-      .spyOn(api, 'nuclenFetchUpdates')
-      .mockResolvedValueOnce({ success: true, data: { processed: 1, total: 2 } })
-      .mockResolvedValueOnce({ success: true, data: { processed: 2, total: 2, finalReport: 'r' } });
+	const fetchMock = vi
+	  .spyOn(api, 'nuclenFetchUpdates')
+	  .mockResolvedValueOnce({ success: true, data: { processed: 1, total: 2 } })
+	  .mockResolvedValueOnce({ success: true, data: { processed: 2, total: 2, finalReport: 'r' } });
 
-    const progress = vi.fn();
-    const complete = vi.fn();
+	const progress = vi.fn();
+	const complete = vi.fn();
 
-    NuclenPollAndPullUpdates({ intervalMs: 1000, generationId: 'g', onProgress: progress, onComplete: complete });
+	NuclenPollAndPullUpdates({ intervalMs: 1000, generationId: 'g', onProgress: progress, onComplete: complete });
 
-    await vi.runOnlyPendingTimersAsync();
-    await Promise.resolve();
-    expect(progress).toHaveBeenCalledWith(1, 2);
-    expect(complete).not.toHaveBeenCalled();
+	await vi.runOnlyPendingTimersAsync();
+	await Promise.resolve();
+	expect(progress).toHaveBeenCalledWith(1, 2);
+	expect(complete).not.toHaveBeenCalled();
 
-    await vi.runOnlyPendingTimersAsync();
-    await Promise.resolve();
-    expect(progress).toHaveBeenCalledWith(2, 2);
-    expect(complete).toHaveBeenCalledWith({
-      processed: 2,
-      total: 2,
-      successCount: 2,
-      failCount: undefined,
-      finalReport: 'r',
-      results: undefined,
-      workflow: undefined,
-    });
+	await vi.runOnlyPendingTimersAsync();
+	await Promise.resolve();
+	expect(progress).toHaveBeenCalledWith(2, 2);
+	expect(complete).toHaveBeenCalledWith({
+	  processed: 2,
+	  total: 2,
+	  successCount: 2,
+	  failCount: undefined,
+	  finalReport: 'r',
+	  results: undefined,
+	  workflow: undefined,
+	});
 
-    expect(fetchMock).toHaveBeenCalledTimes(2);
+	expect(fetchMock).toHaveBeenCalledTimes(2);
   });
 
   it('calls onError when request fails', async () => {
-    vi.spyOn(api, 'nuclenFetchUpdates').mockRejectedValue(new Error('boom'));
-    const onError = vi.fn();
+	vi.spyOn(api, 'nuclenFetchUpdates').mockRejectedValue(new Error('boom'));
+	const onError = vi.fn();
 
-    NuclenPollAndPullUpdates({ intervalMs: 1000, generationId: 'g', onError });
+	NuclenPollAndPullUpdates({ intervalMs: 1000, generationId: 'g', onError });
 
-    await vi.runOnlyPendingTimersAsync();
-    await Promise.resolve();
-    expect(onError).toHaveBeenCalledWith('boom');
+	await vi.runOnlyPendingTimersAsync();
+	await Promise.resolve();
+	expect(onError).toHaveBeenCalledWith('boom');
   });
 });

--- a/tests/frontend/admin-utils.test.ts
+++ b/tests/frontend/admin-utils.test.ts
@@ -3,53 +3,53 @@ import { nuclenShowElement, nuclenHideElement, nuclenUpdateProgressBarStep, nucl
 
 describe('nuclenShowElement & nuclenHideElement', () => {
   it('toggles nuclen-hidden class', () => {
-    document.body.innerHTML = '<div id="el" class="nuclen-hidden"></div>';
-    const el = document.getElementById('el') as HTMLElement;
-    nuclenShowElement(el);
-    expect(el.classList.contains('nuclen-hidden')).toBe(false);
-    nuclenHideElement(el);
-    expect(el.classList.contains('nuclen-hidden')).toBe(true);
+	document.body.innerHTML = '<div id="el" class="nuclen-hidden"></div>';
+	const el = document.getElementById('el') as HTMLElement;
+	nuclenShowElement(el);
+	expect(el.classList.contains('nuclen-hidden')).toBe(false);
+	nuclenHideElement(el);
+	expect(el.classList.contains('nuclen-hidden')).toBe(true);
   });
 });
 
 describe('nuclenUpdateProgressBarStep', () => {
   it('applies state class', () => {
-    document.body.innerHTML = '<div id="step" class="ne-step-bar__step--todo"></div>';
-    const el = document.getElementById('step') as HTMLElement;
-    nuclenUpdateProgressBarStep(el, 'done');
-    expect(el.className).toBe('ne-step-bar__step--done');
+	document.body.innerHTML = '<div id="step" class="ne-step-bar__step--todo"></div>';
+	const el = document.getElementById('step') as HTMLElement;
+	nuclenUpdateProgressBarStep(el, 'done');
+	expect(el.className).toBe('ne-step-bar__step--done');
   });
 });
 
 describe('nuclenToggleSummaryFields', () => {
   beforeEach(() => {
-    document.body.innerHTML = `
-      <select id="nuclen_generate_workflow">
-        <option value="posts">Posts</option>
-        <option value="summary">Summary</option>
-      </select>
-      <div id="nuclen-summary-settings" class="nuclen-hidden"></div>
-      <div id="nuclen-summary-paragraph-options" class="nuclen-hidden"></div>
-      <div id="nuclen-summary-bullet-options" class="nuclen-hidden"></div>
-      <select id="nuclen_summary_format">
-        <option value="paragraph">Paragraph</option>
-        <option value="bullet">Bullet</option>
-      </select>
-    `;
+	document.body.innerHTML = `
+	  <select id="nuclen_generate_workflow">
+		<option value="posts">Posts</option>
+		<option value="summary">Summary</option>
+	  </select>
+	  <div id="nuclen-summary-settings" class="nuclen-hidden"></div>
+	  <div id="nuclen-summary-paragraph-options" class="nuclen-hidden"></div>
+	  <div id="nuclen-summary-bullet-options" class="nuclen-hidden"></div>
+	  <select id="nuclen_summary_format">
+		<option value="paragraph">Paragraph</option>
+		<option value="bullet">Bullet</option>
+	  </select>
+	`;
   });
 
   it('shows paragraph options when workflow is summary and format paragraph', () => {
-    (document.getElementById('nuclen_generate_workflow') as HTMLSelectElement).value = 'summary';
-    (document.getElementById('nuclen_summary_format') as HTMLSelectElement).value = 'paragraph';
-    nuclenToggleSummaryFields();
-    expect(document.getElementById('nuclen-summary-settings')!.classList.contains('nuclen-hidden')).toBe(false);
-    expect(document.getElementById('nuclen-summary-paragraph-options')!.classList.contains('nuclen-hidden')).toBe(false);
-    expect(document.getElementById('nuclen-summary-bullet-options')!.classList.contains('nuclen-hidden')).toBe(true);
+	(document.getElementById('nuclen_generate_workflow') as HTMLSelectElement).value = 'summary';
+	(document.getElementById('nuclen_summary_format') as HTMLSelectElement).value = 'paragraph';
+	nuclenToggleSummaryFields();
+	expect(document.getElementById('nuclen-summary-settings')!.classList.contains('nuclen-hidden')).toBe(false);
+	expect(document.getElementById('nuclen-summary-paragraph-options')!.classList.contains('nuclen-hidden')).toBe(false);
+	expect(document.getElementById('nuclen-summary-bullet-options')!.classList.contains('nuclen-hidden')).toBe(true);
   });
 
   it('hides settings when workflow is posts', () => {
-    (document.getElementById('nuclen_generate_workflow') as HTMLSelectElement).value = 'posts';
-    nuclenToggleSummaryFields();
-    expect(document.getElementById('nuclen-summary-settings')!.classList.contains('nuclen-hidden')).toBe(true);
+	(document.getElementById('nuclen_generate_workflow') as HTMLSelectElement).value = 'posts';
+	nuclenToggleSummaryFields();
+	expect(document.getElementById('nuclen-summary-settings')!.classList.contains('nuclen-hidden')).toBe(true);
   });
 });

--- a/tests/frontend/display-error.test.ts
+++ b/tests/frontend/display-error.test.ts
@@ -3,23 +3,23 @@ import { displayError } from '../../src/admin/ts/utils/displayError';
 
 describe('displayError', () => {
   beforeEach(() => {
-    vi.useFakeTimers();
+	vi.useFakeTimers();
   });
 
   afterEach(() => {
-    vi.useRealTimers();
-    vi.restoreAllMocks();
-    document.body.innerHTML = '';
+	vi.useRealTimers();
+	vi.restoreAllMocks();
+	document.body.innerHTML = '';
   });
 
   it('adds and removes toast and logs to console', async () => {
-    const log = vi.spyOn(console, 'error').mockImplementation(() => {});
-    displayError('boom');
-    const toast = document.querySelector('.nuclen-error-toast');
-    expect(toast).not.toBeNull();
-    expect(log).toHaveBeenCalledWith('boom');
-    vi.advanceTimersByTime(5000);
-    await Promise.resolve();
-    expect(document.querySelector('.nuclen-error-toast')).toBeNull();
+	const log = vi.spyOn(console, 'error').mockImplementation(() => {});
+	displayError('boom');
+	const toast = document.querySelector('.nuclen-error-toast');
+	expect(toast).not.toBeNull();
+	expect(log).toHaveBeenCalledWith('boom');
+	vi.advanceTimersByTime(5000);
+	await Promise.resolve();
+	expect(document.querySelector('.nuclen-error-toast')).toBeNull();
   });
 });

--- a/tests/frontend/logger.test.ts
+++ b/tests/frontend/logger.test.ts
@@ -7,20 +7,20 @@ afterEach(() => {
 
 describe('logger functions', () => {
   it('forwards to console.log', () => {
-    const spy = vi.spyOn(console, 'log').mockImplementation(() => {});
-    log('a', 1);
-    expect(spy).toHaveBeenCalledWith('a', 1);
+	const spy = vi.spyOn(console, 'log').mockImplementation(() => {});
+	log('a', 1);
+	expect(spy).toHaveBeenCalledWith('a', 1);
   });
 
   it('forwards to console.warn', () => {
-    const spy = vi.spyOn(console, 'warn').mockImplementation(() => {});
-    warn('b', 2);
-    expect(spy).toHaveBeenCalledWith('b', 2);
+	const spy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+	warn('b', 2);
+	expect(spy).toHaveBeenCalledWith('b', 2);
   });
 
   it('forwards to console.error', () => {
-    const spy = vi.spyOn(console, 'error').mockImplementation(() => {});
-    error('c', 3);
-    expect(spy).toHaveBeenCalledWith('c', 3);
+	const spy = vi.spyOn(console, 'error').mockImplementation(() => {});
+	error('c', 3);
+	expect(spy).toHaveBeenCalledWith('c', 3);
   });
 });

--- a/tests/frontend/nuclen-admin-single-generation.test.ts
+++ b/tests/frontend/nuclen-admin-single-generation.test.ts
@@ -4,11 +4,11 @@ vi.mock('../../src/admin/ts/generation/api', async () => {
   const actual: any = await vi.importActual('../../src/admin/ts/generation/api');
   const nuclenFetchWithRetry = vi.fn();
   return {
-    ...actual,
-    nuclenFetchWithRetry,
-    NuclenStartGeneration: vi.fn(async (...args) => {
-      return await nuclenFetchWithRetry(...args);
-    }),
+	...actual,
+	nuclenFetchWithRetry,
+	NuclenStartGeneration: vi.fn(async (...args) => {
+	  return await nuclenFetchWithRetry(...args);
+	}),
   };
 });
 
@@ -18,8 +18,8 @@ vi.mock('../../src/admin/ts/nuclen-admin-generate', async () => {
   const api = await import('../../src/admin/ts/generation/api');
   const { NuclenPollAndPullUpdates } = await vi.importActual('../../src/admin/ts/generation/polling');
   return {
-    ...api,
-    NuclenPollAndPullUpdates: vi.fn(),
+	...api,
+	NuclenPollAndPullUpdates: vi.fn(),
   };
 });
 
@@ -40,67 +40,67 @@ beforeAll(async () => {
 
 describe('nuclen-admin-single-generation', () => {
   beforeEach(() => {
-    document.body.innerHTML = '<button class="nuclen-generate-single" data-post-id="1" data-workflow="quiz">Generate</button>';
-    (window as any).nuclenAdminVars = { ajax_url: 'a' };
-    (window as any).nuclenAjax = { nonce: 'n', fetch_action: 'f', ajax_url: 'a' };
+	document.body.innerHTML = '<button class="nuclen-generate-single" data-post-id="1" data-workflow="quiz">Generate</button>';
+	(window as any).nuclenAdminVars = { ajax_url: 'a' };
+	(window as any).nuclenAjax = { nonce: 'n', fetch_action: 'f', ajax_url: 'a' };
   });
 
   afterEach(() => {
-    vi.clearAllMocks();
-    document.body.innerHTML = '';
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    delete (window as any).nuclenAdminVars;
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    delete (window as any).nuclenAjax;
+	vi.clearAllMocks();
+	document.body.innerHTML = '';
+	// eslint-disable-next-line @typescript-eslint/no-explicit-any
+	delete (window as any).nuclenAdminVars;
+	// eslint-disable-next-line @typescript-eslint/no-explicit-any
+	delete (window as any).nuclenAjax;
   });
 
   it('starts generation and updates progress', async () => {
-    let pollOpts: any;
-    (NuclenPollAndPullUpdates as unknown as vi.Mock).mockImplementation((opts) => {
-      pollOpts = opts;
-    });
+	let pollOpts: any;
+	(NuclenPollAndPullUpdates as unknown as vi.Mock).mockImplementation((opts) => {
+	  pollOpts = opts;
+	});
 
-    (api.nuclenFetchWithRetry as vi.Mock).mockResolvedValueOnce({
-        ok: true,
-        status: 200,
-        data: { success: true, generation_id: 'gid' },
-      });
+	(api.nuclenFetchWithRetry as vi.Mock).mockResolvedValueOnce({
+		ok: true,
+		status: 200,
+		data: { success: true, generation_id: 'gid' },
+	  });
 
-    const btn = document.querySelector<HTMLButtonElement>('.nuclen-generate-single')!;
-    btn.dispatchEvent(new MouseEvent('click', { bubbles: true }));
-    await Promise.resolve();
-    await Promise.resolve();
+	const btn = document.querySelector<HTMLButtonElement>('.nuclen-generate-single')!;
+	btn.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+	await Promise.resolve();
+	await Promise.resolve();
 
-    expect(api.nuclenFetchWithRetry).toHaveBeenCalled();
-    expect(pollOpts).toBeDefined();
+	expect(api.nuclenFetchWithRetry).toHaveBeenCalled();
+	expect(pollOpts).toBeDefined();
 
-    pollOpts.onProgress(1, 2);
-    expect(btn.textContent).toBe('Generating...');
+	pollOpts.onProgress(1, 2);
+	expect(btn.textContent).toBe('Generating...');
 
-    await pollOpts.onComplete({ workflow: 'quiz', results: { '1': {} } });
-    await Promise.resolve();
+	await pollOpts.onComplete({ workflow: 'quiz', results: { '1': {} } });
+	await Promise.resolve();
 
-    expect(utils.storeGenerationResults).toHaveBeenCalledWith('quiz', { '1': {} });
-    expect(btn.textContent).toBe('Stored!');
-    expect(btn.disabled).toBe(false);
+	expect(utils.storeGenerationResults).toHaveBeenCalledWith('quiz', { '1': {} });
+	expect(btn.textContent).toBe('Stored!');
+	expect(btn.disabled).toBe(false);
   });
 
   it('displays error when generation fails', async () => {
-    (api.nuclenFetchWithRetry as vi.Mock).mockResolvedValueOnce({
-        ok: false,
-        status: 500,
-        data: null,
-        error: 'fail',
-      });
+	(api.nuclenFetchWithRetry as vi.Mock).mockResolvedValueOnce({
+		ok: false,
+		status: 500,
+		data: null,
+		error: 'fail',
+	  });
 
-    const btn = document.querySelector<HTMLButtonElement>('.nuclen-generate-single')!;
-    btn.dispatchEvent(new MouseEvent('click', { bubbles: true }));
-    await Promise.resolve();
-    await Promise.resolve();
+	const btn = document.querySelector<HTMLButtonElement>('.nuclen-generate-single')!;
+	btn.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+	await Promise.resolve();
+	await Promise.resolve();
 
-    expect(utils.alertApiError).toHaveBeenCalledWith('fail');
-    expect(btn.textContent).toBe('Generate');
-    expect(btn.disabled).toBe(false);
+	expect(utils.alertApiError).toHaveBeenCalledWith('fail');
+	expect(btn.textContent).toBe('Generate');
+	expect(btn.disabled).toBe(false);
   });
 });
 

--- a/tests/frontend/nuclen-admin-ui.test.ts
+++ b/tests/frontend/nuclen-admin-ui.test.ts
@@ -3,13 +3,13 @@ import { describe, it, beforeEach, afterEach, expect, vi } from 'vitest';
 beforeEach(() => {
   vi.resetModules();
   document.body.innerHTML = `
-    <a href="#tab1" class="nav-tab nav-tab-active" id="tab1-link">Tab1</a>
-    <a href="#tab2" class="nav-tab" id="tab2-link">Tab2</a>
-    <div id="tab1" class="nuclen-tab-content">One</div>
-    <div id="tab2" class="nuclen-tab-content" style="display:none">Two</div>
-    <div id="nuclen-custom-theme-section" class="nuclen-hidden"></div>
-    <input type="radio" name="nuclen_theme" value="default" id="theme-default" checked>
-    <input type="radio" name="nuclen_theme" value="custom" id="theme-custom">
+	<a href="#tab1" class="nav-tab nav-tab-active" id="tab1-link">Tab1</a>
+	<a href="#tab2" class="nav-tab" id="tab2-link">Tab2</a>
+	<div id="tab1" class="nuclen-tab-content">One</div>
+	<div id="tab2" class="nuclen-tab-content" style="display:none">Two</div>
+	<div id="nuclen-custom-theme-section" class="nuclen-hidden"></div>
+	<input type="radio" name="nuclen_theme" value="default" id="theme-default" checked>
+	<input type="radio" name="nuclen_theme" value="custom" id="theme-custom">
   `;
 });
 
@@ -19,41 +19,41 @@ afterEach(() => {
 
 describe('nuclen-admin-ui tabs', () => {
   it('toggles active tab and content', async () => {
-    await import('../../src/admin/ts/nuclen-admin-ui');
-    document.dispatchEvent(new Event('DOMContentLoaded'));
+	await import('../../src/admin/ts/nuclen-admin-ui');
+	document.dispatchEvent(new Event('DOMContentLoaded'));
 
-    const tab1 = document.getElementById('tab1-link')!;
-    const tab2 = document.getElementById('tab2-link')!;
-    const content1 = document.getElementById('tab1')!;
-    const content2 = document.getElementById('tab2')!;
+	const tab1 = document.getElementById('tab1-link')!;
+	const tab2 = document.getElementById('tab2-link')!;
+	const content1 = document.getElementById('tab1')!;
+	const content2 = document.getElementById('tab2')!;
 
-    tab2.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+	tab2.dispatchEvent(new MouseEvent('click', { bubbles: true }));
 
-    expect(tab1.classList.contains('nav-tab-active')).toBe(false);
-    expect(tab2.classList.contains('nav-tab-active')).toBe(true);
-    expect(content1.style.display).toBe('none');
-    expect(content2.style.display).toBe('block');
+	expect(tab1.classList.contains('nav-tab-active')).toBe(false);
+	expect(tab2.classList.contains('nav-tab-active')).toBe(true);
+	expect(content1.style.display).toBe('none');
+	expect(content2.style.display).toBe('block');
   });
 });
 
 describe('nuclen-admin-ui custom theme', () => {
   it('shows and hides custom theme section', async () => {
-    await import('../../src/admin/ts/nuclen-admin-ui');
-    document.dispatchEvent(new Event('DOMContentLoaded'));
+	await import('../../src/admin/ts/nuclen-admin-ui');
+	document.dispatchEvent(new Event('DOMContentLoaded'));
 
-    const customSection = document.getElementById('nuclen-custom-theme-section')!;
-    const defaultRadio = document.getElementById('theme-default') as HTMLInputElement;
-    const customRadio = document.getElementById('theme-custom') as HTMLInputElement;
+	const customSection = document.getElementById('nuclen-custom-theme-section')!;
+	const defaultRadio = document.getElementById('theme-default') as HTMLInputElement;
+	const customRadio = document.getElementById('theme-custom') as HTMLInputElement;
 
-    expect(customSection.classList.contains('nuclen-hidden')).toBe(true);
+	expect(customSection.classList.contains('nuclen-hidden')).toBe(true);
 
-    customRadio.checked = true;
-    customRadio.dispatchEvent(new Event('change', { bubbles: true }));
-    expect(customSection.classList.contains('nuclen-hidden')).toBe(false);
+	customRadio.checked = true;
+	customRadio.dispatchEvent(new Event('change', { bubbles: true }));
+	expect(customSection.classList.contains('nuclen-hidden')).toBe(false);
 
-    defaultRadio.checked = true;
-    defaultRadio.dispatchEvent(new Event('change', { bubbles: true }));
-    expect(customSection.classList.contains('nuclen-hidden')).toBe(true);
+	defaultRadio.checked = true;
+	defaultRadio.dispatchEvent(new Event('change', { bubbles: true }));
+	expect(customSection.classList.contains('nuclen-hidden')).toBe(true);
   });
 });
 

--- a/tests/frontend/nuclen-front-global.test.ts
+++ b/tests/frontend/nuclen-front-global.test.ts
@@ -3,9 +3,9 @@ import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 beforeEach(() => {
   vi.resetModules();
   document.body.innerHTML = `
-    <div class="nuclen-toc-sticky" data-offset-y="20" data-offset-x="20">
-      <nav class="nuclen-toc"></nav>
-    </div>`;
+	<div class="nuclen-toc-sticky" data-offset-y="20" data-offset-x="20">
+	  <nav class="nuclen-toc"></nav>
+	</div>`;
   (window as any).nuclenTocL10n = { show: 'Show', hide: 'Hide' };
 });
 
@@ -16,19 +16,19 @@ afterEach(() => {
 
 describe('nuclen-toc-front lazy boot', () => {
   it('registers DOMContentLoaded listener and attaches window handlers', async () => {
-    Object.defineProperty(document, 'readyState', { value: 'loading', configurable: true });
-    const docSpy = vi.spyOn(document, 'addEventListener');
-    const winSpy = vi.spyOn(window, 'addEventListener');
+	Object.defineProperty(document, 'readyState', { value: 'loading', configurable: true });
+	const docSpy = vi.spyOn(document, 'addEventListener');
+	const winSpy = vi.spyOn(window, 'addEventListener');
 
-    await import('../../src/modules/toc/ts/nuclen-toc-front');
+	await import('../../src/modules/toc/ts/nuclen-toc-front');
 
-    expect(docSpy).toHaveBeenCalledWith('DOMContentLoaded', expect.any(Function));
-    const cb = docSpy.mock.calls.find(c => c[0] === 'DOMContentLoaded')?.[1] as () => void;
-    expect(cb).toBeTypeOf('function');
+	expect(docSpy).toHaveBeenCalledWith('DOMContentLoaded', expect.any(Function));
+	const cb = docSpy.mock.calls.find(c => c[0] === 'DOMContentLoaded')?.[1] as () => void;
+	expect(cb).toBeTypeOf('function');
 
-    cb();
+	cb();
 
-    expect(winSpy).toHaveBeenCalledWith('scroll', expect.any(Function), { passive: true });
-    expect(winSpy).toHaveBeenCalledWith('resize', expect.any(Function));
+	expect(winSpy).toHaveBeenCalledWith('scroll', expect.any(Function), { passive: true });
+	expect(winSpy).toHaveBeenCalledWith('resize', expect.any(Function));
   });
 });

--- a/tests/frontend/nuclen-front-lazy.test.ts
+++ b/tests/frontend/nuclen-front-lazy.test.ts
@@ -12,19 +12,19 @@ beforeEach(() => {
   originalMO = global.MutationObserver;
 
   global.IntersectionObserver = vi.fn(function (this: any, cb: any, options: any) {
-    this.callback = cb;
-    this.options = options;
-    this.observe = vi.fn();
-    this.unobserve = vi.fn();
-    this.disconnect = vi.fn();
-    ioInstances.push(this);
+	this.callback = cb;
+	this.options = options;
+	this.observe = vi.fn();
+	this.unobserve = vi.fn();
+	this.disconnect = vi.fn();
+	ioInstances.push(this);
   }) as unknown as typeof IntersectionObserver;
 
   global.MutationObserver = vi.fn(function (this: any, cb: any) {
-    this.cb = cb;
-    this.observe = vi.fn();
-    this.disconnect = vi.fn();
-    moInstance = this;
+	this.cb = cb;
+	this.observe = vi.fn();
+	this.disconnect = vi.fn();
+	moInstance = this;
   }) as unknown as typeof MutationObserver;
 
   (global as any).gtag = vi.fn();
@@ -40,33 +40,33 @@ afterEach(() => {
 
 describe('nuclen-front-lazy', () => {
   it('lazy loads component and calls init on intersection', async () => {
-    await import('../../src/front/ts/nuclen-front-lazy');
-    document.body.innerHTML = '<div id="lazy-el"></div>';
-    const initFn = vi.fn();
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    (window as any).testInit = initFn;
-    window.NuclenLazyLoadComponent!('lazy-el', 'testInit');
+	await import('../../src/front/ts/nuclen-front-lazy');
+	document.body.innerHTML = '<div id="lazy-el"></div>';
+	const initFn = vi.fn();
+	// eslint-disable-next-line @typescript-eslint/no-explicit-any
+	(window as any).testInit = initFn;
+	window.NuclenLazyLoadComponent!('lazy-el', 'testInit');
 
-    expect(ioInstances).toHaveLength(1);
-    const inst = ioInstances[0];
-    expect(inst.options).toEqual({ rootMargin: '0px 0px -200px 0px', threshold: 0.1 });
-    expect(inst.observe).toHaveBeenCalledWith(document.getElementById('lazy-el'));
+	expect(ioInstances).toHaveLength(1);
+	const inst = ioInstances[0];
+	expect(inst.options).toEqual({ rootMargin: '0px 0px -200px 0px', threshold: 0.1 });
+	expect(inst.observe).toHaveBeenCalledWith(document.getElementById('lazy-el'));
 
-    inst.callback([{ isIntersecting: true }]);
-    expect(initFn).toHaveBeenCalled();
-    expect(inst.disconnect).toHaveBeenCalled();
+	inst.callback([{ isIntersecting: true }]);
+	expect(initFn).toHaveBeenCalled();
+	expect(inst.disconnect).toHaveBeenCalled();
   });
 
   it('dispatches GA event when element fully visible', async () => {
-    await import('../../src/front/ts/nuclen-front-lazy');
-    document.body.innerHTML = '<div id="nuclen-quiz-container"></div><div id="nuclen-summary-container"></div>';
-    moInstance.cb([], moInstance);
+	await import('../../src/front/ts/nuclen-front-lazy');
+	document.body.innerHTML = '<div id="nuclen-quiz-container"></div><div id="nuclen-summary-container"></div>';
+	moInstance.cb([], moInstance);
 
-    expect(ioInstances).toHaveLength(2);
-    const summaryIO = ioInstances[0];
-    const summaryEl = document.getElementById('nuclen-summary-container');
-    summaryIO.callback([{ isIntersecting: true, intersectionRatio: 1, target: summaryEl }], summaryIO);
-    expect((global as any).gtag).toHaveBeenCalledWith('event', 'nuclen_summary_view');
-    expect(summaryIO.unobserve).toHaveBeenCalledWith(summaryEl);
+	expect(ioInstances).toHaveLength(2);
+	const summaryIO = ioInstances[0];
+	const summaryEl = document.getElementById('nuclen-summary-container');
+	summaryIO.callback([{ isIntersecting: true, intersectionRatio: 1, target: summaryEl }], summaryIO);
+	expect((global as any).gtag).toHaveBeenCalledWith('event', 'nuclen_summary_view');
+	expect(summaryIO.unobserve).toHaveBeenCalledWith(summaryEl);
   });
 });

--- a/tests/frontend/nuclen-quiz-optin.test.ts
+++ b/tests/frontend/nuclen-quiz-optin.test.ts
@@ -27,77 +27,77 @@ afterEach(() => {
 
 describe('buildOptinInlineHTML', () => {
   it('returns expected HTML', () => {
-    const html = buildOptinInlineHTML({
-      ...baseCtx,
-      position: 'with_results',
-    });
-    const expected = `
+	const html = buildOptinInlineHTML({
+	  ...baseCtx,
+	  position: 'with_results',
+	});
+	const expected = `
   <div id="nuclen-optin-container" class="nuclen-optin-with-results">
-    <p class="nuclen-fg"><strong>Join us</strong></p>
-    <label for="nuclen-optin-name"  class="nuclen-fg">Name</label>
-    <input  type="text"  id="nuclen-optin-name">
-    <label for="nuclen-optin-email" class="nuclen-fg">Email</label>
-    <input  type="email" id="nuclen-optin-email" required>
-    <button type="button" id="nuclen-optin-submit">Submit</button>
+	<p class="nuclen-fg"><strong>Join us</strong></p>
+	<label for="nuclen-optin-name"  class="nuclen-fg">Name</label>
+	<input  type="text"  id="nuclen-optin-name">
+	<label for="nuclen-optin-email" class="nuclen-fg">Email</label>
+	<input  type="email" id="nuclen-optin-email" required>
+	<button type="button" id="nuclen-optin-submit">Submit</button>
   </div>`;
-    expect(html).toBe(expected);
+	expect(html).toBe(expected);
   });
 });
 
 describe('mountOptinBeforeResults', () => {
   it('renders opt-in with skip link when not mandatory', () => {
-    const container = createContainer();
-    mountOptinBeforeResults(container, baseCtx, vi.fn(), vi.fn());
-    expect(container.innerHTML).toContain('nuclen-optin-skip');
+	const container = createContainer();
+	mountOptinBeforeResults(container, baseCtx, vi.fn(), vi.fn());
+	expect(container.innerHTML).toContain('nuclen-optin-skip');
   });
 
   it('omits skip link when mandatory', () => {
-    const container = createContainer();
-    mountOptinBeforeResults(container, { ...baseCtx, mandatory: true }, vi.fn(), vi.fn());
-    expect(container.innerHTML).not.toContain('nuclen-optin-skip');
+	const container = createContainer();
+	mountOptinBeforeResults(container, { ...baseCtx, mandatory: true }, vi.fn(), vi.fn());
+	expect(container.innerHTML).not.toContain('nuclen-optin-skip');
   });
 
   it('handles submit success', async () => {
-    const container = createContainer();
-    const complete = vi.fn();
-    const skip = vi.fn();
-    vi.spyOn(utils, 'isValidEmail').mockReturnValue(true);
-    vi.spyOn(utils, 'storeOptinLocally').mockResolvedValue();
-    vi.spyOn(utils, 'submitToWebhook').mockResolvedValue();
-    mountOptinBeforeResults(container, baseCtx, complete, skip);
-    (document.getElementById('nuclen-optin-name') as HTMLInputElement).value = 'n';
-    (document.getElementById('nuclen-optin-email') as HTMLInputElement).value = 'e@b.com';
-    (document.getElementById('nuclen-optin-submit') as HTMLElement).click();
-    await Promise.resolve();
-    await Promise.resolve();
-    expect(utils.storeOptinLocally).toHaveBeenCalled();
-    expect(utils.submitToWebhook).toHaveBeenCalled();
-    expect(complete).toHaveBeenCalled();
-    expect(skip).not.toHaveBeenCalled();
+	const container = createContainer();
+	const complete = vi.fn();
+	const skip = vi.fn();
+	vi.spyOn(utils, 'isValidEmail').mockReturnValue(true);
+	vi.spyOn(utils, 'storeOptinLocally').mockResolvedValue();
+	vi.spyOn(utils, 'submitToWebhook').mockResolvedValue();
+	mountOptinBeforeResults(container, baseCtx, complete, skip);
+	(document.getElementById('nuclen-optin-name') as HTMLInputElement).value = 'n';
+	(document.getElementById('nuclen-optin-email') as HTMLInputElement).value = 'e@b.com';
+	(document.getElementById('nuclen-optin-submit') as HTMLElement).click();
+	await Promise.resolve();
+	await Promise.resolve();
+	expect(utils.storeOptinLocally).toHaveBeenCalled();
+	expect(utils.submitToWebhook).toHaveBeenCalled();
+	expect(complete).toHaveBeenCalled();
+	expect(skip).not.toHaveBeenCalled();
   });
 
   it('alerts on invalid email', () => {
-    const container = createContainer();
-    const alertMock = vi.fn();
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    (global as any).alert = alertMock;
-    vi.spyOn(utils, 'storeOptinLocally').mockResolvedValue();
-    vi.spyOn(utils, 'submitToWebhook').mockResolvedValue();
-    vi.spyOn(utils, 'isValidEmail').mockReturnValue(false);
-    vi.spyOn(utils, 'storeOptinLocally');
-    vi.spyOn(utils, 'submitToWebhook');
-    mountOptinBeforeResults(container, baseCtx, vi.fn(), vi.fn());
-    (document.getElementById('nuclen-optin-submit') as HTMLElement).click();
-    expect(alertMock).toHaveBeenCalled();
-    expect(utils.storeOptinLocally).not.toHaveBeenCalled();
-    expect(utils.submitToWebhook).not.toHaveBeenCalled();
+	const container = createContainer();
+	const alertMock = vi.fn();
+	// eslint-disable-next-line @typescript-eslint/no-explicit-any
+	(global as any).alert = alertMock;
+	vi.spyOn(utils, 'storeOptinLocally').mockResolvedValue();
+	vi.spyOn(utils, 'submitToWebhook').mockResolvedValue();
+	vi.spyOn(utils, 'isValidEmail').mockReturnValue(false);
+	vi.spyOn(utils, 'storeOptinLocally');
+	vi.spyOn(utils, 'submitToWebhook');
+	mountOptinBeforeResults(container, baseCtx, vi.fn(), vi.fn());
+	(document.getElementById('nuclen-optin-submit') as HTMLElement).click();
+	expect(alertMock).toHaveBeenCalled();
+	expect(utils.storeOptinLocally).not.toHaveBeenCalled();
+	expect(utils.submitToWebhook).not.toHaveBeenCalled();
   });
 
   it('calls skip callback', () => {
-    const container = createContainer();
-    const skip = vi.fn();
-    mountOptinBeforeResults(container, baseCtx, vi.fn(), skip);
-    (document.getElementById('nuclen-optin-skip') as HTMLElement).dispatchEvent(new Event('click', { bubbles: true }));
-    expect(skip).toHaveBeenCalled();
+	const container = createContainer();
+	const skip = vi.fn();
+	mountOptinBeforeResults(container, baseCtx, vi.fn(), skip);
+	(document.getElementById('nuclen-optin-skip') as HTMLElement).dispatchEvent(new Event('click', { bubbles: true }));
+	expect(skip).toHaveBeenCalled();
   });
 });

--- a/tests/frontend/nuclen-quiz-utils.test.ts
+++ b/tests/frontend/nuclen-quiz-utils.test.ts
@@ -5,133 +5,133 @@ import type { OptinContext } from '../../src/front/ts/nuclen-quiz-types';
 
 describe('shuffle', () => {
   it('shuffles deterministically', () => {
-    const arr = [1, 2, 3];
-    const rand = vi.spyOn(Math, 'random')
-      .mockReturnValueOnce(0.5) // j=1
-      .mockReturnValueOnce(0);  // j=0
-    const res = shuffle(arr);
-    expect(res).toEqual([3, 1, 2]);
-    expect(res).not.toBe(arr);
-    rand.mockRestore();
+	const arr = [1, 2, 3];
+	const rand = vi.spyOn(Math, 'random')
+	  .mockReturnValueOnce(0.5) // j=1
+	  .mockReturnValueOnce(0);  // j=0
+	const res = shuffle(arr);
+	expect(res).toEqual([3, 1, 2]);
+	expect(res).not.toBe(arr);
+	rand.mockRestore();
   });
 });
 
 describe('isValidEmail', () => {
   it('validates basic email format', () => {
-    expect(isValidEmail('a@b.com')).toBe(true);
-    expect(isValidEmail('invalid')).toBe(false);
+	expect(isValidEmail('a@b.com')).toBe(true);
+	expect(isValidEmail('invalid')).toBe(false);
   });
 });
 
 describe('escapeHtml', () => {
   it('escapes HTML characters', () => {
-    const res = escapeHtml('<div>"O\'H&"</div>');
-    expect(res).toBe('&lt;div&gt;&quot;O&#039;H&amp;&quot;&lt;/div&gt;');
+	const res = escapeHtml('<div>"O\'H&"</div>');
+	expect(res).toBe('&lt;div&gt;&quot;O&#039;H&amp;&quot;&lt;/div&gt;');
   });
 });
 
 describe('storeOptinLocally', () => {
   const baseCtx: OptinContext = {
-    position: 'with_results',
-    mandatory: false,
-    promptText: '',
-    submitLabel: '',
-    enabled: true,
-    webhook: '',
-    ajaxUrl: 'https://example.com',
-    ajaxNonce: '123'
+	position: 'with_results',
+	mandatory: false,
+	promptText: '',
+	submitLabel: '',
+	enabled: true,
+	webhook: '',
+	ajaxUrl: 'https://example.com',
+	ajaxNonce: '123'
   };
 
   afterEach(() => {
-    vi.restoreAllMocks();
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    delete (global as any).fetch;
+	vi.restoreAllMocks();
+	// eslint-disable-next-line @typescript-eslint/no-explicit-any
+	delete (global as any).fetch;
   });
 
   it('posts to ajax url', async () => {
-    const fetchMock = vi.fn().mockResolvedValue({ ok: true });
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    (global as any).fetch = fetchMock;
-    const log = vi.spyOn(logger, 'error').mockImplementation(() => {});
-    await storeOptinLocally('n', 'e', 'u', baseCtx);
-    expect(fetchMock).toHaveBeenCalled();
-    expect(log).not.toHaveBeenCalled();
+	const fetchMock = vi.fn().mockResolvedValue({ ok: true });
+	// eslint-disable-next-line @typescript-eslint/no-explicit-any
+	(global as any).fetch = fetchMock;
+	const log = vi.spyOn(logger, 'error').mockImplementation(() => {});
+	await storeOptinLocally('n', 'e', 'u', baseCtx);
+	expect(fetchMock).toHaveBeenCalled();
+	expect(log).not.toHaveBeenCalled();
   });
 
   it('logs when response not ok', async () => {
-    const fetchMock = vi.fn().mockResolvedValue({ ok: false, status: 500 });
-    (global as any).fetch = fetchMock;
-    const log = vi.spyOn(logger, 'error').mockImplementation(() => {});
-    await storeOptinLocally('n', 'e', 'u', baseCtx);
-    expect(log).toHaveBeenCalledWith('[NE] Local opt-in failed', 500);
+	const fetchMock = vi.fn().mockResolvedValue({ ok: false, status: 500 });
+	(global as any).fetch = fetchMock;
+	const log = vi.spyOn(logger, 'error').mockImplementation(() => {});
+	await storeOptinLocally('n', 'e', 'u', baseCtx);
+	expect(log).toHaveBeenCalledWith('[NE] Local opt-in failed', 500);
   });
 
   it('logs network error', async () => {
-    const err = new Error('fail');
-    const fetchMock = vi.fn().mockRejectedValue(err);
-    (global as any).fetch = fetchMock;
-    const log = vi.spyOn(logger, 'error').mockImplementation(() => {});
-    await storeOptinLocally('n', 'e', 'u', baseCtx);
-    expect(log).toHaveBeenCalledWith('[NE] Local opt-in network error', err);
+	const err = new Error('fail');
+	const fetchMock = vi.fn().mockRejectedValue(err);
+	(global as any).fetch = fetchMock;
+	const log = vi.spyOn(logger, 'error').mockImplementation(() => {});
+	await storeOptinLocally('n', 'e', 'u', baseCtx);
+	expect(log).toHaveBeenCalledWith('[NE] Local opt-in network error', err);
   });
 
   it('skips when ajax info missing', async () => {
-    const fetchMock = vi.fn();
-    (global as any).fetch = fetchMock;
-    const ctx = { ...baseCtx, ajaxUrl: '', ajaxNonce: '' };
-    await storeOptinLocally('n', 'e', 'u', ctx);
-    expect(fetchMock).not.toHaveBeenCalled();
+	const fetchMock = vi.fn();
+	(global as any).fetch = fetchMock;
+	const ctx = { ...baseCtx, ajaxUrl: '', ajaxNonce: '' };
+	await storeOptinLocally('n', 'e', 'u', ctx);
+	expect(fetchMock).not.toHaveBeenCalled();
   });
 });
 
 describe('submitToWebhook', () => {
   const baseCtx: OptinContext = {
-    position: 'with_results',
-    mandatory: false,
-    promptText: '',
-    submitLabel: '',
-    enabled: true,
-    webhook: 'https://example.com',
-    ajaxUrl: '',
-    ajaxNonce: ''
+	position: 'with_results',
+	mandatory: false,
+	promptText: '',
+	submitLabel: '',
+	enabled: true,
+	webhook: 'https://example.com',
+	ajaxUrl: '',
+	ajaxNonce: ''
   };
 
   afterEach(() => {
-    vi.restoreAllMocks();
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    delete (global as any).fetch;
+	vi.restoreAllMocks();
+	// eslint-disable-next-line @typescript-eslint/no-explicit-any
+	delete (global as any).fetch;
   });
 
   it('posts to webhook', async () => {
-    const fetchMock = vi.fn().mockResolvedValue({ ok: true });
-    (global as any).fetch = fetchMock;
-    const log = vi.spyOn(logger, 'error').mockImplementation(() => {});
-    await submitToWebhook('n', 'e', baseCtx);
-    expect(fetchMock).toHaveBeenCalledWith('https://example.com', expect.objectContaining({ method: 'POST' }));
-    expect(log).not.toHaveBeenCalled();
+	const fetchMock = vi.fn().mockResolvedValue({ ok: true });
+	(global as any).fetch = fetchMock;
+	const log = vi.spyOn(logger, 'error').mockImplementation(() => {});
+	await submitToWebhook('n', 'e', baseCtx);
+	expect(fetchMock).toHaveBeenCalledWith('https://example.com', expect.objectContaining({ method: 'POST' }));
+	expect(log).not.toHaveBeenCalled();
   });
 
   it('skips when webhook missing', async () => {
-    const fetchMock = vi.fn();
-    (global as any).fetch = fetchMock;
-    await submitToWebhook('n', 'e', { ...baseCtx, webhook: '' });
-    expect(fetchMock).not.toHaveBeenCalled();
+	const fetchMock = vi.fn();
+	(global as any).fetch = fetchMock;
+	await submitToWebhook('n', 'e', { ...baseCtx, webhook: '' });
+	expect(fetchMock).not.toHaveBeenCalled();
   });
 
   it('throws on non ok response', async () => {
-    const fetchMock = vi.fn().mockResolvedValue({ ok: false, status: 400 });
-    (global as any).fetch = fetchMock;
-    const log = vi.spyOn(logger, 'error').mockImplementation(() => {});
-    await expect(submitToWebhook('n', 'e', baseCtx)).rejects.toBeTruthy();
-    expect(log).toHaveBeenCalledWith('[NE] Webhook responded with', 400);
+	const fetchMock = vi.fn().mockResolvedValue({ ok: false, status: 400 });
+	(global as any).fetch = fetchMock;
+	const log = vi.spyOn(logger, 'error').mockImplementation(() => {});
+	await expect(submitToWebhook('n', 'e', baseCtx)).rejects.toBeTruthy();
+	expect(log).toHaveBeenCalledWith('[NE] Webhook responded with', 400);
   });
 
   it('throws on fetch error', async () => {
-    const err = new Error('net');
-    const fetchMock = vi.fn().mockRejectedValue(err);
-    (global as any).fetch = fetchMock;
-    const log = vi.spyOn(logger, 'error').mockImplementation(() => {});
-    await expect(submitToWebhook('n', 'e', baseCtx)).rejects.toBe(err);
-    expect(log).toHaveBeenCalledWith('[NE] Webhook request error', err);
+	const err = new Error('net');
+	const fetchMock = vi.fn().mockRejectedValue(err);
+	(global as any).fetch = fetchMock;
+	const log = vi.spyOn(logger, 'error').mockImplementation(() => {});
+	await expect(submitToWebhook('n', 'e', baseCtx)).rejects.toBe(err);
+	expect(log).toHaveBeenCalledWith('[NE] Webhook request error', err);
   });
 });

--- a/tests/frontend/onboarding.test.ts
+++ b/tests/frontend/onboarding.test.ts
@@ -16,9 +16,9 @@ beforeEach(() => {
   vi.resetModules();
   document.body.innerHTML = '<div id="target"></div>';
   (window as any).nePointerData = {
-    pointers: [{ id: 'p1', target: '#target', title: 'T', content: 'C', position: { edge: 'top', align: 'center' } }],
-    ajaxurl: 'ajax.php',
-    nonce: 'n'
+	pointers: [{ id: 'p1', target: '#target', title: 'T', content: 'C', position: { edge: 'top', align: 'center' } }],
+	ajaxurl: 'ajax.php',
+	nonce: 'n'
   };
 });
 
@@ -29,17 +29,17 @@ afterEach(() => {
 
 describe('nuclen-admin-onboarding', () => {
   it('renders pointer from window data', async () => {
-    await import('../../src/admin/ts/nuclen-admin-onboarding');
-    document.dispatchEvent(new Event('DOMContentLoaded'));
-    expect(document.querySelector('.wp-pointer')).not.toBeNull();
+	await import('../../src/admin/ts/nuclen-admin-onboarding');
+	document.dispatchEvent(new Event('DOMContentLoaded'));
+	expect(document.querySelector('.wp-pointer')).not.toBeNull();
   });
 
   it('sends AJAX dismissal request', async () => {
-    await import('../../src/admin/ts/nuclen-admin-onboarding');
-    document.dispatchEvent(new Event('DOMContentLoaded'));
-    const close = document.querySelector<HTMLAnchorElement>('.wp-pointer .close')!;
-    close.click();
-    await Promise.resolve();
-    expect(nuclenFetchWithRetry).toHaveBeenCalled();
+	await import('../../src/admin/ts/nuclen-admin-onboarding');
+	document.dispatchEvent(new Event('DOMContentLoaded'));
+	const close = document.querySelector<HTMLAnchorElement>('.wp-pointer .close')!;
+	close.click();
+	await Promise.resolve();
+	expect(nuclenFetchWithRetry).toHaveBeenCalled();
   });
 });

--- a/tests/frontend/quiz.test.ts
+++ b/tests/frontend/quiz.test.ts
@@ -6,26 +6,26 @@ import type { QuizQuestion, QuizUIRefs, QuizState, OptinContext } from '../../sr
 // Basic DOM markup used by the quiz scripts
 function setupDOM() {
   document.body.innerHTML = `
-    <div id="nuclen-quiz-container">
-      <div id="nuclen-quiz-question-container"></div>
-      <div id="nuclen-quiz-answers-container"></div>
-      <div id="nuclen-quiz-explanation-container" class="nuclen-quiz-hidden"></div>
-      <div id="nuclen-quiz-progress-bar"></div>
-      <button id="nuclen-quiz-next-button" class="nuclen-quiz-hidden"></button>
-      <div id="nuclen-quiz-final-result-container" class="nuclen-quiz-hidden"></div>
-    </div>`;
+	<div id="nuclen-quiz-container">
+	  <div id="nuclen-quiz-question-container"></div>
+	  <div id="nuclen-quiz-answers-container"></div>
+	  <div id="nuclen-quiz-explanation-container" class="nuclen-quiz-hidden"></div>
+	  <div id="nuclen-quiz-progress-bar"></div>
+	  <button id="nuclen-quiz-next-button" class="nuclen-quiz-hidden"></button>
+	  <div id="nuclen-quiz-final-result-container" class="nuclen-quiz-hidden"></div>
+	</div>`;
 }
 
 const sampleQuestions: QuizQuestion[] = [
   {
-    question: 'First Q',
-    answers: ['A1', 'A2'],
-    explanation: 'Because',
+	question: 'First Q',
+	answers: ['A1', 'A2'],
+	explanation: 'Because',
   },
   {
-    question: 'Second Q',
-    answers: ['B1', 'B2'],
-    explanation: 'So',
+	question: 'Second Q',
+	answers: ['B1', 'B2'],
+	explanation: 'So',
   },
 ];
 
@@ -62,53 +62,53 @@ beforeEach(() => {
 
 describe('initQuiz', () => {
   it('renders first question and processes answers', () => {
-    initQuiz();
-    const qEl = document.getElementById('nuclen-quiz-question-container')!;
-    const aEl = document.getElementById('nuclen-quiz-answers-container')!;
-    expect(qEl.textContent).toContain('First Q');
-    const btn = aEl.querySelector('button') as HTMLButtonElement;
-    expect(btn).toBeTruthy();
-    // simulate answer selection
-    btn.click();
-    const expl = document.getElementById('nuclen-quiz-explanation-container')!;
-    const next = document.getElementById('nuclen-quiz-next-button')!;
-    expect(expl.classList.contains('nuclen-quiz-hidden')).toBe(false);
-    expect(next.classList.contains('nuclen-quiz-hidden')).toBe(false);
-    const gtag = (globalThis as any).gtag as ReturnType<typeof vi.fn>;
-    expect(gtag).toHaveBeenCalledWith('event', 'nuclen_quiz_start');
-    expect(gtag).toHaveBeenCalledWith('event', 'nuclen_quiz_answer');
+	initQuiz();
+	const qEl = document.getElementById('nuclen-quiz-question-container')!;
+	const aEl = document.getElementById('nuclen-quiz-answers-container')!;
+	expect(qEl.textContent).toContain('First Q');
+	const btn = aEl.querySelector('button') as HTMLButtonElement;
+	expect(btn).toBeTruthy();
+	// simulate answer selection
+	btn.click();
+	const expl = document.getElementById('nuclen-quiz-explanation-container')!;
+	const next = document.getElementById('nuclen-quiz-next-button')!;
+	expect(expl.classList.contains('nuclen-quiz-hidden')).toBe(false);
+	expect(next.classList.contains('nuclen-quiz-hidden')).toBe(false);
+	const gtag = (globalThis as any).gtag as ReturnType<typeof vi.fn>;
+	expect(gtag).toHaveBeenCalledWith('event', 'nuclen_quiz_start');
+	expect(gtag).toHaveBeenCalledWith('event', 'nuclen_quiz_answer');
   });
 });
 
 describe('renderFinal', () => {
   it('outputs opt-in markup and callbacks', () => {
-    setupDOM();
-    const ui: QuizUIRefs = {
-      qContainer: document.getElementById('nuclen-quiz-question-container')!,
-      aContainer: document.getElementById('nuclen-quiz-answers-container')!,
-      explContainer: document.getElementById('nuclen-quiz-explanation-container')!,
-      nextBtn: document.getElementById('nuclen-quiz-next-button')!,
-      finalContainer: document.getElementById('nuclen-quiz-final-result-container')!,
-      progBar: document.getElementById('nuclen-quiz-progress-bar')!,
-    };
-    const state: QuizState = { currIdx: 0, score: 2, userAnswers: [0, 1] };
-    const optin: OptinContext = {
-      position: 'with_results',
-      mandatory: false,
-      promptText: 'Join us',
-      submitLabel: 'Submit',
-      enabled: true,
-      webhook: '',
-      ajaxUrl: '',
-      ajaxNonce: '',
-    };
-    const gtag = vi.fn();
-    (globalThis as any).gtag = gtag;
-    renderFinal(ui, optin, sampleQuestions, state, () => {});
-    const form = document.getElementById('nuclen-optin-container');
-    expect(form).toBeTruthy();
-    expect(typeof window.nuclearEngagementShowQuizQuestionDetails).toBe('function');
-    expect(typeof window.nuclearEngagementRetakeQuiz).toBe('function');
-    expect(gtag).toHaveBeenCalledWith('event', 'nuclen_quiz_end');
+	setupDOM();
+	const ui: QuizUIRefs = {
+	  qContainer: document.getElementById('nuclen-quiz-question-container')!,
+	  aContainer: document.getElementById('nuclen-quiz-answers-container')!,
+	  explContainer: document.getElementById('nuclen-quiz-explanation-container')!,
+	  nextBtn: document.getElementById('nuclen-quiz-next-button')!,
+	  finalContainer: document.getElementById('nuclen-quiz-final-result-container')!,
+	  progBar: document.getElementById('nuclen-quiz-progress-bar')!,
+	};
+	const state: QuizState = { currIdx: 0, score: 2, userAnswers: [0, 1] };
+	const optin: OptinContext = {
+	  position: 'with_results',
+	  mandatory: false,
+	  promptText: 'Join us',
+	  submitLabel: 'Submit',
+	  enabled: true,
+	  webhook: '',
+	  ajaxUrl: '',
+	  ajaxNonce: '',
+	};
+	const gtag = vi.fn();
+	(globalThis as any).gtag = gtag;
+	renderFinal(ui, optin, sampleQuestions, state, () => {});
+	const form = document.getElementById('nuclen-optin-container');
+	expect(form).toBeTruthy();
+	expect(typeof window.nuclearEngagementShowQuizQuestionDetails).toBe('function');
+	expect(typeof window.nuclearEngagementRetakeQuiz).toBe('function');
+	expect(gtag).toHaveBeenCalledWith('event', 'nuclen_quiz_end');
   });
 });

--- a/tests/wp-admin/includes/upgrade.php
+++ b/tests/wp-admin/includes/upgrade.php
@@ -1,5 +1,5 @@
 <?php
 function dbDelta( $sql ) {
-    global $dbDelta_called;
-    $dbDelta_called = true;
+	global $dbDelta_called;
+	$dbDelta_called = true;
 }

--- a/tests/wp-stubs.php
+++ b/tests/wp-stubs.php
@@ -1,48 +1,48 @@
 <?php
 if (!function_exists('wp_upload_dir')) {
-    function wp_upload_dir() {
-        return [
-            'basedir' => $GLOBALS['test_upload_basedir'] ?? sys_get_temp_dir(),
-            'baseurl'  => $GLOBALS['test_upload_baseurl'] ?? 'http://example.com/uploads',
-            'error'    => $GLOBALS['test_upload_error'] ?? '',
-        ];
-    }
+	function wp_upload_dir() {
+		return [
+			'basedir' => $GLOBALS['test_upload_basedir'] ?? sys_get_temp_dir(),
+			'baseurl'  => $GLOBALS['test_upload_baseurl'] ?? 'http://example.com/uploads',
+			'error'    => $GLOBALS['test_upload_error'] ?? '',
+		];
+	}
 }
 if (!function_exists('wp_mkdir_p')) {
-    function wp_mkdir_p($dir) {
-        if (!empty($GLOBALS['test_wp_mkdir_p_failure'])) {
-            return false;
-        }
-        return mkdir($dir, 0777, true);
-    }
+	function wp_mkdir_p($dir) {
+		if (!empty($GLOBALS['test_wp_mkdir_p_failure'])) {
+			return false;
+		}
+		return mkdir($dir, 0777, true);
+	}
 }
 if (!function_exists('wp_verify_nonce')) {
-    function wp_verify_nonce($nonce, $action) {
-        if (array_key_exists('test_verify_nonce', $GLOBALS)) {
-            return (bool) $GLOBALS['test_verify_nonce'];
-        }
-        return $nonce === 'valid';
-    }
+	function wp_verify_nonce($nonce, $action) {
+		if (array_key_exists('test_verify_nonce', $GLOBALS)) {
+			return (bool) $GLOBALS['test_verify_nonce'];
+		}
+		return $nonce === 'valid';
+	}
 }
 if (!function_exists('wp_remote_post')) {
-    function wp_remote_post(string $url, array $args = []) {
-        return $GLOBALS['test_http_response'] ?? null;
-    }
+	function wp_remote_post(string $url, array $args = []) {
+		return $GLOBALS['test_http_response'] ?? null;
+	}
 }
 if (!function_exists('wp_remote_retrieve_response_code')) {
-    function wp_remote_retrieve_response_code($res) {
-        return is_array($res) ? ($res['code'] ?? 0) : 0;
-    }
+	function wp_remote_retrieve_response_code($res) {
+		return is_array($res) ? ($res['code'] ?? 0) : 0;
+	}
 }
 if (!function_exists('wp_remote_retrieve_body')) {
-    function wp_remote_retrieve_body($res) {
-        return is_array($res) ? ($res['body'] ?? '') : '';
-    }
+	function wp_remote_retrieve_body($res) {
+		return is_array($res) ? ($res['body'] ?? '') : '';
+	}
 }
 
 if (!function_exists('locate_template')) {
-    function locate_template($names, $load = false, $require_once = true, $args = []) {
-        return '';
-    }
+	function locate_template($names, $load = false, $require_once = true, $args = []) {
+		return '';
+	}
 }
 

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -2,7 +2,7 @@ import { defineConfig } from 'vitest/config';
 
 export default defineConfig({
   test: {
-    environment: 'jsdom',
-    include: ['tests/**/*.test.ts']
+	environment: 'jsdom',
+	include: ['tests/**/*.test.ts']
   }
 });


### PR DESCRIPTION
## Summary
- update EditorConfig to use tabs
- disallow space indentation in PHPCS config
- enforce tab indentation in ESLint
- convert leading spaces to tabs in PHP and TypeScript files

## Testing
- `composer lint` *(fails: command not found)*
- `npm run lint` *(fails: cannot find module @typescript-eslint/eslint-plugin)*

------
https://chatgpt.com/codex/tasks/task_e_685e4173b4e08327b137954fb0292509

<!-- Korbit AI PR Description Start -->
## Description by Korbit AI

### What change is being made?
Enforce tab indentation across the entire codebase by updating configuration files and modifying the affected code files to replace space indentation with tabs.

### Why are these changes being made?
These changes were made to maintain consistency in code formatting and adhere to project standards that require tab indentation. Enforcing this indentation style improves readability and maintains uniform coding practices across the project.

> Is this description stale? Ask me to generate a new description by commenting `/korbit-generate-pr-description`
<!-- Korbit AI PR Description End -->