### PR TITLE
Fix asset trait syntax error

### DIFF
--- a/nuclear-engagement/front/traits/AssetsTrait.php
+++ b/nuclear-engagement/front/traits/AssetsTrait.php
@@ -65,6 +65,46 @@ trait AssetsTrait {
 return false;
 }
 
+	
+		$post_id = get_the_ID();
+		if ( ! $post_id ) {
+			return false;
+		}
+
+		$post    = get_post( $post_id );
+		$content = $post ? $post->post_content : '';
+
+		if ( function_exists( 'has_block' ) && $post ) {
+			if ( has_block( 'nuclear-engagement/quiz', $post ) || has_block( 'nuclear-engagement/summary', $post ) ) {
+				return true;
+			}
+		}
+
+		if ( has_shortcode( $content, 'nuclear_engagement_quiz' ) || has_shortcode( $content, 'nuclear_engagement_summary' ) ) {
+			return true;
+		}
+
+		$settings_repo   = $this->nuclen_get_settings_repository();
+		$display_quiz    = $settings_repo->get( 'display_quiz', 'manual' );
+		$display_summary = $settings_repo->get( 'display_summary', 'manual' );
+
+		if ( $display_quiz !== 'manual' && $display_quiz !== 'none' ) {
+			$quiz_meta = maybe_unserialize( get_post_meta( $post_id, 'nuclen-quiz-data', true ) );
+			if ( is_array( $quiz_meta ) && ! empty( $quiz_meta['questions'] ) ) {
+				return true;
+			}
+		}
+
+				if ( $display_summary !== 'manual' && $display_summary !== 'none' ) {
+						$summary_meta = get_post_meta( $post_id, Summary_Service::META_KEY, true );
+			if ( is_array( $summary_meta ) && ! empty( trim( $summary_meta['summary'] ?? '' ) ) ) {
+				return true;
+			}
+		}
+
+}
+		return false;
+}
 /**
  * Build inline JS variables for opt-in settings.
  */
@@ -130,44 +170,6 @@ return false;
 		);
 	}
 	
-		$post_id = get_the_ID();
-		if ( ! $post_id ) {
-			return false;
-		}
-
-		$post    = get_post( $post_id );
-		$content = $post ? $post->post_content : '';
-
-		if ( function_exists( 'has_block' ) && $post ) {
-			if ( has_block( 'nuclear-engagement/quiz', $post ) || has_block( 'nuclear-engagement/summary', $post ) ) {
-				return true;
-			}
-		}
-
-		if ( has_shortcode( $content, 'nuclear_engagement_quiz' ) || has_shortcode( $content, 'nuclear_engagement_summary' ) ) {
-			return true;
-		}
-
-		$settings_repo   = $this->nuclen_get_settings_repository();
-		$display_quiz    = $settings_repo->get( 'display_quiz', 'manual' );
-		$display_summary = $settings_repo->get( 'display_summary', 'manual' );
-
-		if ( $display_quiz !== 'manual' && $display_quiz !== 'none' ) {
-			$quiz_meta = maybe_unserialize( get_post_meta( $post_id, 'nuclen-quiz-data', true ) );
-			if ( is_array( $quiz_meta ) && ! empty( $quiz_meta['questions'] ) ) {
-				return true;
-			}
-		}
-
-				if ( $display_summary !== 'manual' && $display_summary !== 'none' ) {
-						$summary_meta = get_post_meta( $post_id, Summary_Service::META_KEY, true );
-			if ( is_array( $summary_meta ) && ! empty( trim( $summary_meta['summary'] ?? '' ) ) ) {
-				return true;
-			}
-		}
-
-		return false;
-	}
 
 	/*
 	────────────────────────────


### PR DESCRIPTION
## Summary
- ensure `should_load_assets` closes correctly and move detection logic inside
- remove duplicate asset detection code

## Testing
- `composer lint` *(fails: command not found)*
- `composer test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685e742b04cc8327a43ba27f832bfe5b

<!-- Korbit AI PR Description Start -->
## Description by Korbit AI

### What change is being made?

Refactor the `should_load_assets` function in `AssetsTrait.php` to correct the syntax and improve readability by removing duplicate code blocks.

### Why are these changes being made?

This change addresses a syntax error and optimizes the function by eliminating redundancies, ensuring consistent behavior when checking if assets should load based on specific post content or settings.

> Is this description stale? Ask me to generate a new description by commenting `/korbit-generate-pr-description`
<!-- Korbit AI PR Description End -->