### PR TITLE
Refactor dashboard data methods

### DIFF
--- a/nuclear-engagement/admin/Dashboard.php
+++ b/nuclear-engagement/admin/Dashboard.php
@@ -55,152 +55,147 @@ public function render(): void {
 	*
 	* @return array Dashboard data arrays.
 	*/
-private function gather_dashboard_data(): array {
-		global $wpdb;
-
+	private function gather_dashboard_data(): array {
 		$allowed_post_types = $this->settings_repo->get( 'generation_post_types', array( 'post' ) );
 		$allowed_post_types = is_array( $allowed_post_types ) ? $allowed_post_types : array( 'post' );
-
+		
 		$post_statuses  = array( 'publish', 'pending', 'draft', 'future' );
 		$inventory_cache = \NuclearEngagement\Core\InventoryCache::get();
-
+		
 		if ( null === $inventory_cache ) {
-				$status_rows    = $this->data_service->get_dual_counts( 'p.post_status', $allowed_post_types, $post_statuses );
-				$status_objects = get_post_stati( array(), 'objects' );
-				$by_status_quiz = $by_status_summary = array();
-				foreach ( $status_rows as $r ) {
-						$label                                  = $status_objects[ $r['g'] ]->label ?? ucfirst( $r['g'] );
-						$by_status_quiz[ $label ]['with']       = (int) $r['quiz_with'];
-						$by_status_quiz[ $label ]['without']    = (int) $r['quiz_without'];
-						$by_status_summary[ $label ]['with']    = (int) $r['summary_with'];
-						$by_status_summary[ $label ]['without'] = (int) $r['summary_without'];
-				}
-
-				$ptype_rows = $this->data_service->get_dual_counts( 'p.post_type', $allowed_post_types, $post_statuses );
-				$by_post_type_quiz = $by_post_type_summary = array();
-				foreach ( $ptype_rows as $r ) {
-						$pt_obj                                    = get_post_type_object( $r['g'] );
-						$label                                     = $pt_obj->labels->name ?? ucfirst( $r['g'] );
-						$by_post_type_quiz[ $label ]['with']       = (int) $r['quiz_with'];
-						$by_post_type_quiz[ $label ]['without']    = (int) $r['quiz_without'];
-						$by_post_type_summary[ $label ]['with']    = (int) $r['summary_with'];
-						$by_post_type_summary[ $label ]['without'] = (int) $r['summary_without'];
-				}
-
-				$author_rows = $this->data_service->get_dual_counts( 'p.post_author', $allowed_post_types, $post_statuses );
-				$author_ids  = array_map( static fn ( $row ) => (int) $row['g'], $author_rows );
-
-				$author_names = array();
-				if ( $author_ids ) {
-						$users = get_users(
-								array(
-										'include' => $author_ids,
-										'fields'  => array( 'ID', 'display_name' ),
-								)
-						);
-						foreach ( $users as $user ) {
-								$author_names[ (int) $user->ID ] = $user->display_name;
-						}
-				}
-
-				$by_author_quiz = $by_author_summary = array();
-				foreach ( $author_rows as $r ) {
-						$id                                    = (int) $r['g'];
-						$name                                  = $author_names[ $id ] ?? __( 'Unknown Author', 'nuclear-engagement' );
-						$by_author_quiz[ $name ]['with']       = (int) $r['quiz_with'];
-						$by_author_quiz[ $name ]['without']    = (int) $r['quiz_without'];
-						$by_author_summary[ $name ]['with']    = (int) $r['summary_with'];
-						$by_author_summary[ $name ]['without'] = (int) $r['summary_without'];
-				}
-
-				$with_cat_pt      = array_filter( $allowed_post_types, fn( $pt ) => in_array( 'category', get_object_taxonomies( $pt ), true ) );
-				$by_category_quiz = $by_category_summary = array();
-				if ( $with_cat_pt ) {
-						$sanitized_pt    = array_map( 'sanitize_key', $with_cat_pt );
-						$sanitized_st    = array_map( 'sanitize_key', $post_statuses );
-						$placeholders_pt = implode( ',', array_fill( 0, count( $sanitized_pt ), '%s' ) );
-						$placeholders_st = implode( ',', array_fill( 0, count( $sanitized_st ), '%s' ) );
-						$sql_cat         = $wpdb->prepare(
-								"SELECT t.term_id,
-								t.name AS cat_name,
-								SUM(CASE WHEN pm_q.meta_id IS NULL THEN 0 ELSE 1 END) AS quiz_with,
-								SUM(CASE WHEN pm_q.meta_id IS NULL THEN 1 ELSE 0 END) AS quiz_without,
-								SUM(CASE WHEN pm_s.meta_id IS NULL THEN 0 ELSE 1 END) AS summary_with,
-								SUM(CASE WHEN pm_s.meta_id IS NULL THEN 1 ELSE 0 END) AS summary_without
-						FROM {$wpdb->posts} p
-						JOIN {$wpdb->term_relationships} tr ON tr.object_id = p.ID
-						JOIN {$wpdb->term_taxonomy}  tt ON tt.term_taxonomy_id = tr.term_taxonomy_id AND tt.taxonomy = 'category'
-						JOIN {$wpdb->terms}          t  ON t.term_id = tt.term_id
-						LEFT JOIN {$wpdb->postmeta}  pm_q ON pm_q.post_id = p.ID AND pm_q.meta_key = 'nuclen-quiz-data'
-						LEFT JOIN {$wpdb->postmeta}  pm_s ON pm_s.post_id = p.ID AND pm_s.meta_key = '" . Summary_Service::META_KEY . "'
-						WHERE p.post_type  IN ($placeholders_pt)
-						AND p.post_status IN ($placeholders_st)
-						GROUP BY t.term_id",
-								array_merge( $sanitized_pt, $sanitized_st )
-						);
-						$cat_rows = $wpdb->get_results( $sql_cat, ARRAY_A );
-						if ( ! empty( $wpdb->last_error ) ) {
-								\NuclearEngagement\Services\LoggingService::log( 'Category stats query error: ' . $wpdb->last_error );
-								$cat_rows = array();
-						}
-						foreach ( $cat_rows as $r ) {
-								$by_category_quiz[ $r['cat_name'] ]['with']       = (int) $r['quiz_with'];
-								$by_category_quiz[ $r['cat_name'] ]['without']    = (int) $r['quiz_without'];
-								$by_category_summary[ $r['cat_name'] ]['with']    = (int) $r['summary_with'];
-								$by_category_summary[ $r['cat_name'] ]['without'] = (int) $r['summary_without'];
-						}
-				}
-
-				$drop_zeros = static function ( array $arr ) {
-						return array_filter( $arr, static fn ( $c ) => ( ( $c['with'] ?? 0 ) + ( $c['without'] ?? 0 ) ) > 0 );
-				};
-
-				$by_status_quiz       = $drop_zeros( $by_status_quiz );
-				$by_status_summary    = $drop_zeros( $by_status_summary );
-				$by_post_type_quiz    = $drop_zeros( $by_post_type_quiz );
-				$by_post_type_summary = $drop_zeros( $by_post_type_summary );
-				$by_author_quiz       = $drop_zeros( $by_author_quiz );
-				$by_author_summary    = $drop_zeros( $by_author_summary );
-				$by_category_quiz     = $drop_zeros( $by_category_quiz );
-				$by_category_summary  = $drop_zeros( $by_category_summary );
-
-				\NuclearEngagement\Core\InventoryCache::set(
-						array(
-								'by_status_quiz'       => $by_status_quiz,
-								'by_status_summary'    => $by_status_summary,
-								'by_post_type_quiz'    => $by_post_type_quiz,
-								'by_post_type_summary' => $by_post_type_summary,
-								'by_author_quiz'       => $by_author_quiz,
-								'by_author_summary'    => $by_author_summary,
-								'by_category_quiz'     => $by_category_quiz,
-								'by_category_summary'  => $by_category_summary,
-						)
-				);
+		$status  = $this->get_status_stats( $allowed_post_types, $post_statuses );
+		$ptype   = $this->get_post_type_stats( $allowed_post_types, $post_statuses );
+		$author  = $this->get_author_stats( $allowed_post_types, $post_statuses );
+		$cat     = $this->get_category_stats( $allowed_post_types, $post_statuses );
+		
+		$by_status_quiz       = $status['quiz'];
+		$by_status_summary    = $status['summary'];
+		$by_post_type_quiz    = $ptype['quiz'];
+		$by_post_type_summary = $ptype['summary'];
+		$by_author_quiz       = $author['quiz'];
+		$by_author_summary    = $author['summary'];
+		$by_category_quiz     = $cat['quiz'];
+		$by_category_summary  = $cat['summary'];
+		
+		\NuclearEngagement\Core\InventoryCache::set(
+		array(
+		'by_status_quiz'       => $by_status_quiz,
+		'by_status_summary'    => $by_status_summary,
+		'by_post_type_quiz'    => $by_post_type_quiz,
+		'by_post_type_summary' => $by_post_type_summary,
+		'by_author_quiz'       => $by_author_quiz,
+		'by_author_summary'    => $by_author_summary,
+		'by_category_quiz'     => $by_category_quiz,
+		'by_category_summary'  => $by_category_summary,
+		)
+		);
 		} else {
-				$by_status_quiz       = $inventory_cache['by_status_quiz'] ?? array();
-				$by_status_summary    = $inventory_cache['by_status_summary'] ?? array();
-				$by_post_type_quiz    = $inventory_cache['by_post_type_quiz'] ?? array();
-				$by_post_type_summary = $inventory_cache['by_post_type_summary'] ?? array();
-				$by_author_quiz       = $inventory_cache['by_author_quiz'] ?? array();
-				$by_author_summary    = $inventory_cache['by_author_summary'] ?? array();
-				$by_category_quiz     = $inventory_cache['by_category_quiz'] ?? array();
-				$by_category_summary  = $inventory_cache['by_category_summary'] ?? array();
+		$by_status_quiz       = $inventory_cache['by_status_quiz'] ?? array();
+		$by_status_summary    = $inventory_cache['by_status_summary'] ?? array();
+		$by_post_type_quiz    = $inventory_cache['by_post_type_quiz'] ?? array();
+		$by_post_type_summary = $inventory_cache['by_post_type_summary'] ?? array();
+		$by_author_quiz       = $inventory_cache['by_author_quiz'] ?? array();
+		$by_author_summary    = $inventory_cache['by_author_summary'] ?? array();
+		$by_category_quiz     = $inventory_cache['by_category_quiz'] ?? array();
+		$by_category_summary  = $inventory_cache['by_category_summary'] ?? array();
 		}
-
+		
 		$scheduled_tasks = $this->data_service->get_scheduled_generations();
-
+		
 		return array(
-				'by_status_quiz'       => $by_status_quiz,
-				'by_status_summary'    => $by_status_summary,
-				'by_post_type_quiz'    => $by_post_type_quiz,
-				'by_post_type_summary' => $by_post_type_summary,
-				'by_author_quiz'       => $by_author_quiz,
-				'by_author_summary'    => $by_author_summary,
-				'by_category_quiz'     => $by_category_quiz,
-				'by_category_summary'  => $by_category_summary,
-				'scheduled_tasks'      => $scheduled_tasks,
+		'by_status_quiz'       => $by_status_quiz,
+		'by_status_summary'    => $by_status_summary,
+		'by_post_type_quiz'    => $by_post_type_quiz,
+		'by_post_type_summary' => $by_post_type_summary,
+		'by_author_quiz'       => $by_author_quiz,
+		'by_author_summary'    => $by_author_summary,
+		'by_category_quiz'     => $by_category_quiz,
+		'by_category_summary'  => $by_category_summary,
+		'scheduled_tasks'      => $scheduled_tasks,
 		);
 }
+
+	private function drop_zero_rows( array $arr ): array {
+		return array_filter( $arr, static fn ( $c ) => ( ( $c['with'] ?? 0 ) + ( $c['without'] ?? 0 ) ) > 0 );
+		}
+		
+		private function get_status_stats( array $post_types, array $statuses ): array {
+		$rows = $this->data_service->get_dual_counts( 'p.post_status', $post_types, $statuses );
+		$status_objects = get_post_stati( array(), 'objects' );
+		$quiz = $summary = array();
+		foreach ( $rows as $r ) {
+		$label = $status_objects[ $r['g'] ]->label ?? ucfirst( $r['g'] );
+		$quiz[ $label ]['with'] = (int) $r['quiz_with'];
+		$quiz[ $label ]['without'] = (int) $r['quiz_without'];
+		$summary[ $label ]['with'] = (int) $r['summary_with'];
+		$summary[ $label ]['without'] = (int) $r['summary_without'];
+		}
+		return array(
+		'quiz'    => $this->drop_zero_rows( $quiz ),
+		'summary' => $this->drop_zero_rows( $summary ),
+		);
+		}
+		
+		private function get_post_type_stats( array $post_types, array $statuses ): array {
+		$rows = $this->data_service->get_dual_counts( 'p.post_type', $post_types, $statuses );
+		$quiz = $summary = array();
+		foreach ( $rows as $r ) {
+		$pt_obj = get_post_type_object( $r['g'] );
+		$label  = $pt_obj->labels->name ?? ucfirst( $r['g'] );
+		$quiz[ $label ]['with'] = (int) $r['quiz_with'];
+		$quiz[ $label ]['without'] = (int) $r['quiz_without'];
+		$summary[ $label ]['with'] = (int) $r['summary_with'];
+		$summary[ $label ]['without'] = (int) $r['summary_without'];
+		}
+		return array(
+		'quiz'    => $this->drop_zero_rows( $quiz ),
+		'summary' => $this->drop_zero_rows( $summary ),
+		);
+		}
+		
+		private function get_author_stats( array $post_types, array $statuses ): array {
+		$rows = $this->data_service->get_dual_counts( 'p.post_author', $post_types, $statuses );
+		$author_ids = array_map( static fn ( $row ) => (int) $row['g'], $rows );
+		$author_names = array();
+		if ( $author_ids ) {
+		$users = get_users( array( 'include' => $author_ids, 'fields' => array( 'ID', 'display_name' ) ) );
+		foreach ( $users as $user ) {
+		$author_names[ (int) $user->ID ] = $user->display_name;
+		}
+		}
+		$quiz = $summary = array();
+		foreach ( $rows as $r ) {
+		$id = (int) $r['g'];
+		$name = $author_names[ $id ] ?? __( 'Unknown Author', 'nuclear-engagement' );
+		$quiz[ $name ]['with'] = (int) $r['quiz_with'];
+		$quiz[ $name ]['without'] = (int) $r['quiz_without'];
+		$summary[ $name ]['with'] = (int) $r['summary_with'];
+		$summary[ $name ]['without'] = (int) $r['summary_without'];
+		}
+		return array(
+		'quiz'    => $this->drop_zero_rows( $quiz ),
+		'summary' => $this->drop_zero_rows( $summary ),
+		);
+		}
+		
+		private function get_category_stats( array $post_types, array $statuses ): array {
+		$with_cat_pt = array_filter( $post_types, fn( $pt ) => in_array( 'category', get_object_taxonomies( $pt ), true ) );
+		$quiz = $summary = array();
+		if ( $with_cat_pt ) {
+		$rows = $this->data_service->get_category_dual_counts( $with_cat_pt, $statuses );
+		foreach ( $rows as $r ) {
+		$quiz[ $r['cat_name'] ]['with'] = (int) $r['quiz_with'];
+		$quiz[ $r['cat_name'] ]['without'] = (int) $r['quiz_without'];
+		$summary[ $r['cat_name'] ]['with'] = (int) $r['summary_with'];
+		$summary[ $r['cat_name'] ]['without'] = (int) $r['summary_without'];
+		}
+		}
+		return array(
+		'quiz'    => $this->drop_zero_rows( $quiz ),
+		'summary' => $this->drop_zero_rows( $summary ),
+		);
+		}
+		
 
 /**
 	* Render the dashboard template.

--- a/nuclear-engagement/inc/Services/DashboardDataService.php
+++ b/nuclear-engagement/inc/Services/DashboardDataService.php
@@ -114,7 +114,7 @@ class DashboardDataService {
 	 * @param array  $statuses   Allowed post statuses.
 	 * @return array             Rows with counts for quiz and summary.
 	 */
-	public function get_dual_counts( string $group_by, array $post_types, array $statuses ): array {
+public function get_dual_counts( string $group_by, array $post_types, array $statuses ): array {
 		global $wpdb;
 
 		$post_types = array_map( 'sanitize_key', $post_types );
@@ -160,8 +160,53 @@ class DashboardDataService {
 		wp_cache_set( $cache_key, $rows, self::CACHE_GROUP, self::CACHE_TTL );
 		set_transient( $transient, $rows, self::CACHE_TTL );
 
+return $rows;
+}
+
+/**
+ * Retrieve counts grouped by category.
+ *
+ * @param array $post_types Allowed post types.
+ * @param array $statuses   Allowed post statuses.
+ * @return array            Rows of counts.
+ */
+	public function get_category_dual_counts( array $post_types, array $statuses ): array {
+		global $wpdb;
+		
+		$post_types = array_map( 'sanitize_key', $post_types );
+		$statuses   = array_map( 'sanitize_key', $statuses );
+		
+		$placeholders_pt = implode( ',', array_fill( 0, count( $post_types ), '%s' ) );
+		$placeholders_st = implode( ',', array_fill( 0, count( $statuses ), '%s' ) );
+		
+		$sql = $wpdb->prepare(
+		"SELECT t.term_id,
+		 t.name AS cat_name,
+		 SUM(CASE WHEN pm_q.meta_id IS NULL THEN 0 ELSE 1 END) AS quiz_with,
+		 SUM(CASE WHEN pm_q.meta_id IS NULL THEN 1 ELSE 0 END) AS quiz_without,
+		 SUM(CASE WHEN pm_s.meta_id IS NULL THEN 0 ELSE 1 END) AS summary_with,
+		 SUM(CASE WHEN pm_s.meta_id IS NULL THEN 1 ELSE 0 END) AS summary_without
+		FROM {$wpdb->posts} p
+		JOIN {$wpdb->term_relationships} tr ON tr.object_id = p.ID
+		JOIN {$wpdb->term_taxonomy}  tt ON tt.term_taxonomy_id = tr.term_taxonomy_id AND tt.taxonomy = 'category'
+		JOIN {$wpdb->terms}          t  ON t.term_id = tt.term_id
+		LEFT JOIN {$wpdb->postmeta}  pm_q ON pm_q.post_id = p.ID AND pm_q.meta_key = 'nuclen-quiz-data'
+		LEFT JOIN {$wpdb->postmeta}  pm_s ON pm_s.post_id = p.ID AND pm_s.meta_key = '" . Summary_Service::META_KEY . "'
+		WHERE p.post_type  IN ($placeholders_pt)
+		AND p.post_status IN ($placeholders_st)
+		GROUP BY t.term_id",
+		array_merge( $post_types, $statuses )
+		);
+		
+		$rows = $wpdb->get_results( $sql, ARRAY_A );
+		
+		if ( ! empty( $wpdb->last_error ) ) {
+		LoggingService::log( 'Category stats query error: ' . $wpdb->last_error );
+		return array();
+		}
+		
 		return $rows;
-	}
+		}
 
 	/**
 	 * Retrieve any scheduled generation tasks.

--- a/tests/DashboardStatsMethodsTest.php
+++ b/tests/DashboardStatsMethodsTest.php
@@ -1,0 +1,58 @@
+<?php
+namespace {
+use PHPUnit\Framework\TestCase;
+use NuclearEngagement\Admin\Dashboard;
+use NuclearEngagement\Services\DashboardDataService;
+
+if ( ! function_exists( 'get_post_stati' ) ) {
+function get_post_stati( $a = [], $o = 'objects' ) { return ['publish' => (object)['label' => 'Published']]; }
+}
+if ( ! function_exists( 'get_post_type_object' ) ) {
+function get_post_type_object( $t ) { return (object)['labels' => (object)['name' => 'Post']]; }
+}
+if ( ! function_exists( 'get_users' ) ) {
+function get_users( $a ) { return [ (object)['ID' => 1, 'display_name' => 'Admin'] ]; }
+}
+if ( ! function_exists( '__' ) ) { function __( $t, $d = null ){ return $t; } }
+if ( ! function_exists( 'get_object_taxonomies' ) ) { function get_object_taxonomies( $pt ){ return ['category']; } }
+
+class DummySvc extends DashboardDataService {
+public array $rows = [];
+public function get_dual_counts( string $g, array $pt, array $st ): array { return $this->rows; }
+public function get_category_dual_counts( array $pt, array $st ): array { return $this->rows; }
+public function get_scheduled_generations(): array { return []; }
+}
+
+class DashboardStatsMethodsTest extends TestCase {
+private Dashboard $dash;
+private DummySvc $svc;
+
+protected function setUp(): void {
+$this->svc = new DummySvc();
+$repo = new class {
+public function get() { return null; }
+};
+$this->dash = new Dashboard( $repo, $this->svc );
+}
+
+private function call( string $method, array $args ) {
+$ref = new \ReflectionMethod( Dashboard::class, $method );
+$ref->setAccessible( true );
+return $ref->invokeArgs( $this->dash, $args );
+}
+
+public function test_get_status_stats_maps_labels(): void {
+$this->svc->rows = [ [ 'g' => 'publish', 'quiz_with' => 1, 'quiz_without' => 0, 'summary_with' => 2, 'summary_without' => 0 ] ];
+$res = $this->call( 'get_status_stats', [ ['post'], ['publish'] ] );
+$this->assertSame( 1, $res['quiz']['Published']['with'] );
+$this->assertSame( 2, $res['summary']['Published']['with'] );
+}
+
+public function test_get_category_stats_uses_service(): void {
+$this->svc->rows = [ [ 'cat_name' => 'News', 'quiz_with' => 1, 'quiz_without' => 0, 'summary_with' => 1, 'summary_without' => 0 ] ];
+$res = $this->call( 'get_category_stats', [ ['post'], ['publish'] ] );
+$this->assertSame( 1, $res['quiz']['News']['with'] );
+}
+}
+}
+}


### PR DESCRIPTION
## Summary
- move category query to DashboardDataService
- refactor `Dashboard` inventory gathering
- add unit tests for new stats helpers

## Testing
- `composer lint` *(fails: composer not found)*
- `composer test` *(fails: composer not found)*

------
https://chatgpt.com/codex/tasks/task_e_685f7c87017c83279e8e8b8b1fbb18e8