### PR TITLE
Update header image URL

### DIFF
--- a/nuclear-engagement/inc/Utils/Utils.php
+++ b/nuclear-engagement/inc/Utils/Utils.php
@@ -29,7 +29,7 @@ class Utils {
 	 * @return void
 	 */
        public function display_nuclen_page_header(): void {
-	$image_url = plugin_dir_url( NUCLEN_PLUGIN_FILE ) . 'assets/nuclear-engagement-logo.webp';
+$image_url = plugins_url( 'assets/nuclear-engagement-logo.webp', NUCLEN_PLUGIN_FILE );
                if ( ! filter_var( $image_url, FILTER_VALIDATE_URL ) ) {
                        return;
                }


### PR DESCRIPTION
## Summary
- point page header image URL to plugin assets

## Testing
- `composer lint` *(fails: composer not found)*
- `composer test` *(fails: composer not found)*

------
https://chatgpt.com/codex/tasks/task_e_685f79e4100c83278388c47641a05871

<!-- Korbit AI PR Description Start -->
## Description by Korbit AI

### What change is being made?

Update the function `display_nuclen_page_header` to use `plugins_url` for generating the header image URL.

### Why are these changes being made?

The change improves URL generation by using `plugins_url`, which is more appropriate for plugin assets and ensures correct handling of URLs regardless of the plugin's location, resolving any potential issues with incorrect URL formation previously observed with `plugin_dir_url`.

> Is this description stale? Ask me to generate a new description by commenting `/korbit-generate-pr-description`
<!-- Korbit AI PR Description End -->