### PR TITLE
Fix DI container remote service instantiation

### DIFF
--- a/nuclear-engagement/inc/Core/ContainerRegistrar.php
+++ b/nuclear-engagement/inc/Core/ContainerRegistrar.php
@@ -28,8 +28,8 @@ final class ContainerRegistrar {
 		$container->register( 'admin_notice_service', static fn() => new AdminNoticeService() );
 		$container->register( 'logging_service', static fn( Container $c ) => new LoggingService( $c->get( 'admin_notice_service' ) ) );
 
-		$container->register( 'remote_request', static fn() => new Services\Remote\RemoteRequest() );
-		$container->register( 'api_response_handler', static fn() => new Services\Remote\ApiResponseHandler() );
+               $container->register( 'remote_request', static fn() => new RemoteRequest() );
+               $container->register( 'api_response_handler', static fn() => new ApiResponseHandler() );
 		$container->register( 'remote_api', static fn( Container $c ) => new RemoteApiService( $c->get( 'settings' ), $c->get( 'remote_request' ), $c->get( 'api_response_handler' ) ) );
 		$container->register( 'content_storage', static fn( Container $c ) => new ContentStorageService( $c->get( 'settings' ) ) );
 


### PR DESCRIPTION
## Summary
- correct instantiation paths for RemoteRequest and ApiResponseHandler

## Testing
- `composer lint` *(fails: command not found)*
- `composer test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685e61e4b7508327982d98ff35fd3e77


> [!NOTE]
> I'm currently writing a description for your pull request. I should be done shortly (<1 minute). Please don't edit the description field until I'm finished, or we may overwrite each other. If I find nothing to write about, I'll delete this message.
