### PR TITLE
Fix AssetsTrait parse error

### DIFF
--- a/nuclear-engagement/front/traits/AssetsTrait.php
+++ b/nuclear-engagement/front/traits/AssetsTrait.php
@@ -102,7 +102,6 @@ return false;
 			}
 		}
 
-}
 		return false;
 }
 /**


### PR DESCRIPTION
## Summary
- remove stray brace in `AssetsTrait` to fix plugin activation error

## Testing
- `composer lint` *(fails: command not found)*
- `composer test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685e77db1aa88327803c3702c73dedd9

<!-- Korbit AI PR Description Start -->
## Description by Korbit AI

### What change is being made?

Remove an extraneous closing curly brace in the `should_load_assets()` function within the `AssetsTrait.php` file.

### Why are these changes being made?

The additional closing curly brace was causing a parse error, preventing the application from running correctly. Removing it resolves the syntax error, ensuring the code executes as intended.

> Is this description stale? Ask me to generate a new description by commenting `/korbit-generate-pr-description`
<!-- Korbit AI PR Description End -->