### PR TITLE
Flush post inventory cache on settings save

### DIFF
--- a/nuclear-engagement/inc/Traits/SettingsPersistenceTrait.php
+++ b/nuclear-engagement/inc/Traits/SettingsPersistenceTrait.php
@@ -46,9 +46,12 @@ trait SettingsPersistenceTrait {
 		// Only update if settings have changed.
 		if ( $merged !== $current ) {
 			$autoload = $this->should_autoload( $merged );
-			$result   = update_option( self::OPTION, $merged, $autoload ? 'yes' : 'no' );
+                        $result   = update_option( self::OPTION, $merged, $autoload ? 'yes' : 'no' );
+                        if ( $result ) {
+                                \NuclearEngagement\Core\InventoryCache::clear();
+                        }
 
-			// Also update legacy option for backward compatibility.
+                        // Also update legacy option for backward compatibility.
 			if ( $result && false !== get_option( 'nuclear_engagement_setup' ) ) {
 				$legacy_data = array(
 					'api_key'             => $merged['api_key'] ?? '',


### PR DESCRIPTION
## Summary
- ensure InventoryCache is cleared whenever plugin settings are saved
- cover new behaviour in SettingsRepositoryTest

## Testing
- `composer lint` *(fails: command not found)*
- `composer test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685e8b1dd14c8327b196e6a05849308a

<!-- Korbit AI PR Description Start -->
## Description by Korbit AI

### What change is being made?

Flush the post inventory cache when settings are saved, and add corresponding tests to ensure this functionality.

### Why are these changes being made?

The changes ensure consistency and prevent stale data by clearing the inventory cache whenever settings are updated. This approach helps maintain synchronization between the configuration saved in the system and the associated cached inventory data. The added test case verifies that the inventory cache is correctly cleared upon saving new settings.

> Is this description stale? Ask me to generate a new description by commenting `/korbit-generate-pr-description`
<!-- Korbit AI PR Description End -->