### PR TITLE
Fix fatal error on post publish

### DIFF
--- a/nuclear-engagement/inc/Modules/TOC/Nuclen_TOC_Headings.php
+++ b/nuclear-engagement/inc/Modules/TOC/Nuclen_TOC_Headings.php
@@ -21,12 +21,12 @@ if ( ! defined( 'ABSPATH' ) ) {
 final class Nuclen_TOC_Headings {
 
 	/** Meta key for stored headings. */
-	public const META_KEY = 'nuclen_toc_headings';
+		public const META_KEY = 'nuclen_toc_headings';
 
 	/**
 	 * Hook into content filters.
 	 */
-	public function __construct() {
+		public function __construct() {
 		add_filter( 'the_content', array( $this, 'nuclen_add_heading_ids' ), 99 );
 		add_action( 'save_post', array( $this, 'cache_headings_on_save' ), 10, 3 );
 		add_action( 'delete_post', array( $this, 'delete_headings_cache' ) );
@@ -38,7 +38,7 @@ final class Nuclen_TOC_Headings {
 		 * @param string $content Post content to filter.
 		 * @return string Filtered content.
 		 */
-	public function nuclen_add_heading_ids( string $content ): string {
+		public function nuclen_add_heading_ids( string $content ): string {
 			return $this->add_heading_ids( $content );
 	}
 
@@ -48,7 +48,7 @@ final class Nuclen_TOC_Headings {
 		 * @param string $content HTML content to modify.
 		 * @return string Modified HTML content.
 		 */
-	public function add_heading_ids( string $content ): string {
+		public function add_heading_ids( string $content ): string {
 		if ( ! apply_filters( 'nuclen_toc_enable_heading_ids', true ) ) {
 				return $content;
 		}
@@ -72,13 +72,14 @@ final class Nuclen_TOC_Headings {
 		return $content;
 	}
 
-	/**
-	 * Cache extracted headings when a post is saved.
-	 *
-	 * @param int      $post_id Post ID.
-	 * @param \WP_Post $post    Post object.
-	 */
-	public function cache_headings_on_save( int $post_id, \WP_Post $post ): void {
+		/**
+		* Cache extracted headings when a post is saved.
+		*
+		* @param int      $post_id Post ID.
+		* @param \WP_Post $post    Post object.
+		* @param bool     $update  Whether this is an existing post being updated.
+		*/
+		public function cache_headings_on_save( int $post_id, \WP_Post $post, bool $update ): void {
 		delete_post_meta( $post_id, self::META_KEY );
 				$headings = HeadingExtractor::extract( $post->post_content, range( 1, 6 ), $post_id );
 		update_post_meta( $post_id, self::META_KEY, $headings );
@@ -89,7 +90,7 @@ final class Nuclen_TOC_Headings {
 	 *
 	 * @param int $post_id Post ID.
 	 */
-	public function delete_headings_cache( int $post_id ): void {
+		public function delete_headings_cache( int $post_id ): void {
 		delete_post_meta( $post_id, self::META_KEY );
 	}
 }


### PR DESCRIPTION
## Summary
- handle update flag when caching TOC headings

## Testing
- `composer lint` *(fails: command not found)*
- `composer test` *(fails: command not found)*
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_685f8199ca8083278f9ce15a1e29a4fc

<!-- Korbit AI PR Description Start -->
## Description by Korbit AI

### What change is being made?

Add an `update` parameter to the `cache_headings_on_save` method in the `Nuclen_TOC_Headings` class to handle post updates correctly.

### Why are these changes being made?

This change fixes a fatal error occurring when posts are published or updated by ensuring that method signatures match the expected WordPress hook requirements. It allows the `cache_headings_on_save` method to utilize the new `update` parameter indicating whether a post is being updated, which helps manage post meta data accurately without causing issues.

> Is this description stale? Ask me to generate a new description by commenting `/korbit-generate-pr-description`
<!-- Korbit AI PR Description End -->