### PR TITLE
Add Bootloader init unit test

### DIFF
--- a/tests/BootloaderTest.php
+++ b/tests/BootloaderTest.php
@@ -1,0 +1,69 @@
+<?php
+namespace NuclearEngagement\Core {
+	function add_action(...$args) {
+		$GLOBALS['bl_actions'][] = $args;
+	}
+	function register_activation_hook(...$args) {
+		$GLOBALS['bl_activation'][] = $args;
+	}
+	function register_deactivation_hook(...$args) {
+		$GLOBALS['bl_deactivation'][] = $args;
+	}
+	if ( ! function_exists('__') ) {
+		function __( $t, $d = null ) { return $t; }
+	}
+	if ( ! function_exists( 'get_file_data' ) ) {
+		function get_file_data( $f, $k, $t = null ) { return array( 'Version' => '1.0' ); }
+	}
+}
+
+namespace {
+	use PHPUnit\Framework\TestCase;
+	use NuclearEngagement\Core\Bootloader;
+
+	class BootloaderTest extends TestCase {
+		private string $vendorDir;
+
+		protected function setUp(): void {
+			$this->vendorDir = dirname( __DIR__ ) . '/nuclear-engagement/vendor';
+			$GLOBALS['bl_actions'] = array();
+			$GLOBALS['bl_activation'] = array();
+			$GLOBALS['bl_deactivation'] = array();
+			$GLOBALS['vendor_autoload_included'] = false;
+			@mkdir( $this->vendorDir, 0777, true );
+			file_put_contents(
+			    $this->vendorDir . '/autoload.php',
+			    "<?php\n\$GLOBALS['vendor_autoload_included'] = true;\n"
+			);
+			if ( ! defined( 'NUCLEN_PLUGIN_FILE' ) ) {
+			    define( 'NUCLEN_PLUGIN_FILE', dirname( __DIR__ ) . '/nuclear-engagement/nuclear-engagement.php' );
+			}
+		}
+
+		protected function tearDown(): void {
+			@unlink( $this->vendorDir . '/autoload.php' );
+			@rmdir( $this->vendorDir );
+			unset( $GLOBALS['vendor_autoload_included'] );
+		}
+
+		public function test_init_defines_constants_and_registers_hooks(): void {
+			$before = spl_autoload_functions() ?: array();
+			require_once dirname( __DIR__ ) . '/nuclear-engagement/inc/Core/Bootloader.php';
+			Bootloader::init();
+
+			$this->assertTrue( defined( 'NUCLEN_PLUGIN_DIR' ) );
+			$this->assertTrue( defined( 'NUCLEN_PLUGIN_VERSION' ) );
+			$this->assertTrue( defined( 'NUCLEN_ASSET_VERSION' ) );
+
+			$hooks = array_column( $GLOBALS['bl_actions'], 0 );
+			$this->assertContains( 'init', $hooks );
+			$this->assertContains( 'plugins_loaded', $hooks );
+			$this->assertNotEmpty( $GLOBALS['bl_activation'] );
+			$this->assertNotEmpty( $GLOBALS['bl_deactivation'] );
+
+			$after = spl_autoload_functions();
+			$this->assertGreaterThan( count( $before ), count( $after ) );
+			$this->assertTrue( $GLOBALS['vendor_autoload_included'] );
+		}
+	}
+}


### PR DESCRIPTION
## Summary
- add `BootloaderTest` covering Bootloader::init hooks and constants

## Testing
- `composer lint --working-dir=nuclear-engagement` *(fails: composer not found)*
- `composer test --working-dir=nuclear-engagement` *(fails: composer not found)*

------
https://chatgpt.com/codex/tasks/task_e_685e65002d248327b5b5901902449ab7

<!-- Korbit AI PR Description Start -->
## Description by Korbit AI

### What change is being made?

Add a unit test for the Bootloader initialization process in `BootloaderTest.php` to verify constants definition and hooks registration.

### Why are these changes being made?

This change ensures that the Bootloader correctly defines necessary constants and registers appropriate hooks during initialization, which is critical for the plugin's proper functioning. This approach offers comprehensive test coverage to prevent potential issues in the Bootloader setup and provides a structured way to validate the essential initialization logic.

> Is this description stale? Ask me to generate a new description by commenting `/korbit-generate-pr-description`
<!-- Korbit AI PR Description End -->