### PR TITLE
Fix syntax in PHP traits and service

### DIFF
--- a/nuclear-engagement/admin/Traits/SettingsPersistTrait.php
+++ b/nuclear-engagement/admin/Traits/SettingsPersistTrait.php
@@ -15,9 +15,10 @@ if ( ! defined( 'ABSPATH' ) ) {
 }
 
 trait SettingsPersistTrait {
-		 * Sanitize input and merge with defaults.
-		 */
-		private function nuclen_sanitize_and_defaults( array $raw, array $defaults ): array {
+	/**
+	 * Sanitize input and merge with defaults.
+	 */
+	private function nuclen_sanitize_and_defaults( array $raw, array $defaults ): array {
 				$new_settings = $this->nuclen_sanitize_settings( $raw );
 
 				$toc_keys = array(

--- a/nuclear-engagement/inc/Services/OptinExportService.php
+++ b/nuclear-engagement/inc/Services/OptinExportService.php
@@ -6,10 +6,10 @@ declare(strict_types=1);
  * @package NuclearEngagement\\Services
  */
 
-namespace NuclearEngagement\\Services;
+namespace NuclearEngagement\Services;
 
-use NuclearEngagement\\OptinData;
-use NuclearEngagement\\Services\\LoggingService;
+use NuclearEngagement\OptinData;
+use NuclearEngagement\Services\LoggingService;
 
 if ( ! defined( 'ABSPATH' ) ) {
 	exit;


### PR DESCRIPTION
## Summary
- fix docblock in SettingsPersistTrait
- fix namespace in OptinExportService

## Testing
- `composer lint` *(fails: command not found)*
- `composer test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685e4cff86a88327a637b82a2d88f0f5


> [!NOTE]
> I'm currently writing a description for your pull request. I should be done shortly (<1 minute). Please don't edit the description field until I'm finished, or we may overwrite each other. If I find nothing to write about, I'll delete this message.
