### PR TITLE
Fix plugin logo path

### DIFF
--- a/nuclear-engagement/inc/Utils/Utils.php
+++ b/nuclear-engagement/inc/Utils/Utils.php
@@ -29,7 +29,7 @@ class Utils {
 	 * @return void
 	 */
        public function display_nuclen_page_header(): void {
-               $image_url = plugin_dir_url( __DIR__ ) . 'assets/nuclear-engagement-logo.webp';
+	$image_url = plugin_dir_url( NUCLEN_PLUGIN_FILE ) . 'assets/nuclear-engagement-logo.webp';
                if ( ! filter_var( $image_url, FILTER_VALIDATE_URL ) ) {
                        return;
                }


### PR DESCRIPTION
## Summary
- fix admin page header's logo URL so the image displays correctly

## Testing
- `composer lint` *(fails: command not found)*
- `composer test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685e89f596a88327bc534e7b69e0b09f

<!-- Korbit AI PR Description Start -->
## Description by Korbit AI

### What change is being made?

Fix the plugin logo path by updating the base directory reference in `display_nuclen_page_header()` method.

### Why are these changes being made?

The change corrects the path to the plugin logo by using `NUCLEN_PLUGIN_FILE` as the base, ensuring a valid URL is formed regardless of the current file's directory structure. This prevents potential errors when displaying the logo due to incorrect URL formation.

> Is this description stale? Ask me to generate a new description by commenting `/korbit-generate-pr-description`
<!-- Korbit AI PR Description End -->