### PR TITLE
Use templates for admin header and notices

### DIFF
--- a/nuclear-engagement/inc/Services/AdminNoticeService.php
+++ b/nuclear-engagement/inc/Services/AdminNoticeService.php
@@ -23,10 +23,14 @@ class AdminNoticeService {
 		}
 	}
 
-	public function render(): void {
-		foreach ( $this->messages as $msg ) {
-			echo '<div class="notice notice-error"><p>' . esc_html( $msg ) . '</p></div>';
-		}
-		$this->messages = array();
-	}
+       public function render(): void {
+               foreach ( $this->messages as $msg ) {
+                       load_template(
+                               NUCLEN_PLUGIN_DIR . 'templates/admin/notice.php',
+                               true,
+                               array( 'msg' => $msg )
+                       );
+               }
+               $this->messages = array();
+       }
 }

--- a/nuclear-engagement/inc/Utils/Utils.php
+++ b/nuclear-engagement/inc/Utils/Utils.php
@@ -28,17 +28,18 @@ class Utils {
 	 *
 	 * @return void
 	 */
-	public function display_nuclen_page_header(): void {
-		$image_url = plugin_dir_url( __DIR__ ) . 'assets/nuclear-engagement-logo.webp';
-		if ( ! filter_var( $image_url, FILTER_VALIDATE_URL ) ) {
-			return;
-		}
-		$image_html = '<img height="40" width="40" src="' . esc_url( $image_url ) . '" alt="' . esc_attr__( 'Nuclear Engagement Logo', 'nuclear-engagement' ) . '" />';
-		echo '<div id="nuclen-page-header">
-				' . wp_kses_post( $image_html ) . '
-				<p><b>' . esc_html__( 'NUCLEAR ENGAGEMENT', 'nuclear-engagement' ) . '</b></p>
-		</div>';
-	}
+       public function display_nuclen_page_header(): void {
+               $image_url = plugin_dir_url( __DIR__ ) . 'assets/nuclear-engagement-logo.webp';
+               if ( ! filter_var( $image_url, FILTER_VALIDATE_URL ) ) {
+                       return;
+               }
+
+               load_template(
+                       NUCLEN_PLUGIN_DIR . 'templates/admin/page-header.php',
+                       true,
+                       array( 'image_url' => $image_url )
+               );
+       }
 
 	/**
 	 * Retrieve paths and URLs for the custom CSS file.

--- a/nuclear-engagement/templates/admin/notice.php
+++ b/nuclear-engagement/templates/admin/notice.php
@@ -1,0 +1,16 @@
+<?php
+declare(strict_types=1);
+if ( ! defined( 'ABSPATH' ) ) {
+    exit;
+}
+/**
+ * Single admin notice.
+ *
+ * Variables:
+ *   - $msg (string) Notice message.
+ *
+ * @package NuclearEngagement\Admin
+ */
+?>
+<div class="notice notice-error"><p><?php echo esc_html( $msg ); ?></p></div>
+

--- a/nuclear-engagement/templates/admin/page-header.php
+++ b/nuclear-engagement/templates/admin/page-header.php
@@ -1,0 +1,19 @@
+<?php
+declare(strict_types=1);
+if ( ! defined( 'ABSPATH' ) ) {
+    exit;
+}
+/**
+ * Admin page header template.
+ *
+ * Variables:
+ *   - $image_url (string) URL to the logo image.
+ *
+ * @package NuclearEngagement\Admin
+ */
+?>
+<div id="nuclen-page-header">
+    <img height="40" width="40" src="<?php echo esc_url( $image_url ); ?>" alt="<?php esc_attr_e( 'Nuclear Engagement Logo', 'nuclear-engagement' ); ?>" />
+    <p><b><?php esc_html_e( 'NUCLEAR ENGAGEMENT', 'nuclear-engagement' ); ?></b></p>
+</div>
+

--- a/tests/AdminNoticeServiceTest.php
+++ b/tests/AdminNoticeServiceTest.php
@@ -9,12 +9,15 @@ namespace NuclearEngagement\Services {
 }
 
 namespace {
-	use PHPUnit\Framework\TestCase;
-	use NuclearEngagement\Services\AdminNoticeService;
-	class AdminNoticeServiceTest extends TestCase {
-		protected function setUp(): void {
-			$GLOBALS['ans_actions'] = [];
-		}
+        use PHPUnit\Framework\TestCase;
+        use NuclearEngagement\Services\AdminNoticeService;
+        class AdminNoticeServiceTest extends TestCase {
+                protected function setUp(): void {
+                        $GLOBALS['ans_actions'] = [];
+                        if ( ! defined( 'NUCLEN_PLUGIN_DIR' ) ) {
+                                define( 'NUCLEN_PLUGIN_DIR', dirname( __DIR__ ) . '/nuclear-engagement/' );
+                        }
+                }
 
 		public function test_add_hooks_into_admin_notices_once(): void {
 			$service = new AdminNoticeService();

--- a/tests/wp-stubs.php
+++ b/tests/wp-stubs.php
@@ -41,8 +41,21 @@ if (!function_exists('wp_remote_retrieve_body')) {
 }
 
 if (!function_exists('locate_template')) {
-	function locate_template($names, $load = false, $require_once = true, $args = []) {
-		return '';
-	}
+        function locate_template($names, $load = false, $require_once = true, $args = []) {
+                return '';
+        }
+}
+
+if (!function_exists('load_template')) {
+       function load_template($file, $require_once = true, $args = []) {
+               if (is_array($args)) {
+                       extract($args, EXTR_SKIP);
+               }
+               if ($require_once) {
+                       require $file;
+               } else {
+                       require $file;
+               }
+       }
 }
 


### PR DESCRIPTION
## Summary
- add `templates/admin/page-header.php` to centralize header HTML
- refactor `Utils::display_nuclen_page_header()` to load the template
- add `templates/admin/notice.php` for notice rows
- refactor `AdminNoticeService::render()` to output using the notice template
- update test stubs and tests for the new template loading

## Testing
- `composer lint` *(fails: composer not found)*
- `composer test` *(fails: composer not found)*

------
https://chatgpt.com/codex/tasks/task_e_685e5862f2308327989b895ea70263f7


> [!NOTE]
> I'm currently writing a description for your pull request. I should be done shortly (<1 minute). Please don't edit the description field until I'm finished, or we may overwrite each other. If I find nothing to write about, I'll delete this message.
