### PR TITLE
Fix SettingsRepository import

### DIFF
--- a/nuclear-engagement/admin/Settings.php
+++ b/nuclear-engagement/admin/Settings.php
@@ -10,6 +10,8 @@ declare(strict_types=1);
 
 namespace NuclearEngagement\Admin;
 
+use NuclearEngagement\Core\SettingsRepository;
+
 if ( ! defined( 'ABSPATH' ) ) {
 		exit;
 }


### PR DESCRIPTION
## Summary
- reference the correct SettingsRepository in the admin Settings class

## Testing
- `composer lint` *(fails: command not found)*
- `composer test` *(fails: command not found)*
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_685e80b0962083278e0f891c65e3129c

<!-- Korbit AI PR Description Start -->
## Description by Korbit AI

### What change is being made?

Add the `use NuclearEngagement\Core\SettingsRepository;` import statement in the `Settings.php` file within the `NuclearEngagement\Admin` namespace.

### Why are these changes being made?

The import statement for `SettingsRepository` was missing, which likely caused runtime errors when `SettingsRepository` was referenced in the code. Adding the import statement ensures that the `SettingsRepository` class is properly recognized and can be utilized within the `Settings.php` file.

> Is this description stale? Ask me to generate a new description by commenting `/korbit-generate-pr-description`
<!-- Korbit AI PR Description End -->