### PR TITLE
Refactor TOC interactions into smaller modules

### DIFF
--- a/src/modules/toc/ts/toc-click-close.ts
+++ b/src/modules/toc/ts/toc-click-close.ts
@@ -1,0 +1,40 @@
+// modules/toc/ts/toc-click-close.ts
+
+/**
+ * Closes the open TOC when clicking a link or outside the sticky container.
+ */
+export function initClickToClose(): void {
+	document.addEventListener('click', (e) => {
+		const link = (e.target as HTMLElement).closest('.nuclen-toc a');
+		const wrapper = link ? link.closest('.nuclen-toc-sticky') : null;
+		if (!link || !wrapper) {
+			return;
+		}
+		setTimeout(() => {
+			const btn = wrapper!.querySelector<HTMLElement>(
+				'.nuclen-toc-toggle[aria-expanded="true"]',
+			);
+			if (btn) {
+				btn.click();
+			}
+		}, 120);
+	});
+
+	document.addEventListener('click', (e) => {
+		const stuck = document.querySelector<HTMLElement>(
+			'.nuclen-toc-sticky.nuclen-toc-stuck',
+		);
+		if (!stuck) {
+			return;
+		}
+		const target = e.target as HTMLElement;
+		if (!stuck.contains(target) && !target.closest('.nuclen-toc-toggle')) {
+			const btn = stuck.querySelector<HTMLElement>(
+				'.nuclen-toc-toggle[aria-expanded="true"]',
+			);
+			if (btn) {
+				btn.click();
+			}
+		}
+	});
+}

--- a/src/modules/toc/ts/toc-interactions.ts
+++ b/src/modules/toc/ts/toc-interactions.ts
@@ -1,95 +1,16 @@
 // modules/toc/ts/toc-interactions.ts
 
 /**
- * Handles TOC toggle buttons and scroll‑spy highlighting.
+ * Composes TOC behaviours like toggle buttons and scroll‑spy highlighting.
  */
+import { initTocToggle } from './toc-toggle';
+import { initClickToClose } from './toc-click-close';
+import { initScrollSpy } from './toc-scroll-spy';
+
 export function initTocInteractions(): void {
-	document.addEventListener('click', (e) => {
-	const btn = (e.target as HTMLElement).closest('.nuclen-toc-toggle');
-	if (!btn) {
-		return;
-	}
-	const navId = (btn as HTMLElement).getAttribute('aria-controls');
-	const nav = navId ? document.getElementById(navId) : null;
-	const expanded = (btn as HTMLElement).getAttribute('aria-expanded') === 'true';
-	(btn as HTMLElement).setAttribute('aria-expanded', expanded ? 'false' : 'true');
-	if (nav) {
-		nav.style.display = expanded ? 'none' : '';
-	}
-	// @ts-expect-error defined via wp_localize_script
-	const l10n = window.nuclenTocL10n as { show: string; hide: string };
-	(btn as HTMLElement).textContent = expanded ? l10n.show : l10n.hide;
-	});
-
-	document.addEventListener('click', (e) => {
-	const link = (e.target as HTMLElement).closest('.nuclen-toc a');
-	const wrapper = link ? (link as HTMLElement).closest('.nuclen-toc-sticky') : null;
-	if (!link || !wrapper) {
-		return;
-	}
-	setTimeout(() => {
-		const btn = wrapper!.querySelector<HTMLElement>(
-		'.nuclen-toc-toggle[aria-expanded="true"]',
-		);
-		if (btn) {
-		btn.click();
-		}
-	}, 120);
-	});
-
-	document.addEventListener('click', (e) => {
-	const stuck = document.querySelector<HTMLElement>(
-		'.nuclen-toc-sticky.nuclen-toc-stuck',
-	);
-	if (!stuck) {
-		return;
-	}
-	const target = e.target as HTMLElement;
-	if (!stuck.contains(target) && !target.closest('.nuclen-toc-toggle')) {
-		const btn = stuck.querySelector<HTMLElement>(
-		'.nuclen-toc-toggle[aria-expanded="true"]',
-		);
-		if (btn) {
-		btn.click();
-		}
-	}
-	});
-
-	const navs = document.querySelectorAll<HTMLElement>(
-	'.nuclen-toc[data-highlight="true"]',
-	);
-	if (!navs.length || !('IntersectionObserver' in window)) {
-	return;
-	}
-	const ioOpts: IntersectionObserverInit = { rootMargin: '0px 0px -60%', threshold: 0 };
-
-	navs.forEach((nav) => {
-	const map = new Map<Element, HTMLAnchorElement>();
-	nav.querySelectorAll<HTMLAnchorElement>('a[href^="#"]').forEach((a) => {
-		const id = a.getAttribute('href')!.slice(1);
-		const tgt = id && document.getElementById(id);
-		if (tgt) map.set(tgt, a);
-	});
-	if (!map.size) {
-		return;
-	}
-
-	const io = new IntersectionObserver((entries) => {
-		entries.forEach((en) => {
-		const link = map.get(en.target);
-		if (!link) {
-			return;
-		}
-		if (en.isIntersecting) {
-			nav.querySelectorAll<HTMLAnchorElement>('a.is-active').forEach((el) => {
-			el.classList.remove('is-active');
-			el.removeAttribute('aria-current');
-			});
-			link.classList.add('is-active');
-			link.setAttribute('aria-current', 'location');
-		}
-		});
-	}, ioOpts);
-	map.forEach((_l, tgt) => io.observe(tgt));
-	});
+	initTocToggle();
+	initClickToClose();
+	initScrollSpy();
 }
+
+export { initTocToggle, initClickToClose, initScrollSpy };

--- a/src/modules/toc/ts/toc-scroll-spy.ts
+++ b/src/modules/toc/ts/toc-scroll-spy.ts
@@ -1,0 +1,44 @@
+// modules/toc/ts/toc-scroll-spy.ts
+
+/**
+ * Highlights TOC links based on scroll position.
+ */
+export function initScrollSpy(): void {
+	const navs = document.querySelectorAll<HTMLElement>(
+		'.nuclen-toc[data-highlight="true"]',
+	);
+	if (!navs.length || !('IntersectionObserver' in window)) {
+		return;
+	}
+	const ioOpts: IntersectionObserverInit = { rootMargin: '0px 0px -60%', threshold: 0 };
+
+	navs.forEach((nav) => {
+		const map = new Map<Element, HTMLAnchorElement>();
+		nav.querySelectorAll<HTMLAnchorElement>('a[href^="#"]').forEach((a) => {
+			const id = a.getAttribute('href')!.slice(1);
+			const tgt = id && document.getElementById(id);
+			if (tgt) map.set(tgt, a);
+		});
+		if (!map.size) {
+			return;
+		}
+
+		const io = new IntersectionObserver((entries) => {
+			entries.forEach((en) => {
+				const link = map.get(en.target);
+				if (!link) {
+					return;
+				}
+				if (en.isIntersecting) {
+					nav.querySelectorAll<HTMLAnchorElement>('a.is-active').forEach((el) => {
+						el.classList.remove('is-active');
+						el.removeAttribute('aria-current');
+					});
+					link.classList.add('is-active');
+					link.setAttribute('aria-current', 'location');
+				}
+			});
+		}, ioOpts);
+		map.forEach((_l, tgt) => io.observe(tgt));
+	});
+}

--- a/src/modules/toc/ts/toc-toggle.ts
+++ b/src/modules/toc/ts/toc-toggle.ts
@@ -1,0 +1,23 @@
+// modules/toc/ts/toc-toggle.ts
+
+/**
+ * Handles click events on TOC toggle buttons.
+ */
+export function initTocToggle(): void {
+	document.addEventListener('click', (e) => {
+		const btn = (e.target as HTMLElement).closest('.nuclen-toc-toggle');
+		if (!btn) {
+			return;
+		}
+		const navId = btn.getAttribute('aria-controls');
+		const nav = navId ? document.getElementById(navId) : null;
+		const expanded = btn.getAttribute('aria-expanded') === 'true';
+		btn.setAttribute('aria-expanded', expanded ? 'false' : 'true');
+		if (nav) {
+			nav.style.display = expanded ? 'none' : '';
+		}
+		// @ts-expect-error defined via wp_localize_script
+		const l10n = window.nuclenTocL10n as { show: string; hide: string };
+		btn.textContent = expanded ? l10n.show : l10n.hide;
+	});
+}

--- a/tests/frontend/toc-interactions.test.ts
+++ b/tests/frontend/toc-interactions.test.ts
@@ -1,0 +1,75 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { initTocToggle } from '../../src/modules/toc/ts/toc-toggle';
+import { initClickToClose } from '../../src/modules/toc/ts/toc-click-close';
+import { initScrollSpy } from '../../src/modules/toc/ts/toc-scroll-spy';
+
+let originalIO: typeof IntersectionObserver;
+let ioCallback: any;
+let observed: Element[] = [];
+
+beforeEach(() => {
+  document.body.innerHTML = `
+    <div class="nuclen-toc-sticky">
+      <button class="nuclen-toc-toggle" aria-controls="tocnav" aria-expanded="false">Show</button>
+      <nav id="tocnav" class="nuclen-toc" data-highlight="true">
+        <a href="#h1">H1</a>
+      </nav>
+    </div>
+    <h2 id="h1">Heading</h2>`;
+  (window as any).nuclenTocL10n = { show: 'Show', hide: 'Hide' };
+  originalIO = global.IntersectionObserver;
+  observed = [];
+  global.IntersectionObserver = vi.fn(function (this: any, cb: any) {
+    ioCallback = cb;
+    this.observe = (el: Element) => observed.push(el);
+  }) as unknown as typeof IntersectionObserver;
+  vi.useFakeTimers();
+});
+
+afterEach(() => {
+  global.IntersectionObserver = originalIO;
+  vi.useRealTimers();
+  vi.restoreAllMocks();
+  delete (window as any).nuclenTocL10n;
+  document.body.innerHTML = '';
+});
+
+describe('toc interactions modules', () => {
+  it('toggles nav visibility', () => {
+    initTocToggle();
+    const btn = document.querySelector('.nuclen-toc-toggle') as HTMLElement;
+    const nav = document.getElementById('tocnav') as HTMLElement;
+    btn.click();
+    expect(btn.getAttribute('aria-expanded')).toBe('true');
+    expect(nav.style.display).toBe('');
+    expect(btn.textContent).toBe('Hide');
+    btn.click();
+    expect(btn.getAttribute('aria-expanded')).toBe('false');
+    expect(nav.style.display).toBe('none');
+    expect(btn.textContent).toBe('Show');
+  });
+
+  it('closes on link click and outside click', () => {
+    initTocToggle();
+    initClickToClose();
+    const btn = document.querySelector('.nuclen-toc-toggle') as HTMLElement;
+    const link = document.querySelector('.nuclen-toc a') as HTMLElement;
+    btn.click();
+    link.click();
+    vi.runAllTimers();
+    expect(btn.getAttribute('aria-expanded')).toBe('false');
+
+    btn.click();
+    document.body.click();
+    expect(btn.getAttribute('aria-expanded')).toBe('false');
+  });
+
+  it('highlights links on intersection', () => {
+    initScrollSpy();
+    expect(observed).toContain(document.getElementById('h1'));
+    const link = document.querySelector('.nuclen-toc a') as HTMLElement;
+    ioCallback([{ target: document.getElementById('h1'), isIntersecting: true }]);
+    expect(link.classList.contains('is-active')).toBe(true);
+    expect(link.getAttribute('aria-current')).toBe('location');
+  });
+});


### PR DESCRIPTION
## Summary
- break up `toc-interactions.ts` logic
- create `toc-toggle`, `toc-click-close` and `toc-scroll-spy` modules
- update main interactions module to compose the new pieces
- add unit tests covering the new behaviour

## Testing
- `npm test` *(fails: vitest not found)*
- `composer lint` *(fails: command not found)*
- `composer test` *(fails: command not found)*
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_685e4c5ad4d88327bccfa843c728e086


> [!NOTE]
> I'm currently writing a description for your pull request. I should be done shortly (<1 minute). Please don't edit the description field until I'm finished, or we may overwrite each other. If I find nothing to write about, I'll delete this message.
