### PR TITLE
Fix onboarding pointers script

### DIFF
--- a/nuclear-engagement/admin/js/onboarding-pointers.js
+++ b/nuclear-engagement/admin/js/onboarding-pointers.js
@@ -12,7 +12,8 @@ function nuclenLog(){
 			try {
 				const l = await fetch( e,t ),{status:c,ok:i} = l,d = await l.text().catch( () => "" ),u = d ? (() => {try {
 						return JSON.parse( d )} catch {}})() :null;if (i) {
-						returnok : ! 0,status :c,data :u};return{ok : ! 1,status :c,data :u,error :d}} catch (l) {
+                                                return { ok: !0, status: c, data: u };
+                                } return { ok: !1, status: c, data: u, error: d } } catch (l) {
 				if (s = l,o === n) {
 					break;
 				}nuclenWarn( `Retrying request to ${e} with method ${t.method || "GET"} (${n - o} attempts left). Error : ${s.message}`,s ),await new Promise( m => setTimeout( m,a ) ),a *= 2}o += 1}nuclenError(

--- a/src/admin/ts/generation/api.ts
+++ b/src/admin/ts/generation/api.ts
@@ -31,11 +31,22 @@ export async function nuclenFetchWithRetry<T = unknown>(
 		}
 		}
 
-		if (ok) {
-		return { ok: true, status, data };
-		}
+                if (ok) {
+                const success: NuclenFetchResult<T> = {
+                        ok: true,
+                        status: status,
+                        data: data,
+                };
+                return success;
+                }
 
-		return { ok: false, status, data, error: bodyText };
+                const fail: NuclenFetchResult<T> = {
+                        ok: false,
+                        status: status,
+                        data: data,
+                        error: bodyText,
+                };
+                return fail;
 	} catch (error: unknown) {
 		lastError = error as Error;
 		if (attempt === retries) {


### PR DESCRIPTION
## Summary
- correct malformed return statement in onboarding-pointers.js
- adjust TypeScript fetch helper to build stable object returns

## Testing
- `composer lint` *(fails: command not found)*
- `composer test` *(fails: command not found)*
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_685e88e125388327aee399ca8b186c39

<!-- Korbit AI PR Description Start -->
## Description by Korbit AI

### What change is being made?

Refactor return statements in `onboarding-pointers.js` and `api.ts` to improve readability by assigning return values to descriptive variables before returning.

### Why are these changes being made?

The refactor enhances code clarity by assigning the objects being returned to variables (`success` or `fail`) before they are returned, making the code more understandable and maintainable without altering the existing logic or functionality.

> Is this description stale? Ask me to generate a new description by commenting `/korbit-generate-pr-description`
<!-- Korbit AI PR Description End -->