### PR TITLE
Fix Utils class references in templates

### DIFF
--- a/nuclear-engagement/templates/admin/nuclen-admin-generate.php
+++ b/nuclear-engagement/templates/admin/nuclen-admin-generate.php
@@ -27,7 +27,7 @@ $authors    = get_users( array( 'who' => 'authors' ) );
 // We'll still fetch all public post types, but only show the allowed ones
 $post_types = get_post_types( array( 'public' => true ), 'objects' );
 
-$utils = new \NuclearEngagement\Utils();
+$utils = new \NuclearEngagement\Utils\Utils();
 $utils->display_nuclen_page_header();
 ?>
 

--- a/nuclear-engagement/templates/admin/nuclen-dashboard-page.php
+++ b/nuclear-engagement/templates/admin/nuclen-dashboard-page.php
@@ -15,7 +15,7 @@ use NuclearEngagement\Helpers\SettingsFunctions;
 // Fetch plugin setup info to decide if we show credits
 $fully_setup = ( SettingsFunctions::get_bool( 'connected', false ) && SettingsFunctions::get_bool( 'wp_app_pass_created', false ) );
 
-$utils = new \NuclearEngagement\Utils();
+$utils = new \NuclearEngagement\Utils\Utils();
 $utils->display_nuclen_page_header();
 ?>
 <div class="wrap nuclen-container">


### PR DESCRIPTION
## Summary
- correct Utils namespace in dashboard and generate templates

## Testing
- `composer lint` *(fails: command not found)*
- `composer test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685e8266fc0083278189e8417153decb