### PR TITLE
Add autoloader test

### DIFF
--- a/tests/AutoloaderTest.php
+++ b/tests/AutoloaderTest.php
@@ -1,0 +1,52 @@
+<?php
+use PHPUnit\Framework\TestCase;
+use NuclearEngagement\Core\Autoloader;
+
+class AutoloaderTest extends TestCase {
+	private string $dir;
+
+	protected function setUp(): void {
+		$this->dir = sys_get_temp_dir() . '/autoload_' . uniqid();
+		mkdir($this->dir . '/inc/Core', 0777, true);
+		mkdir($this->dir . '/admin', 0777, true);
+		file_put_contents(
+			$this->dir . '/inc/Core/DummyClass.php',
+			"<?php\nnamespace NuclearEngagement\\Core;\nclass DummyClass {}\n"
+		);
+		file_put_contents(
+			$this->dir . '/admin/DummyAdmin.php',
+			"<?php\nnamespace NuclearEngagement\\Admin;\nclass DummyAdmin {}\n"
+		);
+		define('NUCLEN_PLUGIN_DIR', $this->dir . '/');
+		require_once dirname(__DIR__) . '/nuclear-engagement/inc/Core/Autoloader.php';
+		Autoloader::register();
+	}
+
+	protected function tearDown(): void {
+		$this->deleteDir($this->dir);
+	}
+
+	private function deleteDir(string $dir): void {
+		if (!is_dir($dir)) {
+			return;
+		}
+		$items = scandir($dir);
+		foreach ($items as $item) {
+			if ($item === '.' || $item === '..') {
+				continue;
+			}
+			$path = $dir . '/' . $item;
+			if (is_dir($path)) {
+				$this->deleteDir($path);
+			} else {
+				@unlink($path);
+			}
+		}
+		@rmdir($dir);
+	}
+
+	public function test_autoloader_loads_classes(): void {
+		$this->assertTrue(class_exists('NuclearEngagement\\Core\\DummyClass'));
+		$this->assertTrue(class_exists('NuclearEngagement\\Admin\\DummyAdmin'));
+	}
+}


### PR DESCRIPTION
## Summary
- add AutoloaderTest covering PSR-4 registration

## Testing
- `composer lint --working-dir=nuclear-engagement` *(fails: command not found)*
- `composer test --working-dir=nuclear-engagement` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685e7d319cb8832783c3055340d58b52

<!-- Korbit AI PR Description Start -->
## Description by Korbit AI

### What change is being made?

Add a new test suite `AutoloaderTest` to ensure that the `Autoloader` class properly loads classes in the `NuclearEngagement\Core` and `NuclearEngagement\Admin` namespaces.

### Why are these changes being made?

This change aims to verify that the autoloader can dynamically load class files without explicit requires or includes, which is crucial for maintaining scalability and manageability in larger codebases. The test creates a temporary directory structure to simulate class loading and validates that the autoloader registers and recognizes classes correctly.

> Is this description stale? Ask me to generate a new description by commenting `/korbit-generate-pr-description`
<!-- Korbit AI PR Description End -->