### PR TITLE
Fix undefined constant error

### DIFF
--- a/nuclear-engagement/inc/Core/SettingsSanitizer.php
+++ b/nuclear-engagement/inc/Core/SettingsSanitizer.php
@@ -99,9 +99,9 @@ final class SettingsSanitizer {
 	 * @return mixed Sanitized value.
 	 */
 	public static function sanitize_setting( string $key, $value ) {
-		if ( isset( self::SANITIZATION_RULES[ $key ] ) ) {
-			$rule = self::SANITIZATION_RULES[ $key ];
-			return is_callable( $rule ) ? call_user_func( $rule, $value ) : $value;
+		if ( defined( __CLASS__ . '::SANITIZATION_RULES' ) && isset( self::SANITIZATION_RULES[ $key ] ) ) {
+		$rule = self::SANITIZATION_RULES[ $key ];
+		return is_callable( $rule ) ? call_user_func( $rule, $value ) : $value;
 		}
 
 		if ( is_array( $value ) ) {


### PR DESCRIPTION
## Summary
- guard `SANITIZATION_RULES` access in `SettingsSanitizer`

## Testing
- `composer lint` *(fails: composer not found)*
- `composer test` *(fails: composer not found)*

------
https://chatgpt.com/codex/tasks/task_e_685e82532c248327b32bafec3c607112

<!-- Korbit AI PR Description Start -->
## Description by Korbit AI

### What change is being made?

Add a check to ensure the `SANITIZATION_RULES` constant is defined before accessing it in the `sanitize_setting` method of the `SettingsSanitizer` class.

### Why are these changes being made?

The change fixes an undefined constant error by verifying that `SANITIZATION_RULES` is defined before usage, preventing potential runtime errors when the constant is missing. This approach ensures the code handles cases where the constant might not be available more gracefully, thereby improving robustness.

> Is this description stale? Ask me to generate a new description by commenting `/korbit-generate-pr-description`
<!-- Korbit AI PR Description End -->