### PR TITLE
Add PHPDoc to bootstrap functions

### DIFF
--- a/nuclear-engagement/bootstrap.php
+++ b/nuclear-engagement/bootstrap.php
@@ -16,6 +16,14 @@ require_once __DIR__ . '/inc/Core/Bootloader.php';
 
 Bootloader::init();
 
+/**
+ * Load the plugin text domain for translations.
+ *
+ * This enables localization by loading translation files from the
+ * languages directory.
+ *
+ * @return void
+ */
 function nuclear_engagement_load_textdomain() {
 	load_plugin_textdomain(
 		'nuclear-engagement',
@@ -24,6 +32,14 @@ function nuclear_engagement_load_textdomain() {
 	);
 }
 
+/**
+ * Redirect to the setup screen on plugin activation.
+ *
+ * Checks a transient set during activation and, if present, redirects the
+ * administrator to the plugin setup page.
+ *
+ * @return void
+ */
 function nuclear_engagement_redirect_on_activation() {
 	if ( get_transient( 'nuclen_plugin_activation_redirect' ) ) {
 		delete_transient( 'nuclen_plugin_activation_redirect' );
@@ -34,12 +50,27 @@ function nuclear_engagement_redirect_on_activation() {
 	}
 }
 
+/**
+ * Initialize and execute the core plugin logic.
+ *
+ * Sets up meta registration and runs the main plugin class.
+ *
+ * @return void
+ */
 function nuclear_engagement_run_plugin() {
 	MetaRegistration::init();
 	$plugin = new Plugin();
 	$plugin->nuclen_run();
 }
 
+/**
+ * Register services and bootstrap the plugin.
+ *
+ * Sets up caching, query services and other runtime hooks, then
+ * runs the plugin.
+ *
+ * @return void
+ */
 function nuclear_engagement_init() {
 	try {
 		InventoryCache::register_hooks();


### PR DESCRIPTION
## Summary
- document initialization functions in `bootstrap.php`

## Testing
- `composer lint` *(fails: command not found)*
- `composer test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685e5863c92c832799a858884828c2a4

<!-- Korbit AI PR Description Start -->
## Description by Korbit AI

### What change is being made?

Add PHPDoc comments to bootstrap functions in the `nuclear-engagement/bootstrap.php` file to provide detailed explanations and descriptions.

### Why are these changes being made?

These changes improve the code's readability and maintainability by providing developers with context and explanations of what each function does, its purpose, and its return value. Adding PHPDoc enhances understanding and facilitates easier onboarding for new developers, while also supporting better code documentation practices.

> Is this description stale? Ask me to generate a new description by commenting `/korbit-generate-pr-description`
<!-- Korbit AI PR Description End -->