### PR TITLE
Refactor settings helpers

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -20,6 +20,10 @@ Release notes for the Nuclear Engagement plugin.
 ## 1.1.2 – 2025-07-01
 - Added: Database indexes on `wp_postmeta` for quiz and summary meta keys to improve query performance.
 
+## 1.1.3 – 2025-07-15
+- Changed: Settings helpers moved to `Helpers\SettingsFunctions`.
+- Deprecated: `nuclen_settings_*` global wrappers.
+
 ## 1.0.3 – 2025-06-11
 - Added: Uninstall data options.
 - Fixed: Auto content generation upon post publish.

--- a/nuclear-engagement/inc/Core/MetaRegistration.php
+++ b/nuclear-engagement/inc/Core/MetaRegistration.php
@@ -10,7 +10,7 @@ declare(strict_types=1);
 
 namespace NuclearEngagement\Core;
 
-use function NuclearEngagement\nuclen_settings_array;
+use NuclearEngagement\Helpers\SettingsFunctions;
 use NuclearEngagement\Modules\Summary\Summary_Service;
 
 if ( ! defined( 'ABSPATH' ) ) {
@@ -36,7 +36,7 @@ class MetaRegistration {
 	 */
 	public static function register_meta_keys(): void {
 		// Get allowed post types from settings
-		$post_types = nuclen_settings_array( 'generation_post_types', array( 'post' ) );
+               $post_types = SettingsFunctions::get_array( 'generation_post_types', array( 'post' ) );
 
 		// Register quiz data meta
 		foreach ( $post_types as $post_type ) {

--- a/nuclear-engagement/inc/Helpers/SettingsFunctions.php
+++ b/nuclear-engagement/inc/Helpers/SettingsFunctions.php
@@ -1,0 +1,59 @@
+<?php
+/**
+ * Class providing static wrappers for retrieving settings values.
+ *
+ * @package NuclearEngagement\\Helpers
+ */
+declare(strict_types=1);
+
+namespace NuclearEngagement\\Helpers;
+
+if ( ! defined( 'ABSPATH' ) ) {
+exit;
+}
+
+/**
+ * Static wrappers around {@see SettingsHelper}.
+ */
+final class SettingsFunctions {
+
+/**
+ * Get any setting or all settings if no key provided.
+ *
+ * @param string|null $key     Setting key or null for all.
+ * @param mixed       $default Default value.
+ * @return mixed
+ */
+public static function get( ?string $key = null, $default = null ) {
+return SettingsHelper::get( $key, $default );
+}
+
+/**
+ * Get a boolean setting.
+ */
+public static function get_bool( string $key, bool $default = false ): bool {
+return SettingsHelper::get_bool( $key, $default );
+}
+
+/**
+ * Get an integer setting.
+ */
+public static function get_int( string $key, int $default = 0 ): int {
+return SettingsHelper::get_int( $key, $default );
+}
+
+/**
+ * Get a string setting.
+ */
+public static function get_string( string $key, string $default = '' ): string {
+return SettingsHelper::get_string( $key, $default );
+}
+
+/**
+ * Get an array setting.
+ */
+public static function get_array( string $key, array $default = array() ): array {
+return SettingsHelper::get_array( $key, $default );
+}
+}
+

--- a/nuclear-engagement/inc/Helpers/settings-functions.php
+++ b/nuclear-engagement/inc/Helpers/settings-functions.php
@@ -9,36 +9,51 @@ declare(strict_types=1);
 
 namespace {
 
-use NuclearEngagement\Helpers\SettingsHelper;
+use NuclearEngagement\Helpers\SettingsFunctions;
 
 if ( ! function_exists( 'nuclen_settings' ) ) {
-	function nuclen_settings( ?string $key = null, $default = null ) {
-		return SettingsHelper::get( $key, $default );
-	}
+       /**
+        * @deprecated 1.2 Use SettingsFunctions::get() instead.
+        */
+       function nuclen_settings( ?string $key = null, $default = null ) {
+               return SettingsFunctions::get( $key, $default );
+       }
 }
 
 if ( ! function_exists( 'nuclen_settings_bool' ) ) {
-	function nuclen_settings_bool( string $key, bool $default = false ): bool {
-		return SettingsHelper::get_bool( $key, $default );
-	}
+       /**
+        * @deprecated 1.2 Use SettingsFunctions::get_bool() instead.
+        */
+       function nuclen_settings_bool( string $key, bool $default = false ): bool {
+               return SettingsFunctions::get_bool( $key, $default );
+       }
 }
 
 if ( ! function_exists( 'nuclen_settings_int' ) ) {
-	function nuclen_settings_int( string $key, int $default = 0 ): int {
-		return SettingsHelper::get_int( $key, $default );
-	}
+       /**
+        * @deprecated 1.2 Use SettingsFunctions::get_int() instead.
+        */
+       function nuclen_settings_int( string $key, int $default = 0 ): int {
+               return SettingsFunctions::get_int( $key, $default );
+       }
 }
 
 if ( ! function_exists( 'nuclen_settings_string' ) ) {
-	function nuclen_settings_string( string $key, string $default = '' ): string {
-		return SettingsHelper::get_string( $key, $default );
-	}
+       /**
+        * @deprecated 1.2 Use SettingsFunctions::get_string() instead.
+        */
+       function nuclen_settings_string( string $key, string $default = '' ): string {
+               return SettingsFunctions::get_string( $key, $default );
+       }
 }
 
 if ( ! function_exists( 'nuclen_settings_array' ) ) {
-	function nuclen_settings_array( string $key, array $default = array() ): array {
-		return SettingsHelper::get_array( $key, $default );
-	}
+       /**
+        * @deprecated 1.2 Use SettingsFunctions::get_array() instead.
+        */
+       function nuclen_settings_array( string $key, array $default = array() ): array {
+               return SettingsFunctions::get_array( $key, $default );
+       }
 }
 
 }

--- a/nuclear-engagement/inc/Modules/TOC/includes/Nuclen_TOC_Utils.php
+++ b/nuclear-engagement/inc/Modules/TOC/includes/Nuclen_TOC_Utils.php
@@ -14,7 +14,7 @@ declare(strict_types=1);
 
 namespace NuclearEngagement\Modules\TOC;
 
-use function NuclearEngagement\nuclen_settings_array;
+use NuclearEngagement\Helpers\SettingsFunctions;
 
 if ( ! defined( 'ABSPATH' ) ) {
 	exit;
@@ -242,7 +242,7 @@ final class Nuclen_TOC_Utils {
 				return;
 		}
 
-			$levels = nuclen_settings_array( 'toc_heading_levels', range( 2, 6 ) );
+               $levels = SettingsFunctions::get_array( 'toc_heading_levels', range( 2, 6 ) );
 
 			$levels = array_unique( array_map( 'intval', $levels ) );
 			sort( $levels );

--- a/nuclear-engagement/templates/admin/nuclen-dashboard-page.php
+++ b/nuclear-engagement/templates/admin/nuclen-dashboard-page.php
@@ -10,10 +10,10 @@ if ( ! defined( 'ABSPATH' ) ) {
  * We'll fix the “No credits info returned.” by referencing `data.data.remaining_credits`.
  */
 
-use function NuclearEngagement\nuclen_settings_bool;
+use NuclearEngagement\Helpers\SettingsFunctions;
 
 // Fetch plugin setup info to decide if we show credits
-$fully_setup = ( nuclen_settings_bool( 'connected', false ) && nuclen_settings_bool( 'wp_app_pass_created', false ) );
+$fully_setup = ( SettingsFunctions::get_bool( 'connected', false ) && SettingsFunctions::get_bool( 'wp_app_pass_created', false ) );
 
 $utils = new \NuclearEngagement\Utils();
 $utils->display_nuclen_page_header();

--- a/nuclear-engagement/templates/front/nuclear-engagement-public-display.php
+++ b/nuclear-engagement/templates/front/nuclear-engagement-public-display.php
@@ -16,17 +16,16 @@ if ( ! defined( 'ABSPATH' ) ) {
  * @subpackage Nuclear_Engagement/public/partials
  */
 
-use function NuclearEngagement\nuclen_settings_string;
-use function NuclearEngagement\nuclen_settings_int;
+use NuclearEngagement\Helpers\SettingsFunctions;
 
 // Get theme settings with type-safe methods
-$theme        = nuclen_settings_string( 'theme', 'bright' );
-$font_size    = nuclen_settings_int( 'font_size', 16 );
-$font_color   = nuclen_settings_string( 'font_color', '#000000' );
-$bg_color     = nuclen_settings_string( 'bg_color', '#ffffff' );
-$border_color = nuclen_settings_string( 'border_color', '#000000' );
-$border_style = nuclen_settings_string( 'border_style', 'solid' );
-$border_width = nuclen_settings_int( 'border_width', 1 );
+$theme        = SettingsFunctions::get_string( 'theme', 'bright' );
+$font_size    = SettingsFunctions::get_int( 'font_size', 16 );
+$font_color   = SettingsFunctions::get_string( 'font_color', '#000000' );
+$bg_color     = SettingsFunctions::get_string( 'bg_color', '#ffffff' );
+$border_color = SettingsFunctions::get_string( 'border_color', '#000000' );
+$border_style = SettingsFunctions::get_string( 'border_style', 'solid' );
+$border_width = SettingsFunctions::get_int( 'border_width', 1 );
 
 // For backward compatibility, create an options array
 $options = array(


### PR DESCRIPTION
## Summary
- add `Helpers\SettingsFunctions` class
- deprecate global helper functions
- reference the new namespaced helpers
- note deprecations in changelog

## Testing
- `composer lint` *(fails: command not found)*
- `composer test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685e4966ea7c8327a191f0fd3ffa5a2d

<!-- Korbit AI PR Description Start -->
## Description by Korbit AI

### What change is being made?

Refactor settings helpers by moving them to a new `Helpers\SettingsFunctions` class and deprecating the `nuclen_settings_*` global functions.

### Why are these changes being made?

This change promotes better organization and improves maintainability by centralizing settings retrieval into a dedicated class, allowing for cleaner code and easier future extensions. The use of static methods in a class also enhances namespace management and reduces global function clutter. Although backward compatibility is maintained with deprecated functions, developers are encouraged to transition to the new class methods.

> Is this description stale? Ask me to generate a new description by commenting `/korbit-generate-pr-description`
<!-- Korbit AI PR Description End -->