### PR TITLE
Fix undefined image_url usage

### DIFF
--- a/nuclear-engagement/templates/admin/page-header.php
+++ b/nuclear-engagement/templates/admin/page-header.php
@@ -1,19 +1,24 @@
 <?php
 declare(strict_types=1);
+
 if ( ! defined( 'ABSPATH' ) ) {
-    exit;
+	exit;
 }
+
+
 /**
- * Admin page header template.
- *
- * Variables:
- *   - $image_url (string) URL to the logo image.
- *
- * @package NuclearEngagement\Admin
- */
+	* Admin page header template.
+	*
+	* Variables:
+	*   - $image_url (string) URL to the logo image.
+	*
+	* @package NuclearEngagement\Admin
+	*/
+
+$image_url = isset( $image_url ) ? (string) $image_url : '';
 ?>
 <div id="nuclen-page-header">
-    <img height="40" width="40" src="<?php echo esc_url( $image_url ); ?>" alt="<?php esc_attr_e( 'Nuclear Engagement Logo', 'nuclear-engagement' ); ?>" />
-    <p><b><?php esc_html_e( 'NUCLEAR ENGAGEMENT', 'nuclear-engagement' ); ?></b></p>
+	<img height="40" width="40" src="<?php echo esc_url( $image_url ); ?>" alt="<?php esc_attr_e( 'Nuclear Engagement Logo', 'nuclear-engagement' ); ?>" />
+	<p><b><?php esc_html_e( 'NUCLEAR ENGAGEMENT', 'nuclear-engagement' ); ?></b></p>
 </div>
 


### PR DESCRIPTION
## Summary
- prevent undefined variable notices in the admin header template

## Testing
- `composer install` *(fails: command not found)*
- `composer lint` *(fails: command not found)*
- `composer test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685e82106f8c83278c5ba3a2be5f0a52

<!-- Korbit AI PR Description Start -->
## Description by Korbit AI

### What change is being made? 

Fix the use of the undefined `$image_url` variable in the admin page header template by initializing it with an empty string if it is not set.

### Why are these changes being made?

These changes prevent potential undefined variable warnings when `$image_url` is not previously defined, ensuring the logo image can be safely used even if the variable has not been set, thereby improving code robustness and eliminating possible errors.

> Is this description stale? Ask me to generate a new description by commenting `/korbit-generate-pr-description`
<!-- Korbit AI PR Description End -->