### PR TITLE
Fix namespace syntax in SettingsFunctions

### DIFF
--- a/nuclear-engagement/inc/Helpers/SettingsFunctions.php
+++ b/nuclear-engagement/inc/Helpers/SettingsFunctions.php
@@ -2,14 +2,14 @@
 /**
  * Class providing static wrappers for retrieving settings values.
  *
- * @package NuclearEngagement\\Helpers
- */
+ * @package NuclearEngagement\Helpers
+*/
 declare(strict_types=1);
 
-namespace NuclearEngagement\\Helpers;
+namespace NuclearEngagement\Helpers;
 
 if ( ! defined( 'ABSPATH' ) ) {
-exit;
+	exit;
 }
 
 /**
@@ -17,43 +17,43 @@ exit;
  */
 final class SettingsFunctions {
 
-/**
- * Get any setting or all settings if no key provided.
- *
- * @param string|null $key     Setting key or null for all.
- * @param mixed       $default Default value.
- * @return mixed
- */
-public static function get( ?string $key = null, $default = null ) {
-return SettingsHelper::get( $key, $default );
-}
-
-/**
- * Get a boolean setting.
- */
-public static function get_bool( string $key, bool $default = false ): bool {
-return SettingsHelper::get_bool( $key, $default );
-}
-
-/**
- * Get an integer setting.
- */
-public static function get_int( string $key, int $default = 0 ): int {
-return SettingsHelper::get_int( $key, $default );
-}
-
-/**
- * Get a string setting.
- */
-public static function get_string( string $key, string $default = '' ): string {
-return SettingsHelper::get_string( $key, $default );
-}
-
-/**
- * Get an array setting.
- */
-public static function get_array( string $key, array $default = array() ): array {
-return SettingsHelper::get_array( $key, $default );
-}
+	/**
+	 * Get any setting or all settings if no key provided.
+	 *
+	 * @param string|null $key     Setting key or null for all.
+	 * @param mixed       $default Default value.
+	 * @return mixed
+	 */
+	public static function get( ?string $key = null, $default = null ) {
+	return SettingsHelper::get( $key, $default );
+	}
+	
+	/**
+	 * Get a boolean setting.
+	 */
+	public static function get_bool( string $key, bool $default = false ): bool {
+	return SettingsHelper::get_bool( $key, $default );
+	}
+	
+	/**
+	 * Get an integer setting.
+	 */
+	public static function get_int( string $key, int $default = 0 ): int {
+	return SettingsHelper::get_int( $key, $default );
+	}
+	
+	/**
+	 * Get a string setting.
+	 */
+	public static function get_string( string $key, string $default = '' ): string {
+	return SettingsHelper::get_string( $key, $default );
+	}
+	
+	/**
+	 * Get an array setting.
+	 */
+	public static function get_array( string $key, array $default = array() ): array {
+	return SettingsHelper::get_array( $key, $default );
+	}
 }
 


### PR DESCRIPTION
## Summary
- correct namespace declaration in SettingsFunctions
- indent SettingsFunctions with tabs to follow style

## Testing
- `composer lint` *(fails: command not found)*
- `composer test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685e56ae1fac8327bb408b54863132c8


> [!NOTE]
> I'm currently writing a description for your pull request. I should be done shortly (<1 minute). Please don't edit the description field until I'm finished, or we may overwrite each other. If I find nothing to write about, I'll delete this message.
