### PR TITLE
Fix incorrect namespace for Blocks

### DIFF
--- a/nuclear-engagement/inc/Core/Plugin.php
+++ b/nuclear-engagement/inc/Core/Plugin.php
@@ -81,7 +81,7 @@ class Plugin {
 		OptinData::init();
 
 				( new ModuleLoader() )->load_all();
-				$this->loader = new Loader();
+			$this->loader = new Loader();
 	}
 
 	/*
@@ -163,7 +163,7 @@ class Plugin {
 		$this->loader->nuclen_add_action( 'init', $plugin_public, 'nuclen_register_quiz_shortcode' );
 		$this->loader->nuclen_add_action( 'init', $plugin_public, 'nuclen_register_summary_shortcode' );
 		$this->loader->nuclen_add_filter( 'the_content', $plugin_public, 'nuclen_auto_insert_shortcodes', 50 );
-		$this->loader->nuclen_add_action( 'init', '\\NuclearEngagement\\Blocks', 'register' );
+			$this->loader->nuclen_add_action( 'init', '\\NuclearEngagement\\Core\\Blocks', 'register' );
 	}
 
 	/*


### PR DESCRIPTION
## Summary
- fix Blocks namespace reference to avoid fatal error

## Testing
- `composer lint` *(fails: command not found)*
- `composer test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685e79f0dd788327839205f97e52844c

<!-- Korbit AI PR Description Start -->
## Description by Korbit AI

### What change is being made?

Correct the namespace for the 'Blocks' registration from `\NuclearEngagement\Blocks` to `\NuclearEngagement\Core\Blocks`.

### Why are these changes being made?

The namespace for the 'Blocks' class was incorrect, causing issues in class registration during initialization. Updating the namespace to include `Core` correctly specifies the location of the class for successful loading and execution.

> Is this description stale? Ask me to generate a new description by commenting `/korbit-generate-pr-description`
<!-- Korbit AI PR Description End -->