### PR TITLE
Switch onboarding to WP pointer

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -222,14 +222,13 @@ These routines now reside in a dedicated `PostsQueryService` used by
 
 This keeps query logic contained while leaving `Utils` focused on rendering tasks.
 
-## jQuery Removal from Onboarding
+## Onboarding Pointer Implementation
 
-The original onboarding pointer script relied on jQuery and the `wp-pointer` plugin.
-To meet the "no jQuery" guideline, the logic now uses vanilla TypeScript.
-`onboarding-pointers.js` manually positions `.wp-pointer` elements and sends
-dismissal requests via `fetch`. The PHP loader no longer enqueues the
-`wp-pointer` script or lists jQuery as a dependency—only the style sheet
-remains. This reduces dependencies and keeps the admin bundle lightweight.
+The plugin leverages WordPress' native `wp-pointer` script which depends on
+jQuery. `nuclen-admin-onboarding.ts` feeds pointer data into the standard
+`pointer()` API and sends dismissal requests via `fetch`. Both the style and
+script are enqueued so the default behavior is preserved while keeping the PHP
+loader concise.
 
 ## jQuery Removal from Settings Display
 

--- a/nuclear-engagement/admin/Onboarding.php
+++ b/nuclear-engagement/admin/Onboarding.php
@@ -83,15 +83,16 @@ class Onboarding {
 		}
 
 		/* ───── 4. Enqueue pointer assets ───── */
-				wp_enqueue_style( 'wp-pointer' );
+wp_enqueue_style( 'wp-pointer' );
+wp_enqueue_script( 'wp-pointer' );
 
-				wp_enqueue_script(
-					'nuclen-onboarding',
-					NUCLEN_PLUGIN_URL . 'admin/js/onboarding-pointers.js',
-					array( 'wp-util' ),
-					AssetVersions::get( 'onboarding_js' ),
-					true
-				);
+wp_enqueue_script(
+'nuclen-onboarding',
+NUCLEN_PLUGIN_URL . 'admin/js/onboarding-pointers.js',
+array( 'jquery', 'wp-pointer', 'wp-util' ),
+AssetVersions::get( 'onboarding_js' ),
+true
+);
 
 		/* ───── 5. Inject payload via wp_add_inline_script() ───── */
 		$payload = array(

--- a/nuclear-engagement/admin/js/onboarding-pointers.js
+++ b/nuclear-engagement/admin/js/onboarding-pointers.js
@@ -1,199 +1,49 @@
 /**
  * @file admin/js/onboarding-pointers.js
- *
- * Nuclear Engagement – onboarding pointers
- * Handles per-screen WP Pointer display & dismissal.
+ * Uses WordPress' native wp-pointer script to display onboarding tips.
  */
-
-function nuclenLog() {
-    console.log.apply(console, arguments);
+(function($){
+$(document).ready(function(){
+var data = window.nePointerData;
+if(!data || !Array.isArray(data.pointers) || !data.pointers.length){
+return;
 }
-
-function nuclenWarn() {
-    console.warn.apply(console, arguments);
+var index = 0;
+function dismiss(id){
+var form = new URLSearchParams();
+form.append('action','nuclen_dismiss_pointer');
+form.append('pointer', id);
+if(data.nonce){
+form.append('nonce', data.nonce);
 }
-
-function nuclenError() {
-    console.error.apply(console, arguments);
+fetch(data.ajaxurl, {
+method: 'POST',
+credentials: 'same-origin',
+headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+body: form.toString()
+}).catch(function(){});
 }
-
-async function nuclenFetchWithRetry(url, options, maxRetries = 3, initialDelay = 500) {
-    let attempt = 0;
-    let delay = initialDelay;
-    let lastError;
-    
-    while (attempt <= maxRetries) {
-        try {
-            const response = await fetch(url, options);
-            const { status, ok } = response;
-            const text = await response.text().catch(() => "");
-            const data = text ? (() => {
-                try {
-                    return JSON.parse(text);
-                } catch {
-                    return null;
-                }
-            })() : null;
-            
-            if (ok) {
-                return { ok: true, status: status, data: data };
-            }
-            
-            return { ok: false, status: status, data: data, error: text };
-            
-        } catch (error) {
-            lastError = error;
-            
-            if (attempt === maxRetries) {
-                break;
-            }
-            
-            nuclenWarn(
-                `Retrying request to ${url} with method ${options.method || "GET"} (${maxRetries - attempt} attempts left). Error: ${lastError.message}`,
-                lastError
-            );
-            
-            await new Promise(resolve => setTimeout(resolve, delay));
-            delay *= 2;
-        }
-        
-        attempt += 1;
-    }
-    
-    nuclenError(
-        `Max retries reached for ${url} with method ${options.method || "GET"}:`,
-        lastError
-    );
-    
-    throw lastError;
+function showNext(){
+if(index >= data.pointers.length){
+return;
 }
-
-function displayError(message) {
-    const toast = document.createElement('div');
-    toast.className = 'nuclen-error-toast';
-    toast.textContent = message;
-    document.body.appendChild(toast);
-    setTimeout(() => toast.remove(), 5000);
-    console.error(message);
+var ptr = data.pointers[index];
+var $target = jQuery(ptr.target);
+if(!$target.length){
+index++;
+showNext();
+return;
 }
-
-(function() {
-    if (typeof window.nePointerData === 'undefined') {
-        return;
-    }
-    
-    const { pointers, ajaxurl, nonce } = window.nePointerData;
-    
-    if (!Array.isArray(pointers) || !pointers.length) {
-        return;
-    }
-    
-    let index = 0;
-    
-    function showNext() {
-        if (index >= pointers.length) {
-            return;
-        }
-        
-        const ptr = pointers[index];
-        const target = document.querySelector(ptr.target);
-        
-        if (!target) {
-            index++;
-            showNext();
-            return;
-        }
-        
-        const wrapper = document.createElement('div');
-        wrapper.className = 'wp-pointer pointer-' + ptr.position.edge;
-        wrapper.style.position = 'absolute';
-        wrapper.innerHTML =
-            '<div class="wp-pointer-content"><h3>' +
-            ptr.title +
-            '</h3><p>' +
-            ptr.content +
-            '</p><a class="close" href="#">Dismiss</a></div>';
-        
-        document.body.appendChild(wrapper);
-        
-        const rect = target.getBoundingClientRect();
-        let top = window.scrollY + rect.top;
-        let left = window.scrollX + rect.left;
-        
-        switch (ptr.position.edge) {
-            case 'top':
-                top -= wrapper.offsetHeight;
-                break;
-            case 'bottom':
-                top += rect.height;
-                break;
-            case 'left':
-                left -= wrapper.offsetWidth;
-                break;
-            case 'right':
-                left += rect.width;
-                break;
-        }
-        
-        if (ptr.position.align === 'center') {
-            if (ptr.position.edge === 'top' || ptr.position.edge === 'bottom') {
-                left += (rect.width - wrapper.offsetWidth) / 2;
-            } else {
-                top += (rect.height - wrapper.offsetHeight) / 2;
-            }
-        } else if (ptr.position.align === 'right' || ptr.position.align === 'bottom') {
-            if (ptr.position.edge === 'top' || ptr.position.edge === 'bottom') {
-                left += rect.width - wrapper.offsetWidth;
-            } else {
-                top += rect.height - wrapper.offsetHeight;
-            }
-        }
-        
-        wrapper.style.top = Math.max(top, 0) + 'px';
-        wrapper.style.left = Math.max(left, 0) + 'px';
-        
-        const close = wrapper.querySelector('.close');
-        if (close) {
-            close.addEventListener('click', function(e) {
-                e.preventDefault();
-                
-                const params = new URLSearchParams({
-                    action: 'nuclen_dismiss_pointer',
-                    pointer: ptr.id,
-                });
-                
-                if (nonce) {
-                    params.append('nonce', nonce);
-                }
-                
-                (async () => {
-                    try {
-                        const response = await nuclenFetchWithRetry(
-                            ajaxurl,
-                            {
-                                method: 'POST',
-                                credentials: 'same-origin',
-                                headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
-                                body: params.toString(),
-                            }
-                        );
-                        
-                        if (!response.ok) {
-                            nuclenError('Failed to dismiss pointer:', response.error);
-                            displayError('Failed to dismiss pointer.');
-                        }
-                    } catch (err) {
-                        nuclenError('Error dismissing pointer:', err);
-                        displayError('Network error while dismissing pointer.');
-                    }
-                    
-                    wrapper.remove();
-                    index++;
-                    showNext();
-                })();
-            });
-        }
-    }
-    
-    document.addEventListener('DOMContentLoaded', showNext);
-})();
+$target.pointer({
+content: '<h3>' + ptr.title + '</h3><p>' + ptr.content + '</p>',
+position: ptr.position,
+close: function(){
+dismiss(ptr.id);
+index++;
+showNext();
+}
+}).pointer('open');
+}
+showNext();
+});
+})(jQuery);

--- a/src/admin/ts/nuclen-admin-onboarding.ts
+++ b/src/admin/ts/nuclen-admin-onboarding.ts
@@ -3,18 +3,20 @@ import { nuclenFetchWithRetry } from './nuclen-admin-generate';
 import { displayError } from './utils/displayError';
 import * as logger from './utils/logger';
 
+declare const jQuery: any;
+
 // 1) Declare the global shape of window.nePointerData.
 declare global {
 	interface Window {
-	nePointerData?: NuclenPointerData;
+		nePointerData?: NuclenPointerData;
 	}
 }
 
 // 2) Describe the structure of the pointer data
 export interface NuclenPointerData {
-pointers: NuclenPointer[];
-ajaxurl: string;
-nonce: string | undefined;
+	pointers: NuclenPointer[];
+	ajaxurl: string;
+	nonce: string | undefined;
 }
 
 // 3) Each pointer has the properties your PHP code provides
@@ -24,127 +26,75 @@ export interface NuclenPointer {
 	title: string;
 	content: string;
 	position: {
-	edge: 'top' | 'bottom' | 'left' | 'right';
-	align: 'top' | 'bottom' | 'left' | 'right' | 'center';
+		edge: 'top' | 'bottom' | 'left' | 'right';
+		align: 'top' | 'bottom' | 'left' | 'right' | 'center';
 	};
 }
 
 // Wrap our logic in an IIFE
-(function() {
-	// Wait for DOM ready
-	document.addEventListener('DOMContentLoaded', () => {
-	const pointerData = window.nePointerData;
+(function ($: any) {
+	$(document).ready(() => {
+		const pointerData = window.nePointerData;
 
-	// Check that pointerData exists and has pointers
-	if (!pointerData || !pointerData.pointers || pointerData.pointers.length === 0) {
-		return;
-	}
-
-	let currentIndex = 0;
-	const pointers = pointerData.pointers;
-	const ajaxurl = pointerData.ajaxurl;
-	const nonce = pointerData.nonce; // We'll send this in our AJAX
-
-	function nuclenShowNextPointer() {
-		if (currentIndex >= pointers.length) {
-		return;
+		if (!pointerData || !pointerData.pointers || pointerData.pointers.length === 0) {
+			return;
 		}
 
-		const ptr = pointers[currentIndex];
-const target = document.querySelector(ptr.target) as HTMLElement | null;
+		let currentIndex = 0;
+		const pointers = pointerData.pointers;
+		const ajaxurl = pointerData.ajaxurl;
+		const nonce = pointerData.nonce;
 
-		if (!target) {
-		currentIndex++;
-		nuclenShowNextPointer();
-		return;
-		}
-
-		const wrapper = document.createElement('div');
-		wrapper.className = `wp-pointer pointer-${ptr.position.edge}`;
-		wrapper.style.position = 'absolute';
-		wrapper.innerHTML = `
-		<div class="wp-pointer-content">
-			<h3>${ptr.title}</h3>
-			<p>${ptr.content}</p>
-			<a class="close" href="#">Dismiss</a>
-		</div>
-		`;
-		document.body.appendChild(wrapper);
-
-		const rect = target.getBoundingClientRect();
-		let top = window.scrollY + rect.top;
-		let left = window.scrollX + rect.left;
-
-		switch (ptr.position.edge) {
-		case 'top':
-			top -= wrapper.offsetHeight;
-			break;
-		case 'bottom':
-			top += rect.height;
-			break;
-		case 'left':
-			left -= wrapper.offsetWidth;
-			break;
-		case 'right':
-			left += rect.width;
-			break;
-		}
-
-		if (ptr.position.align === 'center') {
-		if (ptr.position.edge === 'top' || ptr.position.edge === 'bottom') {
-			left += (rect.width - wrapper.offsetWidth) / 2;
-		} else {
-			top += (rect.height - wrapper.offsetHeight) / 2;
-		}
-		} else if (ptr.position.align === 'right' || ptr.position.align === 'bottom') {
-		if (ptr.position.edge === 'top' || ptr.position.edge === 'bottom') {
-			left += rect.width - wrapper.offsetWidth;
-		} else {
-			top += rect.height - wrapper.offsetHeight;
-		}
-		}
-
-		wrapper.style.top = `${Math.max(top, 0)}px`;
-		wrapper.style.left = `${Math.max(left, 0)}px`;
-
-const close = wrapper.querySelector('.close') as HTMLAnchorElement | null;
-if ( close ) {
-close.addEventListener('click', async (e) => {
-		e.preventDefault();
-
-		const form = new URLSearchParams();
-		form.append('action', 'nuclen_dismiss_pointer');
-		form.append('pointer', ptr.id);
-		if (nonce) {
-			form.append('nonce', nonce);
-		}
-
-		try {
-			const result = await nuclenFetchWithRetry(ajaxurl, {
-			method: 'POST',
-			credentials: 'same-origin',
-			headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
-			body: form.toString(),
-			});
-			if (!result.ok) {
-			logger.error('Failed to dismiss pointer:', result.error);
-			displayError('Failed to dismiss pointer.');
+		async function dismissPointer(id: string) {
+			const form = new URLSearchParams();
+			form.append('action', 'nuclen_dismiss_pointer');
+			form.append('pointer', id);
+			if (nonce) {
+				form.append('nonce', nonce);
 			}
-} catch (err) {
-logger.error('Error dismissing pointer:', err);
-displayError('Network error while dismissing pointer.');
-}
 
-		wrapper.remove();
-		currentIndex++;
-nuclenShowNextPointer();
-});
-}
+			try {
+				const result = await nuclenFetchWithRetry(ajaxurl, {
+					method: 'POST',
+					credentials: 'same-origin',
+					headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+					body: form.toString(),
+				});
+				if (!result.ok) {
+					logger.error('Failed to dismiss pointer:', result.error);
+					displayError('Failed to dismiss pointer.');
+				}
+			} catch (err) {
+				logger.error('Error dismissing pointer:', err);
+				displayError('Network error while dismissing pointer.');
+			}
+		}
 
-// End nuclenShowNextPointer()
-}
+		function showNextPointer() {
+			if (currentIndex >= pointers.length) {
+				return;
+			}
 
-// Start the sequence
-nuclenShowNextPointer();
-});
-})();
+			const ptr = pointers[currentIndex];
+			const $target = $(ptr.target);
+
+			if (!$target.length) {
+				currentIndex++;
+				showNextPointer();
+				return;
+			}
+
+			$target.pointer({
+				content: `<h3>${ptr.title}</h3><p>${ptr.content}</p>`,
+				position: ptr.position,
+				close: async () => {
+					await dismissPointer(ptr.id);
+					currentIndex++;
+					showNextPointer();
+				},
+			}).pointer('open');
+		}
+
+		showNextPointer();
+	});
+})(jQuery);

--- a/tests/frontend/onboarding.test.ts
+++ b/tests/frontend/onboarding.test.ts
@@ -15,17 +15,44 @@ const { nuclenFetchWithRetry } = await import('../../src/admin/ts/nuclen-admin-g
 beforeEach(() => {
   vi.resetModules();
   document.body.innerHTML = '<div id="target"></div>';
+  (global as any).jQuery = (selector: any) => {
+    if (typeof selector === 'function') {
+      selector(jQuery);
+      return;
+    }
+    const element = document.querySelector(selector);
+    const api: any = {
+      pointer(opts: any) {
+        if (typeof opts === 'object') {
+          const wrapper = document.createElement('div');
+          wrapper.className = 'wp-pointer';
+          wrapper.innerHTML = `${opts.content}<a class="close" href="#">Dismiss</a>`;
+          element?.appendChild(wrapper);
+          if (opts.close) {
+            wrapper.querySelector('.close')?.addEventListener('click', opts.close);
+          }
+        }
+        return api;
+      },
+    };
+    api.pointer['open'] = () => {};
+    return api;
+  };
+  (global as any).$ = (global as any).jQuery;
   (window as any).nePointerData = {
-	pointers: [{ id: 'p1', target: '#target', title: 'T', content: 'C', position: { edge: 'top', align: 'center' } }],
-	ajaxurl: 'ajax.php',
-	nonce: 'n'
+    pointers: [{ id: 'p1', target: '#target', title: 'T', content: 'C', position: { edge: 'top', align: 'center' } }],
+    ajaxurl: 'ajax.php',
+    nonce: 'n'
   };
 });
 
 afterEach(() => {
+  delete (global as any).jQuery;
+  delete (global as any).$;
   delete (window as any).nePointerData;
   document.body.innerHTML = '';
 });
+
 
 describe('nuclen-admin-onboarding', () => {
   it('renders pointer from window data', async () => {


### PR DESCRIPTION
## Summary
- rely on WordPress `wp-pointer` script instead of custom pointer JS
- update TypeScript and JS onboarding logic
- document the pointer implementation
- adjust tests for jQuery-based pointer

## Testing
- `npm run build` *(fails: vite not found)*
- `composer lint` *(fails: command not found)*
- `composer test` *(fails: command not found)*
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_685f820e73ec8327b2a922a816cfca0f

<!-- Korbit AI PR Description Start -->
## Description by Korbit AI


### What change is being made?
Switch from a custom vanilla JavaScript implementation to using WordPress' native `wp-pointer` script for onboarding pointers, while re-introducing jQuery as a dependency.

### Why are these changes being made?
This change simplifies the codebase by utilizing WordPress' native jQuery-dependent `wp-pointer` API instead of maintaining a custom implementation, which was initially an attempt to meet a "no jQuery" guideline. This approach leverages the robust functionality provided by the existing WordPress ecosystem, thereby reducing maintenance burden and potential errors in custom logic. Any previous attempt to eliminate jQuery has been reversed to preserve the default behavior and align with typical WordPress practices.


> Is this description stale? Ask me to generate a new description by commenting `/korbit-generate-pr-description`
<!-- Korbit AI PR Description End -->