### PR TITLE
Add ContentRequest unit tests

### DIFF
--- a/tests/ContentRequestTest.php
+++ b/tests/ContentRequestTest.php
@@ -1,0 +1,39 @@
+<?php
+use PHPUnit\Framework\TestCase;
+use NuclearEngagement\Requests\ContentRequest;
+
+if (!function_exists('sanitize_text_field')) {
+	function sanitize_text_field($text) {
+		return is_string($text) ? trim($text) : '';
+	}
+}
+
+require_once dirname(__DIR__) . '/nuclear-engagement/inc/Requests/ContentRequest.php';
+
+class ContentRequestTest extends TestCase {
+	public function test_from_json_success(): void {
+		$data = [
+			'workflow' => ' quiz ',
+			'results'  => [1 => ['a' => 'b']],
+		];
+		$req = ContentRequest::fromJson($data);
+		$this->assertInstanceOf(ContentRequest::class, $req);
+		$this->assertSame('quiz', $req->workflow);
+		$this->assertSame($data['results'], $req->results);
+	}
+
+	public function test_from_json_missing_workflow_throws(): void {
+		$this->expectException(InvalidArgumentException::class);
+		ContentRequest::fromJson(['results' => []]);
+	}
+
+	public function test_from_json_missing_results_throws(): void {
+		$this->expectException(InvalidArgumentException::class);
+		ContentRequest::fromJson(['workflow' => 'summary']);
+	}
+
+	public function test_from_json_nonarray_results_throws(): void {
+		$this->expectException(InvalidArgumentException::class);
+		ContentRequest::fromJson(['workflow' => 'summary', 'results' => 'fail']);
+	}
+}


### PR DESCRIPTION
## Summary
- add `ContentRequestTest` covering success and failure cases

## Testing
- `composer lint` *(fails: command not found)*
- `composer test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685e87559a488327894c24e8154aae73

<!-- Korbit AI PR Description Start -->
## Description by Korbit AI

### What change is being made?

Add unit tests for the `ContentRequest` class to ensure its correct behavior when handling JSON data.

### Why are these changes being made?

These changes are being made to verify the robustness and correctness of the `ContentRequest::fromJson()` method by testing various scenarios, including correct case handling, and edge cases that should throw exceptions. This enhances code reliability and helps catch potential regressions in the future.

> Is this description stale? Ask me to generate a new description by commenting `/korbit-generate-pr-description`
<!-- Korbit AI PR Description End -->