### PR TITLE
Fix buildOptinInlineHTML test indentation

### DIFF
--- a/tests/frontend/nuclen-quiz-optin.test.ts
+++ b/tests/frontend/nuclen-quiz-optin.test.ts
@@ -32,14 +32,14 @@ describe('buildOptinInlineHTML', () => {
 	  position: 'with_results',
 	});
 	const expected = `
-  <div id="nuclen-optin-container" class="nuclen-optin-with-results">
+	<div id="nuclen-optin-container" class="nuclen-optin-with-results">
 	<p class="nuclen-fg"><strong>Join us</strong></p>
 	<label for="nuclen-optin-name"  class="nuclen-fg">Name</label>
 	<input  type="text"  id="nuclen-optin-name">
 	<label for="nuclen-optin-email" class="nuclen-fg">Email</label>
 	<input  type="email" id="nuclen-optin-email" required>
 	<button type="button" id="nuclen-optin-submit">Submit</button>
-  </div>`;
+	</div>`;
 	expect(html).toBe(expected);
   });
 });


### PR DESCRIPTION
## Summary
- adjust tabs in nuclen-quiz-optin.test.ts to match HTML output

## Testing
- `composer lint` *(fails: command not found)*
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_685e4cd8e70c8327bedba0dfc4843eca

<!-- Korbit AI PR Description Start -->
## Description by Korbit AI

### What change is being made?

Fix the indentation of the expected HTML string in the `buildOptinInlineHTML` test within the `nuclen-quiz-optin.test.ts` file.

### Why are these changes being made?

The previous indentation was inconsistent, causing potential confusion in understandability and reducing readability. Proper indentation is critical for maintaining clarity and ensuring accurate test results, especially when comparing multi-line strings.

> Is this description stale? Ask me to generate a new description by commenting `/korbit-generate-pr-description`
<!-- Korbit AI PR Description End -->