### PR TITLE
Fix fatal error on post publish

### DIFF
--- a/nuclear-engagement/inc/Modules/TOC/Nuclen_TOC_Headings.php
+++ b/nuclear-engagement/inc/Modules/TOC/Nuclen_TOC_Headings.php
@@ -28,7 +28,7 @@ final class Nuclen_TOC_Headings {
 	 */
 	public function __construct() {
 		add_filter( 'the_content', array( $this, 'nuclen_add_heading_ids' ), 99 );
-		add_action( 'save_post', array( $this, 'cache_headings_on_save' ), 10, 3 );
+               add_action( 'save_post', array( $this, 'cache_headings_on_save' ), 10, 2 );
 		add_action( 'delete_post', array( $this, 'delete_headings_cache' ) );
 	}
 


### PR DESCRIPTION
## Summary
- fix hook argument mismatch when saving posts

## Testing
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_685f8199ca8083278f9ce15a1e29a4fc