### PR TITLE
Handle meta match on update failure

### DIFF
--- a/nuclear-engagement/inc/Services/ContentStorageService.php
+++ b/nuclear-engagement/inc/Services/ContentStorageService.php
@@ -143,7 +143,10 @@ class ContentStorageService {
 			);
 
 			if ( ! update_post_meta( $postId, 'nuclen-quiz-data', $formatted ) ) {
+				$existing = get_post_meta( $postId, 'nuclen-quiz-data', true );
+				if ( $existing !== $formatted ) {
 					throw new \RuntimeException( "Failed to update quiz data for post {$postId}" );
+				}
 			}
 	}
 
@@ -190,9 +193,12 @@ class ContentStorageService {
 			'date'    => $data['date'] ?? current_time( 'mysql' ),
 		);
 
-		if ( ! update_post_meta( $postId, Summary_Service::META_KEY, $formatted ) ) {
-			throw new \RuntimeException( "Failed to update summary data for post {$postId}" );
-		}
+			if ( ! update_post_meta( $postId, Summary_Service::META_KEY, $formatted ) ) {
+				$existing = get_post_meta( $postId, Summary_Service::META_KEY, true );
+				if ( $existing !== $formatted ) {
+					throw new \RuntimeException( "Failed to update summary data for post {$postId}" );
+				}
+			}
 	}
 
 	/**

--- a/tests/ContentStorageServiceFailureTest.php
+++ b/tests/ContentStorageServiceFailureTest.php
@@ -10,6 +10,7 @@ namespace {
 	use PHPUnit\Framework\TestCase;
 	use NuclearEngagement\Services\ContentStorageService;
 	use NuclearEngagement\Core\SettingsRepository;
+	use NuclearEngagement\Modules\Summary\Summary_Service;
 
 	class ContentStorageServiceFailureTest extends TestCase {
 		protected function setUp(): void {
@@ -18,13 +19,22 @@ namespace {
 			SettingsRepository::reset_for_tests();
 		}
 
-		public function test_store_results_returns_failure_status(): void {
+		public function test_store_results_succeeds_when_meta_matches(): void {
 			$settings = SettingsRepository::get_instance();
-			$service = new ContentStorageService($settings);
-			$data = ['summary' => 'S'];
-			$result = $service->storeResults([1 => $data], 'summary');
-			$this->assertSame('Failed to update summary data for post 1', $result[1]);
+			$service  = new ContentStorageService($settings);
+			$data     = ['summary' => 'S', 'date' => '2025-01-01'];
+			$GLOBALS['wp_meta'][1][Summary_Service::META_KEY] = $data;
+			$result   = $service->storeResults([1 => $data], 'summary');
+			$this->assertTrue($result[1]);
+		}
+
+		public function test_store_results_returns_failure_status_for_mismatch(): void {
+			$settings = SettingsRepository::get_instance();
+			$service  = new ContentStorageService($settings);
+			$data     = ['summary' => 'S', 'date' => '2025-01-01'];
+			$GLOBALS['wp_meta'][2][Summary_Service::META_KEY] = ['summary' => 'X', 'date' => '2025-01-01'];
+			$result   = $service->storeResults([2 => $data], 'summary');
+			$this->assertSame('Failed to update summary data for post 2', $result[2]);
 		}
 	}
 }
-


### PR DESCRIPTION
## Summary
- allow `ContentStorageService` to succeed when update fails but existing meta matches
- expand tests for `ContentStorageService` failure handling

## Testing
- `composer lint` *(fails: command not found)*
- `composer test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685f7607c7d0832788f5e5c9824cc917

<!-- Korbit AI PR Description Start -->
## Description by Korbit AI

### What change is being made?

Add logic to handle cases where metadata update failures occur only if the existing metadata differs from the new data, and update unit tests to validate this behavior.

### Why are these changes being made? 

Previously, metadata update failures were thrown regardless of whether the metadata actually changed, potentially causing false negative error reports. By adding a check for data equality before throwing an exception, we ensure that update failures are only reported when there is an actual discrepancy, thus improving data integrity handling and reducing unnecessary error reporting. Unit tests have been updated to reflect and verify this new behavior.

> Is this description stale? Ask me to generate a new description by commenting `/korbit-generate-pr-description`
<!-- Korbit AI PR Description End -->