### PR TITLE
Add CacheInvalidationTrait for hook registration

### DIFF
--- a/nuclear-engagement/inc/Core/InventoryCache.php
+++ b/nuclear-engagement/inc/Core/InventoryCache.php
@@ -14,7 +14,10 @@ if ( ! defined( 'ABSPATH' ) ) {
     exit;
 }
 
+use NuclearEngagement\Traits\CacheInvalidationTrait;
+
 final class InventoryCache {
+	use CacheInvalidationTrait;
     /** Cache key base for inventory data. */
     public const CACHE_KEY = 'nuclen_inventory_data';
 
@@ -34,37 +37,9 @@ final class InventoryCache {
      * Register hooks to automatically clear the cache when posts change.
      */
     public static function register_hooks(): void {
-        $cb = array( self::class, 'clear' );
-        foreach ( array(
-            'save_post',
-            'delete_post',
-            'deleted_post',
-            'trashed_post',
-            'untrashed_post',
-            'transition_post_status',
-            'clean_post_cache',
-        ) as $hook ) {
-            add_action( $hook, $cb );
-        }
-        foreach ( array( 'added_post_meta', 'updated_post_meta', 'deleted_post_meta' ) as $hook ) {
-            add_action( $hook, $cb );
-        }
-        foreach ( array(
-            'create_term',
-            'created_term',
-            'edit_term',
-            'edited_term',
-            'delete_term',
-            'deleted_term',
-            'set_object_terms',
-            'added_term_relationship',
-            'deleted_term_relationships',
-            'edited_terms',
-        ) as $hook ) {
-            add_action( $hook, $cb );
-        }
-        add_action( 'switch_blog', $cb );
-    }
+	$cb = array( self::class, 'clear' );
+	self::register_cache_invalidation_hooks( $cb );
+}
 
     /**
      * Get the cache key for the current site.

--- a/nuclear-engagement/inc/Services/PostsQueryService.php
+++ b/nuclear-engagement/inc/Services/PostsQueryService.php
@@ -13,6 +13,7 @@ namespace NuclearEngagement\Services;
 use NuclearEngagement\Requests\PostsCountRequest;
 use NuclearEngagement\Services\LoggingService;
 use NuclearEngagement\Modules\Summary\Summary_Service;
+use NuclearEngagement\Traits\CacheInvalidationTrait;
 
 if ( ! defined( 'ABSPATH' ) ) {
     exit;
@@ -22,6 +23,7 @@ if ( ! defined( 'ABSPATH' ) ) {
  * Service for querying posts
  */
 class PostsQueryService {
+	use CacheInvalidationTrait;
         /** Cache group for query results. */
     private const CACHE_GROUP = 'nuclen_posts_query';
 
@@ -35,41 +37,9 @@ class PostsQueryService {
          * Register hooks to invalidate caches when posts or terms change.
          */
     public static function register_hooks(): void {
-            $cb = array( self::class, 'clear_cache' );
-
-        foreach ( array(
-            'save_post',
-            'delete_post',
-            'deleted_post',
-            'trashed_post',
-            'untrashed_post',
-            'transition_post_status',
-            'clean_post_cache',
-        ) as $hook ) {
-                add_action( $hook, $cb );
-        }
-
-        foreach ( array( 'added_post_meta', 'updated_post_meta', 'deleted_post_meta' ) as $hook ) {
-                add_action( $hook, $cb );
-        }
-
-        foreach ( array(
-            'create_term',
-            'created_term',
-            'edit_term',
-            'edited_term',
-            'delete_term',
-            'deleted_term',
-            'set_object_terms',
-            'added_term_relationship',
-            'deleted_term_relationships',
-            'edited_terms',
-        ) as $hook ) {
-                add_action( $hook, $cb );
-        }
-
-            add_action( 'switch_blog', $cb );
-    }
+	$cb = array( self::class, 'clear_cache' );
+	self::register_cache_invalidation_hooks( $cb );
+}
 
         /**
          * Clear all cached query results.

--- a/nuclear-engagement/inc/Traits/CacheInvalidationTrait.php
+++ b/nuclear-engagement/inc/Traits/CacheInvalidationTrait.php
@@ -1,0 +1,61 @@
+<?php
+/**
+ * File: includes/Traits/CacheInvalidationTrait.php
+ *
+ * Provides a helper to register standard post and term hooks
+ * used for cache invalidation.
+ *
+ * @package NuclearEngagement
+ * @subpackage Traits
+ */
+
+declare( strict_types = 1 );
+
+namespace NuclearEngagement\Traits;
+
+// If this file is called directly, abort.
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+trait CacheInvalidationTrait {
+	/**
+	 * Register hooks that invalidate caches.
+	 *
+	 * @param callable $callback Callback to execute when hooks fire.
+	 */
+	protected static function register_cache_invalidation_hooks( callable $callback ): void {
+		foreach ( array(
+			'save_post',
+			'delete_post',
+			'deleted_post',
+			'trashed_post',
+			'untrashed_post',
+			'transition_post_status',
+			'clean_post_cache',
+		) as $hook ) {
+			add_action( $hook, $callback );
+		}
+
+		foreach ( array( 'added_post_meta', 'updated_post_meta', 'deleted_post_meta' ) as $hook ) {
+			add_action( $hook, $callback );
+		}
+
+		foreach ( array(
+			'create_term',
+			'created_term',
+			'edit_term',
+			'edited_term',
+			'delete_term',
+			'deleted_term',
+			'set_object_terms',
+			'added_term_relationship',
+			'deleted_term_relationships',
+			'edited_terms',
+		) as $hook ) {
+			add_action( $hook, $callback );
+		}
+
+		add_action( 'switch_blog', $callback );
+	}
+}


### PR DESCRIPTION
## Summary
- implement `CacheInvalidationTrait` to consolidate cache invalidation hooks
- use the trait in `InventoryCache` and `PostsQueryService`

## Testing
- `composer lint` *(fails: command not found)*
- `composer test` *(fails: command not found)*


------
https://chatgpt.com/codex/tasks/task_e_685e4174b1b88327bda915bcc8f455c5

<!-- Korbit AI PR Description Start -->
## Description by Korbit AI

### What change is being made?

Add a `CacheInvalidationTrait` to centralize and simplify the registration of hooks for cache invalidation across classes, applying it to both `InventoryCache` and `PostsQueryService`.

### Why are these changes being made?

The changes aim to reduce code duplication and improve maintainability by introducing a reusable trait that handles hook registration for cache invalidation, simplifying hook management in both the `InventoryCache` and `PostsQueryService`. This approach provides a cleaner and more consistent method to handle cache invalidation triggers.

> Is this description stale? Ask me to generate a new description by commenting `/korbit-generate-pr-description`
<!-- Korbit AI PR Description End -->