### PR TITLE
Fix asset paths in AdminAssets trait

### DIFF
--- a/nuclear-engagement/admin/Traits/AdminAssets.php
+++ b/nuclear-engagement/admin/Traits/AdminAssets.php
@@ -23,7 +23,7 @@ trait AdminAssets {
 	public function wp_enqueue_styles() {
 		wp_enqueue_style(
 			$this->nuclen_get_plugin_name(),
-			plugin_dir_url( __FILE__ ) . 'css/nuclen-admin.css',
+plugin_dir_url( dirname( __DIR__ ) ) . 'admin/css/nuclen-admin.css',
 			array(),
 			AssetVersions::get( 'admin_css' ),
 			'all'
@@ -55,7 +55,7 @@ trait AdminAssets {
 				// separately, so no wp-pointer or jQuery dependencies here.
 				wp_enqueue_script(
 					'nuclen-admin',
-					plugin_dir_url( __DIR__ ) . 'admin/js/nuclen-admin.js',
+plugin_dir_url( dirname( __DIR__ ) ) . 'admin/js/nuclen-admin.js',
 					array(),
 					AssetVersions::get( 'admin_js' ),
 					true
@@ -111,7 +111,7 @@ trait AdminAssets {
 		if ( $hook === 'toplevel_page_nuclear-engagement' ) {
 			wp_enqueue_style(
 				$this->nuclen_get_plugin_name() . '-dashboard',
-				plugin_dir_url( __FILE__ ) . 'css/nuclen-admin-dashboard.css?v=' . NUCLEN_ASSET_VERSION,
+plugin_dir_url( dirname( __DIR__ ) ) . 'admin/css/nuclen-admin-dashboard.css?v=' . NUCLEN_ASSET_VERSION,
 				array(),
 				$this->nuclen_get_version(),
 				'all'


### PR DESCRIPTION
## Summary
- correct plugin URL base when enqueuing admin CSS and JS

## Testing
- `composer lint` *(fails: command not found)*
- `composer test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685e8241984c83278e5180a16a18d92e

<!-- Korbit AI PR Description Start -->
## Description by Korbit AI

### What change is being made?

Correct the file paths for assets within the `AdminAssets` trait to ensure proper loading of CSS and JavaScript files in the admin panel.

### Why are these changes being made?

The previous implementation incorrectly used the `__FILE__` constant resulting in incorrect asset paths, which led to assets not being loaded correctly. The updated implementation uses `dirname( __DIR__ )` which correctly points to the directory structure, ensuring assets are properly linked and loaded in the admin interface.

> Is this description stale? Ask me to generate a new description by commenting `/korbit-generate-pr-description`
<!-- Korbit AI PR Description End -->