### PR TITLE
Add ES2017 build target

### DIFF
--- a/vite.config.js
+++ b/vite.config.js
@@ -7,6 +7,7 @@ export default defineConfig({
   root: 'src',
 
   build: {
+    target: 'es2017',
     // Output to the "nuclear-engagement" folder (the plugin root).
     outDir: path.resolve(__dirname, 'nuclear-engagement'),
     emptyOutDir: false,


### PR DESCRIPTION
## Summary
- target older browsers by specifying `target: 'es2017'` in `vite.config.js`

## Testing
- `npm run build` *(fails: `vite: not found`)*

------
https://chatgpt.com/codex/tasks/task_e_685f7d7d65e0832785a67c64e7716a22