### PR TITLE
Register admin script for early use

### DIFF
--- a/nuclear-engagement/admin/Admin.php
+++ b/nuclear-engagement/admin/Admin.php
@@ -48,12 +48,13 @@ class Admin {
 		$this->version             = $version;
 		$this->utils               = new Utils();
 		$this->settings_repository = $settings_repository;
-		$this->container           = $container;
+               $this->container           = $container;
 
 // Meta-boxes handled by module loader
 
-		// AJAX & assets
-		add_action( 'wp_ajax_nuclen_fetch_app_updates', array( $this, 'nuclen_fetch_app_updates' ) );
+               // AJAX & assets
+               add_action( 'init', array( $this, 'nuclen_register_admin_scripts' ), 9 );
+               add_action( 'wp_ajax_nuclen_fetch_app_updates', array( $this, 'nuclen_fetch_app_updates' ) );
 		add_action( 'admin_enqueue_scripts', array( $this, 'wp_enqueue_scripts' ) );
 		add_action( 'admin_enqueue_scripts', array( $this, 'wp_enqueue_styles' ) );
 		add_action( 'admin_enqueue_scripts', array( $this, 'nuclen_enqueue_dashboard_styles' ) );

--- a/nuclear-engagement/admin/Traits/AdminAssets.php
+++ b/nuclear-engagement/admin/Traits/AdminAssets.php
@@ -18,6 +18,19 @@ if ( ! defined( 'ABSPATH' ) ) {
 trait AdminAssets {
 
 	/**
+	 * Register the admin script for later use.
+	 */
+	public function nuclen_register_admin_scripts() {
+	wp_register_script(
+	'nuclen-admin',
+	plugin_dir_url( dirname( __DIR__ ) ) . 'admin/js/nuclen-admin.js',
+	array(),
+	AssetVersions::get( 'admin_js' ),
+	true
+	);
+	}
+
+	/**
 	 * Enqueue base admin CSS for all plugin admin screens.
 	 */
 	public function wp_enqueue_styles() {


### PR DESCRIPTION
## Summary
- add nuclen_register_admin_scripts() to AdminAssets
- register admin script on `init` so blocks can find the handle

## Testing
- `composer lint` *(fails: command not found)*
- `composer test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685f760668f48327b279a892df8037c6

<!-- Korbit AI PR Description Start -->
## Description by Korbit AI

### What change is being made?

Register the admin script early in the process by adding a new action hook in the constructor and implementing the script registration logic.

### Why are these changes being made?

These changes ensure that the admin script is registered early during initialization (`init` hook with a priority of 9), improving script management and preventing issues that may occur due to late script registration in the WordPress admin panel. This approach aligns with the best practices for script management within WordPress plugins.

> Is this description stale? Ask me to generate a new description by commenting `/korbit-generate-pr-description`
<!-- Korbit AI PR Description End -->