### PR TITLE
Fix PHP indent to tabs

### DIFF
--- a/nuclear-engagement/admin/Admin.php
+++ b/nuclear-engagement/admin/Admin.php
@@ -1,12 +1,12 @@
 <?php
 declare(strict_types=1);
 /**
- * File: admin/Admin.php
- *
- * Main Admin Class for Nuclear Engagement Plugin
- *
- * @package NuclearEngagement\Admin
- */
+	* File: admin/Admin.php
+	*
+	* Main Admin Class for Nuclear Engagement Plugin
+	*
+	* @package NuclearEngagement\Admin
+	*/
 
 namespace NuclearEngagement\Admin;
 
@@ -48,13 +48,13 @@ class Admin {
 		$this->version             = $version;
 		$this->utils               = new Utils();
 		$this->settings_repository = $settings_repository;
-               $this->container           = $container;
+				$this->container           = $container;
 
 // Meta-boxes handled by module loader
 
-               // AJAX & assets
-               add_action( 'init', array( $this, 'nuclen_register_admin_scripts' ), 9 );
-               add_action( 'wp_ajax_nuclen_fetch_app_updates', array( $this, 'nuclen_fetch_app_updates' ) );
+				// AJAX & assets
+				add_action( 'init', array( $this, 'nuclen_register_admin_scripts' ), 9 );
+				add_action( 'wp_ajax_nuclen_fetch_app_updates', array( $this, 'nuclen_fetch_app_updates' ) );
 		add_action( 'admin_enqueue_scripts', array( $this, 'wp_enqueue_scripts' ) );
 		add_action( 'admin_enqueue_scripts', array( $this, 'wp_enqueue_styles' ) );
 		add_action( 'admin_enqueue_scripts', array( $this, 'nuclen_enqueue_dashboard_styles' ) );

--- a/nuclear-engagement/admin/Dashboard.php
+++ b/nuclear-engagement/admin/Dashboard.php
@@ -1,12 +1,12 @@
 <?php
 declare(strict_types=1);
 /**
- * File: admin/Dashboard.php
- *
- * Handles data preparation and rendering for the admin dashboard.
- *
- * @package NuclearEngagement\Admin
- */
+	* File: admin/Dashboard.php
+	*
+	* Handles data preparation and rendering for the admin dashboard.
+	*
+	* @package NuclearEngagement\Admin
+	*/
 
 namespace NuclearEngagement\Admin;
 
@@ -32,192 +32,192 @@ $this->data_service = $data_service;
 }
 
 /**
- * Render the dashboard page.
- */
+	* Render the dashboard page.
+	*/
 public function render(): void {
-       if (
-               isset( $_GET['nuclen_refresh_inventory'] ) &&
-               isset( $_GET['nuclen_refresh_inventory_nonce'] ) &&
-               wp_verify_nonce( sanitize_text_field( wp_unslash( $_GET['nuclen_refresh_inventory_nonce'] ) ), 'nuclen_refresh_inventory' ) &&
-               current_user_can( 'manage_options' )
-       ) {
-               \NuclearEngagement\Core\InventoryCache::clear();
-               wp_safe_redirect( remove_query_arg( array( 'nuclen_refresh_inventory', 'nuclen_refresh_inventory_nonce' ) ) );
-               exit;
-       }
+		if (
+				isset( $_GET['nuclen_refresh_inventory'] ) &&
+				isset( $_GET['nuclen_refresh_inventory_nonce'] ) &&
+				wp_verify_nonce( sanitize_text_field( wp_unslash( $_GET['nuclen_refresh_inventory_nonce'] ) ), 'nuclen_refresh_inventory' ) &&
+				current_user_can( 'manage_options' )
+		) {
+				\NuclearEngagement\Core\InventoryCache::clear();
+				wp_safe_redirect( remove_query_arg( array( 'nuclen_refresh_inventory', 'nuclen_refresh_inventory_nonce' ) ) );
+				exit;
+		}
 
-       $data = $this->gather_dashboard_data();
-       $this->render_dashboard_view( $data );
+		$data = $this->gather_dashboard_data();
+		$this->render_dashboard_view( $data );
 }
 
 /**
- * Collect all dashboard stats.
- *
- * @return array Dashboard data arrays.
- */
+	* Collect all dashboard stats.
+	*
+	* @return array Dashboard data arrays.
+	*/
 private function gather_dashboard_data(): array {
-       global $wpdb;
+		global $wpdb;
 
-       $allowed_post_types = $this->settings_repo->get( 'generation_post_types', array( 'post' ) );
-       $allowed_post_types = is_array( $allowed_post_types ) ? $allowed_post_types : array( 'post' );
+		$allowed_post_types = $this->settings_repo->get( 'generation_post_types', array( 'post' ) );
+		$allowed_post_types = is_array( $allowed_post_types ) ? $allowed_post_types : array( 'post' );
 
-       $post_statuses  = array( 'publish', 'pending', 'draft', 'future' );
-       $inventory_cache = \NuclearEngagement\Core\InventoryCache::get();
+		$post_statuses  = array( 'publish', 'pending', 'draft', 'future' );
+		$inventory_cache = \NuclearEngagement\Core\InventoryCache::get();
 
-       if ( null === $inventory_cache ) {
-               $status_rows    = $this->data_service->get_dual_counts( 'p.post_status', $allowed_post_types, $post_statuses );
-               $status_objects = get_post_stati( array(), 'objects' );
-               $by_status_quiz = $by_status_summary = array();
-               foreach ( $status_rows as $r ) {
-                       $label                                  = $status_objects[ $r['g'] ]->label ?? ucfirst( $r['g'] );
-                       $by_status_quiz[ $label ]['with']       = (int) $r['quiz_with'];
-                       $by_status_quiz[ $label ]['without']    = (int) $r['quiz_without'];
-                       $by_status_summary[ $label ]['with']    = (int) $r['summary_with'];
-                       $by_status_summary[ $label ]['without'] = (int) $r['summary_without'];
-               }
+		if ( null === $inventory_cache ) {
+				$status_rows    = $this->data_service->get_dual_counts( 'p.post_status', $allowed_post_types, $post_statuses );
+				$status_objects = get_post_stati( array(), 'objects' );
+				$by_status_quiz = $by_status_summary = array();
+				foreach ( $status_rows as $r ) {
+						$label                                  = $status_objects[ $r['g'] ]->label ?? ucfirst( $r['g'] );
+						$by_status_quiz[ $label ]['with']       = (int) $r['quiz_with'];
+						$by_status_quiz[ $label ]['without']    = (int) $r['quiz_without'];
+						$by_status_summary[ $label ]['with']    = (int) $r['summary_with'];
+						$by_status_summary[ $label ]['without'] = (int) $r['summary_without'];
+				}
 
-               $ptype_rows = $this->data_service->get_dual_counts( 'p.post_type', $allowed_post_types, $post_statuses );
-               $by_post_type_quiz = $by_post_type_summary = array();
-               foreach ( $ptype_rows as $r ) {
-                       $pt_obj                                    = get_post_type_object( $r['g'] );
-                       $label                                     = $pt_obj->labels->name ?? ucfirst( $r['g'] );
-                       $by_post_type_quiz[ $label ]['with']       = (int) $r['quiz_with'];
-                       $by_post_type_quiz[ $label ]['without']    = (int) $r['quiz_without'];
-                       $by_post_type_summary[ $label ]['with']    = (int) $r['summary_with'];
-                       $by_post_type_summary[ $label ]['without'] = (int) $r['summary_without'];
-               }
+				$ptype_rows = $this->data_service->get_dual_counts( 'p.post_type', $allowed_post_types, $post_statuses );
+				$by_post_type_quiz = $by_post_type_summary = array();
+				foreach ( $ptype_rows as $r ) {
+						$pt_obj                                    = get_post_type_object( $r['g'] );
+						$label                                     = $pt_obj->labels->name ?? ucfirst( $r['g'] );
+						$by_post_type_quiz[ $label ]['with']       = (int) $r['quiz_with'];
+						$by_post_type_quiz[ $label ]['without']    = (int) $r['quiz_without'];
+						$by_post_type_summary[ $label ]['with']    = (int) $r['summary_with'];
+						$by_post_type_summary[ $label ]['without'] = (int) $r['summary_without'];
+				}
 
-               $author_rows = $this->data_service->get_dual_counts( 'p.post_author', $allowed_post_types, $post_statuses );
-               $author_ids  = array_map( static fn ( $row ) => (int) $row['g'], $author_rows );
+				$author_rows = $this->data_service->get_dual_counts( 'p.post_author', $allowed_post_types, $post_statuses );
+				$author_ids  = array_map( static fn ( $row ) => (int) $row['g'], $author_rows );
 
-               $author_names = array();
-               if ( $author_ids ) {
-                       $users = get_users(
-                               array(
-                                       'include' => $author_ids,
-                                       'fields'  => array( 'ID', 'display_name' ),
-                               )
-                       );
-                       foreach ( $users as $user ) {
-                               $author_names[ (int) $user->ID ] = $user->display_name;
-                       }
-               }
+				$author_names = array();
+				if ( $author_ids ) {
+						$users = get_users(
+								array(
+										'include' => $author_ids,
+										'fields'  => array( 'ID', 'display_name' ),
+								)
+						);
+						foreach ( $users as $user ) {
+								$author_names[ (int) $user->ID ] = $user->display_name;
+						}
+				}
 
-               $by_author_quiz = $by_author_summary = array();
-               foreach ( $author_rows as $r ) {
-                       $id                                    = (int) $r['g'];
-                       $name                                  = $author_names[ $id ] ?? __( 'Unknown Author', 'nuclear-engagement' );
-                       $by_author_quiz[ $name ]['with']       = (int) $r['quiz_with'];
-                       $by_author_quiz[ $name ]['without']    = (int) $r['quiz_without'];
-                       $by_author_summary[ $name ]['with']    = (int) $r['summary_with'];
-                       $by_author_summary[ $name ]['without'] = (int) $r['summary_without'];
-               }
+				$by_author_quiz = $by_author_summary = array();
+				foreach ( $author_rows as $r ) {
+						$id                                    = (int) $r['g'];
+						$name                                  = $author_names[ $id ] ?? __( 'Unknown Author', 'nuclear-engagement' );
+						$by_author_quiz[ $name ]['with']       = (int) $r['quiz_with'];
+						$by_author_quiz[ $name ]['without']    = (int) $r['quiz_without'];
+						$by_author_summary[ $name ]['with']    = (int) $r['summary_with'];
+						$by_author_summary[ $name ]['without'] = (int) $r['summary_without'];
+				}
 
-               $with_cat_pt      = array_filter( $allowed_post_types, fn( $pt ) => in_array( 'category', get_object_taxonomies( $pt ), true ) );
-               $by_category_quiz = $by_category_summary = array();
-               if ( $with_cat_pt ) {
-                       $sanitized_pt    = array_map( 'sanitize_key', $with_cat_pt );
-                       $sanitized_st    = array_map( 'sanitize_key', $post_statuses );
-                       $placeholders_pt = implode( ',', array_fill( 0, count( $sanitized_pt ), '%s' ) );
-                       $placeholders_st = implode( ',', array_fill( 0, count( $sanitized_st ), '%s' ) );
-                       $sql_cat         = $wpdb->prepare(
-                               "SELECT t.term_id,
-                               t.name AS cat_name,
-                               SUM(CASE WHEN pm_q.meta_id IS NULL THEN 0 ELSE 1 END) AS quiz_with,
-                               SUM(CASE WHEN pm_q.meta_id IS NULL THEN 1 ELSE 0 END) AS quiz_without,
-                               SUM(CASE WHEN pm_s.meta_id IS NULL THEN 0 ELSE 1 END) AS summary_with,
-                               SUM(CASE WHEN pm_s.meta_id IS NULL THEN 1 ELSE 0 END) AS summary_without
-                       FROM {$wpdb->posts} p
-                       JOIN {$wpdb->term_relationships} tr ON tr.object_id = p.ID
-                       JOIN {$wpdb->term_taxonomy}  tt ON tt.term_taxonomy_id = tr.term_taxonomy_id AND tt.taxonomy = 'category'
-                       JOIN {$wpdb->terms}          t  ON t.term_id = tt.term_id
-                       LEFT JOIN {$wpdb->postmeta}  pm_q ON pm_q.post_id = p.ID AND pm_q.meta_key = 'nuclen-quiz-data'
-                       LEFT JOIN {$wpdb->postmeta}  pm_s ON pm_s.post_id = p.ID AND pm_s.meta_key = '" . Summary_Service::META_KEY . "'
-                       WHERE p.post_type  IN ($placeholders_pt)
-                       AND p.post_status IN ($placeholders_st)
-                       GROUP BY t.term_id",
-                               array_merge( $sanitized_pt, $sanitized_st )
-                       );
-                       $cat_rows = $wpdb->get_results( $sql_cat, ARRAY_A );
-                       if ( ! empty( $wpdb->last_error ) ) {
-                               \NuclearEngagement\Services\LoggingService::log( 'Category stats query error: ' . $wpdb->last_error );
-                               $cat_rows = array();
-                       }
-                       foreach ( $cat_rows as $r ) {
-                               $by_category_quiz[ $r['cat_name'] ]['with']       = (int) $r['quiz_with'];
-                               $by_category_quiz[ $r['cat_name'] ]['without']    = (int) $r['quiz_without'];
-                               $by_category_summary[ $r['cat_name'] ]['with']    = (int) $r['summary_with'];
-                               $by_category_summary[ $r['cat_name'] ]['without'] = (int) $r['summary_without'];
-                       }
-               }
+				$with_cat_pt      = array_filter( $allowed_post_types, fn( $pt ) => in_array( 'category', get_object_taxonomies( $pt ), true ) );
+				$by_category_quiz = $by_category_summary = array();
+				if ( $with_cat_pt ) {
+						$sanitized_pt    = array_map( 'sanitize_key', $with_cat_pt );
+						$sanitized_st    = array_map( 'sanitize_key', $post_statuses );
+						$placeholders_pt = implode( ',', array_fill( 0, count( $sanitized_pt ), '%s' ) );
+						$placeholders_st = implode( ',', array_fill( 0, count( $sanitized_st ), '%s' ) );
+						$sql_cat         = $wpdb->prepare(
+								"SELECT t.term_id,
+								t.name AS cat_name,
+								SUM(CASE WHEN pm_q.meta_id IS NULL THEN 0 ELSE 1 END) AS quiz_with,
+								SUM(CASE WHEN pm_q.meta_id IS NULL THEN 1 ELSE 0 END) AS quiz_without,
+								SUM(CASE WHEN pm_s.meta_id IS NULL THEN 0 ELSE 1 END) AS summary_with,
+								SUM(CASE WHEN pm_s.meta_id IS NULL THEN 1 ELSE 0 END) AS summary_without
+						FROM {$wpdb->posts} p
+						JOIN {$wpdb->term_relationships} tr ON tr.object_id = p.ID
+						JOIN {$wpdb->term_taxonomy}  tt ON tt.term_taxonomy_id = tr.term_taxonomy_id AND tt.taxonomy = 'category'
+						JOIN {$wpdb->terms}          t  ON t.term_id = tt.term_id
+						LEFT JOIN {$wpdb->postmeta}  pm_q ON pm_q.post_id = p.ID AND pm_q.meta_key = 'nuclen-quiz-data'
+						LEFT JOIN {$wpdb->postmeta}  pm_s ON pm_s.post_id = p.ID AND pm_s.meta_key = '" . Summary_Service::META_KEY . "'
+						WHERE p.post_type  IN ($placeholders_pt)
+						AND p.post_status IN ($placeholders_st)
+						GROUP BY t.term_id",
+								array_merge( $sanitized_pt, $sanitized_st )
+						);
+						$cat_rows = $wpdb->get_results( $sql_cat, ARRAY_A );
+						if ( ! empty( $wpdb->last_error ) ) {
+								\NuclearEngagement\Services\LoggingService::log( 'Category stats query error: ' . $wpdb->last_error );
+								$cat_rows = array();
+						}
+						foreach ( $cat_rows as $r ) {
+								$by_category_quiz[ $r['cat_name'] ]['with']       = (int) $r['quiz_with'];
+								$by_category_quiz[ $r['cat_name'] ]['without']    = (int) $r['quiz_without'];
+								$by_category_summary[ $r['cat_name'] ]['with']    = (int) $r['summary_with'];
+								$by_category_summary[ $r['cat_name'] ]['without'] = (int) $r['summary_without'];
+						}
+				}
 
-               $drop_zeros = static function ( array $arr ) {
-                       return array_filter( $arr, static fn ( $c ) => ( ( $c['with'] ?? 0 ) + ( $c['without'] ?? 0 ) ) > 0 );
-               };
+				$drop_zeros = static function ( array $arr ) {
+						return array_filter( $arr, static fn ( $c ) => ( ( $c['with'] ?? 0 ) + ( $c['without'] ?? 0 ) ) > 0 );
+				};
 
-               $by_status_quiz       = $drop_zeros( $by_status_quiz );
-               $by_status_summary    = $drop_zeros( $by_status_summary );
-               $by_post_type_quiz    = $drop_zeros( $by_post_type_quiz );
-               $by_post_type_summary = $drop_zeros( $by_post_type_summary );
-               $by_author_quiz       = $drop_zeros( $by_author_quiz );
-               $by_author_summary    = $drop_zeros( $by_author_summary );
-               $by_category_quiz     = $drop_zeros( $by_category_quiz );
-               $by_category_summary  = $drop_zeros( $by_category_summary );
+				$by_status_quiz       = $drop_zeros( $by_status_quiz );
+				$by_status_summary    = $drop_zeros( $by_status_summary );
+				$by_post_type_quiz    = $drop_zeros( $by_post_type_quiz );
+				$by_post_type_summary = $drop_zeros( $by_post_type_summary );
+				$by_author_quiz       = $drop_zeros( $by_author_quiz );
+				$by_author_summary    = $drop_zeros( $by_author_summary );
+				$by_category_quiz     = $drop_zeros( $by_category_quiz );
+				$by_category_summary  = $drop_zeros( $by_category_summary );
 
-               \NuclearEngagement\Core\InventoryCache::set(
-                       array(
-                               'by_status_quiz'       => $by_status_quiz,
-                               'by_status_summary'    => $by_status_summary,
-                               'by_post_type_quiz'    => $by_post_type_quiz,
-                               'by_post_type_summary' => $by_post_type_summary,
-                               'by_author_quiz'       => $by_author_quiz,
-                               'by_author_summary'    => $by_author_summary,
-                               'by_category_quiz'     => $by_category_quiz,
-                               'by_category_summary'  => $by_category_summary,
-                       )
-               );
-       } else {
-               $by_status_quiz       = $inventory_cache['by_status_quiz'] ?? array();
-               $by_status_summary    = $inventory_cache['by_status_summary'] ?? array();
-               $by_post_type_quiz    = $inventory_cache['by_post_type_quiz'] ?? array();
-               $by_post_type_summary = $inventory_cache['by_post_type_summary'] ?? array();
-               $by_author_quiz       = $inventory_cache['by_author_quiz'] ?? array();
-               $by_author_summary    = $inventory_cache['by_author_summary'] ?? array();
-               $by_category_quiz     = $inventory_cache['by_category_quiz'] ?? array();
-               $by_category_summary  = $inventory_cache['by_category_summary'] ?? array();
-       }
+				\NuclearEngagement\Core\InventoryCache::set(
+						array(
+								'by_status_quiz'       => $by_status_quiz,
+								'by_status_summary'    => $by_status_summary,
+								'by_post_type_quiz'    => $by_post_type_quiz,
+								'by_post_type_summary' => $by_post_type_summary,
+								'by_author_quiz'       => $by_author_quiz,
+								'by_author_summary'    => $by_author_summary,
+								'by_category_quiz'     => $by_category_quiz,
+								'by_category_summary'  => $by_category_summary,
+						)
+				);
+		} else {
+				$by_status_quiz       = $inventory_cache['by_status_quiz'] ?? array();
+				$by_status_summary    = $inventory_cache['by_status_summary'] ?? array();
+				$by_post_type_quiz    = $inventory_cache['by_post_type_quiz'] ?? array();
+				$by_post_type_summary = $inventory_cache['by_post_type_summary'] ?? array();
+				$by_author_quiz       = $inventory_cache['by_author_quiz'] ?? array();
+				$by_author_summary    = $inventory_cache['by_author_summary'] ?? array();
+				$by_category_quiz     = $inventory_cache['by_category_quiz'] ?? array();
+				$by_category_summary  = $inventory_cache['by_category_summary'] ?? array();
+		}
 
-       $scheduled_tasks = $this->data_service->get_scheduled_generations();
+		$scheduled_tasks = $this->data_service->get_scheduled_generations();
 
-       return array(
-               'by_status_quiz'       => $by_status_quiz,
-               'by_status_summary'    => $by_status_summary,
-               'by_post_type_quiz'    => $by_post_type_quiz,
-               'by_post_type_summary' => $by_post_type_summary,
-               'by_author_quiz'       => $by_author_quiz,
-               'by_author_summary'    => $by_author_summary,
-               'by_category_quiz'     => $by_category_quiz,
-               'by_category_summary'  => $by_category_summary,
-               'scheduled_tasks'      => $scheduled_tasks,
-       );
+		return array(
+				'by_status_quiz'       => $by_status_quiz,
+				'by_status_summary'    => $by_status_summary,
+				'by_post_type_quiz'    => $by_post_type_quiz,
+				'by_post_type_summary' => $by_post_type_summary,
+				'by_author_quiz'       => $by_author_quiz,
+				'by_author_summary'    => $by_author_summary,
+				'by_category_quiz'     => $by_category_quiz,
+				'by_category_summary'  => $by_category_summary,
+				'scheduled_tasks'      => $scheduled_tasks,
+		);
 }
 
 /**
- * Render the dashboard template.
- *
- * @param array $data Dashboard context.
- */
+	* Render the dashboard template.
+	*
+	* @param array $data Dashboard context.
+	*/
 private function render_dashboard_view( array $data ): void {
-       extract( $data );
-       require NUCLEN_PLUGIN_DIR . 'templates/admin/nuclen-dashboard-page.php';
+		extract( $data );
+		require NUCLEN_PLUGIN_DIR . 'templates/admin/nuclen-dashboard-page.php';
 }
 
 /**
- * Helper: build a small "with / without" stats table.
- *
- * @param array $data Stats array.
- * @return string HTML table.
- */
+	* Helper: build a small "with / without" stats table.
+	*
+	* @param array $data Stats array.
+	* @return string HTML table.
+	*/
 private function nuclen_render_dashboard_stats_table( $data ) {
 if ( empty( $data ) ) {
 return '<p>' . esc_html__( 'No items found.', 'nuclear-engagement' ) . '</p>';

--- a/nuclear-engagement/admin/Traits/AdminMenu.php
+++ b/nuclear-engagement/admin/Traits/AdminMenu.php
@@ -1,13 +1,13 @@
 <?php
 declare(strict_types=1);
 /**
- * File: admin/Traits/AdminMenu.php
- *
- * Adds the Nuclear Engagement admin menu and hides the “Generate” page
- * until **both** setup steps are finished (API key + WP App Password).
- *
- * @package NuclearEngagement\Admin
- */
+	* File: admin/Traits/AdminMenu.php
+	*
+	* Adds the Nuclear Engagement admin menu and hides the “Generate” page
+	* until **both** setup steps are finished (API key + WP App Password).
+	*
+	* @package NuclearEngagement\Admin
+	*/
 
 namespace NuclearEngagement\Admin\Traits;
 
@@ -64,12 +64,12 @@ trait AdminMenu {
 	}
 
 	/** Dashboard page callback */
-       public function nuclen_display_dashboard() {
-               $settings_repo = $this->nuclen_get_settings_repository();
-               $data_service  = $this->get_container()->get( 'dashboard_data_service' );
-               $dashboard     = new Dashboard( $settings_repo, $data_service );
-               $dashboard->render();
-       }
+		public function nuclen_display_dashboard() {
+				$settings_repo = $this->nuclen_get_settings_repository();
+				$data_service  = $this->get_container()->get( 'dashboard_data_service' );
+				$dashboard     = new Dashboard( $settings_repo, $data_service );
+				$dashboard->render();
+		}
 
 	/**
 	 * “Generate” page callback.

--- a/nuclear-engagement/front/Controller/Rest/ContentController.php
+++ b/nuclear-engagement/front/Controller/Rest/ContentController.php
@@ -1,12 +1,12 @@
 <?php
 declare(strict_types=1);
 /**
- * File: front/Controller/Rest/ContentController.php
- *
- * Content Controller
- *
- * @package NuclearEngagement\Front\Controller\Rest
- */
+	* File: front/Controller/Rest/ContentController.php
+	*
+	* Content Controller
+	*
+	* @package NuclearEngagement\Front\Controller\Rest
+	*/
 
 namespace NuclearEngagement\Front\Controller\Rest;
 
@@ -21,12 +21,12 @@ if ( ! defined( 'ABSPATH' ) ) {
 }
 
 /**
- * REST controller for receiving content.
- *
- * Accepts authentication via the custom header `X-WP-App-Password`
- * using the plugin-generated password, or falls back to a standard
- * admin nonce check when present.
- */
+	* REST controller for receiving content.
+	*
+	* Accepts authentication via the custom header `X-WP-App-Password`
+	* using the plugin-generated password, or falls back to a standard
+	* admin nonce check when present.
+	*/
 class ContentController {
 	/**
 	 * @var ContentStorageService
@@ -86,16 +86,16 @@ class ContentController {
 
 			$contentRequest = ContentRequest::fromJson( $data );
 
-                        // Store the results
-                        $statuses = $this->storage->storeResults( $contentRequest->results, $contentRequest->workflow );
-                        if ( array_filter( $statuses, static fn( $s ) => $s !== true ) ) {
-                                return new \WP_Error( 'ne_store_failed', __( 'Failed to store content', 'nuclear-engagement' ), array( 'status' => 500 ) );
-                        }
+						// Store the results
+						$statuses = $this->storage->storeResults( $contentRequest->results, $contentRequest->workflow );
+						if ( array_filter( $statuses, static fn( $s ) => $s !== true ) ) {
+								return new \WP_Error( 'ne_store_failed', __( 'Failed to store content', 'nuclear-engagement' ), array( 'status' => 500 ) );
+						}
 
 			// Get date from first stored item
 			reset( $contentRequest->results );
 			$firstPostId = key( $contentRequest->results );
-                        $metaKey     = $contentRequest->workflow === 'quiz' ? 'nuclen-quiz-data' : Summary_Service::META_KEY;
+						$metaKey     = $contentRequest->workflow === 'quiz' ? 'nuclen-quiz-data' : Summary_Service::META_KEY;
 			$stored      = get_post_meta( $firstPostId, $metaKey, true );
 			$date        = is_array( $stored ) && ! empty( $stored['date'] ) ? $stored['date'] : '';
 

--- a/nuclear-engagement/inc/Core/ContainerRegistrar.php
+++ b/nuclear-engagement/inc/Core/ContainerRegistrar.php
@@ -1,10 +1,10 @@
 <?php
 declare(strict_types=1);
 /**
- * File: includes/ContainerRegistrar.php
- *
- * Registers services and controllers in the DI container.
- */
+	* File: includes/ContainerRegistrar.php
+	*
+	* Registers services and controllers in the DI container.
+	*/
 
 namespace NuclearEngagement\Core;
 
@@ -22,101 +22,101 @@ if ( ! defined( 'ABSPATH' ) ) {
 }
 
 final class ContainerRegistrar {
-       public static function register( Container $container, SettingsRepository $settings ): void {
-               $container->register( 'settings', static fn() => $settings );
+		public static function register( Container $container, SettingsRepository $settings ): void {
+				$container->register( 'settings', static fn() => $settings );
 
-               self::register_base_services( $container );
-               self::register_remote_services( $container );
-               self::register_generation_services( $container );
-               self::register_utility_services( $container );
-               self::register_controllers( $container );
-       }
+				self::register_base_services( $container );
+				self::register_remote_services( $container );
+				self::register_generation_services( $container );
+				self::register_utility_services( $container );
+				self::register_controllers( $container );
+		}
 
-       private static function register_base_services( Container $container ): void {
-               $container->register( 'admin_notice_service', static fn() => new AdminNoticeService() );
-               $container->register( 'logging_service', static fn( Container $c ) => new LoggingService( $c->get( 'admin_notice_service' ) ) );
-       }
+		private static function register_base_services( Container $container ): void {
+				$container->register( 'admin_notice_service', static fn() => new AdminNoticeService() );
+				$container->register( 'logging_service', static fn( Container $c ) => new LoggingService( $c->get( 'admin_notice_service' ) ) );
+		}
 
-       private static function register_remote_services( Container $container ): void {
-               $container->register( 'remote_request', static fn() => new RemoteRequest() );
-               $container->register( 'api_response_handler', static fn() => new ApiResponseHandler() );
-               $container->register( 'remote_api', static fn( Container $c ) => new RemoteApiService( $c->get( 'settings' ), $c->get( 'remote_request' ), $c->get( 'api_response_handler' ) ) );
-               $container->register( 'content_storage', static fn( Container $c ) => new ContentStorageService( $c->get( 'settings' ) ) );
-       }
+		private static function register_remote_services( Container $container ): void {
+				$container->register( 'remote_request', static fn() => new RemoteRequest() );
+				$container->register( 'api_response_handler', static fn() => new ApiResponseHandler() );
+				$container->register( 'remote_api', static fn( Container $c ) => new RemoteApiService( $c->get( 'settings' ), $c->get( 'remote_request' ), $c->get( 'api_response_handler' ) ) );
+				$container->register( 'content_storage', static fn( Container $c ) => new ContentStorageService( $c->get( 'settings' ) ) );
+		}
 
-       private static function register_generation_services( Container $container ): void {
-               $container->register(
-                       'generation_poller',
-                       static fn( Container $c ) => new GenerationPoller(
-                               $c->get( 'settings' ),
-                               $c->get( 'remote_api' ),
-                               $c->get( 'content_storage' )
-                       )
-               );
+		private static function register_generation_services( Container $container ): void {
+				$container->register(
+						'generation_poller',
+						static fn( Container $c ) => new GenerationPoller(
+								$c->get( 'settings' ),
+								$c->get( 'remote_api' ),
+								$c->get( 'content_storage' )
+						)
+				);
 
-               $container->register(
-                       'auto_generation_queue',
-                       static fn( Container $c ) => new AutoGenerationQueue(
-                               $c->get( 'remote_api' ),
-                               $c->get( 'content_storage' ),
-                               new PostDataFetcher()
-                       )
-               );
+				$container->register(
+						'auto_generation_queue',
+						static fn( Container $c ) => new AutoGenerationQueue(
+								$c->get( 'remote_api' ),
+								$c->get( 'content_storage' ),
+								new PostDataFetcher()
+						)
+				);
 
-               $container->register(
-                       'auto_generation_scheduler',
-                       static fn( Container $c ) => new AutoGenerationScheduler(
-                               $c->get( 'generation_poller' )
-                       )
-               );
+				$container->register(
+						'auto_generation_scheduler',
+						static fn( Container $c ) => new AutoGenerationScheduler(
+								$c->get( 'generation_poller' )
+						)
+				);
 
-               $container->register(
-                       'publish_generation_handler',
-                       static fn( Container $c ) => new PublishGenerationHandler(
-                               $c->get( 'settings' )
-                       )
-               );
+				$container->register(
+						'publish_generation_handler',
+						static fn( Container $c ) => new PublishGenerationHandler(
+								$c->get( 'settings' )
+						)
+				);
 
-               $container->register(
-                       'auto_generation_service',
-                       static fn( Container $c ) => new AutoGenerationService(
-                               $c->get( 'settings' ),
-                               $c->get( 'auto_generation_queue' ),
-                               $c->get( 'auto_generation_scheduler' ),
-                               $c->get( 'publish_generation_handler' )
-                       )
-               );
+				$container->register(
+						'auto_generation_service',
+						static fn( Container $c ) => new AutoGenerationService(
+								$c->get( 'settings' ),
+								$c->get( 'auto_generation_queue' ),
+								$c->get( 'auto_generation_scheduler' ),
+								$c->get( 'publish_generation_handler' )
+						)
+				);
 
-               $container->register(
-                       'generation_service',
-                       static fn( Container $c ) => new GenerationService(
-                               $c->get( 'settings' ),
-                               $c->get( 'remote_api' ),
-                               $c->get( 'content_storage' ),
-                               new PostDataFetcher()
-                       )
-               );
-       }
+				$container->register(
+						'generation_service',
+						static fn( Container $c ) => new GenerationService(
+								$c->get( 'settings' ),
+								$c->get( 'remote_api' ),
+								$c->get( 'content_storage' ),
+								new PostDataFetcher()
+						)
+				);
+		}
 
-       private static function register_utility_services( Container $container ): void {
-               $container->register( 'pointer_service', static fn() => new PointerService() );
-               $container->register( 'posts_query_service', static fn() => new PostsQueryService() );
-               $container->register( 'dashboard_data_service', static fn() => new DashboardDataService() );
-               $container->register( 'version_service', static fn() => new VersionService() );
-       }
+		private static function register_utility_services( Container $container ): void {
+				$container->register( 'pointer_service', static fn() => new PointerService() );
+				$container->register( 'posts_query_service', static fn() => new PostsQueryService() );
+				$container->register( 'dashboard_data_service', static fn() => new DashboardDataService() );
+				$container->register( 'version_service', static fn() => new VersionService() );
+		}
 
-       private static function register_controllers( Container $container ): void {
-               $container->register( 'generate_controller', static fn( Container $c ) => new GenerateController( $c->get( 'generation_service' ) ) );
-               $container->register( 'updates_controller', static fn( Container $c ) => new UpdatesController( $c->get( 'remote_api' ), $c->get( 'content_storage' ) ) );
-               $container->register( 'pointer_controller', static fn( Container $c ) => new PointerController( $c->get( 'pointer_service' ) ) );
-               $container->register( 'posts_count_controller', static fn( Container $c ) => new PostsCountController( $c->get( 'posts_query_service' ) ) );
-               $container->register(
-                       'content_controller',
-                       static fn( Container $c ) => new ContentController(
-                               $c->get( 'content_storage' ),
-                               $c->get( 'settings' )
-                       )
-               );
-               $container->register( 'optin_export_controller', static fn() => new OptinExportController() );
-       }
+		private static function register_controllers( Container $container ): void {
+				$container->register( 'generate_controller', static fn( Container $c ) => new GenerateController( $c->get( 'generation_service' ) ) );
+				$container->register( 'updates_controller', static fn( Container $c ) => new UpdatesController( $c->get( 'remote_api' ), $c->get( 'content_storage' ) ) );
+				$container->register( 'pointer_controller', static fn( Container $c ) => new PointerController( $c->get( 'pointer_service' ) ) );
+				$container->register( 'posts_count_controller', static fn( Container $c ) => new PostsCountController( $c->get( 'posts_query_service' ) ) );
+				$container->register(
+						'content_controller',
+						static fn( Container $c ) => new ContentController(
+								$c->get( 'content_storage' ),
+								$c->get( 'settings' )
+						)
+				);
+				$container->register( 'optin_export_controller', static fn() => new OptinExportController() );
+		}
 }

--- a/nuclear-engagement/inc/Core/MetaRegistration.php
+++ b/nuclear-engagement/inc/Core/MetaRegistration.php
@@ -1,12 +1,12 @@
 <?php
 declare(strict_types=1);
 /**
- * File: includes/MetaRegistration.php
- *
- * Register meta keys for better query performance
- *
- * @package NuclearEngagement
- */
+	* File: includes/MetaRegistration.php
+	*
+	* Register meta keys for better query performance
+	*
+	* @package NuclearEngagement
+	*/
 
 namespace NuclearEngagement\Core;
 
@@ -18,10 +18,10 @@ if ( ! defined( 'ABSPATH' ) ) {
 }
 
 /**
- * Class MetaRegistration
- *
- * Handles registration of post meta keys for improved query performance
- */
+	* Class MetaRegistration
+	*
+	* Handles registration of post meta keys for improved query performance
+	*/
 class MetaRegistration {
 
 	/**
@@ -36,7 +36,7 @@ class MetaRegistration {
 	 */
 	public static function register_meta_keys(): void {
 		// Get allowed post types from settings
-               $post_types = SettingsFunctions::get_array( 'generation_post_types', array( 'post' ) );
+				$post_types = SettingsFunctions::get_array( 'generation_post_types', array( 'post' ) );
 
 		// Register quiz data meta
 		foreach ( $post_types as $post_type ) {

--- a/nuclear-engagement/inc/Modules/Quiz/loader.php
+++ b/nuclear-engagement/inc/Modules/Quiz/loader.php
@@ -1,11 +1,11 @@
 <?php
 /**
- * File: modules/quiz/loader.php
- *
- * Loads the Nuclen Quiz module.
- *
- * @package NuclearEngagement
- */
+	* File: modules/quiz/loader.php
+	*
+	* Loads the Nuclen Quiz module.
+	*
+	* @package NuclearEngagement
+	*/
 
 declare(strict_types=1);
 
@@ -21,8 +21,8 @@ use NuclearEngagement\Core\Container;
 
 /*
 ------------------------------------------------------------------
- * Local constants (prefixed, module-scoped)
- * ------------------------------------------------------------------
+	* Local constants (prefixed, module-scoped)
+	* ------------------------------------------------------------------
 */
 if ( ! defined( 'NUCLEN_QUIZ_DIR' ) ) {
 		define( 'NUCLEN_QUIZ_DIR', __DIR__ . '/' );
@@ -30,8 +30,8 @@ if ( ! defined( 'NUCLEN_QUIZ_DIR' ) ) {
 
 /*
 ------------------------------------------------------------------
- * Includes
- * ------------------------------------------------------------------
+	* Includes
+	* ------------------------------------------------------------------
 */
 require_once NUCLEN_QUIZ_DIR . 'Quiz_Service.php';
 require_once NUCLEN_QUIZ_DIR . 'Quiz_Admin.php';
@@ -39,20 +39,20 @@ require_once NUCLEN_QUIZ_DIR . 'Quiz_Shortcode.php';
 
 /*
 ------------------------------------------------------------------
- * Spin-up
- * ------------------------------------------------------------------
+	* Spin-up
+	* ------------------------------------------------------------------
 */
 $settings = SettingsRepository::get_instance();
 $service  = new Quiz_Service();
 
 if ( is_admin() ) {
-                ( new Quiz_Admin( $settings, $service ) )->register_hooks();
+				( new Quiz_Admin( $settings, $service ) )->register_hooks();
 } else {
-                $front = new FrontClass(
-                                'nuclear-engagement',
-                                defined( 'NUCLEN_PLUGIN_VERSION' ) ? NUCLEN_PLUGIN_VERSION : '1.0.0',
-                                $settings,
-                                new Container()
-                );
-                ( new Quiz_Shortcode( $settings, $front, $service ) )->register();
+				$front = new FrontClass(
+								'nuclear-engagement',
+								defined( 'NUCLEN_PLUGIN_VERSION' ) ? NUCLEN_PLUGIN_VERSION : '1.0.0',
+								$settings,
+								new Container()
+				);
+				( new Quiz_Shortcode( $settings, $front, $service ) )->register();
 }

--- a/nuclear-engagement/inc/Modules/Summary/loader.php
+++ b/nuclear-engagement/inc/Modules/Summary/loader.php
@@ -1,11 +1,11 @@
 <?php
 /**
- * File: modules/summary/loader.php
- *
- * Loads the Nuclen Summary sub-module.
- *
- * @package NuclearEngagement
- */
+	* File: modules/summary/loader.php
+	*
+	* Loads the Nuclen Summary sub-module.
+	*
+	* @package NuclearEngagement
+	*/
 
 declare(strict_types=1);
 
@@ -20,31 +20,31 @@ use NuclearEngagement\Modules\Summary\Nuclen_Summary_Metabox;
 
 /*
 ------------------------------------------------------------------
- * Local constants (prefixed, module-scoped)
- * ------------------------------------------------------------------ */
+	* Local constants (prefixed, module-scoped)
+	* ------------------------------------------------------------------ */
 define( 'NUCLEN_SUMMARY_DIR', __DIR__ . '/' );
 define( 'NUCLEN_SUMMARY_URL', plugin_dir_url( __FILE__ ) );
 
 /*
 ------------------------------------------------------------------
- * Includes
- * ------------------------------------------------------------------ */
+	* Includes
+	* ------------------------------------------------------------------ */
 require_once NUCLEN_SUMMARY_DIR . 'Nuclen_Summary_View.php';
 require_once NUCLEN_SUMMARY_DIR . 'Nuclen_Summary_Shortcode.php';
 require_once NUCLEN_SUMMARY_DIR . 'Nuclen_Summary_Metabox.php';
 
 /*
 ------------------------------------------------------------------
- * Spin-up
- * ------------------------------------------------------------------ */
+	* Spin-up
+	* ------------------------------------------------------------------ */
 $settings = \NuclearEngagement\Core\SettingsRepository::get_instance();
 $front    = new \NuclearEngagement\Front\FrontClass(
-        'nuclear-engagement',
-        defined( 'NUCLEN_PLUGIN_VERSION' ) ? NUCLEN_PLUGIN_VERSION : '1.0.0',
-        $settings,
-        new \NuclearEngagement\Core\Container()
+		'nuclear-engagement',
+		defined( 'NUCLEN_PLUGIN_VERSION' ) ? NUCLEN_PLUGIN_VERSION : '1.0.0',
+		$settings,
+		new \NuclearEngagement\Core\Container()
 );
 new Nuclen_Summary_Shortcode( $settings, $front );
 if ( is_admin() ) {
-        new Nuclen_Summary_Metabox( $settings );
+		new Nuclen_Summary_Metabox( $settings );
 }

--- a/nuclear-engagement/inc/Modules/TOC/Nuclen_TOC_Headings.php
+++ b/nuclear-engagement/inc/Modules/TOC/Nuclen_TOC_Headings.php
@@ -1,9 +1,9 @@
 <?php
 /**
- * Injects unique IDs into post headings for jump links.
- *
- * @package NuclearEngagement
- */
+	* Injects unique IDs into post headings for jump links.
+	*
+	* @package NuclearEngagement
+	*/
 
 declare(strict_types=1);
 
@@ -16,8 +16,8 @@ if ( ! defined( 'ABSPATH' ) ) {
 }
 
 /**
- * Adds unique IDs to headings within post content.
- */
+	* Adds unique IDs to headings within post content.
+	*/
 final class Nuclen_TOC_Headings {
 
 	/** Meta key for stored headings. */
@@ -55,7 +55,7 @@ final class Nuclen_TOC_Headings {
 		if ( ! nuclen_str_contains( $content, '<h' ) ) {
 			return $content; }
 
-               foreach ( HeadingExtractor::extract( $content, range( 1, 6 ), get_the_ID() ) as $h ) {
+				foreach ( HeadingExtractor::extract( $content, range( 1, 6 ), get_the_ID() ) as $h ) {
 			$pat         = sprintf(
 				'/(<%1$s\b(?![^>]*\bid=)[^>]*>)(%2$s)(<\/%1$s>)/is',
 				$h['tag'],
@@ -80,7 +80,7 @@ final class Nuclen_TOC_Headings {
 	 */
 	public function cache_headings_on_save( int $post_id, \WP_Post $post ): void {
 		delete_post_meta( $post_id, self::META_KEY );
-               $headings = HeadingExtractor::extract( $post->post_content, range( 1, 6 ), $post_id );
+				$headings = HeadingExtractor::extract( $post->post_content, range( 1, 6 ), $post_id );
 		update_post_meta( $post_id, self::META_KEY, $headings );
 	}
 

--- a/nuclear-engagement/inc/Modules/TOC/Nuclen_TOC_Utils.php
+++ b/nuclear-engagement/inc/Modules/TOC/Nuclen_TOC_Utils.php
@@ -1,14 +1,14 @@
 <?php
 /**
- * File: modules/toc/includes/Nuclen_TOC_Utils.php
- *
- * Heavy‑lifting utilities:
- *   ▸ heading extraction with skip‑rules
- *   ▸ slug deduplication
- *   ▸ object‑cache wrapper
- *
- * @package NuclearEngagement
- */
+	* File: modules/toc/includes/Nuclen_TOC_Utils.php
+	*
+	* Heavy‑lifting utilities:
+	*   ▸ heading extraction with skip‑rules
+	*   ▸ slug deduplication
+	*   ▸ object‑cache wrapper
+	*
+	* @package NuclearEngagement
+	*/
 
 declare(strict_types=1);
 
@@ -21,8 +21,8 @@ if ( ! defined( 'ABSPATH' ) ) {
 }
 
 /**
- * Utility helpers for TOC parsing and slug generation.
- */
+	* Utility helpers for TOC parsing and slug generation.
+	*/
 final class Nuclen_TOC_Utils {
 
 	private const CACHE_GROUP = 'nuclen_toc';
@@ -242,7 +242,7 @@ final class Nuclen_TOC_Utils {
 				return;
 		}
 
-               $levels = SettingsFunctions::get_array( 'toc_heading_levels', range( 2, 6 ) );
+				$levels = SettingsFunctions::get_array( 'toc_heading_levels', range( 2, 6 ) );
 
 			$levels = array_unique( array_map( 'intval', $levels ) );
 			sort( $levels );

--- a/nuclear-engagement/inc/Services/AdminNoticeService.php
+++ b/nuclear-engagement/inc/Services/AdminNoticeService.php
@@ -1,8 +1,8 @@
 <?php
 declare(strict_types=1);
 /**
- * Handles admin notices for the plugin.
- */
+	* Handles admin notices for the plugin.
+	*/
 
 namespace NuclearEngagement\Services;
 
@@ -23,14 +23,14 @@ class AdminNoticeService {
 		}
 	}
 
-       public function render(): void {
-               foreach ( $this->messages as $msg ) {
-                       load_template(
-                               NUCLEN_PLUGIN_DIR . 'templates/admin/notice.php',
-                               true,
-                               array( 'msg' => $msg )
-                       );
-               }
-               $this->messages = array();
-       }
+		public function render(): void {
+				foreach ( $this->messages as $msg ) {
+						load_template(
+								NUCLEN_PLUGIN_DIR . 'templates/admin/notice.php',
+								true,
+								array( 'msg' => $msg )
+						);
+				}
+				$this->messages = array();
+		}
 }

--- a/nuclear-engagement/inc/Services/LoggingService.php
+++ b/nuclear-engagement/inc/Services/LoggingService.php
@@ -1,12 +1,12 @@
 <?php
 declare(strict_types=1);
 /**
- * File: includes/Services/LoggingService.php
- *
- * Handles plugin log file storage and writes.
- *
- * @package NuclearEngagement\Services
- */
+	* File: includes/Services/LoggingService.php
+	*
+	* Handles plugin log file storage and writes.
+	*
+	* @package NuclearEngagement\Services
+	*/
 
 namespace NuclearEngagement\Services;
 
@@ -15,39 +15,39 @@ if ( ! defined( 'ABSPATH' ) ) {
 }
 
 class LoggingService {
-       /** Current service instance. */
-       private static ?self $instance = null;
+		/** Current service instance. */
+		private static ?self $instance = null;
 
-       /** Admin notice service instance. */
-       private AdminNoticeService $notices;
+		/** Admin notice service instance. */
+		private AdminNoticeService $notices;
 
-       /** Buffered log messages. */
-       private array $buffer = array();
+		/** Buffered log messages. */
+		private array $buffer = array();
 
-       /** Whether the shutdown hook has been registered. */
-       private bool $shutdown_registered = false;
+		/** Whether the shutdown hook has been registered. */
+		private bool $shutdown_registered = false;
 
-       public function __construct( AdminNoticeService $notices ) {
-               $this->notices  = $notices;
-               self::$instance = $this;
-       }
+		public function __construct( AdminNoticeService $notices ) {
+				$this->notices  = $notices;
+				self::$instance = $this;
+		}
 
-       /** Retrieve the active instance, creating one if needed. */
-       private static function instance(): self {
-               if ( null === self::$instance ) {
-                       self::$instance = new self( new AdminNoticeService() );
-               }
-               return self::$instance;
-       }
+		/** Retrieve the active instance, creating one if needed. */
+		private static function instance(): self {
+				if ( null === self::$instance ) {
+						self::$instance = new self( new AdminNoticeService() );
+				}
+				return self::$instance;
+		}
 
-       /** Get directory, path and URL for the log file. */
-       public static function get_log_file_info(): array {
-               $instance   = self::instance();
-               $upload_dir = wp_upload_dir();
+		/** Get directory, path and URL for the log file. */
+		public static function get_log_file_info(): array {
+				$instance   = self::instance();
+				$upload_dir = wp_upload_dir();
 
 		if ( ! empty( $upload_dir['error'] ) ) {
 			error_log( '[Nuclear Engagement] ' . $upload_dir['error'] );
-                       $instance->add_admin_notice( 'Uploads directory unavailable. Using plugin directory for logs.' );
+						$instance->add_admin_notice( 'Uploads directory unavailable. Using plugin directory for logs.' );
 			$fallback_dir = rtrim( NUCLEN_PLUGIN_DIR, '/' ) . '/logs';
 			return array(
 				'dir'  => $fallback_dir,
@@ -56,9 +56,9 @@ class LoggingService {
 			);
 		}
 
-               $log_folder = $upload_dir['basedir'] . '/nuclear-engagement';
-               $log_file   = $log_folder . '/log.txt';
-               $log_url    = $upload_dir['baseurl'] . '/nuclear-engagement/log.txt';
+				$log_folder = $upload_dir['basedir'] . '/nuclear-engagement';
+				$log_file   = $log_folder . '/log.txt';
+				$log_url    = $upload_dir['baseurl'] . '/nuclear-engagement/log.txt';
 
 		return array(
 			'dir'  => $log_folder,
@@ -67,34 +67,34 @@ class LoggingService {
 		);
 	}
 
-       /** Store an admin notice and ensure the hook is registered. */
-       private function add_admin_notice( string $message ): void {
-               $this->notices->add( $message );
-       }
+		/** Store an admin notice and ensure the hook is registered. */
+		private function add_admin_notice( string $message ): void {
+				$this->notices->add( $message );
+		}
 
-       /** Public helper to show an admin error notice. */
-       public static function notify_admin( string $message ): void {
-               $instance = self::instance();
-               $instance->add_admin_notice( $message );
-       }
+		/** Public helper to show an admin error notice. */
+		public static function notify_admin( string $message ): void {
+				$instance = self::instance();
+				$instance->add_admin_notice( $message );
+		}
 
-       /** Debug level logging, only when WP_DEBUG is true. */
-       public static function debug( string $message ): void {
-               if ( defined( 'WP_DEBUG' ) && WP_DEBUG ) {
-                       self::log( '[DEBUG] ' . $message );
-               }
-       }
+		/** Debug level logging, only when WP_DEBUG is true. */
+		public static function debug( string $message ): void {
+				if ( defined( 'WP_DEBUG' ) && WP_DEBUG ) {
+						self::log( '[DEBUG] ' . $message );
+				}
+		}
 
-       /** Log an exception including file and line. */
-       public static function log_exception( \Throwable $e ): void {
-               $msg = $e->getMessage() . ' in ' . $e->getFile() . ':' . $e->getLine();
-               if ( defined( 'WP_DEBUG' ) && WP_DEBUG ) {
-                       $trace_lines = explode( "\n", $e->getTraceAsString() );
-                       $trace       = implode( ' | ', array_slice( $trace_lines, 0, 3 ) );
-                       $msg        .= ' Stack trace: ' . $trace;
-               }
-               self::log( $msg );
-       }
+		/** Log an exception including file and line. */
+		public static function log_exception( \Throwable $e ): void {
+				$msg = $e->getMessage() . ' in ' . $e->getFile() . ':' . $e->getLine();
+				if ( defined( 'WP_DEBUG' ) && WP_DEBUG ) {
+						$trace_lines = explode( "\n", $e->getTraceAsString() );
+						$trace       = implode( ' | ', array_slice( $trace_lines, 0, 3 ) );
+						$msg        .= ' Stack trace: ' . $trace;
+				}
+				self::log( $msg );
+		}
 
 	/** Fallback when writing to the log fails. */
 	private function fallback( string $original, string $error ): void {
@@ -103,26 +103,26 @@ class LoggingService {
 		$this->add_admin_notice( $error );
 	}
 
-       /** Determine if logging should be buffered. */
-       private function use_buffer(): bool {
-               $default = defined( 'NUCLEN_BUFFER_LOGS' ) ? (bool) NUCLEN_BUFFER_LOGS : true;
-               return (bool) apply_filters( 'nuclen_enable_log_buffer', $default );
-       }
+		/** Determine if logging should be buffered. */
+		private function use_buffer(): bool {
+				$default = defined( 'NUCLEN_BUFFER_LOGS' ) ? (bool) NUCLEN_BUFFER_LOGS : true;
+				return (bool) apply_filters( 'nuclen_enable_log_buffer', $default );
+		}
 
-       /** Flush buffered messages to the log file. */
-       public static function flush(): void {
-               $instance = self::instance();
-               if ( empty( $instance->buffer ) ) {
-                       return;
-               }
+		/** Flush buffered messages to the log file. */
+		public static function flush(): void {
+				$instance = self::instance();
+				if ( empty( $instance->buffer ) ) {
+						return;
+				}
 
-               $instance->write_messages( $instance->buffer );
-               $instance->buffer = array();
-       }
+				$instance->write_messages( $instance->buffer );
+				$instance->buffer = array();
+		}
 
-       /** Write one or more messages to the log. */
-       private function write_messages( array $messages ): void {
-               $info       = self::get_log_file_info();
+		/** Write one or more messages to the log. */
+		private function write_messages( array $messages ): void {
+				$info       = self::get_log_file_info();
 		$log_folder = $info['dir'];
 		$log_file   = $info['path'];
 		$max_size   = defined( 'NUCLEN_LOG_FILE_MAX_SIZE' ) ? NUCLEN_LOG_FILE_MAX_SIZE : MB_IN_BYTES;
@@ -178,28 +178,28 @@ class LoggingService {
 		}
 	}
 
-       /** Append a message to the plugin log file. */
-       public static function log( string $message ): void {
-               if ( $message === '' ) {
-                       return;
-               }
+		/** Append a message to the plugin log file. */
+		public static function log( string $message ): void {
+				if ( $message === '' ) {
+						return;
+				}
 
-               $instance = self::instance();
+				$instance = self::instance();
 
-               $message = wp_strip_all_tags( $message );
-               if ( strlen( $message ) > 1000 ) {
-                       $message = substr( $message, 0, 1000 ) . '...';
-               }
+				$message = wp_strip_all_tags( $message );
+				if ( strlen( $message ) > 1000 ) {
+						$message = substr( $message, 0, 1000 ) . '...';
+				}
 
-               if ( $instance->use_buffer() ) {
-                       $instance->buffer[] = $message;
-                       if ( ! $instance->shutdown_registered ) {
-                               register_shutdown_function( array( self::class, 'flush' ) );
-                               $instance->shutdown_registered = true;
-                       }
-                       return;
-               }
+				if ( $instance->use_buffer() ) {
+						$instance->buffer[] = $message;
+						if ( ! $instance->shutdown_registered ) {
+								register_shutdown_function( array( self::class, 'flush' ) );
+								$instance->shutdown_registered = true;
+						}
+						return;
+				}
 
-               $instance->write_messages( array( $message ) );
-       }
+				$instance->write_messages( array( $message ) );
+		}
 }

--- a/nuclear-engagement/inc/Traits/SettingsPersistenceTrait.php
+++ b/nuclear-engagement/inc/Traits/SettingsPersistenceTrait.php
@@ -1,13 +1,13 @@
 <?php
 /**
- * File: includes/Traits/SettingsPersistenceTrait.php
- *
- * Handles saving logic for SettingsRepository.
- *
- * @package NuclearEngagement
- * @subpackage Traits
- * @since 1.0.0
- */
+	* File: includes/Traits/SettingsPersistenceTrait.php
+	*
+	* Handles saving logic for SettingsRepository.
+	*
+	* @package NuclearEngagement
+	* @subpackage Traits
+	* @since 1.0.0
+	*/
 
 declare( strict_types = 1 );
 
@@ -46,12 +46,12 @@ trait SettingsPersistenceTrait {
 		// Only update if settings have changed.
 		if ( $merged !== $current ) {
 			$autoload = $this->should_autoload( $merged );
-                        $result   = update_option( self::OPTION, $merged, $autoload ? 'yes' : 'no' );
-                        if ( $result ) {
-                                \NuclearEngagement\Core\InventoryCache::clear();
-                        }
+						$result   = update_option( self::OPTION, $merged, $autoload ? 'yes' : 'no' );
+						if ( $result ) {
+								\NuclearEngagement\Core\InventoryCache::clear();
+						}
 
-                        // Also update legacy option for backward compatibility.
+						// Also update legacy option for backward compatibility.
 			if ( $result && false !== get_option( 'nuclear_engagement_setup' ) ) {
 				$legacy_data = array(
 					'api_key'             => $merged['api_key'] ?? '',

--- a/nuclear-engagement/inc/Utils/Utils.php
+++ b/nuclear-engagement/inc/Utils/Utils.php
@@ -1,15 +1,15 @@
 <?php
 /**
- * File: includes/Utils.php
- *
- * Utility helpers used throughout the plugin.
- *
- * Implementation of changes required by WordPress.org guidelines.
- * - Store log files and custom CSS in the standard uploads folder.
- * - No new style expansions needed here.
- *
- * @package NuclearEngagement
- */
+	* File: includes/Utils.php
+	*
+	* Utility helpers used throughout the plugin.
+	*
+	* Implementation of changes required by WordPress.org guidelines.
+	* - Store log files and custom CSS in the standard uploads folder.
+	* - No new style expansions needed here.
+	*
+	* @package NuclearEngagement
+	*/
 declare(strict_types=1);
 
 namespace NuclearEngagement\Utils;
@@ -19,8 +19,8 @@ if ( ! defined( 'ABSPATH' ) ) {
 }
 
 /**
- * Generic helper utilities for the plugin.
- */
+	* Generic helper utilities for the plugin.
+	*/
 class Utils {
 
 	/**
@@ -28,18 +28,18 @@ class Utils {
 	 *
 	 * @return void
 	 */
-       public function display_nuclen_page_header(): void {
+		public function display_nuclen_page_header(): void {
 	$image_url = plugin_dir_url( NUCLEN_PLUGIN_FILE ) . 'assets/nuclear-engagement-logo.webp';
-               if ( ! filter_var( $image_url, FILTER_VALIDATE_URL ) ) {
-                       return;
-               }
+				if ( ! filter_var( $image_url, FILTER_VALIDATE_URL ) ) {
+						return;
+				}
 
-               load_template(
-                       NUCLEN_PLUGIN_DIR . 'templates/admin/page-header.php',
-                       true,
-                       array( 'image_url' => $image_url )
-               );
-       }
+				load_template(
+						NUCLEN_PLUGIN_DIR . 'templates/admin/page-header.php',
+						true,
+						array( 'image_url' => $image_url )
+				);
+		}
 
 	/**
 	 * Retrieve paths and URLs for the custom CSS file.

--- a/nuclear-engagement/templates/admin/notice.php
+++ b/nuclear-engagement/templates/admin/notice.php
@@ -1,16 +1,16 @@
 <?php
 declare(strict_types=1);
 if ( ! defined( 'ABSPATH' ) ) {
-    exit;
+	exit;
 }
 /**
- * Single admin notice.
- *
- * Variables:
- *   - $msg (string) Notice message.
- *
- * @package NuclearEngagement\Admin
- */
+	* Single admin notice.
+	*
+	* Variables:
+	*   - $msg (string) Notice message.
+	*
+	* @package NuclearEngagement\Admin
+	*/
 ?>
 <div class="notice notice-error"><p><?php echo esc_html( $msg ); ?></p></div>
 


### PR DESCRIPTION
## Summary
- enforce tabs for all PHP indentation
- clean up admin and dashboard code

## Testing
- `composer lint --working-dir=nuclear-engagement` *(fails: composer not found)*

------
https://chatgpt.com/codex/tasks/task_e_685f7978df7c83278d6890ef69741860

<!-- Korbit AI PR Description Start -->
## Description by Korbit AI

### What change is being made?

Convert all PHP files from using spaces for indentation to using tabs across the nuclear-engagement codebase.

### Why are these changes being made?

The change to tab indentation is for consistency with the project's coding standards, which mandate the use of tabs. This aligns the code structure properly, making it easier to read and maintain for all developers working with the nuclear-engagement plugin.

> Is this description stale? Ask me to generate a new description by commenting `/korbit-generate-pr-description`
<!-- Korbit AI PR Description End -->