### PR TITLE
Ensure shortcode insertion only on singular posts

### DIFF
--- a/nuclear-engagement/front/traits/ShortcodesTrait.php
+++ b/nuclear-engagement/front/traits/ShortcodesTrait.php
@@ -43,8 +43,12 @@ trait ShortcodesTrait {
 	}
 
 	/* ---------- Auto-insert into content ---------- */
-	public function nuclen_auto_insert_shortcodes( $content ) {
-		$settings_repo    = $this->nuclen_get_settings_repository();
+       public function nuclen_auto_insert_shortcodes( $content ) {
+               if ( ! is_singular() || ! in_the_loop() || ! is_main_query() ) {
+                       return $content;
+               }
+
+               $settings_repo    = $this->nuclen_get_settings_repository();
 		$summary_position = $settings_repo->get( 'display_summary', 'none' );
 		$quiz_position    = $settings_repo->get( 'display_quiz', 'none' );
 		$toc_position     = $settings_repo->get( 'display_toc', 'manual' );


### PR DESCRIPTION
## Summary
- prevent automatic shortcode injection on archives or secondary loops

## Testing
- `./run-all-tests.sh` *(fails: vitest, eslint, vite, playwright, npm issues)*

------
https://chatgpt.com/codex/tasks/task_e_68720c2d43748327a38dcc43154b0dfe