### PR TITLE
Fix static LoggingService use

### DIFF
--- a/nuclear-engagement/inc/Services/LoggingService.php
+++ b/nuclear-engagement/inc/Services/LoggingService.php
@@ -15,47 +15,39 @@ if ( ! defined( 'ABSPATH' ) ) {
 }
 
 class LoggingService {
-	/** Current service instance. */
-	private static ?self $instance = null;
+       /** Current service instance. */
+       private static ?self $instance = null;
 
-	/** Admin notice service instance. */
-	private AdminNoticeService $notices;
+       /** Admin notice service instance. */
+       private AdminNoticeService $notices;
 
-	/** Buffered log messages. */
-	private array $buffer = array();
+       /** Buffered log messages. */
+       private array $buffer = array();
 
-	/** Whether the shutdown hook has been registered. */
-	private bool $shutdown_registered = false;
+       /** Whether the shutdown hook has been registered. */
+       private bool $shutdown_registered = false;
 
-	public function __construct( AdminNoticeService $notices ) {
-		$this->notices  = $notices;
-		self::$instance = $this;
-	}
+       public function __construct( AdminNoticeService $notices ) {
+               $this->notices  = $notices;
+               self::$instance = $this;
+       }
 
-	/** Retrieve the active instance. */
-	private static function instance(): self {
-		if ( null === self::$instance ) {
-			throw new \RuntimeException( 'LoggingService not initialized' );
-		}
-		return self::$instance;
-	}
+       /** Retrieve the active instance, creating one if needed. */
+       private static function instance(): self {
+               if ( null === self::$instance ) {
+                       self::$instance = new self( new AdminNoticeService() );
+               }
+               return self::$instance;
+       }
 
-	/** Forward static calls to the current instance. */
-	public static function __callStatic( string $name, array $arguments ) {
-		$instance = self::instance();
-		if ( ! method_exists( $instance, $name ) ) {
-			throw new \BadMethodCallException( "Method {$name} does not exist" );
-		}
-		return $instance->$name( ...$arguments );
-	}
-
-	/** Get directory, path and URL for the log file. */
-	public function get_log_file_info(): array {
-		$upload_dir = wp_upload_dir();
+       /** Get directory, path and URL for the log file. */
+       public static function get_log_file_info(): array {
+               $instance   = self::instance();
+               $upload_dir = wp_upload_dir();
 
 		if ( ! empty( $upload_dir['error'] ) ) {
 			error_log( '[Nuclear Engagement] ' . $upload_dir['error'] );
-			$this->add_admin_notice( 'Uploads directory unavailable. Using plugin directory for logs.' );
+                       $instance->add_admin_notice( 'Uploads directory unavailable. Using plugin directory for logs.' );
 			$fallback_dir = rtrim( NUCLEN_PLUGIN_DIR, '/' ) . '/logs';
 			return array(
 				'dir'  => $fallback_dir,
@@ -64,9 +56,9 @@ class LoggingService {
 			);
 		}
 
-		$log_folder = $upload_dir['basedir'] . '/nuclear-engagement';
-		$log_file   = $log_folder . '/log.txt';
-		$log_url    = $upload_dir['baseurl'] . '/nuclear-engagement/log.txt';
+               $log_folder = $upload_dir['basedir'] . '/nuclear-engagement';
+               $log_file   = $log_folder . '/log.txt';
+               $log_url    = $upload_dir['baseurl'] . '/nuclear-engagement/log.txt';
 
 		return array(
 			'dir'  => $log_folder,
@@ -75,33 +67,34 @@ class LoggingService {
 		);
 	}
 
-	/** Store an admin notice and ensure the hook is registered. */
-	private function add_admin_notice( string $message ): void {
-		$this->notices->add( $message );
-	}
+       /** Store an admin notice and ensure the hook is registered. */
+       private function add_admin_notice( string $message ): void {
+               $this->notices->add( $message );
+       }
 
-	/** Public helper to show an admin error notice. */
-	public function notify_admin( string $message ): void {
-		$this->add_admin_notice( $message );
-	}
+       /** Public helper to show an admin error notice. */
+       public static function notify_admin( string $message ): void {
+               $instance = self::instance();
+               $instance->add_admin_notice( $message );
+       }
 
-	/** Debug level logging, only when WP_DEBUG is true. */
-	public function debug( string $message ): void {
-		if ( defined( 'WP_DEBUG' ) && WP_DEBUG ) {
-			$this->log( '[DEBUG] ' . $message );
-		}
-	}
+       /** Debug level logging, only when WP_DEBUG is true. */
+       public static function debug( string $message ): void {
+               if ( defined( 'WP_DEBUG' ) && WP_DEBUG ) {
+                       self::log( '[DEBUG] ' . $message );
+               }
+       }
 
-	/** Log an exception including file and line. */
-	public function log_exception( \Throwable $e ): void {
-		$msg = $e->getMessage() . ' in ' . $e->getFile() . ':' . $e->getLine();
-		if ( defined( 'WP_DEBUG' ) && WP_DEBUG ) {
-			$trace_lines = explode( "\n", $e->getTraceAsString() );
-			$trace       = implode( ' | ', array_slice( $trace_lines, 0, 3 ) );
-			$msg        .= ' Stack trace: ' . $trace;
-		}
-		$this->log( $msg );
-	}
+       /** Log an exception including file and line. */
+       public static function log_exception( \Throwable $e ): void {
+               $msg = $e->getMessage() . ' in ' . $e->getFile() . ':' . $e->getLine();
+               if ( defined( 'WP_DEBUG' ) && WP_DEBUG ) {
+                       $trace_lines = explode( "\n", $e->getTraceAsString() );
+                       $trace       = implode( ' | ', array_slice( $trace_lines, 0, 3 ) );
+                       $msg        .= ' Stack trace: ' . $trace;
+               }
+               self::log( $msg );
+       }
 
 	/** Fallback when writing to the log fails. */
 	private function fallback( string $original, string $error ): void {
@@ -110,25 +103,26 @@ class LoggingService {
 		$this->add_admin_notice( $error );
 	}
 
-	/** Determine if logging should be buffered. */
-	private function use_buffer(): bool {
-		$default = defined( 'NUCLEN_BUFFER_LOGS' ) ? (bool) NUCLEN_BUFFER_LOGS : true;
-		return (bool) apply_filters( 'nuclen_enable_log_buffer', $default );
-	}
+       /** Determine if logging should be buffered. */
+       private function use_buffer(): bool {
+               $default = defined( 'NUCLEN_BUFFER_LOGS' ) ? (bool) NUCLEN_BUFFER_LOGS : true;
+               return (bool) apply_filters( 'nuclen_enable_log_buffer', $default );
+       }
 
-	/** Flush buffered messages to the log file. */
-	public function flush(): void {
-		if ( empty( $this->buffer ) ) {
-			return;
-		}
+       /** Flush buffered messages to the log file. */
+       public static function flush(): void {
+               $instance = self::instance();
+               if ( empty( $instance->buffer ) ) {
+                       return;
+               }
 
-		$this->write_messages( $this->buffer );
-		$this->buffer = array();
-	}
+               $instance->write_messages( $instance->buffer );
+               $instance->buffer = array();
+       }
 
-	/** Write one or more messages to the log. */
-	private function write_messages( array $messages ): void {
-		$info       = $this->get_log_file_info();
+       /** Write one or more messages to the log. */
+       private function write_messages( array $messages ): void {
+               $info       = self::get_log_file_info();
 		$log_folder = $info['dir'];
 		$log_file   = $info['path'];
 		$max_size   = defined( 'NUCLEN_LOG_FILE_MAX_SIZE' ) ? NUCLEN_LOG_FILE_MAX_SIZE : MB_IN_BYTES;
@@ -184,26 +178,28 @@ class LoggingService {
 		}
 	}
 
-	/** Append a message to the plugin log file. */
-	public function log( string $message ): void {
-		if ( $message === '' ) {
-			return;
-		}
+       /** Append a message to the plugin log file. */
+       public static function log( string $message ): void {
+               if ( $message === '' ) {
+                       return;
+               }
 
-		$message = wp_strip_all_tags( $message );
-		if ( strlen( $message ) > 1000 ) {
-			$message = substr( $message, 0, 1000 ) . '...';
-		}
+               $instance = self::instance();
 
-		if ( $this->use_buffer() ) {
-			$this->buffer[] = $message;
-			if ( ! $this->shutdown_registered ) {
-				register_shutdown_function( array( self::class, 'flush' ) );
-				$this->shutdown_registered = true;
-			}
-			return;
-		}
+               $message = wp_strip_all_tags( $message );
+               if ( strlen( $message ) > 1000 ) {
+                       $message = substr( $message, 0, 1000 ) . '...';
+               }
 
-		$this->write_messages( array( $message ) );
-	}
+               if ( $instance->use_buffer() ) {
+                       $instance->buffer[] = $message;
+                       if ( ! $instance->shutdown_registered ) {
+                               register_shutdown_function( array( self::class, 'flush' ) );
+                               $instance->shutdown_registered = true;
+                       }
+                       return;
+               }
+
+               $instance->write_messages( array( $message ) );
+       }
 }


### PR DESCRIPTION
## Summary
- ensure LoggingService methods are static-friendly
- create default instance when used statically

## Testing
- `composer lint` *(fails: command not found)*
- `composer test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685e7dca74a48327b8d99ccca3a99508

<!-- Korbit AI PR Description Start -->
## Description by Korbit AI

### What change is being made?

Modify the `LoggingService` class to use static methods for logging operations, ensuring the correct use of a singleton pattern with a lazy-initialized instance.

### Why are these changes being made?

The previous implementation incorrectly forced instance method calls into a static context, which could lead to runtime errors if the instance was uninitialized. By transitioning to static methods and initializing the singleton instance when needed, the updated design improves robustness and aligns with the intended use of the logging service across various static contexts within the codebase. This ensures consistent and safe access to the logging functionality, which is crucial for tracking and debugging in a reliable manner.

> Is this description stale? Ask me to generate a new description by commenting `/korbit-generate-pr-description`
<!-- Korbit AI PR Description End -->