### PR TITLE
Improve meta update logic

### DIFF
--- a/nuclear-engagement/inc/Services/ContentStorageService.php
+++ b/nuclear-engagement/inc/Services/ContentStorageService.php
@@ -142,8 +142,17 @@ class ContentStorageService {
 				'date'      => $data['date'] ?? current_time( 'mysql' ),
 			);
 
-			if ( ! update_post_meta( $postId, 'nuclen-quiz-data', $formatted ) ) {
-					throw new \RuntimeException( "Failed to update quiz data for post {$postId}" );
+			$current = get_post_meta( $postId, 'nuclen-quiz-data', true );
+			if ( $current === $formatted ) {
+			return;
+			}
+
+			$updated = update_post_meta( $postId, 'nuclen-quiz-data', $formatted );
+			if ( $updated === false ) {
+			$check = get_post_meta( $postId, 'nuclen-quiz-data', true );
+			if ( $check !== $formatted ) {
+			throw new \RuntimeException( "Failed to update quiz data for post {$postId}" );
+			}
 			}
 	}
 
@@ -190,9 +199,18 @@ class ContentStorageService {
 			'date'    => $data['date'] ?? current_time( 'mysql' ),
 		);
 
-		if ( ! update_post_meta( $postId, Summary_Service::META_KEY, $formatted ) ) {
+			$current = get_post_meta( $postId, Summary_Service::META_KEY, true );
+			if ( $current === $formatted ) {
+			return;
+			}
+
+			$updated = update_post_meta( $postId, Summary_Service::META_KEY, $formatted );
+			if ( $updated === false ) {
+			$check = get_post_meta( $postId, Summary_Service::META_KEY, true );
+			if ( $check !== $formatted ) {
 			throw new \RuntimeException( "Failed to update summary data for post {$postId}" );
-		}
+			}
+			}
 	}
 
 	/**


### PR DESCRIPTION
## Summary
- check existing post meta before updating quiz data or summary data
- only throw an error if `update_post_meta` fails and the stored value isn't updated

## Testing
- `composer lint` *(fails: command not found)*
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_685f760752a8832794700f8dc1d10b05


> [!NOTE]
> I'm currently writing a description for your pull request. I should be done shortly (<1 minute). Please don't edit the description field until I'm finished, or we may overwrite each other. If I find nothing to write about, I'll delete this message.
