### PR TITLE
Add shortcode templates

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -116,6 +116,12 @@ two dedicated classes: `QuizShortcode` and `SummaryShortcode`. Each class
 registers its shortcode and builds output using the corresponding view class.
 `ShortcodesTrait` merely instantiates these handlers and delegates calls.
 The autoloader maps the new classes under the `Front` namespace.
+## Shortcode Templates
+
+Front-end shortcodes render via minimal templates stored under `templates/front`. These files contain only markup so the handler classes remain purely logical.
+- `templates/front/quiz/shortcode.php` wraps the quiz container and attribution.
+- `templates/front/toc/shortcode.php` outputs the TOC wrapper and sticky content.
+
 
 ## Container Registration Extraction
 

--- a/nuclear-engagement/templates/front/quiz/shortcode.php
+++ b/nuclear-engagement/templates/front/quiz/shortcode.php
@@ -1,0 +1,10 @@
+<?php
+declare(strict_types=1);
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+?>
+<div class="nuclen-root" data-theme="<?php echo esc_attr( $theme ); ?>">
+<?php echo $container; ?>
+<?php echo $attribution; ?>
+</div>

--- a/nuclear-engagement/templates/front/toc/shortcode.php
+++ b/nuclear-engagement/templates/front/toc/shortcode.php
@@ -1,0 +1,18 @@
+<?php
+declare(strict_types=1);
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+?>
+	<div class="nuclen-root" data-theme="<?php echo esc_attr( $theme ); ?>">
+	<section id="<?php echo esc_attr( $nav_id ); ?>-wrapper" class="<?php echo esc_attr( implode( ' ', $classes ) ); ?>"<?php echo $sticky_attrs; ?>>
+	<?php if ( $has_sticky ) : ?>
+	<div class="nuclen-toc-content">
+	<?php endif; ?>
+	<?php echo $toggle_button; ?>
+	<?php echo $nav_markup; ?>
+	<?php if ( $has_sticky ) : ?>
+	</div>
+	<?php endif; ?>
+	</section>
+	</div>


### PR DESCRIPTION
## Summary
- add shortcode template stubs for quiz and TOC
- document templates in ARCHITECTURE.md

## Testing
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_685e4175a9048327876e5356f35d91b2

<!-- Korbit AI PR Description Start -->
## Description by Korbit AI

### What change is being made?

Add minimal template files for front-end shortcodes used for quiz and table of contents (TOC) representation.

### Why are these changes being made?

The changes separate markup from logic by introducing dedicated template files for shortcode rendering, ensuring the handler classes remain purely logical. This approach enhances maintainability and readability while aligning with modern best practices for organizing frontend code.

> Is this description stale? Ask me to generate a new description by commenting `/korbit-generate-pr-description`
<!-- Korbit AI PR Description End -->