### PR TITLE
Fix color picker display on settings page

### DIFF
--- a/nuclear-engagement/admin/css/nuclen-admin.css
+++ b/nuclear-engagement/admin/css/nuclen-admin.css
@@ -171,10 +171,19 @@ Classes for form groups, labels, inputs, and buttons.
 	font-size: 14px;
 }
 
-.nuclen-input:focus {
-		border-color: #007cba;
-		outline: none;
-}
+  .nuclen-input:focus {
+                border-color: #007cba;
+                outline: none;
+  }
+
+  input[type="color"].nuclen-input {
+                min-width: 40px;
+                width: 40px;
+                height: 34px;
+                padding: 0;
+                background: none;
+                border: none;
+  }
 
 /* Utility inputs */
 .nuclen-width-full {


### PR DESCRIPTION
## Summary
- adjust CSS so native color inputs display correctly

## Testing
- `composer lint` *(fails: command not found)*
- `composer test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685e8957bec083278151ee8e33c6615c