### PR TITLE
Fix plugin admin menu load without composer

### DIFF
--- a/nuclear-engagement/README.txt
+++ b/nuclear-engagement/README.txt
@@ -260,6 +260,7 @@ The tiny codebase and lazy loading assure fast loading, both in admin and on fro
 * Changed: Improved security.
 * Changed: Improved performance with optimized database indexes.
 * Changed: Replaced `nuclen_settings_*` helpers with `Helpers\SettingsFunctions`.
+* Fixed: Plugin admin pages missing when Composer dependencies were absent.
 
 = 1.1 – 2025-06-13 =
 * Changed: Architecture refactoring.

--- a/nuclear-engagement/inc/Core/Bootloader.php
+++ b/nuclear-engagement/inc/Core/Bootloader.php
@@ -142,19 +142,25 @@ final class Bootloader {
 		if ( ! file_exists( $autoload ) ) {
 			$autoload = dirname( __DIR__, 2 ) . '/vendor/autoload.php';
 		}
-		if ( file_exists( $autoload ) ) {
-			require_once $autoload;
-		} else {
-			$logging = __DIR__ . '/../Services/LoggingService.php';
-			if ( file_exists( $logging ) ) {
-				require_once $logging;
-			}
-			LoggingService::log( 'Nuclear Engagement: vendor autoload not found.' );
-			LoggingService::notify_admin( 'Nuclear Engagement dependencies missing. Please run composer install.' );
-			return;
-		}
-
-		Autoloader::register();
+	if ( file_exists( $autoload ) ) {
+	require_once $autoload;
+	} else {
+	// Ensure the plugin autoloader is available even without Composer.
+	require_once __DIR__ . '/Autoloader.php';
+	Autoloader::register();
+	
+	$logging = __DIR__ . '/../Services/LoggingService.php';
+	if ( file_exists( $logging ) ) {
+	require_once $logging;
+	LoggingService::log( 'Nuclear Engagement: vendor autoload not found.' );
+	LoggingService::notify_admin( 'Nuclear Engagement dependencies missing. Please run composer install.' );
+	}
+	
+	return;
+	}
+	
+	// Composer autoloader loaded – now register the plugin autoloader.
+	Autoloader::register();
 	}
 	
 	/**


### PR DESCRIPTION
## Summary
- ensure the plugin autoloader always loads even when Composer deps are missing
- clarify changelog

## Testing
- `composer lint` *(fails: command not found)*
- `composer test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68621a3ba2b083278cb4b71c162e310e


> [!NOTE]
> I'm currently writing a description for your pull request. I should be done shortly (<1 minute). Please don't edit the description field until I'm finished, or we may overwrite each other. If I find nothing to write about, I'll delete this message.
