### PR TITLE
Refactor bootstrap logic into Bootloader

### DIFF
--- a/nuclear-engagement/bootstrap.php
+++ b/nuclear-engagement/bootstrap.php
@@ -3,10 +3,6 @@
 declare(strict_types=1);
 
 use NuclearEngagement\Core\Bootloader;
-use NuclearEngagement\Core\MetaRegistration;
-use NuclearEngagement\Core\Plugin;
-use NuclearEngagement\Core\InventoryCache;
-use NuclearEngagement\Services\PostsQueryService;
 
 if ( ! defined( 'ABSPATH' ) ) {
 	exit;
@@ -15,76 +11,3 @@ if ( ! defined( 'ABSPATH' ) ) {
 require_once __DIR__ . '/inc/Core/Bootloader.php';
 
 Bootloader::init();
-
-/**
- * Load the plugin text domain for translations.
- *
- * This enables localization by loading translation files from the
- * languages directory.
- *
- * @return void
- */
-function nuclear_engagement_load_textdomain() {
-	load_plugin_textdomain(
-		'nuclear-engagement',
-		false,
-		dirname( plugin_basename( NUCLEN_PLUGIN_FILE ) ) . '/languages/'
-	);
-}
-
-/**
- * Redirect to the setup screen on plugin activation.
- *
- * Checks a transient set during activation and, if present, redirects the
- * administrator to the plugin setup page.
- *
- * @return void
- */
-function nuclear_engagement_redirect_on_activation() {
-	if ( get_transient( 'nuclen_plugin_activation_redirect' ) ) {
-		delete_transient( 'nuclen_plugin_activation_redirect' );
-		if ( is_admin() && ! ( defined( 'DOING_AJAX' ) && DOING_AJAX ) ) {
-			wp_safe_redirect( admin_url( 'admin.php?page=nuclear-engagement-setup' ) );
-			exit;
-		}
-	}
-}
-
-/**
- * Initialize and execute the core plugin logic.
- *
- * Sets up meta registration and runs the main plugin class.
- *
- * @return void
- */
-function nuclear_engagement_run_plugin() {
-	MetaRegistration::init();
-	$plugin = new Plugin();
-	$plugin->nuclen_run();
-}
-
-/**
- * Register services and bootstrap the plugin.
- *
- * Sets up caching, query services and other runtime hooks, then
- * runs the plugin.
- *
- * @return void
- */
-function nuclear_engagement_init() {
-	try {
-		InventoryCache::register_hooks();
-		PostsQueryService::register_hooks();
-		\NuclearEngagement\Services\PostDataFetcher::register_hooks();
-	} catch ( \Throwable $e ) {
-		\NuclearEngagement\Services\LoggingService::log( 'Nuclear Engagement: Cache system initialization failed - ' . $e->getMessage() );
-		add_action(
-			'admin_notices',
-			static function () {
-				echo '<div class="error"><p>Nuclear Engagement: Cache system initialization failed.</p></div>';
-			}
-		);
-	}
-
-	nuclear_engagement_run_plugin();
-}

--- a/tests/BootstrapTest.php
+++ b/tests/BootstrapTest.php
@@ -29,13 +29,13 @@ class BootstrapTest extends TestCase {
 	public function test_hooks_registered(): void {
 		$found_plugins_loaded = false;
 		$found_init = false;
-		foreach ( $GLOBALS['test_actions'] as $args ) {
-			if ( $args[0] === 'plugins_loaded' && $args[1] === 'nuclear_engagement_init' ) {
-				$found_plugins_loaded = true;
-			}
-			if ( $args[0] === 'init' && $args[1] === 'nuclear_engagement_load_textdomain' ) {
-				$found_init = true;
-			}
+               foreach ( $GLOBALS['test_actions'] as $args ) {
+                       if ( $args[0] === 'plugins_loaded' && $args[1] === array( \NuclearEngagement\Core\Bootloader::class, 'init_plugin' ) ) {
+                               $found_plugins_loaded = true;
+                       }
+                       if ( $args[0] === 'init' && $args[1] === array( \NuclearEngagement\Core\Bootloader::class, 'load_textdomain' ) ) {
+                               $found_init = true;
+                       }
 		}
 		$this->assertTrue( $found_plugins_loaded, 'plugins_loaded hook not registered' );
 		$this->assertTrue( $found_init, 'init hook not registered' );


### PR DESCRIPTION
## Summary
- move bootstrap functions into `Bootloader` static methods
- simplify `bootstrap.php` to only run Bootloader
- reference new methods when registering WordPress hooks
- update unit tests for new hook callbacks

## Testing
- `composer lint` *(fails: composer not found)*
- `composer test` *(fails: composer not found)*

------
https://chatgpt.com/codex/tasks/task_e_685f71b311948327acc8cf2690c0daf1


> [!NOTE]
> I'm currently writing a description for your pull request. I should be done shortly (<1 minute). Please don't edit the description field until I'm finished, or we may overwrite each other. If I find nothing to write about, I'll delete this message.
