### PR TITLE
Add GenerateRequest tests

### DIFF
--- a/tests/GenerateRequestTest.php
+++ b/tests/GenerateRequestTest.php
@@ -1,0 +1,85 @@
+<?php
+namespace {
+	use PHPUnit\Framework\TestCase;
+	use NuclearEngagement\Requests\GenerateRequest;
+
+	if ( ! defined( 'NUCLEN_SUMMARY_LENGTH_MIN' ) ) {
+		define( 'NUCLEN_SUMMARY_LENGTH_MIN', 20 );
+	}
+	if ( ! defined( 'NUCLEN_SUMMARY_LENGTH_MAX' ) ) {
+		define( 'NUCLEN_SUMMARY_LENGTH_MAX', 50 );
+	}
+	if ( ! defined( 'NUCLEN_SUMMARY_LENGTH_DEFAULT' ) ) {
+		define( 'NUCLEN_SUMMARY_LENGTH_DEFAULT', 30 );
+	}
+	if ( ! defined( 'NUCLEN_SUMMARY_ITEMS_MIN' ) ) {
+		define( 'NUCLEN_SUMMARY_ITEMS_MIN', 3 );
+	}
+	if ( ! defined( 'NUCLEN_SUMMARY_ITEMS_MAX' ) ) {
+		define( 'NUCLEN_SUMMARY_ITEMS_MAX', 7 );
+	}
+	if ( ! defined( 'NUCLEN_SUMMARY_ITEMS_DEFAULT' ) ) {
+		define( 'NUCLEN_SUMMARY_ITEMS_DEFAULT', 3 );
+	}
+	if ( ! function_exists( 'sanitize_text_field' ) ) {
+		function sanitize_text_field( $t ) { return $t; }
+	}
+	if ( ! function_exists( 'wp_unslash' ) ) {
+		function wp_unslash( $v ) { return $v; }
+	}
+
+	require_once dirname( __DIR__ ) . '/nuclear-engagement/inc/Requests/GenerateRequest.php';
+
+	class GenerateRequestTest extends TestCase {
+		public function test_valid_payload_produces_expected_values(): void {
+			$post = array(
+				'payload' => json_encode( array(
+					'nuclen_selected_post_ids' => json_encode( array( 3, 4 ) ),
+					'nuclen_selected_post_status' => 'draft',
+					'nuclen_selected_post_type' => 'page',
+					'nuclen_selected_generate_workflow' => 'quiz',
+					'nuclen_selected_summary_format' => 'bullet_list',
+					'nuclen_selected_summary_length' => 40,
+					'nuclen_selected_summary_number_of_items' => 5,
+					'generation_id' => 'abc123',
+				) )
+			);
+			$req = GenerateRequest::fromPost( $post );
+			$this->assertSame( array( 3, 4 ), $req->postIds );
+			$this->assertSame( 'draft', $req->postStatus );
+			$this->assertSame( 'page', $req->postType );
+			$this->assertSame( 'quiz', $req->workflowType );
+			$this->assertSame( 'bullet_list', $req->summaryFormat );
+			$this->assertSame( 40, $req->summaryLength );
+			$this->assertSame( 5, $req->summaryItems );
+			$this->assertSame( 'abc123', $req->generationId );
+		}
+
+		public function test_invalid_json_triggers_exception(): void {
+			$this->expectException( \InvalidArgumentException::class );
+			GenerateRequest::fromPost( array( 'payload' => '{bad' ) );
+		}
+
+		public function test_invalid_post_ids_throw_exception(): void {
+			$post = array(
+				'payload' => json_encode( array(
+					'nuclen_selected_post_ids' => json_encode( array( 0, -2 ) ),
+					'nuclen_selected_generate_workflow' => 'quiz',
+				) )
+			);
+			$this->expectException( \InvalidArgumentException::class );
+			GenerateRequest::fromPost( $post );
+		}
+
+		public function test_invalid_workflow_throws_exception(): void {
+			$post = array(
+				'payload' => json_encode( array(
+					'nuclen_selected_post_ids' => json_encode( array( 1 ) ),
+					'nuclen_selected_generate_workflow' => 'foo',
+				) )
+			);
+			$this->expectException( \InvalidArgumentException::class );
+			GenerateRequest::fromPost( $post );
+		}
+	}
+}


### PR DESCRIPTION
## Summary
- add GenerateRequestTest covering request parsing

## Testing
- `composer lint` *(fails: command not found)*
- `composer test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685e8bf9fe2c8327a15bd679f559c67e

<!-- Korbit AI PR Description Start -->
## Description by Korbit AI

### What change is being made?

Add unit tests for the `GenerateRequest` class in the `NuclearEngagement\Requests` namespace using PHPUnit.

### Why are these changes being made?

These changes ensure that the `GenerateRequest` class accurately processes valid input and correctly handles various invalid inputs by triggering exceptions. This addition helps maintain code reliability and functionality by validating that the class performs as intended per expected use cases.

> Is this description stale? Ask me to generate a new description by commenting `/korbit-generate-pr-description`
<!-- Korbit AI PR Description End -->