### PR TITLE
Refactor TOC utilities into separate classes

### DIFF
--- a/nuclear-engagement/inc/Modules/TOC/includes/HeadingExtractor.php
+++ b/nuclear-engagement/inc/Modules/TOC/includes/HeadingExtractor.php
@@ -1,0 +1,148 @@
+<?php
+/**
+ * Parse post headings with caching.
+ *
+ * @package NuclearEngagement
+ */
+
+declare(strict_types=1);
+
+namespace NuclearEngagement\Modules\TOC;
+
+if ( ! defined( 'ABSPATH' ) ) {
+exit;
+}
+
+final class HeadingExtractor {
+	
+	private const CACHE_GROUP = 'nuclen_toc';
+	private const CACHE_TTL   = 6 * HOUR_IN_SECONDS;
+	
+	/**
+	 * Extract headings from HTML content.
+	 */
+	public static function extract( string $html, array $heading_levels, int $post_id = 0 ): array {
+	$t0 = microtime( true );
+	
+	if ( empty( $heading_levels ) ) {
+	$heading_levels = range( 2, 6 );
+	}
+	
+	$heading_levels = array_filter(
+	array_map( 'intval', $heading_levels ),
+	static function ( $level ) {
+	return $level >= 1 && $level <= 6;
+	}
+	);
+	
+	if ( empty( $heading_levels ) ) {
+	$heading_levels = range( 2, 6 );
+	}
+	
+	sort( $heading_levels );
+	$heading_levels = array_unique( $heading_levels );
+	
+	if ( $post_id > 0 ) {
+	$stored = get_post_meta( $post_id, Nuclen_TOC_Headings::META_KEY, true );
+	if ( is_array( $stored ) && ! empty( $stored ) ) {
+	SlugGenerator::reset();
+	SlugGenerator::prime( wp_list_pluck( $stored, 'id' ) );
+	TocCache::set_last_parse_ms( (int) round( ( microtime( true ) - $t0 ) * 1000 ) );
+	return $stored;
+	}
+	}
+	
+	list( $key, $transient, $hit ) = self::get_cached_headings( $html, $heading_levels );
+	if ( false !== $hit ) {
+	SlugGenerator::reset();
+	SlugGenerator::prime( wp_list_pluck( $hit, 'id' ) );
+	TocCache::set_last_parse_ms( (int) round( ( microtime( true ) - $t0 ) * 1000 ) );
+	return $hit;
+	}
+	
+	$out = self::parse_headings( $html, $heading_levels );
+	
+	wp_cache_set( $key, $out, self::CACHE_GROUP, self::CACHE_TTL );
+	set_transient( $transient, $out, self::CACHE_TTL );
+	TocCache::set_last_parse_ms( (int) round( ( microtime( true ) - $t0 ) * 1000 ) );
+	return $out;
+	}
+	
+	/**
+	 * Get cached headings and cache keys.
+	 */
+	private static function get_cached_headings( string $html, array $heading_levels ): array {
+	$key       = md5( $html ) . '_' . implode( '', $heading_levels );
+	$transient = 'nuclen_toc_' . $key;
+	$hit       = wp_cache_get( $key, self::CACHE_GROUP );
+	if ( false === $hit ) {
+	$hit = get_transient( $transient );
+	}
+	return array( $key, $transient, $hit );
+	}
+	
+	/**
+	 * Parse headings from HTML using DOM.
+	 */
+	private static function parse_headings( string $html, array $heading_levels ): array {
+	$out = array();
+	SlugGenerator::reset();
+	
+	if ( nuclen_str_contains( $html, '<h' ) ) {
+	libxml_use_internal_errors( true );
+	$dom = new \DOMDocument();
+	$dom->loadHTML( '<meta http-equiv="Content-Type" content="text/html; charset=utf-8">' . $html, \LIBXML_HTML_NOIMPLIED | \LIBXML_HTML_NODEFDTD );
+	libxml_clear_errors();
+	
+	$xpath = new \DOMXPath( $dom );
+	$nodes = $xpath->query( '//h1|//h2|//h3|//h4|//h5|//h6' );
+	
+	foreach ( $nodes as $node ) {
+	$tag = strtolower( $node->nodeName );
+	$lvl = (int) substr( $tag, 1 );
+	
+	if ( ! in_array( $lvl, $heading_levels, true ) ) {
+	continue;
+	}
+	if ( preg_match( '/\bno-?toc\b/i', $node->getAttribute( 'class' ) ) ) {
+	continue;
+	}
+	$data_toc = $node->getAttribute( 'data-toc' );
+	if ( '' !== $data_toc && strtolower( $data_toc ) === 'false' ) {
+	continue;
+	}
+	
+	$inner = self::inner_html( $node );
+	$text  = trim( wp_strip_all_tags( $inner ) );
+	if ( '' === $text ) {
+	continue;
+	}
+	
+	$id = $node->hasAttribute( 'id' )
+	? sanitize_html_class( $node->getAttribute( 'id' ) )
+	: SlugGenerator::generate( $text );
+	
+	$out[] = array(
+	'tag'   => $tag,
+	'level' => $lvl,
+	'text'  => $text,
+	'inner' => $inner,
+	'id'    => $id,
+	);
+	}
+	}
+	
+	return $out;
+	}
+	
+	/**
+	 * Get inner HTML of a DOM element.
+	 */
+	private static function inner_html( \DOMElement $el ): string {
+	$html = '';
+	foreach ( $el->childNodes as $child ) {
+	$html .= $el->ownerDocument->saveHTML( $child );
+	}
+	return $html;
+	}
+	}

--- a/nuclear-engagement/inc/Modules/TOC/includes/Nuclen_TOC_Headings.php
+++ b/nuclear-engagement/inc/Modules/TOC/includes/Nuclen_TOC_Headings.php
@@ -9,6 +9,8 @@ declare(strict_types=1);
 
 namespace NuclearEngagement\Modules\TOC;
 
+use NuclearEngagement\Modules\TOC\HeadingExtractor;
+
 if ( ! defined( 'ABSPATH' ) ) {
 	exit;
 }
@@ -53,7 +55,7 @@ final class Nuclen_TOC_Headings {
 		if ( ! nuclen_str_contains( $content, '<h' ) ) {
 			return $content; }
 
-		foreach ( Nuclen_TOC_Utils::extract( $content, range( 1, 6 ), get_the_ID() ) as $h ) {
+               foreach ( HeadingExtractor::extract( $content, range( 1, 6 ), get_the_ID() ) as $h ) {
 			$pat         = sprintf(
 				'/(<%1$s\b(?![^>]*\bid=)[^>]*>)(%2$s)(<\/%1$s>)/is',
 				$h['tag'],
@@ -78,7 +80,7 @@ final class Nuclen_TOC_Headings {
 	 */
 	public function cache_headings_on_save( int $post_id, \WP_Post $post ): void {
 		delete_post_meta( $post_id, self::META_KEY );
-		$headings = Nuclen_TOC_Utils::extract( $post->post_content, range( 1, 6 ), $post_id );
+               $headings = HeadingExtractor::extract( $post->post_content, range( 1, 6 ), $post_id );
 		update_post_meta( $post_id, self::META_KEY, $headings );
 	}
 

--- a/nuclear-engagement/inc/Modules/TOC/includes/Nuclen_TOC_Render.php
+++ b/nuclear-engagement/inc/Modules/TOC/includes/Nuclen_TOC_Render.php
@@ -12,6 +12,7 @@ declare(strict_types=1);
 namespace NuclearEngagement\Modules\TOC;
 
 use NuclearEngagement\Core\SettingsRepository;
+use NuclearEngagement\Modules\TOC\HeadingExtractor;
 
 if ( ! defined( 'ABSPATH' ) ) {
 	exit;
@@ -181,8 +182,8 @@ final class Nuclen_TOC_Render {
 			$settings = $this->settings;
 			$atts     = $this->prepare_shortcode_attributes( $atts, $settings );
 
-			$list  = ( strtolower( $atts['list'] ) === 'ol' ) ? 'ol' : 'ul';
-			$heads = Nuclen_TOC_Utils::extract( $post->post_content, $atts['heading_levels'], $post->ID );
+$list  = ( strtolower( $atts['list'] ) === 'ol' ) ? 'ol' : 'ul';
+$heads = HeadingExtractor::extract( $post->post_content, $atts['heading_levels'], $post->ID );
 		if ( ! $heads ) {
 			return '';
 		}

--- a/nuclear-engagement/inc/Modules/TOC/includes/SlugGenerator.php
+++ b/nuclear-engagement/inc/Modules/TOC/includes/SlugGenerator.php
@@ -1,0 +1,66 @@
+<?php
+/**
+ * Generate unique slugs for TOC headings.
+ *
+ * @package NuclearEngagement
+ */
+
+declare(strict_types=1);
+
+namespace NuclearEngagement\Modules\TOC;
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+/**
+ * Slug creation helper.
+ */
+final class SlugGenerator {
+
+	/**
+	 * Track generated IDs within a single post.
+	 *
+	 * @var array<string,bool>
+	 */
+private static array $ids_in_post = array();
+
+/**
+ * Prime internal slug tracking with existing IDs.
+ *
+ * @param array $ids IDs already present in the post.
+ */
+	public static function prime( array $ids ): void {
+	foreach ( $ids as $id ) {
+	if ( is_string( $id ) && '' !== $id ) {
+	self::$ids_in_post[ $id ] = true;
+	}
+	}
+	}
+
+	/**
+	 * Reset internal slug tracking.
+	 */
+	public static function reset(): void {
+		self::$ids_in_post = array();
+	}
+
+	/**
+	 * Generate a unique slug from heading text.
+	 *
+	 * @param string $text Heading text.
+	 * @return string Unique slug.
+	 */
+	public static function generate( string $text ): string {
+		$base = sanitize_title( $text );
+		$id   = $base;
+		$n    = 2;
+
+		while ( isset( self::$ids_in_post[ $id ] ) ) {
+			$id = $base . '-' . ( $n++ );
+		}
+
+		self::$ids_in_post[ $id ] = true;
+		return $id;
+	}
+}

--- a/nuclear-engagement/inc/Modules/TOC/includes/TocCache.php
+++ b/nuclear-engagement/inc/Modules/TOC/includes/TocCache.php
@@ -1,0 +1,59 @@
+<?php
+/**
+ * Cache helpers for TOC operations.
+ *
+ * @package NuclearEngagement
+ */
+
+declare(strict_types=1);
+
+namespace NuclearEngagement\Modules\TOC;
+
+use NuclearEngagement\Helpers\SettingsFunctions;
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+	final class TocCache {
+
+	private const CACHE_GROUP = 'nuclen_toc';
+	
+	/** Last parse duration in milliseconds. */
+	private static int $last_parse_ms = 0;
+
+	/**
+	 * Record the parse time.
+	 */
+	public static function set_last_parse_ms( int $ms ): void {
+	self::$last_parse_ms = $ms;
+	}
+
+	/**
+	 * Retrieve the duration of the last heading parse.
+	 */
+	public static function get_last_parse_ms(): int {
+	return self::$last_parse_ms;
+	}
+
+	/**
+ * Clear cached headings for a post.
+ */
+	public static function clear_cache_for_post( int $post_id ): void {
+	$post = get_post( $post_id );
+	if ( ! $post ) {
+	return;
+	}
+	
+	$levels = SettingsFunctions::get_array( 'toc_heading_levels', range( 2, 6 ) );
+	$levels = array_unique( array_map( 'intval', $levels ) );
+	sort( $levels );
+	
+	$key       = md5( $post->post_content ) . '_' . implode( '', $levels );
+	$transient = 'nuclen_toc_' . $key;
+	
+	wp_cache_delete( $key, self::CACHE_GROUP );
+	delete_transient( $transient );
+	delete_post_meta( $post_id, Nuclen_TOC_Headings::META_KEY );
+}
+}

--- a/nuclear-engagement/inc/Modules/TOC/loader.php
+++ b/nuclear-engagement/inc/Modules/TOC/loader.php
@@ -15,10 +15,10 @@ if ( ! defined( 'ABSPATH' ) ) {
 	exit;
 }
 
-use NuclearEngagement\Modules\TOC\Nuclen_TOC_Utils;
 use NuclearEngagement\Modules\TOC\Nuclen_TOC_Headings;
 use NuclearEngagement\Modules\TOC\Nuclen_TOC_Render;
 use NuclearEngagement\Modules\TOC\Nuclen_TOC_Admin;
+use NuclearEngagement\Modules\TOC\TocCache;
 use NuclearEngagement\Core\SettingsRepository;
 
 /*
@@ -35,7 +35,9 @@ define( 'NUCLEN_TOC_URL', plugin_dir_url( __FILE__ ) );
  * ------------------------------------------------------------------
  */
 require_once NUCLEN_TOC_DIR . 'includes/polyfills.php';
-require_once NUCLEN_TOC_DIR . 'includes/Nuclen_TOC_Utils.php';
+require_once NUCLEN_TOC_DIR . 'includes/SlugGenerator.php';
+require_once NUCLEN_TOC_DIR . 'includes/TocCache.php';
+require_once NUCLEN_TOC_DIR . 'includes/HeadingExtractor.php';
 require_once NUCLEN_TOC_DIR . 'includes/Nuclen_TOC_Assets.php';
 require_once NUCLEN_TOC_DIR . 'includes/Nuclen_TOC_View.php';
 require_once NUCLEN_TOC_DIR . 'includes/Nuclen_TOC_Headings.php';
@@ -43,8 +45,8 @@ require_once NUCLEN_TOC_DIR . 'includes/Nuclen_TOC_Render.php';
 require_once NUCLEN_TOC_DIR . 'includes/Nuclen_TOC_Admin.php';
 
 // Clear caches when posts are saved or deleted.
-add_action( 'save_post', array( 'Nuclen_TOC_Utils', 'clear_cache_for_post' ) );
-add_action( 'delete_post', array( 'Nuclen_TOC_Utils', 'clear_cache_for_post' ) );
+add_action( 'save_post', array( 'NuclearEngagement\\Modules\\TOC\\TocCache', 'clear_cache_for_post' ) );
+add_action( 'delete_post', array( 'NuclearEngagement\\Modules\\TOC\\TocCache', 'clear_cache_for_post' ) );
 
 /*
  * ------------------------------------------------------------------

--- a/tests/NuclenTOCHeadingsTest.php
+++ b/tests/NuclenTOCHeadingsTest.php
@@ -52,7 +52,9 @@ namespace NuclearEngagement\Modules\TOC {
 
 namespace {
 	require_once NUCLEN_TOC_DIR . 'includes/polyfills.php';
-	require_once NUCLEN_TOC_DIR . 'includes/class-nuclen-toc-utils.php';
+       require_once NUCLEN_TOC_DIR . 'includes/SlugGenerator.php';
+       require_once NUCLEN_TOC_DIR . 'includes/TocCache.php';
+       require_once NUCLEN_TOC_DIR . 'includes/HeadingExtractor.php';
 	require_once NUCLEN_TOC_DIR . 'includes/class-nuclen-toc-headings.php';
 
 	class NuclenTOCHeadingsTest extends TestCase {

--- a/tests/NuclenTOCMetaCacheTest.php
+++ b/tests/NuclenTOCMetaCacheTest.php
@@ -8,13 +8,15 @@ namespace NuclearEngagement\Modules\TOC {
 
 namespace {
 	use PHPUnit\Framework\TestCase;
-	use NuclearEngagement\Modules\TOC\Nuclen_TOC_Utils;
-	use NuclearEngagement\Modules\TOC\Nuclen_TOC_Headings;
+use NuclearEngagement\Modules\TOC\HeadingExtractor;
+use NuclearEngagement\Modules\TOC\Nuclen_TOC_Headings;
 	if (!defined('HOUR_IN_SECONDS')) { define('HOUR_IN_SECONDS', 3600); }
 	if (!defined('NUCLEN_TOC_DIR')) { define('NUCLEN_TOC_DIR', dirname(__DIR__).'/nuclear-engagement/inc/Modules/TOC/'); }
 	if (!defined('NUCLEN_TOC_URL')) { define('NUCLEN_TOC_URL', 'http://example.com/'); }
 	require_once NUCLEN_TOC_DIR.'includes/polyfills.php';
-	require_once NUCLEN_TOC_DIR.'includes/class-nuclen-toc-utils.php';
+require_once NUCLEN_TOC_DIR.'includes/SlugGenerator.php';
+require_once NUCLEN_TOC_DIR.'includes/TocCache.php';
+require_once NUCLEN_TOC_DIR.'includes/HeadingExtractor.php';
 	require_once NUCLEN_TOC_DIR.'includes/class-nuclen-toc-headings.php';
 
 	class NuclenTOCMetaCacheTest extends TestCase {
@@ -30,7 +32,7 @@ namespace {
 			$stored = [ [ 'tag'=>'h2','level'=>2,'text'=>'One','inner'=>'One','id'=>'one' ] ];
 			$GLOBALS['wp_posts'][1] = $post;
 			$GLOBALS['wp_meta'][1][Nuclen_TOC_Headings::META_KEY] = $stored;
-			$result = Nuclen_TOC_Utils::extract($post->post_content, [2], 1);
+                       $result = HeadingExtractor::extract($post->post_content, [2], 1);
 			$this->assertSame($stored, $result);
 		}
 

--- a/tests/TocModuleTest.php
+++ b/tests/TocModuleTest.php
@@ -172,7 +172,9 @@ if ( ! function_exists( 'get_the_ID' ) ) {
 // Load plugin classes
 // ------------------------------------------------------
 require_once NUCLEN_TOC_DIR . 'includes/polyfills.php';
-require_once NUCLEN_TOC_DIR . 'includes/class-nuclen-toc-utils.php';
+require_once NUCLEN_TOC_DIR . 'includes/SlugGenerator.php';
+require_once NUCLEN_TOC_DIR . 'includes/TocCache.php';
+require_once NUCLEN_TOC_DIR . 'includes/HeadingExtractor.php';
 require_once NUCLEN_TOC_DIR . 'includes/class-nuclen-toc-view.php';
 require_once NUCLEN_TOC_DIR . 'includes/class-nuclen-toc-assets.php';
 require_once NUCLEN_TOC_DIR . 'includes/class-nuclen-toc-headings.php';
@@ -249,13 +251,13 @@ class TocModuleTest extends TestCase {
 
 		$this->registerSettings();
 
-		\NuclearEngagement\Modules\TOC\Nuclen_TOC_Utils::extract( $wp_posts[1]->post_content, [2, 3] );
+\NuclearEngagement\Modules\TOC\HeadingExtractor::extract( $wp_posts[1]->post_content, [2, 3] );
 		$key = md5( $wp_posts[1]->post_content ) . '_23';
 
 		$this->assertArrayHasKey( $key, $wp_cache['nuclen_toc'] );
 		$this->assertArrayHasKey( 'nuclen_toc_' . $key, $transients );
 
-		\NuclearEngagement\Modules\TOC\Nuclen_TOC_Utils::clear_cache_for_post( 1 );
+\NuclearEngagement\Modules\TOC\TocCache::clear_cache_for_post( 1 );
 
 		$this->assertArrayNotHasKey( $key, $wp_cache['nuclen_toc'] );
 		$this->assertArrayNotHasKey( 'nuclen_toc_' . $key, $transients );


### PR DESCRIPTION
## Summary
- create `SlugGenerator`, `TocCache` and `HeadingExtractor`
- use the new classes in the TOC loader and modules
- update unit tests for new API

## Testing
- `composer lint` *(fails: command not found)*
- `composer test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685e4c2312648327918e2203c6a8e613

<!-- Korbit AI PR Description Start -->
## Description by Korbit AI

### What change is being made?
Refactor utilities related to Table of Contents (TOC) by extracting heading extraction, slug generation, and caching functionalities into separate classes: `HeadingExtractor`, `SlugGenerator`, and `TocCache`.

### Why are these changes being made?
This refactor improves the maintainability and readability of the code by encapsulating distinct functionalities into their own classes, which follows the Single Responsibility Principle. This separation allows for better organization, simplifies testing, and enhances future scalability of the TOC module.

> Is this description stale? Ask me to generate a new description by commenting `/korbit-generate-pr-description`
<!-- Korbit AI PR Description End -->