### PR TITLE
Fix utils class reference

### DIFF
--- a/nuclear-engagement/admin/Setup.php
+++ b/nuclear-engagement/admin/Setup.php
@@ -17,6 +17,7 @@ use NuclearEngagement\Core\SettingsRepository;
 use NuclearEngagement\Services\SetupService;
 use NuclearEngagement\Admin\Setup\ConnectHandler;
 use NuclearEngagement\Admin\Setup\AppPasswordHandler;
+use NuclearEngagement\Utils\Utils;
 
 if ( ! defined( 'ABSPATH' ) ) {
 	exit;
@@ -25,7 +26,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 
 class Setup {
 
-/** @var \NuclearEngagement\Utils */
+/** @var Utils */
 private $utils;
 
 private ConnectHandler $connect_handler;
@@ -38,7 +39,7 @@ private AppPasswordHandler $app_password_handler;
 	private $settings_repository;
 
 public function __construct( SettingsRepository $settings_repository ) {
-$this->utils			   = new \NuclearEngagement\Utils();
+$this->utils			   = new Utils();
 $this->setup_service	   = new SetupService();
 $this->settings_repository = $settings_repository;
 $this->connect_handler	   = new ConnectHandler( $this->setup_service, $this->settings_repository );


### PR DESCRIPTION
## Summary
- import `Utils` class in Admin Setup
- construct `Utils` with correct namespace

## Testing
- `composer lint` *(fails: command not found)*
- `composer test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685e641615408327a9523c68528b4a23