### PR TITLE
Add TOC block

### DIFF
--- a/nuclear-engagement/inc/Core/Blocks.php
+++ b/nuclear-engagement/inc/Core/Blocks.php
@@ -41,11 +41,11 @@ final class Blocks {
 			)
 		);
 
-		register_block_type(
-			'nuclear-engagement/summary',
-			array(
-				'api_version'     => 2,
-				'title'           => __( 'Summary', 'nuclear-engagement' ),
+                register_block_type(
+                        'nuclear-engagement/summary',
+                        array(
+                                'api_version'     => 2,
+                                'title'           => __( 'Summary', 'nuclear-engagement' ),
 				'category'        => 'widgets',
 				'icon'            => 'excerpt-view',
 				'render_callback' => static function (): string {
@@ -55,8 +55,26 @@ final class Blocks {
 					}
 					return $out;
 				},
-				'editor_script'   => 'nuclen-admin',
-			)
-		);
-	}
+                                'editor_script'   => 'nuclen-admin',
+                        )
+                );
+
+               register_block_type(
+                       'nuclear-engagement/toc',
+                       array(
+                               'api_version'     => 2,
+                               'title'           => __( 'TOC', 'nuclear-engagement' ),
+                               'category'        => 'widgets',
+                               'icon'            => 'list-view',
+                               'render_callback' => static function (): string {
+                                       $out = do_shortcode( '[nuclear_engagement_toc]' );
+                                       if ( ! is_string( $out ) || trim( $out ) === '' ) {
+                                               return '<p>' . esc_html__( 'TOC unavailable.', 'nuclear-engagement' ) . '</p>';
+                                       }
+                                       return $out;
+                               },
+                               'editor_script'   => 'nuclen-admin',
+                       )
+               );
+        }
 }

--- a/nuclear-engagement/languages/nuclear-engagement.pot
+++ b/nuclear-engagement/languages/nuclear-engagement.pot
@@ -88,6 +88,10 @@ msgstr ""
 msgid "Summary"
 msgstr ""
 
+#: nuclear-engagement/inc/Core/Blocks.php:66
+msgid "TOC"
+msgstr ""
+
 #: nuclear-engagement/inc/OptinData.php:181
 msgid "Insufficient permissions."
 msgstr ""
@@ -264,4 +268,8 @@ msgstr ""
 
 #: src/admin/ts/blocks/nuclen-editor-blocks.ts:21
 msgid "Summary will render on the front-end."
+msgstr ""
+
+#: src/admin/ts/blocks/nuclen-editor-blocks.ts:29
+msgid "TOC will render on the front-end."
 msgstr ""

--- a/src/admin/ts/blocks/nuclen-editor-blocks.ts
+++ b/src/admin/ts/blocks/nuclen-editor-blocks.ts
@@ -19,12 +19,20 @@
 	edit: () => createElement('p', null, __('Quiz will render on the front-end.', 'nuclear-engagement')),
 	save: () => null,
 	});
-	registerBlockType('nuclear-engagement/summary', {
-	apiVersion: 2,
-	title: __('Summary', 'nuclear-engagement'),
-	icon: 'excerpt-view',
-	category: 'widgets',
-	edit: () => createElement('p', null, __('Summary will render on the front-end.', 'nuclear-engagement')),
-	save: () => null,
-	});
+        registerBlockType('nuclear-engagement/summary', {
+        apiVersion: 2,
+        title: __('Summary', 'nuclear-engagement'),
+        icon: 'excerpt-view',
+        category: 'widgets',
+        edit: () => createElement('p', null, __('Summary will render on the front-end.', 'nuclear-engagement')),
+        save: () => null,
+        });
+        registerBlockType('nuclear-engagement/toc', {
+        apiVersion: 2,
+        title: __('TOC', 'nuclear-engagement'),
+        icon: 'list-view',
+        category: 'widgets',
+        edit: () => createElement('p', null, __('TOC will render on the front-end.', 'nuclear-engagement')),
+        save: () => null,
+        });
 })();

--- a/tests/BlocksTest.php
+++ b/tests/BlocksTest.php
@@ -48,29 +48,35 @@ namespace {
 			$this->assertSame([], $GLOBALS['block_regs']);
 		}
 
-		public function test_registers_two_blocks_and_callbacks_use_shortcodes(): void {
-			Blocks::register();
-			$this->assertCount(2, $GLOBALS['block_regs']);
-			$this->assertArrayHasKey('nuclear-engagement/quiz', $GLOBALS['block_regs']);
-			$this->assertArrayHasKey('nuclear-engagement/summary', $GLOBALS['block_regs']);
+               public function test_registers_three_blocks_and_callbacks_use_shortcodes(): void {
+                       Blocks::register();
+                       $this->assertCount(3, $GLOBALS['block_regs']);
+                       $this->assertArrayHasKey('nuclear-engagement/quiz', $GLOBALS['block_regs']);
+                       $this->assertArrayHasKey('nuclear-engagement/summary', $GLOBALS['block_regs']);
+                       $this->assertArrayHasKey('nuclear-engagement/toc', $GLOBALS['block_regs']);
 
-			$quiz_cb = $GLOBALS['block_regs']['nuclear-engagement/quiz']['render_callback'];
-			$summary_cb = $GLOBALS['block_regs']['nuclear-engagement/summary']['render_callback'];
+                       $quiz_cb = $GLOBALS['block_regs']['nuclear-engagement/quiz']['render_callback'];
+                       $summary_cb = $GLOBALS['block_regs']['nuclear-engagement/summary']['render_callback'];
+                       $toc_cb = $GLOBALS['block_regs']['nuclear-engagement/toc']['render_callback'];
 
-			$this->assertIsCallable($quiz_cb);
-			$this->assertIsCallable($summary_cb);
+                       $this->assertIsCallable($quiz_cb);
+                       $this->assertIsCallable($summary_cb);
+                       $this->assertIsCallable($toc_cb);
 
-			$quiz_html = $quiz_cb();
-			$summary_html = $summary_cb();
+                       $quiz_html = $quiz_cb();
+                       $summary_html = $summary_cb();
+                       $toc_html = $toc_cb();
 
-			$this->assertSame('OUT:[nuclear_engagement_quiz]', $quiz_html);
-			$this->assertSame('OUT:[nuclear_engagement_summary]', $summary_html);
+                       $this->assertSame('OUT:[nuclear_engagement_quiz]', $quiz_html);
+                       $this->assertSame('OUT:[nuclear_engagement_summary]', $summary_html);
+                       $this->assertSame('OUT:[nuclear_engagement_toc]', $toc_html);
 
-			$this->assertSame([
-				'[nuclear_engagement_quiz]',
-				'[nuclear_engagement_summary]'
-			], $GLOBALS['shortcode_calls']);
-			$this->assertSame([], \NuclearEngagement\Services\LoggingService::$logs);
-		}
+                       $this->assertSame([
+                                '[nuclear_engagement_quiz]',
+                                '[nuclear_engagement_summary]',
+                                '[nuclear_engagement_toc]'
+                        ], $GLOBALS['shortcode_calls']);
+                       $this->assertSame([], \NuclearEngagement\Services\LoggingService::$logs);
+               }
 	}
 }


### PR DESCRIPTION
## Summary
- register TOC block server-side
- expose TOC block in block editor
- translate new strings
- cover TOC block registration in unit tests

## Testing
- `npm test` *(fails: vitest not found)*
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_685f84dee14c832793b5686c8f35b6ef


> [!NOTE]
> I'm currently writing a description for your pull request. I should be done shortly (<1 minute). Please don't edit the description field until I'm finished, or we may overwrite each other. If I find nothing to write about, I'll delete this message.
