### PR TITLE
Add dedicated setup handlers

### DIFF
--- a/nuclear-engagement/admin/Setup.php
+++ b/nuclear-engagement/admin/Setup.php
@@ -15,6 +15,8 @@ namespace NuclearEngagement\Admin;
 
 use NuclearEngagement\Core\SettingsRepository;
 use NuclearEngagement\Services\SetupService;
+use NuclearEngagement\Admin\Setup\ConnectHandler;
+use NuclearEngagement\Admin\Setup\AppPasswordHandler;
 
 if ( ! defined( 'ABSPATH' ) ) {
 	exit;
@@ -23,10 +25,11 @@ if ( ! defined( 'ABSPATH' ) ) {
 
 class Setup {
 
-		use SetupHandlersTrait;
+/** @var \NuclearEngagement\Utils */
+private $utils;
 
-		/** @var \NuclearEngagement\Utils */
-		private $utils;
+private ConnectHandler $connect_handler;
+private AppPasswordHandler $app_password_handler;
 
 		/** @var SetupService */
 	private $setup_service;
@@ -34,11 +37,13 @@ class Setup {
 	/** @var SettingsRepository */
 	private $settings_repository;
 
-	public function __construct( SettingsRepository $settings_repository ) {
-			$this->utils               = new \NuclearEngagement\Utils();
-			$this->setup_service       = new SetupService();
-			$this->settings_repository = $settings_repository;
-	}
+public function __construct( SettingsRepository $settings_repository ) {
+$this->utils			   = new \NuclearEngagement\Utils();
+$this->setup_service	   = new SetupService();
+$this->settings_repository = $settings_repository;
+$this->connect_handler	   = new ConnectHandler( $this->setup_service, $this->settings_repository );
+$this->app_password_handler = new AppPasswordHandler( $this->setup_service, $this->settings_repository );
+}
 
 	public function nuclen_get_utils() {
 			return $this->utils;
@@ -48,9 +53,25 @@ class Setup {
 			return $this->setup_service;
 	}
 
-	public function nuclen_get_settings_repository() {
-			return $this->settings_repository;
-	}
+public function nuclen_get_settings_repository() {
+return $this->settings_repository;
+}
+
+public function nuclen_handle_connect_app(): void {
+$this->connect_handler->handle_connect_app();
+}
+
+public function nuclen_handle_generate_app_password(): void {
+$this->app_password_handler->generate_app_password();
+}
+
+public function nuclen_handle_reset_api_key(): void {
+$this->connect_handler->handle_reset_api_key();
+}
+
+public function nuclen_handle_reset_wp_app_connection(): void {
+$this->app_password_handler->reset_wp_app_connection();
+}
 
 	/** Add the Setup submenu page. */
 	public function nuclen_add_setup_page() {
@@ -68,13 +89,13 @@ class Setup {
 	public function nuclen_render_setup_page() {
 
 		/* ───── Notices ───── */
-		$nuclen_error   = isset( $_GET['nuclen_error'] )
+		$nuclen_error	= isset( $_GET['nuclen_error'] )
 			? sanitize_text_field( wp_unslash( $_GET['nuclen_error'] ) )
 			: '';
 		$nuclen_success = isset( $_GET['nuclen_success'] )
 			? sanitize_text_field( wp_unslash( $_GET['nuclen_success'] ) )
 			: '';
-		$nonce          = isset( $_GET['_wpnonce'] ) ? sanitize_key( $_GET['_wpnonce'] ) : '';
+		$nonce			= isset( $_GET['_wpnonce'] ) ? sanitize_key( $_GET['_wpnonce'] ) : '';
 
 		if ( $nuclen_error && wp_verify_nonce( $nonce, 'nuclear-engagement-setup' ) ) {
 			echo '<div class="notice notice-error is-dismissible"><p>' . esc_html( $nuclen_error ) . '</p></div>';
@@ -85,12 +106,12 @@ class Setup {
 
 				/* ───── Retrieve settings ───── */
 				$settings = $this->nuclen_get_settings_repository();
-		$app_setup        = array(
-			'api_key'             => $settings->get_string( 'api_key', '' ),
-			'connected'           => $settings->get_bool( 'connected', false ),
+		$app_setup		  = array(
+			'api_key'			  => $settings->get_string( 'api_key', '' ),
+			'connected'			  => $settings->get_bool( 'connected', false ),
 			'wp_app_pass_created' => $settings->get_bool( 'wp_app_pass_created', false ),
-			'wp_app_pass_uuid'    => $settings->get_string( 'wp_app_pass_uuid', '' ),
-			'plugin_password'     => $settings->get_string( 'plugin_password', '' ),
+			'wp_app_pass_uuid'	  => $settings->get_string( 'wp_app_pass_uuid', '' ),
+			'plugin_password'	  => $settings->get_string( 'plugin_password', '' ),
 		);
 
 		$fully_setup = ( $app_setup['connected'] && $app_setup['wp_app_pass_created'] );

--- a/nuclear-engagement/admin/Setup/AppPasswordHandler.php
+++ b/nuclear-engagement/admin/Setup/AppPasswordHandler.php
@@ -1,0 +1,139 @@
+<?php
+namespace NuclearEngagement\Admin\Setup;
+
+use NuclearEngagement\Services\SetupService;
+use NuclearEngagement\Core\SettingsRepository;
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+class AppPasswordHandler {
+	private SetupService $setup_service;
+	private SettingsRepository $settings_repository;
+
+	public function __construct( SetupService $setup_service, SettingsRepository $settings_repository ) {
+		$this->setup_service	   = $setup_service;
+		$this->settings_repository = $settings_repository;
+	}
+
+	public function generate_app_password( bool $bypass_nonce = false ): void {
+		$this->validate_generate_nonce( $bypass_nonce );
+
+		if ( ! $this->settings_repository->get_bool( 'connected', false ) || empty( $this->settings_repository->get( 'api_key' ) ) ) {
+			$this->redirect_with_error( 'Please complete Step 1 first.' );
+		}
+
+		list( $new_password, $uuid, $current_user ) = $this->create_app_password();
+		$api_key = $this->settings_repository->get( 'api_key' );
+		if ( empty( $api_key ) ) {
+			$this->redirect_with_error( 'API key is missing. Please complete Step 1 first.' );
+		}
+
+		if ( ! $this->send_credentials_to_saas( $api_key, $new_password, $uuid, $current_user ) ) {
+			$this->redirect_with_error( 'Failed to send App Password to the SaaS.' );
+		}
+
+		$this->persist_app_password( $new_password, $uuid );
+
+		$this->redirect_with_success( 'Setup completed – you are ready to go!' );
+	}
+
+	public function reset_wp_app_connection(): void {
+		if ( ! isset( $_POST['nuclen_reset_wp_app_nonce'] ) ||
+			! wp_verify_nonce( sanitize_text_field( wp_unslash( $_POST['nuclen_reset_wp_app_nonce'] ) ), 'nuclen_reset_wp_app_action' ) ) {
+			$this->redirect_with_error( 'Invalid nonce.' );
+		}
+		if ( ! current_user_can( 'manage_options' ) ) {
+			$this->redirect_with_error( 'Insufficient permissions.' );
+		}
+
+		$app_setup = get_option( 'nuclear_engagement_setup', array() );
+		$app_setup['wp_app_pass_created'] = false;
+		$app_setup['wp_app_pass_uuid'] = '';
+		$app_setup['plugin_password'] = '';
+		update_option( 'nuclear_engagement_setup', $app_setup );
+
+		$this->settings_repository->set( 'wp_app_pass_created', false )
+			->set( 'wp_app_pass_uuid', '' )
+			->set( 'plugin_password', '' )
+			->save();
+
+		$this->redirect_with_success( 'App Password revoked.' );
+	}
+
+	protected function validate_generate_nonce( bool $bypass ): void {
+		if ( ! $bypass ) {
+			if ( ! isset( $_POST['nuclen_generate_app_password_nonce'] ) ||
+				! wp_verify_nonce( sanitize_text_field( wp_unslash( $_POST['nuclen_generate_app_password_nonce'] ) ), 'nuclen_generate_app_password_action' ) ) {
+				$this->redirect_with_error( 'Invalid nonce.' );
+			}
+		}
+		if ( ! current_user_can( 'manage_options' ) ) {
+			$this->redirect_with_error( 'Insufficient permissions.' );
+		}
+	}
+
+	protected function create_app_password(): array {
+		$new_password = wp_generate_password( 32, false, false );
+		$uuid = wp_generate_uuid4();
+		$current_user = wp_get_current_user();
+		return array( $new_password, $uuid, $current_user );
+	}
+
+	protected function send_credentials_to_saas( string $api_key, string $password, string $uuid, $user ): bool {
+		return $this->setup_service->send_app_password(
+			array(
+				'appApiKey'		=> $api_key,
+				'siteUrl'		=> get_site_url(),
+				'wpUserLogin'	=> $user->user_login,
+				'wpAppPassword' => $password,
+				'wpAppPassUuid' => $uuid,
+			)
+		);
+	}
+
+	protected function persist_app_password( string $password, string $uuid ): void {
+		$this->settings_repository->set( 'wp_app_pass_created', true )
+			->set( 'wp_app_pass_uuid', $uuid )
+			->set( 'plugin_password', $password )
+			->set( 'connected', true )
+			->save();
+
+		$app_setup = get_option( 'nuclear_engagement_setup', array() );
+		$app_setup['wp_app_pass_created'] = true;
+		$app_setup['wp_app_pass_uuid'] = $uuid;
+		$app_setup['plugin_password'] = $password;
+		$app_setup['connected'] = true;
+		update_option( 'nuclear_engagement_setup', $app_setup );
+		wp_cache_delete( 'nuclear_engagement_setup', 'options' );
+	}
+
+	protected function redirect_with_error( $msg ): void {
+		wp_redirect(
+			add_query_arg(
+				array(
+					'page'		   => 'nuclear-engagement-setup',
+					'nuclen_error' => urlencode( $msg ),
+					'_wpnonce'	   => wp_create_nonce( 'nuclear-engagement-setup' ),
+				),
+				admin_url( 'admin.php' )
+			)
+		);
+		exit;
+	}
+
+	protected function redirect_with_success( $msg ): void {
+		wp_redirect(
+			add_query_arg(
+				array(
+					'page'			 => 'nuclear-engagement-setup',
+					'nuclen_success' => urlencode( $msg ),
+					'_wpnonce'		 => wp_create_nonce( 'nuclear-engagement-setup' ),
+				),
+				admin_url( 'admin.php' )
+			)
+		);
+		exit;
+	}
+}

--- a/nuclear-engagement/admin/Setup/ConnectHandler.php
+++ b/nuclear-engagement/admin/Setup/ConnectHandler.php
@@ -1,0 +1,100 @@
+<?php
+namespace NuclearEngagement\Admin\Setup;
+
+use NuclearEngagement\Services\SetupService;
+use NuclearEngagement\Core\SettingsRepository;
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+class ConnectHandler {
+	private SetupService $setup_service;
+	private SettingsRepository $settings_repository;
+
+	public function __construct( SetupService $setup_service, SettingsRepository $settings_repository ) {
+		$this->setup_service	   = $setup_service;
+		$this->settings_repository = $settings_repository;
+	}
+
+	public function handle_connect_app(): void {
+		if ( ! isset( $_POST['nuclen_connect_app_nonce'], $_POST['nuclen_api_key'] ) ||
+			! wp_verify_nonce( sanitize_text_field( wp_unslash( $_POST['nuclen_connect_app_nonce'] ) ), 'nuclen_connect_app_action' ) ) {
+			$this->redirect_with_error( 'Invalid nonce.' );
+		}
+		if ( ! current_user_can( 'manage_options' ) ) {
+			$this->redirect_with_error( 'Insufficient permissions.' );
+		}
+
+		$api_key = sanitize_text_field( wp_unslash( $_POST['nuclen_api_key'] ) );
+		if ( '' === $api_key ) {
+			$this->redirect_with_error( 'Missing Gold Code.' );
+		}
+
+		if ( ! $this->setup_service->validate_api_key( $api_key ) ) {
+			$this->redirect_with_error( 'Invalid or unknown Gold Code.' );
+		}
+
+		$this->settings_repository->set( 'api_key', $api_key )
+			->set( 'connected', true )
+			->save();
+
+		if ( ! $this->settings_repository->get_bool( 'wp_app_pass_created', false ) ) {
+			$this->get_app_password_handler()->generate_app_password( true );
+			return;
+		}
+
+		$this->redirect_with_success( 'Gold Code saved.' );
+	}
+
+	public function handle_reset_api_key(): void {
+		if ( ! isset( $_POST['nuclen_reset_api_key_nonce'] ) ||
+			! wp_verify_nonce( sanitize_text_field( wp_unslash( $_POST['nuclen_reset_api_key_nonce'] ) ), 'nuclen_reset_api_key_action' ) ) {
+			$this->redirect_with_error( 'Invalid nonce.' );
+		}
+		if ( ! current_user_can( 'manage_options' ) ) {
+			$this->redirect_with_error( 'Insufficient permissions.' );
+		}
+
+		$this->settings_repository->set( 'api_key', '' )
+			->set( 'connected', false )
+			->set( 'wp_app_pass_created', false )
+			->set( 'wp_app_pass_uuid', '' )
+			->set( 'plugin_password', '' )
+			->save();
+
+		$this->redirect_with_success( 'Gold Code reset. Site disconnected.' );
+	}
+
+	protected function get_app_password_handler(): AppPasswordHandler {
+		return new AppPasswordHandler( $this->setup_service, $this->settings_repository );
+	}
+
+	protected function redirect_with_error( $msg ): void {
+		wp_redirect(
+			add_query_arg(
+				array(
+					'page'		   => 'nuclear-engagement-setup',
+					'nuclen_error' => urlencode( $msg ),
+					'_wpnonce'	   => wp_create_nonce( 'nuclear-engagement-setup' ),
+				),
+				admin_url( 'admin.php' )
+			)
+		);
+		exit;
+	}
+
+	protected function redirect_with_success( $msg ): void {
+		wp_redirect(
+			add_query_arg(
+				array(
+					'page'			 => 'nuclear-engagement-setup',
+					'nuclen_success' => urlencode( $msg ),
+					'_wpnonce'		 => wp_create_nonce( 'nuclear-engagement-setup' ),
+				),
+				admin_url( 'admin.php' )
+			)
+		);
+		exit;
+	}
+}


### PR DESCRIPTION
## Summary
- create `ConnectHandler` and `AppPasswordHandler` classes
- delegate setup actions through new handlers
- refactor unit tests for new handlers

## Testing
- `composer lint` *(fails: command not found)*
- `composer test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685e4963bea48327b4fa19be3bf78aa0

<!-- Korbit AI PR Description Start -->
## Description by Korbit AI

### What change is being made?
Refactor the `Setup` class by introducing two new dedicated handler classes, `ConnectHandler` and `AppPasswordHandler`, to manage setup procedures including API connection and app password management.

### Why are these changes being made?
This change simplifies the `Setup` class by delegating specific functionalities to specialized handler classes, improving code readability, separation of concerns, and maintainability. Implementing these handlers allows focused unit testing, making it easier to identify and fix issues in the connection and app password management workflows.

> Is this description stale? Ask me to generate a new description by commenting `/korbit-generate-pr-description`
<!-- Korbit AI PR Description End -->