### PR TITLE
Add UpdatesResponse tests

### DIFF
--- a/tests/UpdatesResponseTest.php
+++ b/tests/UpdatesResponseTest.php
@@ -1,0 +1,46 @@
+<?php
+use PHPUnit\Framework\TestCase;
+use NuclearEngagement\Responses\UpdatesResponse;
+
+require_once dirname(__DIR__) . '/nuclear-engagement/inc/Responses/UpdatesResponse.php';
+
+class UpdatesResponseTest extends TestCase {
+	public function test_to_array_contains_all_keys(): void {
+		$r = new UpdatesResponse();
+		$r->success = false;
+		$r->processed = 3;
+		$r->total = 5;
+		$r->results = array( 'a' => true );
+		$r->workflow = 'quiz';
+		$r->remainingCredits = 7;
+		$r->message = 'ok';
+		$r->statusCode = 200;
+
+		$data = $r->toArray();
+
+		$this->assertArrayHasKey('success', $data);
+		$this->assertArrayHasKey('processed', $data);
+		$this->assertArrayHasKey('total', $data);
+		$this->assertArrayHasKey('results', $data);
+		$this->assertArrayHasKey('workflow', $data);
+		$this->assertArrayHasKey('remaining_credits', $data);
+		$this->assertArrayHasKey('message', $data);
+		$this->assertArrayHasKey('status_code', $data);
+	}
+
+	public function test_to_array_omits_null_properties(): void {
+		$r = new UpdatesResponse();
+		$r->processed = 1;
+
+		$data = $r->toArray();
+
+		$this->assertArrayHasKey('success', $data);
+		$this->assertArrayHasKey('processed', $data);
+		$this->assertArrayNotHasKey('total', $data);
+		$this->assertArrayNotHasKey('results', $data);
+		$this->assertArrayNotHasKey('workflow', $data);
+		$this->assertArrayNotHasKey('remaining_credits', $data);
+		$this->assertArrayNotHasKey('message', $data);
+		$this->assertArrayNotHasKey('status_code', $data);
+	}
+}


### PR DESCRIPTION
## Summary
- add unit test covering UpdatesResponse::toArray

## Testing
- `composer lint` *(fails: command not found)*
- `composer test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685e875a1560832780ece7f00da35a58


> [!NOTE]
> I'm currently writing a description for your pull request. I should be done shortly (<1 minute). Please don't edit the description field until I'm finished, or we may overwrite each other. If I find nothing to write about, I'll delete this message.
