### PR TITLE
Add UpdatesRequest tests

### DIFF
--- a/tests/UpdatesRequestTest.php
+++ b/tests/UpdatesRequestTest.php
@@ -1,0 +1,26 @@
+<?php
+namespace {
+	use PHPUnit\Framework\TestCase;
+	use NuclearEngagement\Requests\UpdatesRequest;
+
+	if ( ! function_exists( 'sanitize_text_field' ) ) {
+		function sanitize_text_field( $t ) { return is_string( $t ) ? trim( $t ) : ''; }
+	}
+	if ( ! function_exists( 'wp_unslash' ) ) {
+		function wp_unslash( $v ) { return $v; }
+	}
+
+	require_once __DIR__ . '/../nuclear-engagement/inc/Requests/UpdatesRequest.php';
+
+	class UpdatesRequestTest extends TestCase {
+		public function test_from_post_returns_generation_id(): void {
+			$req = UpdatesRequest::fromPost( [ 'generation_id' => ' gid ' ] );
+			$this->assertSame( 'gid', $req->generationId );
+		}
+
+		public function test_from_post_missing_generation_id_returns_empty_string(): void {
+			$req = UpdatesRequest::fromPost( [] );
+			$this->assertSame( '', $req->generationId );
+		}
+	}
+}


### PR DESCRIPTION
## Summary
- add `tests/UpdatesRequestTest.php` for UpdatesRequest::fromPost

## Testing
- `composer lint --working-dir=nuclear-engagement` *(fails: command not found)*
- `composer test --working-dir=nuclear-engagement` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685e875727f483278e0419439305fbed

<!-- Korbit AI PR Description Start -->
## Description by Korbit AI

### What change is being made?

Add unit tests for the `UpdatesRequest` class to validate the correct handling of requests and associated fields.

### Why are these changes being made?

These changes ensure the functionality of the `UpdatesRequest` class is verified, specifically the correct processing of the `generation_id` field. The tests simulate typical inputs and confirm expected outcomes, aligning with best practices in software development for maintaining code quality and preventing future regressions.

> Is this description stale? Ask me to generate a new description by commenting `/korbit-generate-pr-description`
<!-- Korbit AI PR Description End -->