### PR TITLE
Fix metabox initialization

### DIFF
--- a/nuclear-engagement/inc/Modules/Quiz/loader.php
+++ b/nuclear-engagement/inc/Modules/Quiz/loader.php
@@ -42,22 +42,17 @@ require_once NUCLEN_QUIZ_DIR . 'Quiz_Shortcode.php';
  * Spin-up
  * ------------------------------------------------------------------
 */
-add_action(
-		'plugins_loaded',
-		static function () {
-				$settings = SettingsRepository::get_instance();
-				$service  = new Quiz_Service();
+$settings = SettingsRepository::get_instance();
+$service  = new Quiz_Service();
 
-				if ( is_admin() ) {
-						( new Quiz_Admin( $settings, $service ) )->register_hooks();
-				} else {
-						$front = new FrontClass(
-								'nuclear-engagement',
-								defined( 'NUCLEN_PLUGIN_VERSION' ) ? NUCLEN_PLUGIN_VERSION : '1.0.0',
-								$settings,
-								new Container()
-						);
-						( new Quiz_Shortcode( $settings, $front, $service ) )->register();
-				}
-		}
-);
+if ( is_admin() ) {
+                ( new Quiz_Admin( $settings, $service ) )->register_hooks();
+} else {
+                $front = new FrontClass(
+                                'nuclear-engagement',
+                                defined( 'NUCLEN_PLUGIN_VERSION' ) ? NUCLEN_PLUGIN_VERSION : '1.0.0',
+                                $settings,
+                                new Container()
+                );
+                ( new Quiz_Shortcode( $settings, $front, $service ) )->register();
+}

--- a/nuclear-engagement/inc/Modules/Summary/loader.php
+++ b/nuclear-engagement/inc/Modules/Summary/loader.php
@@ -37,12 +37,14 @@ require_once NUCLEN_SUMMARY_DIR . 'Nuclen_Summary_Metabox.php';
 ------------------------------------------------------------------
  * Spin-up
  * ------------------------------------------------------------------ */
-add_action(
-	'plugins_loaded',
-	static function () {
-		new Nuclen_Summary_Shortcode( \NuclearEngagement\Core\SettingsRepository::get_instance(), new \NuclearEngagement\Front\FrontClass() );
-		if ( is_admin() ) {
-			new Nuclen_Summary_Metabox( \NuclearEngagement\Core\SettingsRepository::get_instance() );
-		}
-	}
+$settings = \NuclearEngagement\Core\SettingsRepository::get_instance();
+$front    = new \NuclearEngagement\Front\FrontClass(
+        'nuclear-engagement',
+        defined( 'NUCLEN_PLUGIN_VERSION' ) ? NUCLEN_PLUGIN_VERSION : '1.0.0',
+        $settings,
+        new \NuclearEngagement\Core\Container()
 );
+new Nuclen_Summary_Shortcode( $settings, $front );
+if ( is_admin() ) {
+        new Nuclen_Summary_Metabox( $settings );
+}


### PR DESCRIPTION
## Summary
- load Quiz and Summary modules immediately instead of hooking to `plugins_loaded`
- construct `FrontClass` correctly for the Summary module

## Testing
- `composer lint` *(fails: command not found)*
- `composer test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685e8a3bf2e88327a32569ebb4c24dd5