### PR TITLE
Add cache invalidation trait

### DIFF
--- a/nuclear-engagement/inc/Core/InventoryCache.php
+++ b/nuclear-engagement/inc/Core/InventoryCache.php
@@ -10,11 +10,14 @@ declare(strict_types=1);
 
 namespace NuclearEngagement\Core;
 
+use NuclearEngagement\Traits\CacheInvalidationTrait;
+
 if ( ! defined( 'ABSPATH' ) ) {
 	exit;
 }
 
 final class InventoryCache {
+	use CacheInvalidationTrait;
 	/** Cache key base for inventory data. */
 	public const CACHE_KEY = 'nuclen_inventory_data';
 
@@ -35,35 +38,7 @@ final class InventoryCache {
 	 */
 	public static function register_hooks(): void {
 		$cb = array( self::class, 'clear' );
-		foreach ( array(
-			'save_post',
-			'delete_post',
-			'deleted_post',
-			'trashed_post',
-			'untrashed_post',
-			'transition_post_status',
-			'clean_post_cache',
-		) as $hook ) {
-			add_action( $hook, $cb );
-		}
-		foreach ( array( 'added_post_meta', 'updated_post_meta', 'deleted_post_meta' ) as $hook ) {
-			add_action( $hook, $cb );
-		}
-		foreach ( array(
-			'create_term',
-			'created_term',
-			'edit_term',
-			'edited_term',
-			'delete_term',
-			'deleted_term',
-			'set_object_terms',
-			'added_term_relationship',
-			'deleted_term_relationships',
-			'edited_terms',
-		) as $hook ) {
-			add_action( $hook, $cb );
-		}
-		add_action( 'switch_blog', $cb );
+		self::register_invalidation_hooks( $cb );
 	}
 
 	/**

--- a/nuclear-engagement/inc/Services/PostsQueryService.php
+++ b/nuclear-engagement/inc/Services/PostsQueryService.php
@@ -13,6 +13,7 @@ namespace NuclearEngagement\Services;
 use NuclearEngagement\Requests\PostsCountRequest;
 use NuclearEngagement\Services\LoggingService;
 use NuclearEngagement\Modules\Summary\Summary_Service;
+use NuclearEngagement\Traits\CacheInvalidationTrait;
 
 if ( ! defined( 'ABSPATH' ) ) {
 	exit;
@@ -22,6 +23,7 @@ if ( ! defined( 'ABSPATH' ) ) {
  * Service for querying posts
  */
 class PostsQueryService {
+	use CacheInvalidationTrait;
 		/** Cache group for query results. */
 	private const CACHE_GROUP = 'nuclen_posts_query';
 
@@ -36,39 +38,7 @@ class PostsQueryService {
 		 */
 	public static function register_hooks(): void {
 			$cb = array( self::class, 'clear_cache' );
-
-		foreach ( array(
-			'save_post',
-			'delete_post',
-			'deleted_post',
-			'trashed_post',
-			'untrashed_post',
-			'transition_post_status',
-			'clean_post_cache',
-		) as $hook ) {
-				add_action( $hook, $cb );
-		}
-
-		foreach ( array( 'added_post_meta', 'updated_post_meta', 'deleted_post_meta' ) as $hook ) {
-				add_action( $hook, $cb );
-		}
-
-		foreach ( array(
-			'create_term',
-			'created_term',
-			'edit_term',
-			'edited_term',
-			'delete_term',
-			'deleted_term',
-			'set_object_terms',
-			'added_term_relationship',
-			'deleted_term_relationships',
-			'edited_terms',
-		) as $hook ) {
-				add_action( $hook, $cb );
-		}
-
-			add_action( 'switch_blog', $cb );
+		self::register_invalidation_hooks( $cb );
 	}
 
 		/**

--- a/nuclear-engagement/inc/Traits/CacheInvalidationTrait.php
+++ b/nuclear-engagement/inc/Traits/CacheInvalidationTrait.php
@@ -1,0 +1,56 @@
+<?php
+/**
+ * File: includes/Traits/CacheInvalidationTrait.php
+ *
+ * Provides helper to register standard cache invalidation hooks.
+ *
+ * @package NuclearEngagement
+ * @subpackage Traits
+ */
+
+declare( strict_types = 1 );
+
+namespace NuclearEngagement\Traits;
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+trait CacheInvalidationTrait {
+	/**
+	 * Register the standard set of post and term hooks.
+	 *
+	 * @param callable $callback Callback to run when hooks fire.
+	 */
+	protected static function register_invalidation_hooks( callable $callback ): void {
+		foreach ( array(
+			'save_post',
+			'delete_post',
+			'deleted_post',
+			'trashed_post',
+			'untrashed_post',
+			'transition_post_status',
+			'clean_post_cache',
+		) as $hook ) {
+			add_action( $hook, $callback );
+		}
+		foreach ( array( 'added_post_meta', 'updated_post_meta', 'deleted_post_meta' ) as $hook ) {
+			add_action( $hook, $callback );
+		}
+		foreach ( array(
+			'create_term',
+			'created_term',
+			'edit_term',
+			'edited_term',
+			'delete_term',
+			'deleted_term',
+			'set_object_terms',
+			'added_term_relationship',
+			'deleted_term_relationships',
+			'edited_terms',
+		) as $hook ) {
+			add_action( $hook, $callback );
+		}
+		add_action( 'switch_blog', $callback );
+	}
+}

--- a/tests/CacheInvalidationTraitTest.php
+++ b/tests/CacheInvalidationTraitTest.php
@@ -1,0 +1,36 @@
+<?php
+namespace NuclearEngagement\Traits {
+	// Stub add_action to record hooks
+	function add_action(...$args) {
+		$GLOBALS['ci_actions'][] = $args;
+	}
+}
+
+namespace {
+	use PHPUnit\Framework\TestCase;
+	use NuclearEngagement\Traits\CacheInvalidationTrait;
+
+	class DummyInvalidator {
+		use CacheInvalidationTrait;
+
+		public static function register(): void {
+			self::register_invalidation_hooks( array( self::class, 'cb' ) );
+		}
+
+		public static function cb(): void {}
+	}
+
+	class CacheInvalidationTraitTest extends TestCase {
+		protected function setUp(): void {
+			$GLOBALS['ci_actions'] = array();
+		}
+
+		public function test_hooks_registered(): void {
+			DummyInvalidator::register();
+			$this->assertCount( 21, $GLOBALS['ci_actions'] );
+			$this->assertSame( 'save_post', $GLOBALS['ci_actions'][0][0] );
+			$this->assertSame( array( DummyInvalidator::class, 'cb' ), $GLOBALS['ci_actions'][0][1] );
+			$this->assertSame( 'switch_blog', $GLOBALS['ci_actions'][20][0] );
+		}
+	}
+}


### PR DESCRIPTION
## Summary
- create `CacheInvalidationTrait` for registering cache invalidation hooks
- refactor `InventoryCache` and `PostsQueryService` to use the trait
- add `CacheInvalidationTraitTest`

## Testing
- `composer lint` *(fails: command not found)*
- `composer test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685e463f3a1c83279f8ed207b2e04a46


> [!NOTE]
> I'm currently writing a description for your pull request. I should be done shortly (<1 minute). Please don't edit the description field until I'm finished, or we may overwrite each other. If I find nothing to write about, I'll delete this message.
