### PR TITLE
Implement plugin autoloader class

### DIFF
--- a/nuclear-engagement/composer.json
+++ b/nuclear-engagement/composer.json
@@ -12,7 +12,10 @@
       "NuclearEngagement\\Utils\\": "inc/Utils/",
       "NuclearEngagement\\Traits\\": "inc/Traits/",
       "NuclearEngagement\\": "inc/"
-    }
+    },
+    "files": [
+      "inc/Core/Autoloader.php"
+    ]
   },
   "config": {
         "allow-plugins": {

--- a/nuclear-engagement/inc/Core/Autoloader.php
+++ b/nuclear-engagement/inc/Core/Autoloader.php
@@ -1,0 +1,55 @@
+<?php
+declare(strict_types=1);
+
+namespace NuclearEngagement\Core;
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+/**
+ * Handles autoloading of plugin classes.
+ */
+final class Autoloader {
+	/**
+	 * Register the autoload callback.
+	 */
+	public static function register(): void {
+		spl_autoload_register( array( self::class, 'autoload' ) );
+	}
+
+	/**
+	 * Autoload callback for plugin classes.
+	 */
+	private static function autoload( string $class ): void {
+		$prefix = 'NuclearEngagement\\';
+		if ( 0 !== strpos( $class, $prefix ) ) {
+			return;
+		}
+
+		$relative = str_replace( '\\', '/', substr( $class, strlen( $prefix ) ) );
+
+		$paths   = array();
+		$paths[] = NUCLEN_PLUGIN_DIR . $relative . '.php';
+
+		$segments = explode( '/', $relative );
+		if ( in_array( $segments[0], array( 'Admin', 'Front' ), true ) ) {
+			$segments[0] = strtolower( $segments[0] );
+			$paths[]     = NUCLEN_PLUGIN_DIR . implode( '/', $segments ) . '.php';
+
+			if ( isset( $segments[1] ) ) {
+				$paths[] = NUCLEN_PLUGIN_DIR . $segments[0] . '/traits/' . $segments[1] . '.php';
+			}
+		}
+
+		$paths[] = NUCLEN_PLUGIN_DIR . 'inc/' . $relative . '.php';
+		$paths[] = NUCLEN_PLUGIN_DIR . 'inc/Core/' . $relative . '.php';
+
+		foreach ( $paths as $file ) {
+			if ( file_exists( $file ) ) {
+				require_once $file;
+				return;
+			}
+		}
+	}
+}

--- a/nuclear-engagement/inc/Core/Bootloader.php
+++ b/nuclear-engagement/inc/Core/Bootloader.php
@@ -14,6 +14,7 @@ use NuclearEngagement\Core\MetaRegistration;
 use NuclearEngagement\Core\AssetVersions;
 use NuclearEngagement\Core\Plugin;
 use NuclearEngagement\Core\InventoryCache;
+use NuclearEngagement\Core\Autoloader;
 use NuclearEngagement\Services\PostsQueryService;
 
 /**
@@ -75,39 +76,7 @@ final class Bootloader {
 			return;
 		}
 
-		spl_autoload_register(
-			static function ( $class ) {
-				$prefix = 'NuclearEngagement\\';
-				if ( 0 !== strpos( $class, $prefix ) ) {
-					return;
-				}
-
-				$relative = str_replace( '\\', '/', substr( $class, strlen( $prefix ) ) );
-
-				$paths	 = array();
-				$paths[] = NUCLEN_PLUGIN_DIR . $relative . '.php';
-
-				$segments = explode( '/', $relative );
-				if ( in_array( $segments[0], array( 'Admin', 'Front' ), true ) ) {
-					$segments[0] = strtolower( $segments[0] );
-					$paths[]	 = NUCLEN_PLUGIN_DIR . implode( '/', $segments ) . '.php';
-
-					if ( isset( $segments[1] ) ) {
-						$paths[] = NUCLEN_PLUGIN_DIR . $segments[0] . '/traits/' . $segments[1] . '.php';
-					}
-				}
-
-				$paths[] = NUCLEN_PLUGIN_DIR . 'inc/' . $relative . '.php';
-				$paths[] = NUCLEN_PLUGIN_DIR . 'inc/Core/' . $relative . '.php';
-
-				foreach ( $paths as $file ) {
-					if ( file_exists( $file ) ) {
-						require_once $file;
-						return;
-					}
-				}
-			}
-		);
+	Autoloader::register();
 
 		if ( ! class_exists( AssetVersions::class ) ) {
 			$asset_versions_path = NUCLEN_PLUGIN_DIR . 'inc/Core/AssetVersions.php';


### PR DESCRIPTION
## Summary
- add `Autoloader` class to register plugin autoload logic
- call new Autoloader from `Bootloader`
- autoload Autoloader via composer.json

## Testing
- `composer dump-autoload --working-dir=nuclear-engagement` *(fails: command not found)*
- `composer lint --working-dir=nuclear-engagement` *(fails: command not found)*
- `composer test --working-dir=nuclear-engagement` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685e64fd13948327a119755dc0a055f9

<!-- Korbit AI PR Description Start -->
## Description by Korbit AI

### What change is being made?

Implement a dedicated plugin autoloader class to manage the autoloading of plugin classes and update `Bootloader.php` to use this new autoloader.

### Why are these changes being made?

The changes aim to maintain clean and organized code by encapsulating the autoloading logic within its class, separating it from the bootstrapping process. This refactoring makes the codebase easier to maintain and extend. Additionally, updating the `composer.json` ensures the autoloader is recognized and included in the build process.

> Is this description stale? Ask me to generate a new description by commenting `/korbit-generate-pr-description`
<!-- Korbit AI PR Description End -->