### PR TITLE
Add plugin URL constant and update asset URLs

### DIFF
--- a/nuclear-engagement/admin/Onboarding.php
+++ b/nuclear-engagement/admin/Onboarding.php
@@ -87,7 +87,7 @@ class Onboarding {
 
 				wp_enqueue_script(
 					'nuclen-onboarding',
-					plugin_dir_url( __DIR__ ) . 'admin/js/onboarding-pointers.js',
+					NUCLEN_PLUGIN_URL . 'admin/js/onboarding-pointers.js',
 					array( 'wp-util' ),
 					AssetVersions::get( 'onboarding_js' ),
 					true

--- a/nuclear-engagement/admin/Traits/AdminAssets.php
+++ b/nuclear-engagement/admin/Traits/AdminAssets.php
@@ -23,7 +23,7 @@ trait AdminAssets {
 	public function nuclen_register_admin_scripts() {
 	wp_register_script(
 	'nuclen-admin',
-	plugin_dir_url( dirname( __DIR__ ) ) . 'admin/js/nuclen-admin.js',
+	NUCLEN_PLUGIN_URL . 'admin/js/nuclen-admin.js',
 	array(),
 	AssetVersions::get( 'admin_js' ),
 	true
@@ -34,13 +34,13 @@ trait AdminAssets {
 	 * Enqueue base admin CSS for all plugin admin screens.
 	 */
 	public function wp_enqueue_styles() {
-		wp_enqueue_style(
-			$this->nuclen_get_plugin_name(),
-plugin_dir_url( dirname( __DIR__ ) ) . 'admin/css/nuclen-admin.css',
-			array(),
-			AssetVersions::get( 'admin_css' ),
-			'all'
-		);
+	wp_enqueue_style(
+	$this->nuclen_get_plugin_name(),
+	NUCLEN_PLUGIN_URL . 'admin/css/nuclen-admin.css',
+	array(),
+	AssetVersions::get( 'admin_css' ),
+	'all'
+	);
 	}
 
 	/**
@@ -66,14 +66,14 @@ plugin_dir_url( dirname( __DIR__ ) ) . 'admin/css/nuclen-admin.css',
 
 				// Enqueue the admin bundle. Onboarding handles pointer styles
 				// separately, so no wp-pointer or jQuery dependencies here.
-				wp_enqueue_script(
-					'nuclen-admin',
-plugin_dir_url( dirname( __DIR__ ) ) . 'admin/js/nuclen-admin.js',
-					array(),
-					AssetVersions::get( 'admin_js' ),
-					true
-				);
-
+	wp_enqueue_script(
+	'nuclen-admin',
+	NUCLEN_PLUGIN_URL . 'admin/js/nuclen-admin.js',
+	array(),
+	AssetVersions::get( 'admin_js' ),
+	true
+	);
+	
 		// Provide two objects:
 		// 1) "security" => wp_create_nonce('nuclen_admin_ajax_nonce') for your admin-ajax calls
 		// 2) "rest_nonce" => wp_create_nonce('wp_rest') for your custom REST route
@@ -123,12 +123,12 @@ plugin_dir_url( dirname( __DIR__ ) ) . 'admin/js/nuclen-admin.js',
 	public function nuclen_enqueue_dashboard_styles( $hook ) {
 		if ( $hook === 'toplevel_page_nuclear-engagement' ) {
 			wp_enqueue_style(
-				$this->nuclen_get_plugin_name() . '-dashboard',
-plugin_dir_url( dirname( __DIR__ ) ) . 'admin/css/nuclen-admin-dashboard.css?v=' . NUCLEN_ASSET_VERSION,
-				array(),
-				$this->nuclen_get_version(),
-				'all'
-			);
-		}
+					$this->nuclen_get_plugin_name() . '-dashboard',
+					NUCLEN_PLUGIN_URL . 'admin/css/nuclen-admin-dashboard.css?v=' . NUCLEN_ASSET_VERSION,
+					array(),
+					$this->nuclen_get_version(),
+					'all'
+				);
+			}
 	}
 }

--- a/nuclear-engagement/front/traits/AssetsTrait.php
+++ b/nuclear-engagement/front/traits/AssetsTrait.php
@@ -180,14 +180,14 @@ return false;
 		}
 
 		/* Base CSS */
-		wp_enqueue_style(
-			$this->plugin_name,
-			plugin_dir_url( __FILE__ ) . '../css/nuclen-front.css',
-			array(),
-			AssetVersions::get( 'front_css' ),
-			'all'
-		);
-
+			wp_enqueue_style(
+				$this->plugin_name,
+					NUCLEN_PLUGIN_URL . 'front/css/nuclen-front.css',
+					array(),
+					AssetVersions::get( 'front_css' ),
+					'all'
+					);
+		
 				/* Custom theme CSS */
 				$settings_repo = $this->nuclen_get_settings_repository();
 				$theme_choice  = $settings_repo->get( 'theme', 'bright' );
@@ -218,11 +218,11 @@ return false;
 		/* Main bundle */
 		wp_enqueue_script(
 			$this->plugin_name . '-front',
-			plugin_dir_url( __DIR__ ) . 'js/nuclen-front.js',
+			NUCLEN_PLUGIN_URL . 'front/js/nuclen-front.js',
 			array(),
 			AssetVersions::get( 'front_js' ),
 			true
-		);
+			);
 
 		$settings_repo = $this->nuclen_get_settings_repository();
 		

--- a/nuclear-engagement/inc/Core/Bootloader.php
+++ b/nuclear-engagement/inc/Core/Bootloader.php
@@ -41,6 +41,10 @@ final class Bootloader {
 			define( 'NUCLEN_PLUGIN_DIR', plugin_dir_path( NUCLEN_PLUGIN_FILE ) );
 		}
 
+		if ( ! defined( 'NUCLEN_PLUGIN_URL' ) ) {
+			define( 'NUCLEN_PLUGIN_URL', plugins_url( '/', NUCLEN_PLUGIN_FILE ) );
+		}
+
 		if ( ! defined( 'NUCLEN_PLUGIN_VERSION' ) ) {
 			if ( ! function_exists( 'get_file_data' ) ) {
 				require_once ABSPATH . 'wp-includes/functions.php';

--- a/nuclear-engagement/inc/Utils/Utils.php
+++ b/nuclear-engagement/inc/Utils/Utils.php
@@ -30,7 +30,7 @@ class Utils {
 	 */
 
        public function display_nuclen_page_header(): void {
-$image_url = plugins_url( 'assets/nuclear-engagement-logo.webp', NUCLEN_PLUGIN_FILE );
+	$image_url = NUCLEN_PLUGIN_URL . 'assets/nuclear-engagement-logo.webp';
                if ( ! filter_var( $image_url, FILTER_VALIDATE_URL ) ) {
                        return;
                }


### PR DESCRIPTION
## Summary
- define `NUCLEN_PLUGIN_URL` in Bootloader
- switch asset paths in traits and utils to use `NUCLEN_PLUGIN_URL`

## Testing
- `composer lint` *(fails: command not found)*
- `composer test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685f79ec92f08327bc711084c8ca8ca9

<!-- Korbit AI PR Description Start -->
## Description by Korbit AI

### What change is being made?

Define a new constant `NUCLEN_PLUGIN_URL` and update all asset URLs to utilize this constant for better code maintainability and readability in the plugin's admin and front-end scripts and styles.

### Why are these changes being made?

These changes were made to simplify and consolidate the mechanism for building URLs to plugin assets, reducing potential errors and enhancing consistency across the codebase. By defining a single `NUCLEN_PLUGIN_URL` constant, it ensures all URLs reflect the correct path, and any changes to plugin URL can be managed by updating just one line of code.

> Is this description stale? Ask me to generate a new description by commenting `/korbit-generate-pr-description`
<!-- Korbit AI PR Description End -->