### PR TITLE
Fix meta key ordering to prevent storage failures

### DIFF
--- a/nuclear-engagement/inc/Services/ContentStorageService.php
+++ b/nuclear-engagement/inc/Services/ContentStorageService.php
@@ -137,10 +137,10 @@ class ContentStorageService {
 				throw new \InvalidArgumentException( "Invalid quiz data for post {$postId}" );
 		}
 
-			$formatted = array(
-				'questions' => $questions,
-				'date'      => $data['date'] ?? current_time( 'mysql' ),
-			);
+				$formatted = array(
+					'date'      => $data['date'] ?? current_time( 'mysql' ),
+					'questions' => $questions,
+);
 
 			$current = get_post_meta( $postId, 'nuclen-quiz-data', true );
 			if ( $current === $formatted ) {
@@ -194,10 +194,10 @@ class ContentStorageService {
 			'span'   => array( 'class' => array() ),
 		);
 
-		$formatted = array(
-			'summary' => wp_kses( $data['summary'], $allowedHtml ),
-			'date'    => $data['date'] ?? current_time( 'mysql' ),
-		);
+				$formatted = array(
+					'date'    => $data['date'] ?? current_time( 'mysql' ),
+					'summary' => wp_kses( $data['summary'], $allowedHtml ),
+);
 
 			$current = get_post_meta( $postId, Summary_Service::META_KEY, true );
 			if ( $current === $formatted ) {

--- a/tests/ContentStorageServiceTest.php
+++ b/tests/ContentStorageServiceTest.php
@@ -44,20 +44,20 @@ namespace {
 			];
 			$service->storeQuizData(1, $data);
 			$expected = [
+				'date' => '2025-01-01',
 				'questions' => [
 					[
-						'question' => 'Q1',
-						'answers' => ['A1','A2'],
-						'explanation' => 'E1',
-					],
-					[
-						'question' => 'Q2',
-						'answers' => ['A1'],
-						'explanation' => '',
-					],
-				],
-				'date' => '2025-01-01',
-			];
+'question' => 'Q1',
+'answers' => ['A1','A2'],
+'explanation' => 'E1',
+],
+[
+'question' => 'Q2',
+'answers' => ['A1'],
+'explanation' => '',
+],
+],
+];
 			$this->assertSame($expected, $GLOBALS['wp_meta'][1]['nuclen-quiz-data']);
 		}
 


### PR DESCRIPTION
## Summary
- align post meta array order with sanitizers
- update tests for new meta structure

## Testing
- `composer lint` *(fails: command not found)*
- `composer test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685f7a6b515c8327807f6079785605c8