### PR TITLE
Fix onboarding pointer overlay

### DIFF
--- a/nuclear-engagement/admin/css/nuclen-admin.css
+++ b/nuclear-engagement/admin/css/nuclen-admin.css
@@ -417,3 +417,8 @@ Quick helper classes for display, text alignment, etc.
 .u-mb-sm { margin-bottom: var(--nuclen-spacing-sm); }
 .u-mb-md { margin-bottom: var(--nuclen-spacing-md); }
 .u-mb-lg { margin-bottom: var(--nuclen-spacing-lg); }
+
+/* Ensure onboarding pointers appear above sidebar */
+.wp-pointer {
+	z-index: 100600 !important;
+}


### PR DESCRIPTION
## Summary
- adjust z-index for onboarding pointers so they show above the WordPress sidebar

## Testing
- `composer lint` *(fails: command not found)*
- `composer test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685f862b02e883279a9f01fab082dbc4