### PR TITLE
Fix ThemeRegistry autoload path

### DIFF
--- a/nuclear-engagement/inc/Core/ThemeRegistry.php
+++ b/nuclear-engagement/inc/Core/ThemeRegistry.php
@@ -1,7 +1,7 @@
 <?php
 declare(strict_types=1);
 /**
- * File: includes/Themes.php
+ * File: inc/Core/ThemeRegistry.php
  *
  * Provides a simple registry of available CSS themes.
  *

--- a/tests/ThemeRegistryTest.php
+++ b/tests/ThemeRegistryTest.php
@@ -4,7 +4,7 @@ use NuclearEngagement\Core\ThemeRegistry;
 
 class ThemeRegistryTest extends TestCase {
 	public static function setUpBeforeClass(): void {
-		require_once dirname(__DIR__) . '/nuclear-engagement/inc/Core/Themes.php';
+       require_once dirname(__DIR__) . '/nuclear-engagement/inc/Core/ThemeRegistry.php';
 	}
 
 	protected function setUp(): void {


### PR DESCRIPTION
## Summary
- rename `Themes.php` to `ThemeRegistry.php`
- update test bootstrap path

## Testing
- `composer lint` *(fails: composer not found)*
- `composer test` *(fails: composer not found)*

------
https://chatgpt.com/codex/tasks/task_e_685e5ed0633883279148d3057938a1cc

<!-- Korbit AI PR Description Start -->
## Description by Korbit AI

### What change is being made?

Fix the autoload path for the `ThemeRegistry` component in the codebase and its corresponding test.

### Why are these changes being made?

Errors were occurring due to incorrect file paths specified in the `ThemeRegistry` component and its test, likely due to a file renaming which was not accompanied by updating these references. This fix ensures that the correct `ThemeRegistry.php` file is loaded, maintaining functionality and integrity.

> Is this description stale? Ask me to generate a new description by commenting `/korbit-generate-pr-description`
<!-- Korbit AI PR Description End -->