### PR TITLE
Add settings helper unit tests

### DIFF
--- a/tests/SettingsFunctionsTest.php
+++ b/tests/SettingsFunctionsTest.php
@@ -1,0 +1,41 @@
+<?php
+use PHPUnit\Framework\TestCase;
+use NuclearEngagement\Helpers\SettingsHelper;
+use NuclearEngagement\Helpers\SettingsFunctions;
+
+require_once dirname(__DIR__) . '/nuclear-engagement/inc/Helpers/SettingsHelper.php';
+require_once dirname(__DIR__) . '/nuclear-engagement/inc/Helpers/SettingsFunctions.php';
+
+class DummyRepo2 {
+public function all(): array { return ['baz' => 'qux']; }
+public function get(string $key, $default = null) { return 'g_' . $key; }
+public function get_bool(string $key, bool $default = false): bool { return false; }
+public function get_int(string $key, int $default = 0): int { return 7; }
+public function get_string(string $key, string $default = ''): string { return 'ok'; }
+public function get_array(string $key, array $default = array()): array { return ['x']; }
+}
+
+class SettingsFunctionsTest extends TestCase {
+private DummyRepo2 $repo;
+private \ReflectionProperty $prop;
+
+protected function setUp(): void {
+$this->repo = new DummyRepo2();
+$this->prop = new \ReflectionProperty(SettingsHelper::class, 'repo');
+$this->prop->setAccessible(true);
+$this->prop->setValue(null, $this->repo);
+}
+
+protected function tearDown(): void {
+$this->prop->setValue(null, null);
+}
+
+public function test_wrappers_proxy_helper_methods(): void {
+$this->assertSame(['baz' => 'qux'], SettingsFunctions::get());
+$this->assertSame('g_name', SettingsFunctions::get('name'));
+$this->assertFalse(SettingsFunctions::get_bool('flag'));
+$this->assertSame(7, SettingsFunctions::get_int('num'));
+$this->assertSame('ok', SettingsFunctions::get_string('text'));
+$this->assertSame(['x'], SettingsFunctions::get_array('arr'));
+}
+}

--- a/tests/SettingsHelperTest.php
+++ b/tests/SettingsHelperTest.php
@@ -1,0 +1,55 @@
+<?php
+use PHPUnit\Framework\TestCase;
+use NuclearEngagement\Helpers\SettingsHelper;
+
+require_once dirname(__DIR__) . '/nuclear-engagement/inc/Helpers/SettingsHelper.php';
+require_once dirname(__DIR__) . '/nuclear-engagement/inc/Core/SettingsRepository.php';
+
+class DummySettingsRepository {
+public function all(): array { return ['foo' => 'bar']; }
+public function get(string $key, $default = null) { return 'val_' . $key; }
+public function get_bool(string $key, bool $default = false): bool { return true; }
+public function get_int(string $key, int $default = 0): int { return 99; }
+public function get_string(string $key, string $default = ''): string { return 'str'; }
+public function get_array(string $key, array $default = array()): array { return ['a', 'b']; }
+}
+
+class SettingsHelperTest extends TestCase {
+private DummySettingsRepository $repo;
+private \ReflectionProperty $prop;
+
+protected function setUp(): void {
+$this->repo = new DummySettingsRepository();
+$this->prop = new \ReflectionProperty(SettingsHelper::class, 'repo');
+$this->prop->setAccessible(true);
+$this->prop->setValue(null, $this->repo);
+}
+
+protected function tearDown(): void {
+$this->prop->setValue(null, null);
+}
+
+public function test_get_returns_all_when_no_key(): void {
+$this->assertSame(['foo' => 'bar'], SettingsHelper::get());
+}
+
+public function test_get_returns_specific_value(): void {
+$this->assertSame('val_key', SettingsHelper::get('key'));
+}
+
+public function test_get_bool_proxies_repository(): void {
+$this->assertTrue(SettingsHelper::get_bool('flag'));
+}
+
+public function test_get_int_proxies_repository(): void {
+$this->assertSame(99, SettingsHelper::get_int('num'));
+}
+
+public function test_get_string_proxies_repository(): void {
+$this->assertSame('str', SettingsHelper::get_string('text'));
+}
+
+public function test_get_array_proxies_repository(): void {
+$this->assertSame(['a', 'b'], SettingsHelper::get_array('arr'));
+}
+}


### PR DESCRIPTION
## Summary
- add unit tests for SettingsHelper behavior
- verify SettingsFunctions wrappers return same values

## Testing
- `composer lint --working-dir=nuclear-engagement` *(fails: composer not found)*
- `composer test --working-dir=nuclear-engagement` *(fails: composer not found)*

------
https://chatgpt.com/codex/tasks/task_e_685e875c746c83279d5c767661474d74

<!-- Korbit AI PR Description Start -->
## Description by Korbit AI

### What change is being made?

Add unit tests for `SettingsHelper` and `SettingsFunctions` classes to verify that their methods correctly proxy calls to their respective repositories.

### Why are these changes being made?

These changes establish a set of unit tests to ensure that the `SettingsHelper` and `SettingsFunctions` classes are functioning correctly and returning expected results. This ensures code reliability and facilitates future modifications by providing immediate feedback if a change causes a function to behave incorrectly. By testing the proxy mechanism, these tests also ensure that the integration between helper and repository is functioning as expected.

> Is this description stale? Ask me to generate a new description by commenting `/korbit-generate-pr-description`
<!-- Korbit AI PR Description End -->